### PR TITLE
fix: normalize CLI backend URLs

### DIFF
--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
 
+pub fn normalize_backend_url(url: &str) -> String {
+    url.trim_end_matches('/').to_string()
+}
+
 /// The container runtime engine behind the CLI command.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ContainerRuntime {
@@ -191,7 +195,7 @@ impl Config {
 
     /// Set the backend URL
     pub fn set_backend_url(&mut self, url: String) -> Result<()> {
-        self.backend_url = Some(url);
+        self.backend_url = Some(normalize_backend_url(&url));
         self.save()
     }
 
@@ -200,10 +204,11 @@ impl Config {
     pub fn get_backend_url(&self) -> String {
         #[cfg(not(test))]
         if let Ok(url) = std::env::var("RISE_URL") {
-            return url;
+            return normalize_backend_url(&url);
         }
         self.backend_url
-            .clone()
+            .as_deref()
+            .map(normalize_backend_url)
             .unwrap_or_else(|| "http://localhost:3000".to_string())
     }
 
@@ -324,6 +329,20 @@ mod tests {
     fn test_backend_url_from_config() {
         let c = config(|c| c.backend_url = Some("https://api.example.com".to_string()));
         assert_eq!(c.get_backend_url(), "https://api.example.com");
+    }
+
+    #[test]
+    fn test_backend_url_trailing_slash_is_trimmed() {
+        let c = config(|c| c.backend_url = Some("https://api.example.com/".to_string()));
+        assert_eq!(c.get_backend_url(), "https://api.example.com");
+    }
+
+    #[test]
+    fn test_normalize_backend_url_trims_multiple_trailing_slashes() {
+        assert_eq!(
+            normalize_backend_url("https://api.example.com///"),
+            "https://api.example.com"
+        );
     }
 
     #[test]

--- a/src/cli/login/device_flow.rs
+++ b/src/cli/login/device_flow.rs
@@ -1,4 +1,4 @@
-use crate::config::Config;
+use crate::config::{normalize_backend_url, Config};
 use crate::login::token_utils::format_token_expiration;
 use anyhow::{Context, Result};
 use reqwest::Client;
@@ -45,6 +45,8 @@ pub async fn handle_device_flow(
     config: &mut Config,
     backend_url_to_save: Option<&str>,
 ) -> Result<()> {
+    let backend_url = normalize_backend_url(backend_url);
+
     eprintln!("⚠️  Warning: Device flow may not be supported by all identity providers.");
     eprintln!("   For best results, use the browser flow: rise login");
     eprintln!();

--- a/src/cli/login/oauth_code.rs
+++ b/src/cli/login/oauth_code.rs
@@ -1,4 +1,4 @@
-use crate::config::Config;
+use crate::config::{normalize_backend_url, Config};
 use crate::login::token_utils::format_token_expiration;
 use anyhow::{Context, Result};
 use axum::{extract::Query, response::IntoResponse, routing::get, Router};
@@ -194,9 +194,11 @@ pub async fn handle_authorization_code_flow(
     config: &mut Config,
     backend_url_to_save: Option<&str>,
 ) -> Result<()> {
+    let backend_url = normalize_backend_url(backend_url);
+
     // Step 1: Discover OpenID endpoints
     tracing::debug!("Discovering authentication endpoints...");
-    let discovery = discover_endpoints(http_client, backend_url)
+    let discovery = discover_endpoints(http_client, &backend_url)
         .await
         .context("Failed to discover authentication endpoints")?;
 
@@ -204,7 +206,7 @@ pub async fn handle_authorization_code_flow(
     let (code_verifier, code_challenge) = generate_pkce_challenge();
 
     // Step 3: Start local callback server
-    let (redirect_uri, code_receiver) = start_callback_server(backend_url)
+    let (redirect_uri, code_receiver) = start_callback_server(&backend_url)
         .await
         .context("Failed to start local callback server")?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -753,17 +753,20 @@ async fn main() -> Result<()> {
             device,
         } => {
             // Use provided URL or fall back to config default
-            let login_url = url.as_deref().unwrap_or(&backend_url);
+            let login_url = url
+                .as_deref()
+                .map(config::normalize_backend_url)
+                .unwrap_or_else(|| backend_url.clone());
 
             if *device {
                 // Device flow (explicit)
-                login::handle_device_flow(&http_client, login_url, &mut config, url.as_deref())
+                login::handle_device_flow(&http_client, &login_url, &mut config, url.as_deref())
                     .await?;
             } else {
                 // Authorization code flow with PKCE (default)
                 login::handle_authorization_code_flow(
                     &http_client,
-                    login_url,
+                    &login_url,
                     &mut config,
                     url.as_deref(),
                 )


### PR DESCRIPTION
## Summary
- normalize backend URLs before building CLI auth endpoints
- apply the normalization in both browser and device login flows
- add coverage for trailing-slash backend URLs

## Testing
- cargo fmt --all
- cargo test --quiet backend_url
- cargo test --quiet normalize_backend_url