### PR TITLE
feat: allow intra-namespace pod communication in NetworkPolicy

### DIFF
--- a/src/server/deployment/controller/kubernetes.rs
+++ b/src/server/deployment/controller/kubernetes.rs
@@ -2438,9 +2438,11 @@ impl KubernetesController {
             ports: None, // Allow all ports from ingress controller
         });
 
-        // Rule: Allow traffic from all pods in the same namespace
+        // Rule: Allow traffic from all pods in the same namespace.
         // This enables apps that schedule additional workloads (e.g. worker pods)
         // to communicate back to the app via cluster-internal networking.
+        // Note: A podSelector with no namespaceSelector scopes to the NetworkPolicy's
+        // own namespace. An empty podSelector ({}) matches all pods in that namespace.
         ingress_rules.push(k8s_openapi::api::networking::v1::NetworkPolicyIngressRule {
             from: Some(vec![NetworkPolicyPeer {
                 pod_selector: Some(LabelSelector::default()),
@@ -2451,9 +2453,10 @@ impl KubernetesController {
 
         let mut egress_rules = vec![];
 
-        // Rule 0: Allow traffic to all pods in the same namespace
+        // Rule 0: Allow traffic to all pods in the same namespace.
         // This enables apps to communicate with additional workloads they schedule
         // (e.g. worker pods, sidecars) via cluster-internal networking.
+        // See ingress rule above for why podSelector alone (no namespaceSelector) is correct.
         egress_rules.push(NetworkPolicyEgressRule {
             to: Some(vec![NetworkPolicyPeer {
                 pod_selector: Some(LabelSelector::default()),

--- a/src/server/deployment/controller/kubernetes.rs
+++ b/src/server/deployment/controller/kubernetes.rs
@@ -2438,7 +2438,29 @@ impl KubernetesController {
             ports: None, // Allow all ports from ingress controller
         });
 
+        // Rule: Allow traffic from all pods in the same namespace
+        // This enables apps that schedule additional workloads (e.g. worker pods)
+        // to communicate back to the app via cluster-internal networking.
+        ingress_rules.push(k8s_openapi::api::networking::v1::NetworkPolicyIngressRule {
+            from: Some(vec![NetworkPolicyPeer {
+                pod_selector: Some(LabelSelector::default()),
+                ..Default::default()
+            }]),
+            ports: None, // Allow all ports from same-namespace pods
+        });
+
         let mut egress_rules = vec![];
+
+        // Rule 0: Allow traffic to all pods in the same namespace
+        // This enables apps to communicate with additional workloads they schedule
+        // (e.g. worker pods, sidecars) via cluster-internal networking.
+        egress_rules.push(NetworkPolicyEgressRule {
+            to: Some(vec![NetworkPolicyPeer {
+                pod_selector: Some(LabelSelector::default()),
+                ..Default::default()
+            }]),
+            ports: None, // Allow all ports to same-namespace pods
+        });
 
         // Rule 1: DNS resolution (UDP + TCP port 53 to kube-system namespace)
         egress_rules.push(NetworkPolicyEgressRule {


### PR DESCRIPTION
## Summary

- Add ingress and egress NetworkPolicy rules allowing all pods within the same namespace to communicate freely
- Enables apps that schedule additional workloads (e.g. worker pods, sidecars) to talk back to the app via cluster-internal networking instead of going through Ingress

## Test plan

- [ ] Deploy an app and verify the NetworkPolicy includes the new intra-namespace rules
- [ ] Verify pods in the same namespace can communicate with each other
- [ ] Verify cross-namespace traffic is still blocked as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)