### PR TITLE
Fix first-time UI login by using server-side PKCE flow

### DIFF
--- a/src/server/auth/handlers.rs
+++ b/src/server/auth/handlers.rs
@@ -677,7 +677,43 @@ pub async fn oauth_callback(
     // Determine redirect URL
     let redirect_url = oauth_state.redirect_url.unwrap_or_else(|| "/".to_string());
 
-    // Check if this is an ingress auth flow (has project context)
+    // Check if this is an ingress auth flow (has project context) vs UI login flow
+    let is_ingress_auth = oauth_state.project_name.is_some();
+
+    // For UI login flow (no project), return an HTML page that stores the token in localStorage
+    if !is_ingress_auth {
+        tracing::info!("UI login flow - returning token storage page");
+
+        // Create a simple HTML page that stores the token and redirects
+        let html = format!(
+            r#"<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Login Successful</title>
+</head>
+<body>
+    <script>
+        // Store token in localStorage
+        localStorage.setItem('rise_token', {});
+
+        // Clean up OAuth params and redirect
+        window.history.replaceState({{}}, document.title, '/');
+        window.location.href = '{}';
+    </script>
+    <noscript>
+        <p>JavaScript is required to complete the login process.</p>
+    </noscript>
+</body>
+</html>"#,
+            serde_json::to_string(&token_info.id_token).unwrap(),
+            redirect_url
+        );
+
+        return Ok(Html(html).into_response());
+    }
+
+    // For ingress auth flow (with project), issue Rise JWT and set cookie
     let (cookie, is_ingress_auth) = if let Some(ref project) = oauth_state.project_name {
         tracing::info!(
             "Issuing Rise JWT for ingress auth (project context: {})",

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -171,22 +171,8 @@ function LoginPage() {
     const [status, setStatus] = useState('');
     const [loading, setLoading] = useState(false);
 
-    // Handle OAuth callback on component mount
-    useEffect(() => {
-        const params = new URLSearchParams(window.location.search);
-        if (params.has('code')) {
-            setStatus('Processing authentication...');
-            setLoading(true);
-            handleOAuthCallback()
-                .catch((error) => {
-                    setStatus(`Error: ${error.message}`);
-                    setLoading(false);
-                });
-        }
-    }, []);
-
     const handleLogin = async () => {
-        setStatus('Initializing authentication...');
+        setStatus('Redirecting to login...');
         setLoading(true);
         try {
             await login();
@@ -291,14 +277,6 @@ function App() {
 
             // Continue with normal auth check - don't skip it!
             // This ensures the user stays logged in after OAuth extension callback
-        }
-
-        // Check if we're handling main app OAuth callback
-        const params = new URLSearchParams(window.location.search);
-        if (params.has('code')) {
-            // Let LoginPage handle the callback
-            setAuthChecked(true);
-            return;
         }
 
         if (!isAuthenticated()) {

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -1,4 +1,4 @@
-// OAuth2 PKCE implementation (mirrors CLI implementation)
+// OAuth2 authentication - uses server-side PKCE flow
 
 // Configuration is injected by the backend via index.html.tera template
 // Fallback to defaults for local development if not injected
@@ -11,109 +11,20 @@ if (!window.CONFIG) {
     };
 }
 
-// Generate random string for PKCE
-function generateRandomString(length) {
-    const charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~';
-    const randomValues = new Uint8Array(length);
-    crypto.getRandomValues(randomValues);
-    return Array.from(randomValues)
-        .map(x => charset[x % charset.length])
-        .join('');
-}
-
-// Generate PKCE code_verifier and code_challenge
-async function generatePKCE() {
-    const codeVerifier = generateRandomString(43);
-
-    // Calculate SHA-256 hash
-    const encoder = new TextEncoder();
-    const data = encoder.encode(codeVerifier);
-    const hashBuffer = await crypto.subtle.digest('SHA-256', data);
-
-    // Base64URL encode
-    const hashArray = Array.from(new Uint8Array(hashBuffer));
-    const base64 = btoa(String.fromCharCode(...hashArray));
-    const codeChallenge = base64
-        .replace(/\+/g, '-')
-        .replace(/\//g, '_')
-        .replace(/=/g, '');
-
-    return { codeVerifier, codeChallenge };
-}
-
-// Initiate OAuth2 authorization code flow
+// Initiate OAuth2 authorization code flow (server-side PKCE)
+// The backend handles PKCE generation, state management, and token exchange
+// to avoid sessionStorage issues on first login
 async function login() {
     try {
-        const { codeVerifier, codeChallenge } = await generatePKCE();
-
-        // Store code_verifier in sessionStorage
-        sessionStorage.setItem('pkce_code_verifier', codeVerifier);
-
-        // Build authorization URL
-        const authUrl = new URL(CONFIG.authorizeUrl);
-        authUrl.searchParams.append('client_id', CONFIG.clientId);
-        authUrl.searchParams.append('redirect_uri', CONFIG.redirectUri);
-        authUrl.searchParams.append('response_type', 'code');
-        authUrl.searchParams.append('scope', 'openid email profile offline_access');
-        authUrl.searchParams.append('code_challenge', codeChallenge);
-        authUrl.searchParams.append('code_challenge_method', 'S256');
-
-        // Redirect to OIDC provider
-        window.location.href = authUrl.toString();
+        // Redirect to backend's OAuth start endpoint
+        // The backend will:
+        // 1. Generate PKCE params and store state server-side
+        // 2. Redirect to OIDC provider
+        // 3. Handle callback and token exchange
+        // 4. Return an HTML page that stores token in localStorage
+        window.location.href = `${CONFIG.backendUrl}/api/v1/auth/signin/start`;
     } catch (error) {
         console.error('Login error:', error);
-        throw error;
-    }
-}
-
-// Handle OAuth callback
-async function handleOAuthCallback() {
-    const params = new URLSearchParams(window.location.search);
-    const code = params.get('code');
-    const error = params.get('error');
-
-    if (error) {
-        console.error('OAuth error:', params.get('error_description') || error);
-        throw new Error('Authentication failed: ' + (params.get('error_description') || error));
-    }
-
-    if (!code) {
-        throw new Error('No authorization code received');
-    }
-
-    const codeVerifier = sessionStorage.getItem('pkce_code_verifier');
-    if (!codeVerifier) {
-        throw new Error('No code verifier found');
-    }
-
-    try {
-        // Exchange code for token
-        const response = await fetch(`${CONFIG.backendUrl}/api/v1/auth/code/exchange`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-                code,
-                code_verifier: codeVerifier,
-                redirect_uri: CONFIG.redirectUri,
-            }),
-        });
-
-        if (!response.ok) {
-            const errorText = await response.text();
-            throw new Error(`Token exchange failed: ${errorText}`);
-        }
-
-        const data = await response.json();
-
-        // Store token in localStorage
-        localStorage.setItem('rise_token', data.token);
-        sessionStorage.removeItem('pkce_code_verifier');
-
-        // Clear OAuth params and reload to show dashboard
-        window.history.replaceState({}, document.title, '/');
-        window.location.reload();
-    } catch (error) {
-        console.error('Code exchange error:', error);
         throw error;
     }
 }


### PR DESCRIPTION
## Summary

Fixes the "No code verifier found" error that occurred on first-time UI logins.

## Problem

The previous client-side PKCE implementation stored the `code_verifier` in `sessionStorage` before redirecting to Dex. On first visits, browsers treat the OAuth redirect as cross-site navigation and may clear `sessionStorage` as a privacy protection, causing authentication to fail. Subsequent logins worked because cookies were already established.

## Solution

- **Backend**: Updated `oauth_callback` handler to detect UI login flow (no project context) and return an HTML page that stores the token in localStorage before redirecting
- **Frontend**: Simplified `auth.js` to redirect to `/api/v1/auth/signin/start` instead of implementing client-side PKCE
- **Frontend**: Removed OAuth callback handling from `app.js` since the backend now manages the entire flow

The backend's server-side token storage (`InMemoryTokenStore`) avoids sessionStorage issues and ensures reliable first-time login.

## Changes

- 75 fewer lines of client-side PKCE code removed
- Server-side state management now handles the entire OAuth flow
- More reliable authentication across all browsers and scenarios

## Test Plan

- [x] Test first-time login in a fresh incognito window
- [x] Verify subsequent logins still work
- [ ] Test across different browsers (Chrome, Firefox, Safari)

🤖 Generated with [Claude Code](https://claude.com/claude-code)