### PR TITLE
fix: only pass --add-host host-gateway when proxy points to localhost

### DIFF
--- a/src/build/docker.rs
+++ b/src/build/docker.rs
@@ -172,8 +172,15 @@ pub(crate) fn build_image_with_dockerfile(options: DockerBuildOptions) -> Result
         }
     }
 
-    cmd.arg("--add-host")
-        .arg("host.docker.internal:host-gateway");
+    // Only add --add-host when a proxy URL was transformed to host.docker.internal.
+    // The host-gateway mapping is not supported by the remote buildx driver.
+    let needs_host_gateway = proxy_vars
+        .values()
+        .any(|v| v.contains("host.docker.internal"));
+    if needs_host_gateway {
+        cmd.arg("--add-host")
+            .arg("host.docker.internal:host-gateway");
+    }
 
     // Add user-specified build arguments
     for build_arg in options.env {


### PR DESCRIPTION
## Summary

- Only add `--add-host host.docker.internal:host-gateway` to `docker buildx build` when a proxy URL was actually transformed from localhost/127.0.0.1 to `host.docker.internal`
- Fixes `host-gateway is not supported by the remote driver` error when using a remote BuildKit builder with a non-localhost proxy

## Test plan

- [ ] Verify builds with a localhost proxy still get `--add-host` added
- [ ] Verify builds with a non-localhost proxy (or no proxy) no longer pass `--add-host`
- [ ] Verify builds with a remote buildx driver and non-localhost proxy succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)