### PR TITLE
Fix OAuth extension callback to pass query parameters for localhost URLs

### DIFF
--- a/src/server/extensions/providers/oauth/handlers.rs
+++ b/src/server/extensions/providers/oauth/handlers.rs
@@ -576,9 +576,7 @@ pub async fn callback(
         "Missing redirect URI in state".to_string(),
     ))?;
 
-    let is_test_flow = final_redirect_uri.starts_with(&state.public_url)
-        || final_redirect_uri.starts_with("http://localhost:")
-        || final_redirect_uri.starts_with("http://127.0.0.1:");
+    let is_test_flow = final_redirect_uri.starts_with(&state.public_url);
 
     debug!(
         "OAuth callback: flow_type={}, final_redirect_uri={}",


### PR DESCRIPTION
## Problem

The Rise OIDC proxy was not passing authorization codes and state parameters back to application callbacks when using localhost URLs for local development.

### Bug Report
When initiating an OAuth flow with `redirect_uri=http://localhost:3001/auth/callback`, Rise would redirect back to the application without any query parameters, breaking the OAuth flow.

**Expected**:
```
http://localhost:3001/auth/callback?code={authorization_code}&state={original_state}
```

**Actual**:
```
http://localhost:3001/auth/callback
```

## Root Cause

**File**: `src/server/extensions/providers/oauth/handlers.rs:579-581`

The callback handler incorrectly classified ALL localhost URLs as "test flows":

```rust
let is_test_flow = final_redirect_uri.starts_with(&state.public_url)
    || final_redirect_uri.starts_with("http://localhost:")      // ❌ BUG
    || final_redirect_uri.starts_with("http://127.0.0.1:");     // ❌ BUG
```

**Test flows** were designed only for the Rise UI's "Test OAuth Flow" button, which:
- Validates OAuth configuration
- Updates extension status with `auth_verified = true`
- Redirects back WITHOUT authorization code (not needed for config testing)

**Real flows** properly:
- Generate a new authorization code
- Store encrypted token response
- Redirect with `?code={auth_code}&state={app_state}` query parameters

### Impact

This broke local development workflows where developers use `http://localhost:PORT/callback` URLs:
1. Flow classified as "test"
2. Callback redirects without query parameters
3. Application cannot exchange code for tokens
4. OAuth flow broken for local development

## Solution

Remove localhost/127.0.0.1 checks from `is_test_flow` logic. Only Rise UI URLs (those starting with `state.public_url`) should be treated as test flows.

**Changed to**:
```rust
let is_test_flow = final_redirect_uri.starts_with(&state.public_url);
```

### Justification

1. **Test flow is Rise UI-specific**: The UI testing feature redirects to Rise's own public URL
2. **Localhost is for development**: Real apps running locally need authorization codes
3. **No breaking changes**: Rise UI continues to work (still matches `state.public_url`)
4. **Aligns with documentation**: OAuth docs mention localhost support for local dev
5. **Example apps use localhost**: Both `example/oauth-pkce-flow` and `example/oauth-exchange-flow` use localhost callbacks

## Testing Plan

### 1. Localhost OAuth Flow (Bug Fix Verification)
- [ ] Start local callback server on `http://localhost:3001`
- [ ] Initiate OAuth flow with `redirect_uri=http://localhost:3001/auth/callback`
- [ ] Verify callback includes `?code={authorization_code}&state={app_state}`

### 2. Rise UI OAuth Flow (Regression Test)
- [ ] Navigate to Rise UI extension page
- [ ] Click "🔐 Test OAuth Flow" button
- [ ] Verify extension status shows `auth_verified: true`
- [ ] Verify no authorization code in URL (test flow behavior preserved)

### 3. Real Deployment OAuth Flow
- [ ] Deploy app with OAuth extension
- [ ] Test OAuth from deployed URL
- [ ] Verify authorization code received and token exchange works

## Changes

- Modified `src/server/extensions/providers/oauth/handlers.rs` - Removed localhost from test flow detection

## Verification

- ✅ Code compiles (`cargo check --features server`)
- ✅ Code formatting correct (`cargo fmt`)
- ✅ No linting issues (`cargo clippy`)
- ✅ SQLX offline compilation works
- ✅ No other code references `is_test_flow` beyond callback handler
- ✅ `validate_redirect_uri` explicitly allows localhost (no changes needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)