### PR TITLE
Remove client_secret_ref and client_secret_env_var deprecations

### DIFF
--- a/docs/user-guide/oauth.md
+++ b/docs/user-guide/oauth.md
@@ -178,10 +178,6 @@ Rise supports two types of OAuth providers:
 
 **3. Store Client Secret in Rise**
 
-There are two ways to store the OAuth provider's client secret:
-
-**Option A: Encrypted in Extension Spec (Recommended)**
-
 Encrypt the secret and store it directly in the extension spec:
 
 ```bash
@@ -210,32 +206,6 @@ echo "your_client_secret_here" | rise encrypt
 ```
 
 The `rise encrypt` command is rate-limited to 100 requests per hour per user.
-
-**Option B: Environment Variable Reference (Legacy)**
-
-Store the secret as an encrypted environment variable and reference it:
-
-```bash
-# Store as environment variable
-rise env set my-app OAUTH_GOOGLE_SECRET "your_client_secret_here" --secret
-
-# Reference in extension spec
-rise extension create oauth-provider -p my-app \
-  --type oauth \
-  --spec '{
-    "provider_name": "My OAuth Provider",
-    "client_id": "your_client_id",
-    "client_secret_ref": "OAUTH_GOOGLE_SECRET",
-    "issuer_url": "https://accounts.google.com",
-    "scopes": ["openid", "email", "profile"]
-  }'
-```
-
-**Which should you use?**
-
-- **New extensions**: Use `client_secret_encrypted` (Option A) for simpler configuration
-- **Existing extensions**: Continue using `client_secret_ref` (Option B) - it will be supported indefinitely
-- **Migration**: Optional - both patterns work identically
 
 ### Creating OAuth Extension
 
@@ -335,9 +305,6 @@ Clients manage token refresh via the `/oidc/{project}/{extension}/token` endpoin
 
 ## Troubleshooting
 
-**"Environment variable 'OAUTH_XXX_SECRET' not found"**
-- Store client secret: `rise env set <project> OAUTH_XXX_SECRET "secret" --secret`
-
 **"Failed to resolve OAuth endpoints"** or **"No authorization_endpoint in spec or OIDC discovery"**
 - For OIDC-compliant providers: Ensure `issuer_url` is correct and provider supports OIDC discovery
 - For non-OIDC providers (GitHub, Snowflake): Set `authorization_endpoint` and `token_endpoint` manually
@@ -348,7 +315,7 @@ Clients manage token refresh via the `/oidc/{project}/{extension}/token` endpoin
 - Don't include trailing slash or paths (e.g., `https://accounts.google.com`, not `https://accounts.google.com/`)
 
 **"Token exchange failed with status 400"**
-- Verify `client_id` and `client_secret_ref` are correct
+- Verify `client_id` and `client_secret_encrypted` are correct
 - Check redirect URI matches OAuth provider configuration
 - Review OAuth provider logs for specific error
 

--- a/example/README.md
+++ b/example/README.md
@@ -61,8 +61,8 @@ The OAuth examples require additional setup to create the OAuth extension:
 
 1. **Create the OAuth extension**:
    ```bash
-   # Store Dex client secret
-   rise env set oauth-demo DEX_CLIENT_SECRET "rise-backend-secret" --secret
+   # Encrypt the Dex client secret
+   ENCRYPTED=$(rise encrypt "rise-backend-secret")
 
    # Create OAuth extension
    rise extension create oauth-demo oauth-dex \
@@ -71,7 +71,7 @@ The OAuth examples require additional setup to create the OAuth extension:
        "provider_name": "Dex (Local Dev)",
        "description": "Local Dex OIDC provider for development",
        "client_id": "rise-backend",
-       "client_secret_ref": "DEX_CLIENT_SECRET",
+       "client_secret_encrypted": "'"$ENCRYPTED"'",
        "authorization_endpoint": "http://localhost:5556/dex/auth",
        "token_endpoint": "http://localhost:5556/dex/token",
        "scopes": ["openid", "email", "profile"]

--- a/frontend/src/features/extension-ui.tsx
+++ b/frontend/src/features/extension-ui.tsx
@@ -232,8 +232,6 @@ export function OAuthExtensionUI({ spec, schema, onChange, projectName, instance
         // Include encrypted client secret if set
         if (clientSecretEncrypted) {
             newSpec.client_secret_encrypted = clientSecretEncrypted;
-            // Unset deprecated client_secret_ref when using encrypted secret
-            newSpec.client_secret_ref = null;
         }
 
         // Include optional endpoint overrides if set
@@ -834,14 +832,6 @@ export function OAuthDetailView({ extension, projectName }) {
                                     <p className="text-sm text-gray-600 dark:text-gray-500">Client ID</p>
                                     <p className="text-gray-700 dark:text-gray-300 font-mono text-sm">{spec.client_id || 'N/A'}</p>
                                 </div>
-                                {spec.client_secret_ref && (
-                                    <div>
-                                        <p className="text-sm text-gray-600 dark:text-gray-500">
-                                            Client Secret Reference <span className="text-yellow-600 dark:text-yellow-400 text-xs">(deprecated)</span>
-                                        </p>
-                                        <p className="text-gray-700 dark:text-gray-300 font-mono text-sm">{spec.client_secret_ref}</p>
-                                    </div>
-                                )}
                             </div>
 
                             {/* Divider */}

--- a/src/server/extensions/providers/oauth/models.rs
+++ b/src/server/extensions/providers/oauth/models.rs
@@ -12,8 +12,9 @@ pub struct OAuthExtensionSpec {
     pub description: String,
     /// OAuth client ID (for upstream provider)
     pub client_id: String,
-    /// DEPRECATED: Environment variable name containing the client secret (for backward compatibility)
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// DEPRECATED: Will be auto-migrated to client_secret_encrypted by the reconciler.
+    /// Kept for deserialization only (existing DB records may still have this field).
+    #[serde(default, skip_serializing)]
     pub client_secret_ref: Option<String>,
     /// Encrypted client secret stored directly in spec (preferred over client_secret_ref)
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/server/extensions/providers/snowflake_oauth.rs
+++ b/src/server/extensions/providers/snowflake_oauth.rs
@@ -1,4 +1,4 @@
-use crate::db::{env_vars as db_env_vars, extensions as db_extensions, projects as db_projects};
+use crate::db::{extensions as db_extensions, projects as db_projects};
 use crate::server::encryption::EncryptionProvider;
 use crate::server::extensions::{Extension, InjectedEnvVar};
 use crate::server::settings::{PrivateKeySource, SnowflakeAuth};
@@ -55,10 +55,6 @@ pub struct SnowflakeOAuthProvisionerStatus {
     /// Redirect URI configured in the integration
     #[serde(skip_serializing_if = "Option::is_none")]
     pub redirect_uri: Option<String>,
-
-    /// Environment variable name used to store the client secret
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub client_secret_env_var: Option<String>,
 
     /// Last error message
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -973,76 +969,7 @@ impl SnowflakeOAuthProvisioner {
             return Ok(());
         }
 
-        let oauth_ext = oauth_ext.unwrap();
-
-        // Migrate old-style client_secret_ref to client_secret_encrypted
-        let oauth_spec: crate::server::extensions::providers::oauth::models::OAuthExtensionSpec =
-            serde_json::from_value(oauth_ext.spec.clone())
-                .context("Failed to parse OAuth extension spec")?;
-
-        if oauth_spec.client_secret_ref.is_some() && oauth_spec.client_secret_encrypted.is_none() {
-            let env_var_name = oauth_spec.client_secret_ref.as_ref().unwrap();
-            info!(
-                "Migrating OAuth extension {} for project {} from client_secret_ref ({}) to client_secret_encrypted",
-                oauth_extension_name, project_name, env_var_name
-            );
-
-            // Use the encrypted secret directly from the provisioner status — it's the
-            // authoritative source (the secret originated from Snowflake and was stored
-            // here first, then copied into the env var).
-            let Some(ref client_secret_encrypted) = status.oauth_client_secret_encrypted else {
-                error!(
-                    "Cannot migrate OAuth extension {} for project {}: \
-                     no client secret in provisioner status",
-                    oauth_extension_name, project_name
-                );
-                status.state = SnowflakeOAuthState::Failed;
-                status.error = Some(
-                    "Migration failed: no client secret available in provisioner status. \
-                     The extension must be deleted and re-created."
-                        .to_string(),
-                );
-                return Ok(());
-            };
-
-            // Update the OAuth spec: set client_secret_encrypted, remove client_secret_ref
-            let mut updated_spec = oauth_spec.clone();
-            updated_spec.client_secret_encrypted = Some(client_secret_encrypted.clone());
-            updated_spec.client_secret_ref = None;
-
-            db_extensions::update_spec(
-                &self.db_pool,
-                project_id,
-                oauth_extension_name,
-                &serde_json::to_value(&updated_spec)
-                    .context("Failed to serialize updated OAuth spec")?,
-            )
-            .await
-            .context("Failed to update OAuth extension spec during migration")?;
-
-            // Best-effort cleanup: delete the legacy env var
-            if let Err(e) =
-                db_env_vars::delete_project_env_var(&self.db_pool, project_id, env_var_name).await
-            {
-                warn!(
-                    "Failed to delete migrated environment variable {}: {:?}",
-                    env_var_name, e
-                );
-            } else {
-                info!(
-                    "Deleted migrated environment variable {} for project {}",
-                    env_var_name, project_name
-                );
-            }
-
-            // Clear the env var name from status
-            status.client_secret_env_var = None;
-
-            info!(
-                "Successfully migrated OAuth extension {} for project {} to client_secret_encrypted",
-                oauth_extension_name, project_name
-            );
-        }
+        let _oauth_ext = oauth_ext.unwrap();
 
         let expected_redirect_uri = format!(
             "{}/oidc/{}/{}/callback",
@@ -1150,21 +1077,7 @@ impl SnowflakeOAuthProvisioner {
             }
         }
 
-        // 3. Delete legacy environment variable (from old-style client_secret_ref configuration)
-        if let Some(env_var_name) = &status.client_secret_env_var {
-            if let Err(e) =
-                db_env_vars::delete_project_env_var(&self.db_pool, project_id, env_var_name).await
-            {
-                warn!(
-                    "Failed to delete legacy environment variable {}: {:?}",
-                    env_var_name, e
-                );
-            } else {
-                info!("Deleted legacy environment variable {}", env_var_name);
-            }
-        }
-
-        // 4. Remove finalizer
+        // 3. Remove finalizer
         let finalizer = self.finalizer_name(extension_name);
         if let Err(e) = db_projects::remove_finalizer(&self.db_pool, project_id, &finalizer).await {
             error!(
@@ -1382,7 +1295,7 @@ with an error message.
 The integration is created with `OAUTH_USE_SECONDARY_ROLES = IMPLICIT`, which enables
 secondary roles for OAuth sessions. This allows users to use multiple roles in their session.
 
-Deletion removes all resources: Snowflake integration, OAuth extension, and environment variables.
+Deletion removes all resources: Snowflake integration and OAuth extension.
 "#
     }
 


### PR DESCRIPTION
## Summary

- Add auto-migration in the OAuth provider reconciler to convert `client_secret_ref` (env var indirection) to `client_secret_encrypted` (direct encrypted storage), then delete the legacy env var
- Mark `client_secret_ref` as `skip_serializing` so it's never written back but can still be deserialized during migration
- Simplify OAuth provider: `validate_spec` requires `client_secret_encrypted`, `resolve_oauth_client_secret` no longer falls back to env vars, schema drops the deprecated field
- Remove `client_secret_env_var` from `SnowflakeOAuthProvisionerStatus` and its associated migration/cleanup code (now handled by the OAuth provider reconciler)
- Remove `client_secret_ref` references from frontend UI, user docs, and examples

## Test plan

- [ ] Verify `cargo check --all-features` passes
- [ ] Verify `cargo clippy --all-features` passes
- [ ] Verify `cargo fmt --check` passes
- [ ] Verify `mise sqlx:check` passes
- [ ] Test that existing extensions with `client_secret_ref` are auto-migrated on reconciler loop
- [ ] Test that new extensions require `client_secret_encrypted` in spec validation
- [ ] Verify Snowflake provisioner still creates OAuth extensions correctly without `client_secret_env_var`

🤖 Generated with [Claude Code](https://claude.com/claude-code)