### PR TITLE
Use access_class ingress_class for ingresses and support config unset via null

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -84,7 +84,6 @@ controller: {}
 # For local development with Minikube, run: mise minikube:launch
 deployment_controller:
   type: "kubernetes"
-  ingress_class: "nginx"
   production_ingress_url_template: "{project_name}.rise.local"
   staging_ingress_url_template: "{project_name}-{deployment_group}.preview.rise.local"
   namespace_format: "rise-{project_name}"
@@ -138,6 +137,17 @@ deployment_controller:
 
   # Access classes define ingress authentication levels
   # Each project must be assigned to one of these access classes
+  # Each access class specifies its own ingress_class (e.g., "nginx", "nginx-internal")
+  #
+  # To remove an inherited access class in environment-specific configs, set it to null:
+  #   access_classes:
+  #     authenticated: null  # Remove this class
+  #     private: null        # Remove this class
+  #     internal:            # Add a new class
+  #       display_name: "Internal"
+  #       description: "Internal access only"
+  #       ingress_class: "nginx-internal"
+  #       access_requirement: Authenticated
   access_classes:
     public:
       display_name: "Public"


### PR DESCRIPTION
## Summary

- **Use per-access-class ingress_class**: The `ingress_class` configured for each access class is now used when creating ingress resources. This replaces the global `deployment_controller.ingress_class` field and allows different access classes to use different ingress controllers (e.g., "public" uses "nginx" while "internal" uses "nginx-internal").

- **Support unsetting config values via null**: Access classes in the config now support null values to remove inherited entries. This allows environment-specific configs (production.yaml) to override default.yaml by explicitly removing unwanted access classes.

## Test plan

- [x] Build passes with `cargo build --all-features`
- [x] All tests pass with `cargo test --all-features`
- [x] Linting passes with `cargo clippy --all-features`
- [x] SQLX check passes
- [ ] Manual testing: deploy a project and verify the ingress uses the access class's ingress_class
- [ ] Manual testing: configure `access_class: null` in local.yaml and verify it's removed from loaded config

🤖 Generated with [Claude Code](https://claude.com/claude-code)