### PR TITLE
fix: store Snowflake OAuth client secret directly in extension spec

### DIFF
--- a/.sqlx/query-8a2c4774ad28d7cbe3f1382d9b893740351046eb22efa9e1d4bbfc95f67199d0.json
+++ b/.sqlx/query-8a2c4774ad28d7cbe3f1382d9b893740351046eb22efa9e1d4bbfc95f67199d0.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        UPDATE project_extensions\n        SET spec = $3, updated_at = NOW()\n        WHERE project_id = $1 AND extension = $2\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "8a2c4774ad28d7cbe3f1382d9b893740351046eb22efa9e1d4bbfc95f67199d0"
+}

--- a/docs/extensions/snowflake-oauth-provisioner.md
+++ b/docs/extensions/snowflake-oauth-provisioner.md
@@ -13,8 +13,7 @@ The `snowflake-oauth-provisioner` extension provisions Snowflake OAuth integrati
 ```json
 {
   "blocked_roles": ["SYSADMIN"],
-  "scopes": ["session:role:ANALYST"],
-  "client_secret_env_var": "SNOWFLAKE_CLIENT_SECRET"
+  "scopes": ["session:role:ANALYST"]
 }
 ```
 
@@ -22,7 +21,6 @@ The `snowflake-oauth-provisioner` extension provisions Snowflake OAuth integrati
 
 - `blocked_roles` (optional): additional blocked roles merged with backend defaults.
 - `scopes` (optional): additional scopes merged with backend defaults.
-- `client_secret_env_var` (optional): env var name for client secret.
 
 ## Lifecycle
 

--- a/frontend/src/features/extension-ui.tsx
+++ b/frontend/src/features/extension-ui.tsx
@@ -1091,7 +1091,6 @@ export function OAuthDetailView({ extension, projectName }) {
 export function SnowflakeOAuthExtensionUI({ spec, schema, onChange }) {
     const [blockedRoles, setBlockedRoles] = useState(spec?.blocked_roles?.join(', ') || '');
     const [scopes, setScopes] = useState(spec?.scopes?.join(', ') || '');
-    const [clientSecretEnvVar, setClientSecretEnvVar] = useState(spec?.client_secret_env_var || 'SNOWFLAKE_CLIENT_SECRET');
 
     // Use a ref to store the latest onChange callback
     const onChangeRef = useRef(onChange);
@@ -1104,11 +1103,10 @@ export function SnowflakeOAuthExtensionUI({ spec, schema, onChange }) {
         const newSpec = {
             blocked_roles: blockedRoles.split(',').map(r => r.trim()).filter(r => r),
             scopes: scopes.split(',').map(s => s.trim()).filter(s => s),
-            client_secret_env_var: clientSecretEnvVar.trim() || 'SNOWFLAKE_CLIENT_SECRET',
         };
 
         onChangeRef.current(newSpec);
-    }, [blockedRoles, scopes, clientSecretEnvVar]);
+    }, [blockedRoles, scopes]);
 
     return (
         <div className="space-y-6">
@@ -1131,15 +1129,6 @@ export function SnowflakeOAuthExtensionUI({ spec, schema, onChange }) {
                     onChange={(e) => setScopes(e.target.value)}
                     placeholder="session:role:ANALYST, session:role:DEVELOPER"
                     helperText="Comma-separated scopes added to backend defaults."
-                />
-
-                <FormField
-                    label="Client Secret Environment Variable"
-                    id="snowflake-client-secret-env-var"
-                    value={clientSecretEnvVar}
-                    onChange={(e) => setClientSecretEnvVar(e.target.value)}
-                    placeholder="SNOWFLAKE_CLIENT_SECRET"
-                    helperText="Environment variable name for OAuth client secret."
                 />
 
                 <MonoNotice tone="success" title="Secondary Roles">

--- a/src/db/extensions.rs
+++ b/src/db/extensions.rs
@@ -185,6 +185,31 @@ pub async fn update_status(
     Ok(())
 }
 
+/// Update extension spec
+#[allow(dead_code)]
+pub async fn update_spec(
+    pool: &PgPool,
+    project_id: Uuid,
+    extension: &str,
+    spec: &Value,
+) -> Result<()> {
+    sqlx::query!(
+        r#"
+        UPDATE project_extensions
+        SET spec = $3, updated_at = NOW()
+        WHERE project_id = $1 AND extension = $2
+        "#,
+        project_id,
+        extension,
+        spec
+    )
+    .execute(pool)
+    .await
+    .context("Failed to update extension spec")?;
+
+    Ok(())
+}
+
 /// Permanently delete extension record
 #[allow(dead_code)]
 pub async fn delete_permanently(pool: &PgPool, project_id: Uuid, extension: &str) -> Result<()> {

--- a/src/server/extensions/providers/snowflake_oauth.rs
+++ b/src/server/extensions/providers/snowflake_oauth.rs
@@ -28,15 +28,6 @@ pub struct SnowflakeOAuthProvisionerSpec {
     /// Additional OAuth scopes (unioned with backend defaults)
     #[serde(default)]
     pub scopes: Vec<String>,
-
-    /// Environment variable name for storing the OAuth client secret
-    /// Defaults to "SNOWFLAKE_CLIENT_SECRET"
-    #[serde(default = "default_client_secret_env_var")]
-    pub client_secret_env_var: String,
-}
-
-fn default_client_secret_env_var() -> String {
-    "SNOWFLAKE_CLIENT_SECRET".to_string()
 }
 
 /// Extension status tracking Snowflake integration state
@@ -529,6 +520,34 @@ impl SnowflakeOAuthProvisioner {
         ))
     }
 
+    /// Resolve a client secret from a project environment variable
+    async fn resolve_client_secret_from_env_var(
+        &self,
+        project_id: Uuid,
+        env_var_name: &str,
+    ) -> Result<String> {
+        let env_vars = db_env_vars::list_project_env_vars(&self.db_pool, project_id).await?;
+
+        let env_var = env_vars
+            .iter()
+            .find(|var| var.key == env_var_name)
+            .ok_or_else(|| {
+                anyhow!(
+                    "Environment variable '{}' not found for client secret migration",
+                    env_var_name
+                )
+            })?;
+
+        if env_var.is_secret {
+            self.encryption_provider
+                .decrypt(&env_var.value)
+                .await
+                .context("Failed to decrypt client secret from env var")
+        } else {
+            Ok(env_var.value.clone())
+        }
+    }
+
     /// Handle Pending state: generate names and add finalizer
     async fn handle_pending(
         &self,
@@ -838,50 +857,12 @@ impl SnowflakeOAuthProvisioner {
             }
         }
 
-        // Decrypt client secret from status
-        let client_secret = self
-            .encryption_provider
-            .decrypt(
-                status
-                    .oauth_client_secret_encrypted
-                    .as_ref()
-                    .ok_or_else(|| anyhow!("Client secret not set"))?,
-            )
-            .await
-            .context("Failed to decrypt client secret")?;
-
-        // Create encrypted environment variable for OAuth extension to use
-        // Use configured env var name or default
-        let env_var_name = if spec.client_secret_env_var.is_empty() {
-            default_client_secret_env_var()
-        } else {
-            spec.client_secret_env_var.clone()
-        };
-
-        let client_secret_encrypted = self
-            .encryption_provider
-            .encrypt(&client_secret)
-            .await
-            .context("Failed to encrypt client secret for env var")?;
-
-        db_env_vars::upsert_project_env_var(
-            &self.db_pool,
-            project_id,
-            &env_var_name,
-            &client_secret_encrypted,
-            true, // is_secret
-            true, // is_protected (system-generated secrets are protected by default)
-        )
-        .await
-        .context("Failed to create environment variable")?;
-
-        info!(
-            "Created environment variable {} for project {}",
-            env_var_name, project_name
-        );
-
-        // Store the env var name in status for later use during deletion
-        status.client_secret_env_var = Some(env_var_name.clone());
+        // Get the encrypted client secret from status to store directly in OAuth spec
+        let client_secret_encrypted = status
+            .oauth_client_secret_encrypted
+            .as_ref()
+            .ok_or_else(|| anyhow!("Client secret not set"))?
+            .clone();
 
         // Get effective config for scopes
         let effective_config = self.get_effective_config(spec);
@@ -895,8 +876,8 @@ impl SnowflakeOAuthProvisioner {
                 .as_ref()
                 .ok_or_else(|| anyhow!("Client ID not set"))?
                 .clone(),
-            client_secret_ref: Some(env_var_name),
-            client_secret_encrypted: None,
+            client_secret_ref: None,
+            client_secret_encrypted: Some(client_secret_encrypted),
             // Snowflake doesn't support OIDC discovery, so we set the issuer_url to the Snowflake base
             // and explicitly provide the authorization and token endpoints
             issuer_url: format!("https://{}.snowflakecomputing.com", self.account),
@@ -1020,6 +1001,71 @@ impl SnowflakeOAuthProvisioner {
             return Ok(());
         }
 
+        let oauth_ext = oauth_ext.unwrap();
+
+        // Migrate old-style client_secret_ref to client_secret_encrypted
+        let oauth_spec: crate::server::extensions::providers::oauth::models::OAuthExtensionSpec =
+            serde_json::from_value(oauth_ext.spec.clone())
+                .context("Failed to parse OAuth extension spec")?;
+
+        if oauth_spec.client_secret_ref.is_some() && oauth_spec.client_secret_encrypted.is_none() {
+            let env_var_name = oauth_spec.client_secret_ref.as_ref().unwrap();
+            info!(
+                "Migrating OAuth extension {} for project {} from client_secret_ref ({}) to client_secret_encrypted",
+                oauth_extension_name, project_name, env_var_name
+            );
+
+            // Resolve the secret from the env var and encrypt it for the spec
+            let client_secret = self
+                .resolve_client_secret_from_env_var(project_id, env_var_name)
+                .await
+                .context("Failed to resolve client secret from env var during migration")?;
+
+            let client_secret_encrypted = self
+                .encryption_provider
+                .encrypt(&client_secret)
+                .await
+                .context("Failed to encrypt client secret during migration")?;
+
+            // Update the OAuth spec: set client_secret_encrypted, remove client_secret_ref
+            let mut updated_spec = oauth_spec.clone();
+            updated_spec.client_secret_encrypted = Some(client_secret_encrypted);
+            updated_spec.client_secret_ref = None;
+
+            db_extensions::update_spec(
+                &self.db_pool,
+                project_id,
+                oauth_extension_name,
+                &serde_json::to_value(&updated_spec)
+                    .context("Failed to serialize updated OAuth spec")?,
+            )
+            .await
+            .context("Failed to update OAuth extension spec during migration")?;
+
+            // Delete the env var (no longer needed)
+            if let Err(e) =
+                db_env_vars::delete_project_env_var(&self.db_pool, project_id, env_var_name).await
+            {
+                warn!(
+                    "Failed to delete migrated environment variable {}: {:?}",
+                    env_var_name, e
+                );
+            } else {
+                info!(
+                    "Deleted migrated environment variable {} for project {}",
+                    env_var_name, project_name
+                );
+            }
+
+            // Clear the env var name from status
+            status.client_secret_env_var = None;
+
+            info!(
+                "Successfully migrated OAuth extension {} for project {} to client_secret_encrypted",
+                oauth_extension_name, project_name
+            );
+        }
+
         let expected_redirect_uri = format!(
             "{}/oidc/{}/{}/callback",
             self.api_domain.trim_end_matches('/'),
@@ -1126,30 +1172,17 @@ impl SnowflakeOAuthProvisioner {
             }
         }
 
-        // 3. Delete environment variable
+        // 3. Delete legacy environment variable (from old-style client_secret_ref configuration)
         if let Some(env_var_name) = &status.client_secret_env_var {
             if let Err(e) =
                 db_env_vars::delete_project_env_var(&self.db_pool, project_id, env_var_name).await
             {
                 warn!(
-                    "Failed to delete environment variable {}: {:?}",
+                    "Failed to delete legacy environment variable {}: {:?}",
                     env_var_name, e
                 );
             } else {
-                info!("Deleted environment variable {}", env_var_name);
-            }
-        } else {
-            // Fallback for extensions created before this field was added
-            let env_var_name = default_client_secret_env_var();
-            if let Err(e) =
-                db_env_vars::delete_project_env_var(&self.db_pool, project_id, &env_var_name).await
-            {
-                warn!(
-                    "Failed to delete environment variable {} (fallback): {:?}",
-                    env_var_name, e
-                );
-            } else {
-                info!("Deleted environment variable {} (fallback)", env_var_name);
+                info!("Deleted legacy environment variable {}", env_var_name);
             }
         }
 
@@ -1345,14 +1378,13 @@ extensions:
 
 ## User Spec
 
-Users can optionally configure additional blocked roles, scopes, and the environment variable name:
+Users can optionally configure additional blocked roles and scopes:
 
 ```yaml
 blocked_roles:
   - SYSADMIN
 scopes:
   - session:role:ANALYST
-client_secret_env_var: SNOWFLAKE_CLIENT_SECRET  # Default if not specified
 ```
 
 ## Lifecycle
@@ -1391,11 +1423,6 @@ Deletion removes all resources: Snowflake integration, OAuth extension, and envi
                     "items": {"type": "string"},
                     "description": "Additional OAuth scopes (unioned with backend defaults)",
                     "default": []
-                },
-                "client_secret_env_var": {
-                    "type": "string",
-                    "description": "Environment variable name for storing the OAuth client secret",
-                    "default": "SNOWFLAKE_CLIENT_SECRET"
                 }
             },
             "additionalProperties": false


### PR DESCRIPTION
## Summary

- Replace the deprecated `client_secret_ref` (env var indirection) pattern with `client_secret_encrypted` stored directly in the OAuth extension spec when the Snowflake provisioner creates OAuth extensions
- Add automatic migration for existing old-style configurations: during the `Available` state reconciliation, extensions using `client_secret_ref` are migrated to `client_secret_encrypted` and the legacy env var is cleaned up
- Remove the `client_secret_env_var` field from `SnowflakeOAuthProvisionerSpec`, frontend UI, and documentation

## Test plan

- [ ] Deploy with an existing Snowflake OAuth extension that uses `client_secret_ref` and verify it gets automatically migrated to `client_secret_encrypted`
- [ ] Verify the legacy env var is deleted after migration
- [ ] Create a new Snowflake OAuth extension and verify the OAuth spec uses `client_secret_encrypted` directly (no env var created)
- [ ] Verify OAuth token exchange still works after migration
- [ ] Verify deletion of a migrated extension cleans up correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)