### PR TITLE
Remove --railpack-embed-ssl-cert option

### DIFF
--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -35,7 +35,6 @@ Most commands accept `-p <project>` to specify the project name. If omitted, Ris
 | `RISE_TOKEN` | Authentication token (skips interactive login) |
 | `RISE_CONTAINER_CLI` | Container CLI: `docker` or `podman` |
 | `RISE_MANAGED_BUILDKIT` | Enable managed BuildKit daemon (`true`/`false`) |
-| `RISE_RAILPACK_EMBED_SSL_CERT` | Enable Railpack SSL cert embedding (`true`/`false`) |
 | `RISE_MANAGED_BUILDKIT_NETWORK_NAME` | Docker network for managed BuildKit daemon |
 | `RISE_MANAGED_BUILDKIT_INSECURE_REGISTRIES` | Comma-separated list of insecure registries |
 | `SSL_CERT_FILE` | CA certificate file for SSL builds |

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -44,7 +44,7 @@ env = ["NODE_ENV=production", "BUILD_VERSION"]
 | `buildpacks` | Array | Buildpacks to use (pack backend only) |
 | `env` | Array | Build-time environment variables (format: `KEY=VALUE` or `KEY` to read from shell) |
 | `container_cli` | String | Container CLI: `docker` or `podman` |
-| `managed_buildkit` | Boolean | Enable managed BuildKit daemon for SSL support |
+| `managed_buildkit` | Boolean | Enable/disable managed BuildKit daemon (auto-enables when `SSL_CERT_FILE` is set) |
 | `no_cache` | Boolean | Disable build cache |
 
 ### Full Example

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -45,7 +45,6 @@ env = ["NODE_ENV=production", "BUILD_VERSION"]
 | `env` | Array | Build-time environment variables (format: `KEY=VALUE` or `KEY` to read from shell) |
 | `container_cli` | String | Container CLI: `docker` or `podman` |
 | `managed_buildkit` | Boolean | Enable managed BuildKit daemon for SSL support |
-| `railpack_embed_ssl_cert` | Boolean | Embed SSL certificate in Railpack builds |
 | `no_cache` | Boolean | Disable build cache |
 
 ### Full Example
@@ -117,6 +116,5 @@ The CLI stores global configuration in `~/.config/rise/config.json`, including:
 - Backend URL
 - Container CLI preference (`docker` or `podman`)
 - Managed BuildKit setting
-- Railpack SSL cert embedding setting
 
 This file is created automatically on first `rise login`.

--- a/docs/user-guide/ssl-proxy.md
+++ b/docs/user-guide/ssl-proxy.md
@@ -6,18 +6,38 @@ When building behind corporate proxies (Zscaler, Cloudflare) or in environments 
 
 Rise can manage a BuildKit daemon container with SSL certificates automatically mounted.
 
-### Enabling
+### Auto-Detection (Default)
+
+When no explicit setting is provided, managed BuildKit **automatically enables** if:
+
+1. The build method requires BuildKit (`docker:buildx`, `buildctl`, `railpack`)
+2. `SSL_CERT_FILE` is set in the environment
+3. `BUILDKIT_HOST` is not already set
+
+This means in most corporate/proxy environments, managed BuildKit "just works" without any flags.
+
+### Disabling
+
+If you don't need managed BuildKit (e.g., you manage your own daemon or don't need SSL certificate support), disable it explicitly:
 
 ```bash
 # CLI flag
-rise deploy --managed-buildkit
+rise deploy --managed-buildkit=false
 
 # Environment variable
-export RISE_MANAGED_BUILDKIT=true
+export RISE_MANAGED_BUILDKIT=false
 
 # rise.toml
 [build]
-managed_buildkit = true
+managed_buildkit = false
+```
+
+### Force Enabling
+
+To force managed BuildKit even without `SSL_CERT_FILE` (e.g., for insecure registries):
+
+```bash
+rise deploy --managed-buildkit
 ```
 
 ### How It Works
@@ -53,10 +73,10 @@ For Railpack builds, when `SSL_CERT_FILE` is set, Rise automatically embeds the 
 
 Unlike the Docker injection above, this **does** embed the certificate in the final image.
 
-**Use `--managed-buildkit` together** for comprehensive SSL support (daemon-level + build-level):
+When `SSL_CERT_FILE` is set, managed BuildKit also auto-enables, giving comprehensive SSL support at both the daemon and build level:
 
 ```bash
-rise deploy --backend railpack --managed-buildkit
+rise deploy --backend railpack
 ```
 
 ## Proxy Support
@@ -86,7 +106,7 @@ When using the managed BuildKit daemon with Docker Compose services (e.g., a loc
 
 ```bash
 export RISE_MANAGED_BUILDKIT_NETWORK_NAME=rise_default
-rise deploy --managed-buildkit
+rise deploy
 ```
 
 The daemon is recreated if the network name changes.
@@ -99,6 +119,8 @@ For local HTTP registries, configure BuildKit to allow insecure connections:
 export RISE_MANAGED_BUILDKIT_INSECURE_REGISTRIES="rise-registry:5000,localhost:5000"
 rise deploy --managed-buildkit
 ```
+
+Note: `--managed-buildkit` is needed here since insecure registries typically don't involve `SSL_CERT_FILE`, so auto-detection won't enable it.
 
 This generates a `buildkitd.toml` config at `~/.rise/buildkitd.toml`. For local development only.
 

--- a/docs/user-guide/ssl-proxy.md
+++ b/docs/user-guide/ssl-proxy.md
@@ -49,25 +49,11 @@ The `docker:build` backend does not support this feature. Use `docker:buildx` in
 
 ## SSL Certificate Embedding (Railpack)
 
-For Railpack builds, the `--railpack-embed-ssl-cert` flag embeds certificates directly into the Railpack build plan:
-
-```bash
-rise deploy --backend railpack --railpack-embed-ssl-cert
-```
-
-This is **automatically enabled** when `SSL_CERT_FILE` is set. Disable explicitly with `--railpack-embed-ssl-cert=false`.
+For Railpack builds, when `SSL_CERT_FILE` is set, Rise automatically embeds the certificate into the Railpack build plan. This ensures `RUN` commands during the build can access the certificate for SSL verification.
 
 Unlike the Docker injection above, this **does** embed the certificate in the final image.
 
-Configure in `rise.toml`:
-
-```toml
-[build]
-backend = "railpack"
-railpack_embed_ssl_cert = true
-```
-
-**Use both flags together** for comprehensive SSL support (daemon-level + build-level):
+**Use `--managed-buildkit` together** for comprehensive SSL support (daemon-level + build-level):
 
 ```bash
 rise deploy --backend railpack --managed-buildkit

--- a/src/build/config.rs
+++ b/src/build/config.rs
@@ -66,9 +66,6 @@ pub struct BuildConfig {
     /// Enable managed BuildKit daemon with SSL certificate support
     pub managed_buildkit: Option<bool>,
 
-    /// Embed SSL certificate into Railpack build plan
-    pub railpack_embed_ssl_cert: Option<bool>,
-
     /// Path to Dockerfile (relative to rise.toml location). Defaults to "Dockerfile" or "Containerfile"
     pub dockerfile: Option<String>,
 

--- a/src/build/method.rs
+++ b/src/build/method.rs
@@ -60,10 +60,6 @@ pub struct BuildArgs {
     #[arg(long, value_parser = clap::value_parser!(bool), default_missing_value = "true", num_args = 0..=1)]
     pub managed_buildkit: Option<bool>,
 
-    /// Embed SSL certificate into Railpack build plan for build-time RUN command support
-    #[arg(long, value_parser = clap::value_parser!(bool), default_missing_value = "true", num_args = 0..=1)]
-    pub railpack_embed_ssl_cert: Option<bool>,
-
     /// Path to Dockerfile (relative to app path / rise.toml location). Defaults to "Dockerfile" or "Containerfile"
     #[arg(long)]
     pub dockerfile: Option<String>,
@@ -100,7 +96,6 @@ pub(crate) struct BuildOptions {
     /// Some(true) = explicitly enable managed buildkit
     /// Some(false) = explicitly disable managed buildkit
     pub managed_buildkit: Option<bool>,
-    pub railpack_embed_ssl_cert: bool,
     pub push: bool,
     /// Path to Dockerfile (relative to app_path / rise.toml location)
     pub dockerfile: Option<String>,
@@ -203,16 +198,6 @@ impl BuildOptions {
                 .or_else(|| crate::build::parse_bool_env_var("RISE_MANAGED_BUILDKIT"))
                 .or_else(|| project_config.as_ref().and_then(|c| c.managed_buildkit))
                 .or(config.managed_buildkit),
-            railpack_embed_ssl_cert: build_args
-                .railpack_embed_ssl_cert
-                .or_else(|| crate::build::parse_bool_env_var("RISE_RAILPACK_EMBED_SSL_CERT"))
-                .or_else(|| {
-                    project_config
-                        .as_ref()
-                        .and_then(|c| c.railpack_embed_ssl_cert)
-                })
-                .unwrap_or_else(|| config.get_railpack_embed_ssl_cert()),
-
             dockerfile: build_args
                 .dockerfile
                 .clone()

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -155,10 +155,6 @@ pub(crate) fn build_image(options: BuildOptions) -> Result<()> {
             if !options.buildpacks.is_empty() {
                 warn!("--buildpack flags are ignored when using docker build method");
             }
-            if options.railpack_embed_ssl_cert {
-                warn!("--railpack-embed-ssl-cert flag is ignored when using docker build method");
-            }
-
             build_image_with_dockerfile(DockerBuildOptions {
                 app_path: &options.app_path,
                 dockerfile: dockerfile.as_deref(),
@@ -181,10 +177,6 @@ pub(crate) fn build_image(options: BuildOptions) -> Result<()> {
             if options.managed_buildkit.is_some() {
                 warn!("--managed-buildkit flag is ignored when using pack build method");
             }
-            if options.railpack_embed_ssl_cert {
-                warn!("--railpack-embed-ssl-cert flag is ignored when using pack build method");
-            }
-
             build_image_with_buildpacks(
                 &options.app_path,
                 &options.image_tag,
@@ -218,7 +210,6 @@ pub(crate) fn build_image(options: BuildOptions) -> Result<()> {
                 use_buildctl,
                 push: options.push,
                 buildkit_host: buildkit_host.as_deref(),
-                embed_ssl_cert: options.railpack_embed_ssl_cert,
                 env: &options.env,
                 no_cache: options.no_cache,
             })?;
@@ -233,10 +224,6 @@ pub(crate) fn build_image(options: BuildOptions) -> Result<()> {
             if options.explicit_container_cli {
                 warn!("--container-cli flag is ignored when using buildctl build method");
             }
-            if options.railpack_embed_ssl_cert {
-                warn!("--railpack-embed-ssl-cert flag is ignored when using buildctl build method");
-            }
-
             // Check for SSL certificate
             let ssl_cert_file = env_var_non_empty("SSL_CERT_FILE");
             let ssl_cert_path = ssl_cert_file.as_ref().and_then(|p| {

--- a/src/build/railpack.rs
+++ b/src/build/railpack.rs
@@ -29,7 +29,6 @@ pub(crate) struct RailpackBuildOptions<'a> {
     pub use_buildctl: bool,
     pub push: bool,
     pub buildkit_host: Option<&'a str>,
-    pub embed_ssl_cert: bool,
     pub env: &'a [String],
     pub no_cache: bool,
 }
@@ -158,21 +157,15 @@ pub(crate) fn build_image_with_railpacks(options: RailpackBuildOptions) -> Resul
 
     info!("✓ Railpack prepare completed");
 
-    // Embed SSL certificate if requested
-    if options.embed_ssl_cert {
-        if let Some(ssl_cert_file) = super::env_var_non_empty("SSL_CERT_FILE") {
-            let cert_path = Path::new(&ssl_cert_file);
-            if cert_path.exists() {
-                embed_ssl_cert_in_plan(&plan_file, cert_path)?;
-            } else {
-                warn!(
-                    "SSL_CERT_FILE set to '{}' but file not found",
-                    ssl_cert_file
-                );
-            }
+    // Embed SSL certificate if SSL_CERT_FILE is set
+    if let Some(ssl_cert_file) = super::env_var_non_empty("SSL_CERT_FILE") {
+        let cert_path = Path::new(&ssl_cert_file);
+        if cert_path.exists() {
+            embed_ssl_cert_in_plan(&plan_file, cert_path)?;
         } else {
             warn!(
-                "--railpack-embed-ssl-cert enabled but SSL_CERT_FILE environment variable not set"
+                "SSL_CERT_FILE set to '{}' but file not found",
+                ssl_cert_file
             );
         }
     }

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -250,7 +250,6 @@ impl Config {
         self.managed_buildkit = Some(enabled);
         self.save()
     }
-
 }
 
 /// Auto-detect which container CLI is available.

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -132,7 +132,6 @@ pub struct Config {
     pub backend_url: Option<String>,
     pub container_cli: Option<String>,
     pub managed_buildkit: Option<bool>,
-    pub railpack_embed_ssl_cert: Option<bool>,
 }
 
 impl Config {
@@ -252,30 +251,6 @@ impl Config {
         self.save()
     }
 
-    /// Get whether to embed SSL certificate in Railpack builds
-    /// Checks RISE_RAILPACK_EMBED_SSL_CERT environment variable first, then falls back to config file
-    /// Defaults to true if SSL_CERT_FILE is set in the environment
-    #[allow(dead_code)]
-    pub fn get_railpack_embed_ssl_cert(&self) -> bool {
-        #[cfg(not(test))]
-        if let Some(val) = crate::build::parse_bool_env_var("RISE_RAILPACK_EMBED_SSL_CERT") {
-            return val;
-        }
-        if let Some(enabled) = self.railpack_embed_ssl_cert {
-            return enabled;
-        }
-        #[cfg(not(test))]
-        return crate::build::env_var_non_empty("SSL_CERT_FILE").is_some();
-        #[cfg(test)]
-        false
-    }
-
-    /// Set whether to embed SSL certificate in Railpack builds
-    #[allow(dead_code)]
-    pub fn set_railpack_embed_ssl_cert(&mut self, enabled: bool) -> Result<()> {
-        self.railpack_embed_ssl_cert = Some(enabled);
-        self.save()
-    }
 }
 
 /// Auto-detect which container CLI is available.
@@ -368,21 +343,6 @@ mod tests {
 
         let c = config(|c| c.managed_buildkit = Some(false));
         assert!(!c.get_managed_buildkit());
-    }
-
-    #[test]
-    fn test_railpack_embed_ssl_cert_default_false() {
-        // In tests, env vars are ignored, so default is always false
-        assert!(!Config::default().get_railpack_embed_ssl_cert());
-    }
-
-    #[test]
-    fn test_railpack_embed_ssl_cert_from_config() {
-        let c = config(|c| c.railpack_embed_ssl_cert = Some(true));
-        assert!(c.get_railpack_embed_ssl_cert());
-
-        let c = config(|c| c.railpack_embed_ssl_cert = Some(false));
-        assert!(!c.get_railpack_embed_ssl_cert());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Remove the `--railpack-embed-ssl-cert` CLI flag, `RISE_RAILPACK_EMBED_SSL_CERT` env var, and `railpack_embed_ssl_cert` config option
- SSL certificate embedding for Railpack builds is now unconditional when `SSL_CERT_FILE` is set, matching how other build backends (Docker, Buildctl) already handle SSL injection unconditionally
- Updated documentation to reflect the simplified behavior

## Test plan
- [ ] Verify Railpack builds with `SSL_CERT_FILE` set still embed the certificate
- [ ] Verify Railpack builds without `SSL_CERT_FILE` work normally (no warnings)
- [ ] Verify existing `rise.toml` files with `railpack_embed_ssl_cert` produce an "unknown field" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)