### PR TITLE
feat: Add config to disable team creation for regular users

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -25,6 +25,8 @@ auth:
   client_secret: "rise-backend-secret"
   admin_users:
     - "admin@example.com"
+  # Allow all users to create teams (default: true). Set to false to restrict team creation to admins only.
+  allow_team_creation: true
   platform_access:
     policy: restrictive
     allowed_user_emails:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -239,8 +239,8 @@ allow_team_creation = true     # Allow regular users to create teams (default: t
 ```
 
 **Team Creation Control:**
-- `allow_team_creation: true` (default): All authenticated users can create teams
-- `allow_team_creation: false`: Only admin users can create teams (suitable for centrally-managed organizations)
+- `allow_team_creation = true` (default): All authenticated users can create teams
+- `allow_team_creation = false`: Only admin users can create teams (suitable for centrally-managed organizations)
 
 ### Database Settings
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -234,7 +234,13 @@ issuer = "http://..."          # OIDC issuer URL
 client_id = "rise-backend"     # OAuth2 client ID
 client_secret = "..."          # OAuth2 client secret
 admin_users = ["email@..."]    # Admin user emails (array)
+allow_team_creation = true     # Allow regular users to create teams (default: true)
+                              # When false, only admins can create teams
 ```
+
+**Team Creation Control:**
+- `allow_team_creation: true` (default): All authenticated users can create teams
+- `allow_team_creation: false`: Only admin users can create teams (suitable for centrally-managed organizations)
 
 ### Database Settings
 

--- a/docs/schemas/backend-settings.schema.json
+++ b/docs/schemas/backend-settings.schema.json
@@ -98,7 +98,7 @@
         },
         "allow_team_creation": {
           "default": true,
-          "description": "Allow regular users to create teams (default: true) When false, only admin users can create teams",
+          "description": "Allow regular users to create teams (default: true). When false, only admin users can create teams.",
           "type": "boolean"
         },
         "authorize_url": {

--- a/docs/schemas/backend-settings.schema.json
+++ b/docs/schemas/backend-settings.schema.json
@@ -96,6 +96,11 @@
           },
           "type": "array"
         },
+        "allow_team_creation": {
+          "default": true,
+          "description": "Allow regular users to create teams (default: true) When false, only admin users can create teams",
+          "type": "boolean"
+        },
         "authorize_url": {
           "default": null,
           "description": "Optional custom authorize endpoint URL If not set, will be discovered from issuer's .well-known/openid-configuration or default to {issuer}/authorize",

--- a/frontend/src/features/teams.tsx
+++ b/frontend/src/features/teams.tsx
@@ -118,11 +118,13 @@ export function TeamsList({ currentUser, openCreate = false }) {
 
     return (
         <section>
-            <div className="flex justify-end items-center mb-6">
-                <Button variant="primary" size="sm" onClick={handleCreateClick}>
-                    Create Team
-                </Button>
-            </div>
+            {currentUser?.can_create_teams && (
+                <div className="flex justify-end items-center mb-6">
+                    <Button variant="primary" size="sm" onClick={handleCreateClick}>
+                        Create Team
+                    </Button>
+                </div>
+            )}
             {actionStatus && <p className="mono-inline-status mb-3">{actionStatus}</p>}
             <MonoTableFrame>
                 <MonoTable className="mono-sticky-table mono-table--sticky" onKeyDown={onKeyDown}>

--- a/src/server/auth/handlers.rs
+++ b/src/server/auth/handlers.rs
@@ -645,6 +645,7 @@ pub struct MeResponse {
     pub id: String,
     pub email: String,
     pub is_admin: bool,
+    pub can_create_teams: bool,
 }
 
 /// Get current user info from auth middleware
@@ -656,10 +657,12 @@ pub async fn me(
     // User is injected by auth middleware
     tracing::debug!("GET /me: user_id={}, email={}", user.id, user.email);
     let is_admin = state.is_admin(&user.email);
+    let can_create_teams = is_admin || state.auth_settings.allow_team_creation;
     Ok(Json(MeResponse {
         id: user.id.to_string(),
         email: user.email,
         is_admin,
+        can_create_teams,
     }))
 }
 

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -167,8 +167,8 @@ pub struct AuthSettings {
     /// Platform access control configuration
     #[serde(default)]
     pub platform_access: PlatformAccessConfig,
-    /// Allow regular users to create teams (default: true)
-    /// When false, only admin users can create teams
+    /// Allow regular users to create teams (default: true).
+    /// When false, only admin users can create teams.
     #[serde(default = "default_allow_team_creation")]
     pub allow_team_creation: bool,
     /// Optional custom authorize endpoint URL

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -111,6 +111,10 @@ fn default_idp_group_sync_enabled() -> bool {
     true
 }
 
+fn default_allow_team_creation() -> bool {
+    true // Backward compatible - existing behavior
+}
+
 #[derive(Debug, Deserialize, Clone, JsonSchema)]
 pub struct ControllerSettings {
     /// Interval in seconds for checking deployments to reconcile (default: 5)
@@ -163,6 +167,10 @@ pub struct AuthSettings {
     /// Platform access control configuration
     #[serde(default)]
     pub platform_access: PlatformAccessConfig,
+    /// Allow regular users to create teams (default: true)
+    /// When false, only admin users can create teams
+    #[serde(default = "default_allow_team_creation")]
+    pub allow_team_creation: bool,
     /// Optional custom authorize endpoint URL
     /// If not set, will be discovered from issuer's .well-known/openid-configuration
     /// or default to {issuer}/authorize

--- a/src/server/team/handlers.rs
+++ b/src/server/team/handlers.rs
@@ -20,6 +20,20 @@ pub async fn create_team(
 ) -> Result<Json<CreateTeamResponse>, (StatusCode, String)> {
     tracing::info!("Creating team '{}' for user {}", payload.name, user.email);
 
+    // Check if user is allowed to create teams
+    let is_admin = state.is_admin(&user.email);
+    if !state.auth_settings.allow_team_creation && !is_admin {
+        tracing::warn!(
+            "User {} attempted to create team '{}' but team creation is disabled for non-admins",
+            user.email,
+            payload.name
+        );
+        return Err((
+            StatusCode::FORBIDDEN,
+            "Team creation is disabled. Please contact your administrator.".to_string(),
+        ));
+    }
+
     // Validate that at least one owner is specified
     if payload.owners.is_empty() {
         return Err((

--- a/src/server/team/handlers.rs
+++ b/src/server/team/handlers.rs
@@ -18,8 +18,6 @@ pub async fn create_team(
     Extension(user): Extension<User>,
     Json(payload): Json<CreateTeamRequest>,
 ) -> Result<Json<CreateTeamResponse>, (StatusCode, String)> {
-    tracing::info!("Creating team '{}' for user {}", payload.name, user.email);
-
     // Check if user is allowed to create teams
     let is_admin = state.is_admin(&user.email);
     if !state.auth_settings.allow_team_creation && !is_admin {
@@ -33,6 +31,8 @@ pub async fn create_team(
             "Team creation is disabled. Please contact your administrator.".to_string(),
         ));
     }
+
+    tracing::info!("Creating team '{}' for user {}", payload.name, user.email);
 
     // Validate that at least one owner is specified
     if payload.owners.is_empty() {


### PR DESCRIPTION
## Summary

- Adds `allow_team_creation` configuration setting to `AuthSettings`
- When set to `false`, only admin users can create teams
- Defaults to `true` for backward compatibility (existing behavior)
- Admin users can always create teams regardless of this setting

## Changes

- **Configuration** (`src/server/settings.rs`): Added `allow_team_creation` field with default value of `true`
- **Authorization** (`src/server/team/handlers.rs`): Added check in `create_team` handler that returns HTTP 403 for non-admins when disabled
- **Example** (`config/development.yaml`): Added example configuration with documentation comment
- **Documentation** (`docs/configuration.md`): Documented the new setting with usage guidance

## Why This Is Needed

Organizations with centralized management may want to restrict team creation to administrators only, preventing team sprawl while maintaining flexibility for self-service environments.

## Behavior

- **Default (`allow_team_creation: true`)**: All authenticated users can create teams (current behavior)
- **Restricted (`allow_team_creation: false`)**: Only admin users can create teams
- **Admin bypass**: Admin users (configured in `auth.admin_users`) can always create teams
- **Error handling**: Non-admins attempting to create teams when disabled receive HTTP 403 with message "Team creation is disabled. Please contact your administrator."
- **Audit trail**: Warn-level log entry created when non-admin attempts team creation

## Test Plan

- [ ] Verify default behavior: Regular users can create teams when setting is `true` or omitted
- [ ] Verify restricted mode: Regular users cannot create teams when setting is `false`
- [ ] Verify admin bypass: Admins can create teams regardless of setting value
- [ ] Verify error message: Clear, actionable message returned to non-admin users
- [ ] Verify logging: Warn-level logs appear for blocked attempts
- [ ] Verify backward compatibility: Existing deployments work without config changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)