### PR TITLE
feat: add --push-image flag for deploy --image

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,11 @@ For user-facing documentation, see the [`/docs`](./docs) directory. Key topics i
 - Configuration: [docs/configuration.md](docs/configuration.md)
 - OAuth extension (end-user authentication): [docs/user-guide/oauth.md](docs/user-guide/oauth.md)
 
+## Git Branching
+
+- The default development branch is `develop`. PRs for feature work should target `develop`, not `main`.
+- Always target the branch your feature branch was created from when opening a PR.
+
 ## Guidelines
 
 - Build features in small increments with frequent commits. Use Git history as a reference for what was done and why.

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -18,7 +18,7 @@ mod ssl;
 pub use method::BuildArgs;
 pub(crate) use method::{BuildMethod, BuildOptions};
 pub(crate) use railpack::{build_with_buildctl, BuildctlFrontend, RailpackBuildOptions};
-pub(crate) use registry::docker_login;
+pub(crate) use registry::{docker_login, docker_pull, docker_push, docker_tag};
 
 use anyhow::{bail, Result};
 use std::collections::HashMap;

--- a/src/build/registry.rs
+++ b/src/build/registry.rs
@@ -24,6 +24,46 @@ pub(crate) fn docker_push(container_cli: &str, image_tag: &str) -> Result<()> {
     Ok(())
 }
 
+/// Pull image from a registry
+pub(crate) fn docker_pull(container_cli: &str, image: &str, platform: &str) -> Result<()> {
+    info!("Pulling image: {} (platform: {})", image, platform);
+
+    let mut cmd = Command::new(container_cli);
+    cmd.arg("pull").arg("--platform").arg(platform).arg(image);
+
+    debug!("Executing command: {:?}", cmd);
+
+    let status = cmd
+        .status()
+        .with_context(|| format!("Failed to execute {} pull", container_cli))?;
+
+    if !status.success() {
+        bail!("{} pull failed with status: {}", container_cli, status);
+    }
+
+    Ok(())
+}
+
+/// Tag a container image
+pub(crate) fn docker_tag(container_cli: &str, source: &str, target: &str) -> Result<()> {
+    info!("Tagging image: {} -> {}", source, target);
+
+    let mut cmd = Command::new(container_cli);
+    cmd.arg("tag").arg(source).arg(target);
+
+    debug!("Executing command: {:?}", cmd);
+
+    let status = cmd
+        .status()
+        .with_context(|| format!("Failed to execute {} tag", container_cli))?;
+
+    if !status.success() {
+        bail!("{} tag failed with status: {}", container_cli, status);
+    }
+
+    Ok(())
+}
+
 /// Login to container registry
 pub(crate) fn docker_login(
     container_cli: &str,

--- a/src/cli/deployment/core.rs
+++ b/src/cli/deployment/core.rs
@@ -523,27 +523,15 @@ pub async fn create_deployment(
             None => config.get_container_cli().command().to_string(),
         };
 
-        // Login to registry
-        if !deployment_info.credentials.username.is_empty() {
-            info!("Logging into registry");
-            if let Err(e) = build::docker_login(
-                &container_cli,
-                &deployment_info.credentials.registry_url,
-                &deployment_info.credentials.username,
-                &deployment_info.credentials.password,
-            ) {
-                update_deployment_status(
-                    http_client,
-                    backend_url,
-                    &token,
-                    &deployment_info.deployment_id,
-                    "Failed",
-                    Some(&e.to_string()),
-                )
-                .await?;
-                return Err(e);
-            }
-        }
+        login_to_registry(
+            http_client,
+            backend_url,
+            &token,
+            &container_cli,
+            &deployment_info.credentials,
+            &deployment_info.deployment_id,
+        )
+        .await?;
 
         // Pull the source image for linux/amd64
         if let Err(e) = build::docker_pull(&container_cli, source_image, "linux/amd64") {
@@ -639,27 +627,15 @@ pub async fn create_deployment(
         );
 
         // Step 2: Login to registry if credentials provided
-        if !deployment_info.credentials.username.is_empty() {
-            info!("Logging into registry");
-            let login_cli = options.container_cli.command().to_string();
-            if let Err(e) = build::docker_login(
-                &login_cli,
-                &deployment_info.credentials.registry_url,
-                &deployment_info.credentials.username,
-                &deployment_info.credentials.password,
-            ) {
-                update_deployment_status(
-                    http_client,
-                    backend_url,
-                    &token,
-                    &deployment_info.deployment_id,
-                    "Failed",
-                    Some(&e.to_string()),
-                )
-                .await?;
-                return Err(e);
-            }
-        }
+        login_to_registry(
+            http_client,
+            backend_url,
+            &token,
+            options.container_cli.command(),
+            &deployment_info.credentials,
+            &deployment_info.deployment_id,
+        )
+        .await?;
 
         // Step 3: Update status to 'building'
         update_deployment_status(
@@ -721,6 +697,39 @@ pub async fn create_deployment(
 
     Ok(())
 }
+/// Login to the container registry, marking the deployment as Failed on error.
+async fn login_to_registry(
+    http_client: &Client,
+    backend_url: &str,
+    token: &str,
+    container_cli: &str,
+    credentials: &RegistryCredentials,
+    deployment_id: &str,
+) -> Result<()> {
+    if credentials.username.is_empty() {
+        return Ok(());
+    }
+    info!("Logging into registry");
+    if let Err(e) = build::docker_login(
+        container_cli,
+        &credentials.registry_url,
+        &credentials.username,
+        &credentials.password,
+    ) {
+        update_deployment_status(
+            http_client,
+            backend_url,
+            token,
+            deployment_id,
+            "Failed",
+            Some(&e.to_string()),
+        )
+        .await?;
+        return Err(e);
+    }
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn call_create_deployment_api(
     http_client: &Client,

--- a/src/cli/deployment/core.rs
+++ b/src/cli/deployment/core.rs
@@ -424,6 +424,8 @@ pub struct DeploymentOptions<'a> {
     pub build_args: &'a build::BuildArgs,
     pub from_deployment: Option<&'a str>,
     pub use_source_env_vars: bool,
+    /// When true with --image, pull the image locally and push to Rise registry.
+    pub push_image: bool,
 }
 
 pub async fn create_deployment(
@@ -472,6 +474,7 @@ pub async fn create_deployment(
         deploy_opts.http_port,
         deploy_opts.from_deployment,
         deploy_opts.use_source_env_vars,
+        deploy_opts.push_image,
     )
     .await?;
 
@@ -506,7 +509,112 @@ pub async fn create_deployment(
         }
     });
 
-    if deploy_opts.image.is_some() || deploy_opts.from_deployment.is_some() {
+    if deploy_opts.image.is_some() && deploy_opts.push_image {
+        // Push-image path: pull image locally, tag it, and push to Rise registry
+        let source_image = deploy_opts.image.unwrap();
+        info!(
+            "Pulling and pushing image '{}' to Rise registry",
+            source_image
+        );
+
+        // Determine container CLI from config/build args
+        let container_cli = match &deploy_opts.build_args.container_cli {
+            Some(cli) => cli.clone(),
+            None => config.get_container_cli().command().to_string(),
+        };
+
+        // Login to registry
+        if !deployment_info.credentials.username.is_empty() {
+            info!("Logging into registry");
+            if let Err(e) = build::docker_login(
+                &container_cli,
+                &deployment_info.credentials.registry_url,
+                &deployment_info.credentials.username,
+                &deployment_info.credentials.password,
+            ) {
+                update_deployment_status(
+                    http_client,
+                    backend_url,
+                    &token,
+                    &deployment_info.deployment_id,
+                    "Failed",
+                    Some(&e.to_string()),
+                )
+                .await?;
+                return Err(e);
+            }
+        }
+
+        // Pull the source image for linux/amd64
+        if let Err(e) = build::docker_pull(&container_cli, source_image, "linux/amd64") {
+            update_deployment_status(
+                http_client,
+                backend_url,
+                &token,
+                &deployment_info.deployment_id,
+                "Failed",
+                Some(&e.to_string()),
+            )
+            .await?;
+            return Err(e);
+        }
+
+        // Tag it with the Rise registry image tag
+        if let Err(e) = build::docker_tag(&container_cli, source_image, &deployment_info.image_tag)
+        {
+            update_deployment_status(
+                http_client,
+                backend_url,
+                &token,
+                &deployment_info.deployment_id,
+                "Failed",
+                Some(&e.to_string()),
+            )
+            .await?;
+            return Err(e);
+        }
+
+        // Update status to Building (reusing existing state for push phase)
+        update_deployment_status(
+            http_client,
+            backend_url,
+            &token,
+            &deployment_info.deployment_id,
+            "Building",
+            None,
+        )
+        .await?;
+
+        // Push to Rise registry
+        if let Err(e) = build::docker_push(&container_cli, &deployment_info.image_tag) {
+            update_deployment_status(
+                http_client,
+                backend_url,
+                &token,
+                &deployment_info.deployment_id,
+                "Failed",
+                Some(&e.to_string()),
+            )
+            .await?;
+            return Err(e);
+        }
+
+        // Mark as pushed (controller will take over deployment)
+        update_deployment_status(
+            http_client,
+            backend_url,
+            &token,
+            &deployment_info.deployment_id,
+            "Pushed",
+            None,
+        )
+        .await?;
+
+        info!(
+            "✓ Successfully pushed {} to {}",
+            source_image, deployment_info.image_tag
+        );
+    } else if deploy_opts.image.is_some() || deploy_opts.from_deployment.is_some() {
         // Pre-built image path or redeploy from existing deployment: Skip build/push, backend already marked as Pushed
         if let Some(from_deployment) = &deploy_opts.from_deployment {
             info!(
@@ -625,6 +733,7 @@ async fn call_create_deployment_api(
     http_port: Option<u16>,
     from_deployment: Option<&str>,
     use_source_env_vars: bool,
+    push_image: bool,
 ) -> Result<CreateDeploymentResponse> {
     let url = format!("{}/api/v1/deployments", backend_url);
     let mut payload = serde_json::json!({
@@ -656,6 +765,11 @@ async fn call_create_deployment_api(
     if let Some(source_deployment_id) = from_deployment {
         payload["from_deployment"] = serde_json::json!(source_deployment_id);
         payload["use_source_env_vars"] = serde_json::json!(use_source_env_vars);
+    }
+
+    // Add push_image field if set
+    if push_image {
+        payload["push_image"] = serde_json::json!(true);
     }
 
     let response = http_client

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,10 @@ struct DeployArgs {
     /// Required when using --image. Defaults to 8080 for buildpack builds.
     #[arg(long)]
     http_port: Option<u16>,
+    /// Push the --image to the Rise registry instead of deploying it directly.
+    /// Pulls the image locally (platform linux/amd64) and pushes to the internal registry.
+    #[arg(long)]
+    push_image: bool,
     #[command(flatten)]
     build_args: build::BuildArgs,
 }
@@ -984,6 +988,18 @@ async fn main() -> Result<()> {
                     std::process::exit(1);
                 }
 
+                // --push-image requires --image
+                if args.push_image && args.image.is_none() {
+                    eprintln!("Error: --push-image requires --image");
+                    std::process::exit(1);
+                }
+
+                // --push-image is incompatible with --from
+                if args.push_image && args.from.is_some() {
+                    eprintln!("Error: --push-image cannot be used with --from");
+                    std::process::exit(1);
+                }
+
                 // For pre-built images, --http-port is required since we can't infer it
                 if let Some(image) = &args.image {
                     if args.http_port.is_none() {
@@ -1015,6 +1031,7 @@ async fn main() -> Result<()> {
                         build_args: &args.build_args,
                         from_deployment: args.from.as_deref(),
                         use_source_env_vars: args.use_source_env_vars,
+                        push_image: args.push_image,
                     },
                 )
                 .await?;

--- a/src/server/deployment/handlers.rs
+++ b/src/server/deployment/handlers.rs
@@ -726,7 +726,97 @@ pub async fn create_deployment(
 
     // Branch based on whether user provided a pre-built image
     if let Some(ref user_image) = payload.image {
-        // Path 1: Pre-built image deployment
+        if payload.push_image {
+            // Path 1a: Push-image deployment — CLI will pull and push to Rise registry
+            // Skip digest resolution: the image will be pushed to the internal registry by tag,
+            // and the controller uses get_image_tag() (the no-digest path) to pull from there.
+            info!("Creating push-image deployment with image: {}", user_image);
+
+            let credentials = state
+                .registry_provider
+                .get_credentials(&payload.project)
+                .await
+                .map_err(|e| {
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("Failed to get credentials: {}", e),
+                    )
+                })?;
+            let image_tag = state.registry_provider.get_image_tag(
+                &payload.project,
+                &deployment_id,
+                ImageTagType::ClientFacing,
+            );
+
+            let deployment = create_deployment_with_hooks(
+                &state,
+                db_deployments::CreateDeploymentParams {
+                    deployment_id: &deployment_id,
+                    project_id: project.id,
+                    created_by_id: user.id,
+                    status: DbDeploymentStatus::Pending,
+                    image: Some(user_image), // Store original user input for display
+                    image_digest: None, // No digest — controller will use internal registry tag
+                    rolled_back_from_deployment_id: None,
+                    deployment_group: &payload.group,
+                    expires_at,
+                    http_port: effective_http_port as i32,
+                    is_active: false,
+                },
+                &project,
+            )
+            .await?;
+
+            info!(
+                "Created push-image deployment {} for project {}",
+                deployment_id, payload.project
+            );
+
+            // Copy project environment variables to deployment
+            crate::db::env_vars::copy_project_env_vars_to_deployment(
+                &state.db_pool,
+                project.id,
+                deployment.id,
+            )
+            .await
+            .map_err(|e| {
+                error!(
+                    "Failed to copy environment variables for deployment {}: {}",
+                    deployment_id, e
+                );
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to copy environment variables: {}", e),
+                )
+            })?;
+
+            crate::db::env_vars::upsert_deployment_env_var(
+                &state.db_pool,
+                deployment.id,
+                "PORT",
+                &effective_http_port.to_string(),
+                false,
+                false,
+            )
+            .await
+            .map_err(|e| {
+                error!("Failed to insert PORT env var: {}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to insert PORT env var: {}", e),
+                )
+            })?;
+
+            insert_rise_env_vars(&state, &deployment, &project).await?;
+
+            return Ok(Json(CreateDeploymentResponse {
+                deployment_id,
+                image_tag,
+                credentials,
+            }));
+        }
+
+        // Path 1b: Direct pre-built image deployment (no push)
         info!("Creating deployment with pre-built image: {}", user_image);
 
         // Normalize image reference (add registry and namespace if missing)
@@ -757,40 +847,6 @@ pub async fn create_deployment(
 
         info!("Successfully resolved image to digest: {}", image_digest);
 
-        // Determine status and credentials based on push_image flag
-        let (initial_status, credentials, image_tag) = if payload.push_image {
-            // push_image: CLI will pull and push to Rise registry, so we need credentials
-            let credentials = state
-                .registry_provider
-                .get_credentials(&payload.project)
-                .await
-                .map_err(|e| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Failed to get credentials: {}", e),
-                    )
-                })?;
-            let image_tag = state.registry_provider.get_image_tag(
-                &payload.project,
-                &deployment_id,
-                ImageTagType::ClientFacing,
-            );
-            (DbDeploymentStatus::Pending, credentials, image_tag)
-        } else {
-            // Direct deploy: skip build/push, go straight to Pushed
-            let empty_credentials = crate::server::registry::models::RegistryCredentials {
-                registry_url: String::new(),
-                username: String::new(),
-                password: String::new(),
-                expires_in: None,
-            };
-            (
-                DbDeploymentStatus::Pushed,
-                empty_credentials,
-                image_digest.clone(),
-            )
-        };
-
         // Create deployment record with image fields set and invoke extension hooks
         let deployment = create_deployment_with_hooks(
             &state,
@@ -798,22 +854,22 @@ pub async fn create_deployment(
                 deployment_id: &deployment_id,
                 project_id: project.id,
                 created_by_id: user.id,
-                status: initial_status,
-                image: Some(user_image), // Store original user input
-                image_digest: Some(&image_digest), // Store resolved digest
-                rolled_back_from_deployment_id: None, // Not a rollback
-                deployment_group: &payload.group, // deployment_group
-                expires_at,              // expires_at
-                http_port: effective_http_port as i32, // http_port
-                is_active: false,        // Deployments start as inactive
+                status: DbDeploymentStatus::Pushed,
+                image: Some(user_image),
+                image_digest: Some(&image_digest),
+                rolled_back_from_deployment_id: None,
+                deployment_group: &payload.group,
+                expires_at,
+                http_port: effective_http_port as i32,
+                is_active: false,
             },
             &project,
         )
         .await?;
 
         info!(
-            "Created pre-built image deployment {} for project {} (push_image: {})",
-            deployment_id, payload.project, payload.push_image
+            "Created pre-built image deployment {} for project {}",
+            deployment_id, payload.project
         );
 
         // Copy project environment variables to deployment
@@ -856,11 +912,16 @@ pub async fn create_deployment(
         // Insert Rise-provided environment variables
         insert_rise_env_vars(&state, &deployment, &project).await?;
 
-        // Return response with image_tag and credentials
+        // Return response with digest as image_tag and empty credentials
         Ok(Json(CreateDeploymentResponse {
             deployment_id,
-            image_tag,
-            credentials,
+            image_tag: image_digest,
+            credentials: crate::server::registry::models::RegistryCredentials {
+                registry_url: String::new(),
+                username: String::new(),
+                password: String::new(),
+                expires_in: None,
+            },
         }))
     } else {
         // Path 2: Build from source (current behavior)

--- a/src/server/deployment/handlers.rs
+++ b/src/server/deployment/handlers.rs
@@ -757,6 +757,40 @@ pub async fn create_deployment(
 
         info!("Successfully resolved image to digest: {}", image_digest);
 
+        // Determine status and credentials based on push_image flag
+        let (initial_status, credentials, image_tag) = if payload.push_image {
+            // push_image: CLI will pull and push to Rise registry, so we need credentials
+            let credentials = state
+                .registry_provider
+                .get_credentials(&payload.project)
+                .await
+                .map_err(|e| {
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("Failed to get credentials: {}", e),
+                    )
+                })?;
+            let image_tag = state.registry_provider.get_image_tag(
+                &payload.project,
+                &deployment_id,
+                ImageTagType::ClientFacing,
+            );
+            (DbDeploymentStatus::Pending, credentials, image_tag)
+        } else {
+            // Direct deploy: skip build/push, go straight to Pushed
+            let empty_credentials = crate::server::registry::models::RegistryCredentials {
+                registry_url: String::new(),
+                username: String::new(),
+                password: String::new(),
+                expires_in: None,
+            };
+            (
+                DbDeploymentStatus::Pushed,
+                empty_credentials,
+                image_digest.clone(),
+            )
+        };
+
         // Create deployment record with image fields set and invoke extension hooks
         let deployment = create_deployment_with_hooks(
             &state,
@@ -764,22 +798,22 @@ pub async fn create_deployment(
                 deployment_id: &deployment_id,
                 project_id: project.id,
                 created_by_id: user.id,
-                status: DbDeploymentStatus::Pushed, // Pre-built images skip build/push, go straight to Pushed
-                image: Some(user_image),            // Store original user input
-                image_digest: Some(&image_digest),  // Store resolved digest
+                status: initial_status,
+                image: Some(user_image), // Store original user input
+                image_digest: Some(&image_digest), // Store resolved digest
                 rolled_back_from_deployment_id: None, // Not a rollback
-                deployment_group: &payload.group,   // deployment_group
-                expires_at,                         // expires_at
+                deployment_group: &payload.group, // deployment_group
+                expires_at,              // expires_at
                 http_port: effective_http_port as i32, // http_port
-                is_active: false,                   // Deployments start as inactive
+                is_active: false,        // Deployments start as inactive
             },
             &project,
         )
         .await?;
 
         info!(
-            "Created pre-built image deployment {} for project {}",
-            deployment_id, payload.project
+            "Created pre-built image deployment {} for project {} (push_image: {})",
+            deployment_id, payload.project, payload.push_image
         );
 
         // Copy project environment variables to deployment
@@ -822,16 +856,11 @@ pub async fn create_deployment(
         // Insert Rise-provided environment variables
         insert_rise_env_vars(&state, &deployment, &project).await?;
 
-        // Return response with digest as image_tag and empty credentials
+        // Return response with image_tag and credentials
         Ok(Json(CreateDeploymentResponse {
             deployment_id,
-            image_tag: image_digest, // Return digest for consistency
-            credentials: crate::server::registry::models::RegistryCredentials {
-                registry_url: String::new(),
-                username: String::new(),
-                password: String::new(),
-                expires_in: None,
-            },
+            image_tag,
+            credentials,
         }))
     } else {
         // Path 2: Build from source (current behavior)

--- a/src/server/deployment/models.rs
+++ b/src/server/deployment/models.rs
@@ -115,6 +115,8 @@ pub struct CreateDeploymentRequest {
     pub from_deployment: Option<String>, // Optional source deployment ID to create from
     #[serde(default)]
     pub use_source_env_vars: bool, // If true and from_deployment is set, copy env vars from source (default: false = use current project env vars)
+    #[serde(default)]
+    pub push_image: bool, // If true with image, CLI will pull and push image to Rise registry
 }
 
 // Response from creating a deployment


### PR DESCRIPTION
## Summary

- Adds `--push-image` CLI flag for `rise deploy --image` that pulls the external image locally (platform `linux/amd64`), tags it, and pushes it to the Rise internal registry
- Backend returns registry credentials and `Pending` status when `push_image` is set (vs `Pushed` status with empty credentials for direct deploy)
- Adds `docker_pull` and `docker_tag` utility functions in `src/build/registry.rs`

## Test plan

- [x] `rise deploy --image nginx:latest --push-image --http-port 80 -p <project>` — verify image is pulled, tagged, pushed to Rise registry, and deployment succeeds
- [ ] `rise deploy --image nginx:latest --http-port 80 -p <project>` — verify existing direct deploy flow still works unchanged
- [ ] `rise deploy --push-image` without `--image` — verify error message
- [ ] `rise deploy --image x --push-image --from y` — verify error message
- [ ] `cargo fmt --all && cargo clippy --all-features -- -D warnings` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)