### PR TITLE
Replace rust-embed with filesystem-based static asset serving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3502,7 +3502,6 @@ dependencies = [
  "regex",
  "reqwest 0.12.25",
  "rsa",
- "rust-embed",
  "rustls 0.23.35",
  "schemars",
  "serde",
@@ -3561,40 +3560,6 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rust-embed"
-version = "8.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "947d7f3fad52b283d261c4c99a084937e2fe492248cb9a68a8435a861b8798ca"
-dependencies = [
- "rust-embed-impl",
- "rust-embed-utils",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-impl"
-version = "8.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fa2c8c9e8711e10f9c4fd2d64317ef13feaab820a4c51541f1a8c8e2e851ab2"
-dependencies = [
- "proc-macro2",
- "quote",
- "rust-embed-utils",
- "syn 2.0.111",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-utils"
-version = "8.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b161f275cb337fe0a44d924a5f4df0ed69c2c39519858f931ce61c779d3475"
-dependencies = [
- "sha2",
- "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,6 @@ backend = [
     "dep:async-trait",
     "dep:oci-distribution",
     "dep:thiserror",
-    "dep:rust-embed",
     "dep:mime_guess",
     "dep:tera",
     "dep:serde_ignored",
@@ -133,7 +132,6 @@ oci-distribution = { version = "0.11", optional = true }
 thiserror = { version = "2.0", optional = true }
 
 # Server: Frontend
-rust-embed = { version = "8.0", optional = true }
 mime_guess = { version = "2.0", optional = true }
 tera = { version = "1.20", optional = true }
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ COPY Cargo.toml Cargo.lock ./
 COPY src ./src
 COPY migrations ./migrations
 COPY static ./static
-COPY --from=frontend-builder /usr/src/frontend/dist ./static/ui
+COPY --from=frontend-builder /usr/src/frontend/dist/ ./static/
 COPY .sqlx ./.sqlx
 
 # Build the application with server features
@@ -69,12 +69,17 @@ COPY --from=builder /usr/local/bin/rise /usr/local/bin/rise
 # Copy the configuration files
 COPY config /etc/rise
 
+# Copy static assets for filesystem-based serving (templates, SVGs, Vite build output)
+COPY --from=builder /usr/src/static /var/lib/rise/static
+
 # Copy documentation files for serving via docs_dir
 COPY docs /var/rise/docs
 
 # Default config location/run mode for containerized execution
 ENV RISE_CONFIG_DIR=/etc/rise
 ENV RISE_CONFIG_RUN_MODE=production
+ENV RISE_STATIC_DIR=/var/lib/rise/static
+ENV RISE_DOCS_DIR=/var/rise/docs
 
 # Expose the application port
 EXPOSE 3000

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -5,12 +5,13 @@ server:
   host: "0.0.0.0"
   port: 3000
   public_url: "http://rise.local:3000"
-  frontend_dev_proxy_url: "http://localhost:5173"
+#  frontend_dev_proxy_url: "http://localhost:5173"
   cookie_domain: "" # Empty = current host only (for localhost:3000 access)
   cookie_secure: false
   jwt_signing_secret: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" # Generate with: openssl rand -base64 32
   jwt_claims: ["sub", "email", "name"]
-  docs_dir: "docs" # Serve docs from repo's docs/ directory
+  static_dir: "${RISE_STATIC_DIR:-static}" # In-container: /var/lib/rise/static; local dev: static/
+  docs_dir: "${RISE_DOCS_DIR:-docs}" # In-container: /var/rise/docs; local dev: docs/
 
 database:
   url: "${DATABASE_URL}"

--- a/docs/schemas/backend-settings.schema.json
+++ b/docs/schemas/backend-settings.schema.json
@@ -951,7 +951,7 @@
         },
         "docs_dir": {
           "default": null,
-          "description": "Directory to serve documentation files from (e.g., \"/var/rise/docs\" or \"docs\") If not set, documentation endpoints return 404.",
+          "description": "Directory to serve documentation files from (e.g., \"/var/rise/docs\" or \"docs\") Defaults to the RISE_DOCS_DIR environment variable.",
           "type": [
             "string",
             "null"
@@ -1010,6 +1010,14 @@
         "rs256_public_key_pem": {
           "default": null,
           "description": "Optional RS256 public key in PEM format for JWT verification If not provided, will be derived from rs256_private_key_pem or generated Generate from private key with: openssl rsa -in rs256.key -pubout -out rs256.pub",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "static_dir": {
+          "default": null,
+          "description": "Directory containing static assets (Tera templates, SVGs, Vite build output). Defaults to the RISE_STATIC_DIR environment variable.",
           "type": [
             "string",
             "null"

--- a/mise.toml
+++ b/mise.toml
@@ -63,7 +63,7 @@ alias = "br"
 [tasks."backend:run-container"]
 description = "Build and run the backend server in its container (host network). Useful to validate the containerized version works as intended."
 depends = ["backend:deps", "db:migrate"]
-run = "docker build . -t rise --target rise && docker run --rm --network host -v $PWD/config:/etc/rise:ro -v $HOME/.kube:/root/.kube:ro -v $HOME/.minikube:$HOME/.minikube:ro -v $PWD/docs:/docs:ro -e DATABASE_URL=$DATABASE_URL -e RISE_CONFIG_DIR=/etc/rise -e RISE_CONFIG_RUN_MODE=development rise backend server"
+run = "docker build . -t rise --target rise && docker run --rm --network host -v $PWD/config:/etc/rise:ro -v $HOME/.kube:/root/.kube:ro -v $HOME/.minikube:$HOME/.minikube:ro -e DATABASE_URL=$DATABASE_URL -e RISE_CONFIG_DIR=/etc/rise -e RISE_CONFIG_RUN_MODE=development rise backend server"
 
 [tasks."frontend:dev"]
 description = "Run the Vite frontend development server."

--- a/src/server/frontend/mod.rs
+++ b/src/server/frontend/mod.rs
@@ -1,107 +1,16 @@
 pub mod routes;
 
-use rust_embed::RustEmbed;
+use std::path::{Component, Path, PathBuf};
 
-#[derive(RustEmbed)]
-#[folder = "static/"]
-pub struct StaticAssets;
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_static_assets_embedded() {
-        // Note: index.html is a Vite build artifact (gitignored) and may not
-        // be present in dev/CI environments without a frontend build.
-        // Only checked-in static assets are asserted here.
-        assert!(
-            StaticAssets::get("auth-signin.html.tera").is_some(),
-            "auth-signin.html.tera should be embedded"
-        );
-        assert!(
-            StaticAssets::get("auth-success.html.tera").is_some(),
-            "auth-success.html.tera should be embedded"
-        );
-        assert!(
-            StaticAssets::get("cli-auth-success.html.tera").is_some(),
-            "cli-auth-success.html.tera should be embedded"
-        );
-        assert!(
-            StaticAssets::get("auth-warning.html.tera").is_some(),
-            "auth-warning.html.tera should be embedded"
-        );
-        assert!(
-            StaticAssets::get("assets/favicon.ico").is_some(),
-            "assets/favicon.ico should be embedded"
-        );
-        assert!(
-            StaticAssets::get("assets/favicon-16x16.png").is_some(),
-            "assets/favicon-16x16.png should be embedded"
-        );
-        assert!(
-            StaticAssets::get("assets/favicon-32x32.png").is_some(),
-            "assets/favicon-32x32.png should be embedded"
-        );
-        assert!(
-            StaticAssets::get("assets/logo.svg").is_some(),
-            "assets/logo.svg should be embedded"
-        );
-        assert!(
-            StaticAssets::get("assets/theme-system.svg").is_some(),
-            "assets/theme-system.svg should be embedded"
-        );
-        assert!(
-            StaticAssets::get("assets/theme-light.svg").is_some(),
-            "assets/theme-light.svg should be embedded"
-        );
-        assert!(
-            StaticAssets::get("assets/theme-dark.svg").is_some(),
-            "assets/theme-dark.svg should be embedded"
-        );
-        assert!(
-            StaticAssets::get("assets/close-x.svg").is_some(),
-            "assets/close-x.svg should be embedded"
-        );
-        assert!(
-            StaticAssets::get("assets/check.svg").is_some(),
-            "assets/check.svg should be embedded"
-        );
-        assert!(
-            StaticAssets::get("assets/info.svg").is_some(),
-            "assets/info.svg should be embedded"
-        );
-        assert!(
-            StaticAssets::get("assets/lock.svg").is_some(),
-            "assets/lock.svg should be embedded"
-        );
-        assert!(
-            StaticAssets::get("assets/globe.svg").is_some(),
-            "assets/globe.svg should be embedded"
-        );
-        assert!(
-            StaticAssets::get("assets/plus.svg").is_some(),
-            "assets/plus.svg should be embedded"
-        );
-        assert!(
-            StaticAssets::get("assets/lightning.svg").is_some(),
-            "assets/lightning.svg should be embedded"
-        );
-        assert!(
-            StaticAssets::get("assets/user.svg").is_some(),
-            "assets/user.svg should be embedded"
-        );
-        assert!(
-            StaticAssets::get("assets/copy.svg").is_some(),
-            "assets/copy.svg should be embedded"
-        );
-        assert!(
-            StaticAssets::get("assets/logout.svg").is_some(),
-            "assets/logout.svg should be embedded"
-        );
-        assert!(
-            StaticAssets::get("assets/arrow-left.svg").is_some(),
-            "assets/arrow-left.svg should be embedded"
-        );
+/// Load a static file from the configured static_dir, with path traversal protection.
+pub async fn load_static_file(static_dir: &str, rel_path: &str) -> Option<Vec<u8>> {
+    let mut safe_path = PathBuf::new();
+    for part in Path::new(rel_path).components() {
+        match part {
+            Component::Normal(seg) => safe_path.push(seg),
+            _ => return None,
+        }
     }
+    let full_path = PathBuf::from(static_dir).join(safe_path);
+    tokio::fs::read(&full_path).await.ok()
 }

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -65,14 +65,27 @@ pub struct ServerSettings {
     #[serde(default = "default_jwt_expiry_seconds")]
     pub jwt_expiry_seconds: u64,
 
+    /// Directory containing static assets (Tera templates, SVGs, Vite build output).
+    /// Defaults to the RISE_STATIC_DIR environment variable.
+    #[serde(default = "default_static_dir")]
+    pub static_dir: Option<String>,
+
     /// Directory to serve documentation files from (e.g., "/var/rise/docs" or "docs")
-    /// If not set, documentation endpoints return 404.
-    #[serde(default)]
+    /// Defaults to the RISE_DOCS_DIR environment variable.
+    #[serde(default = "default_docs_dir")]
     pub docs_dir: Option<String>,
 }
 
 fn default_cookie_secure() -> bool {
     true
+}
+
+fn default_static_dir() -> Option<String> {
+    std::env::var("RISE_STATIC_DIR").ok()
+}
+
+fn default_docs_dir() -> Option<String> {
+    std::env::var("RISE_DOCS_DIR").ok()
 }
 
 fn default_jwt_claims() -> Vec<String> {


### PR DESCRIPTION
## Summary

- Removes `rust-embed` dependency; static assets are now loaded from disk at runtime via a configurable `static_dir` setting (defaults to `RISE_STATIC_DIR` env var)
- Fixes production Docker image: Vite build output is overlaid into `static/` correctly, and all static assets are copied to `/var/lib/rise/static` in the final image
- Updates `docs_dir` to also support `RISE_DOCS_DIR` env var default, consistent with `static_dir`

## Test plan

- [ ] `cargo build --features backend` compiles without `rust-embed`
- [ ] `mise backend:run` — Vite-proxied pages load, auth Tera templates render (signin, success, warning pages)
- [ ] `mise backend:run-container` — Docker image builds, static assets served from `/var/lib/rise/static`, auth pages render
- [ ] `docker build . --target rise` succeeds, image contains assets at `/var/lib/rise/static` and docs at `/var/rise/docs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)