### PR TITLE
feat: expose PORT environment variable to users

### DIFF
--- a/src/cli/deployment/core.rs
+++ b/src/cli/deployment/core.rs
@@ -418,7 +418,9 @@ pub struct DeploymentOptions<'a> {
     pub image: Option<&'a str>,
     pub group: Option<&'a str>,
     pub expires_in: Option<&'a str>,
-    pub http_port: u16,
+    /// HTTP port the application listens on.
+    /// If None, server will use project's PORT env var or default to 8080.
+    pub http_port: Option<u16>,
     pub build_args: &'a build::BuildArgs,
     pub from_deployment: Option<&'a str>,
     pub use_source_env_vars: bool,
@@ -622,15 +624,20 @@ async fn call_create_deployment_api(
     image: Option<&str>,
     group: Option<&str>,
     expires_in: Option<&str>,
-    http_port: u16,
+    http_port: Option<u16>,
     from_deployment: Option<&str>,
     use_source_env_vars: bool,
 ) -> Result<CreateDeploymentResponse> {
     let url = format!("{}/api/v1/deployments", backend_url);
     let mut payload = serde_json::json!({
         "project": project_name,
-        "http_port": http_port,
     });
+
+    // Add http_port field if explicitly provided
+    // If not provided, server will resolve from project's PORT env var or use default (8080)
+    if let Some(port) = http_port {
+        payload["http_port"] = serde_json::json!(port);
+    }
 
     // Add image field if provided
     if let Some(image_ref) = image {

--- a/src/cli/deployment/mod.rs
+++ b/src/cli/deployment/mod.rs
@@ -2,6 +2,6 @@ mod core;
 mod follow_ui;
 
 pub use core::{
-    create_deployment, fetch_deployment, get_logs, list_deployments, show_deployment,
-    stop_deployments_by_group, DeploymentOptions, GetLogsParams,
+    create_deployment, get_logs, list_deployments, show_deployment, stop_deployments_by_group,
+    DeploymentOptions, GetLogsParams,
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use reqwest::Client;
-use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 // Module declarations with feature gates
@@ -850,57 +849,22 @@ async fn main() -> Result<()> {
                     std::process::exit(1);
                 }
 
-                // Validate http_port requirements
-                let port = match (args.image.as_ref(), args.from.as_ref(), args.http_port) {
-                    // If using pre-built image without port, require it
-                    (Some(image_ref), None, None) => {
-                        eprintln!("Error: --http-port is required when using --image");
-                        eprintln!(
-                            "Example: rise deployment create {} --image {} --http-port 80",
-                            project_name, image_ref
-                        );
-                        std::process::exit(1);
-                    }
-                    // If using --from without port, fetch from source deployment
-                    (None, Some(from_id), None) => {
-                        let token = config.get_token().ok_or_else(|| {
-                            anyhow::anyhow!("Not logged in. Please run 'rise login' first.")
-                        })?;
-                        let source_deployment = deployment::fetch_deployment(
-                            &http_client,
-                            &backend_url,
-                            &token,
-                            &project_name,
-                            from_id,
-                        )
-                        .await
-                        .with_context(|| {
-                            format!(
-                                "Failed to fetch source deployment '{}' to get http_port",
-                                from_id
-                            )
-                        })?;
-                        info!(
-                            "Using http_port {} from source deployment '{}'",
-                            source_deployment.http_port, from_id
-                        );
-                        source_deployment.http_port
-                    }
-                    // If using pre-built image or from deployment with port specified, use it
-                    (Some(_), None, Some(p)) | (None, Some(_), Some(p)) => p,
-                    // If building from source without port specified, default to 8080 (Paketo buildpack default)
-                    (None, None, None) => {
-                        info!(
-                            "No --http-port specified, defaulting to 8080 (Paketo buildpack default)"
-                        );
-                        8080
-                    }
-                    // If building from source with port specified, use it
-                    (None, None, Some(p)) => p,
-                    // Both --image and --from cannot be specified together (handled above)
-                    (Some(_), Some(_), _) => unreachable!(),
-                };
+                // For pre-built images, --http-port is required since we can't infer it
+                if args.image.is_some() && args.http_port.is_none() {
+                    eprintln!("Error: --http-port is required when using --image");
+                    eprintln!(
+                        "Example: rise deployment create {} --image {} --http-port 80",
+                        project_name,
+                        args.image.as_ref().unwrap()
+                    );
+                    std::process::exit(1);
+                }
 
+                // Pass through the http_port option - server will resolve from:
+                // 1. Explicit http_port (if provided)
+                // 2. Source deployment's http_port (if --from is used)
+                // 3. Project's PORT env var (if set)
+                // 4. Default 8080
                 deployment::create_deployment(
                     &http_client,
                     &backend_url,
@@ -911,7 +875,7 @@ async fn main() -> Result<()> {
                         image: args.image.as_deref(),
                         group: args.group.as_deref(),
                         expires_in: args.expire.as_deref(),
-                        http_port: port,
+                        http_port: args.http_port,
                         build_args: &args.build_args,
                         from_deployment: args.from.as_deref(),
                         use_source_env_vars: args.use_source_env_vars,

--- a/src/server/deployment/models.rs
+++ b/src/server/deployment/models.rs
@@ -107,7 +107,10 @@ pub struct CreateDeploymentRequest {
     pub group: String, // Deployment group (e.g., 'default', 'mr/27')
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_in: Option<String>, // Expiration duration (e.g., '7d', '2h', '30m')
-    pub http_port: u16,  // HTTP port the application listens on
+    /// HTTP port the application listens on.
+    /// If not provided, uses the project's PORT env var or defaults to 8080.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub http_port: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub from_deployment: Option<String>, // Optional source deployment ID to create from
     #[serde(default)]


### PR DESCRIPTION
## Summary

- Make the `PORT` environment variable visible to users by storing it in `deployment_env_vars`
- PORT value follows this precedence:
  1. Explicit `--http-port` CLI/API option (highest priority)
  2. User-defined `PORT` project environment variable
  3. Default: 8080
- Fix missing env var handling in rollback deployments

## Changes

- **API**: Make `http_port` optional in `CreateDeploymentRequest`
- **CLI**: Pass through Option instead of resolving early
- **Server handler**: Add `resolve_effective_http_port()` function and upsert PORT to `deployment_env_vars`
- **K8s controller**: Remove PORT injection (now loaded from database)
- **Rollback**: Add env var handling (was missing - now copies project vars and upserts PORT)

## Test plan

- [x] All 122 tests pass
- [x] SQLX check passes
- [x] Clippy and formatting pass
- [ ] Deploy without explicit port, no PORT env var → should use 8080, visible via `rise env list --deployment <id>`
- [ ] Set `PORT=3000` via `rise env set`, then deploy → deployment uses 3000
- [ ] Set `PORT=3000`, deploy with `--http-port 5000` → deployment uses 5000
- [ ] Rollback to a deployment and verify PORT is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)