### PR TITLE
feat: add CLI JWT debug logging

### DIFF
--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -185,24 +185,17 @@ impl Config {
     /// Get the authentication token
     /// Checks RISE_TOKEN environment variable first, then falls back to config file
     pub fn get_token(&self) -> Option<String> {
-        let token = {
-            #[cfg(not(test))]
-            if let Ok(token) = std::env::var("RISE_TOKEN") {
-                Some(token)
-            } else {
-                self.token.clone()
-            }
-            #[cfg(test)]
-            {
-                self.token.clone()
-            }
-        };
-
-        if let Some(token) = token.as_deref() {
-            crate::login::token_utils::log_token_debug(token);
+        #[cfg(not(test))]
+        if let Ok(token) = std::env::var("RISE_TOKEN") {
+            crate::login::token_utils::log_token_debug(&token, "RISE_TOKEN environment variable");
+            return Some(token);
         }
 
-        token
+        if let Some(token) = self.token.as_deref() {
+            crate::login::token_utils::log_token_debug(token, "~/.config/rise/config.json");
+        }
+
+        self.token.clone()
     }
 
     /// Set the backend URL

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -185,11 +185,24 @@ impl Config {
     /// Get the authentication token
     /// Checks RISE_TOKEN environment variable first, then falls back to config file
     pub fn get_token(&self) -> Option<String> {
-        #[cfg(not(test))]
-        if let Ok(token) = std::env::var("RISE_TOKEN") {
-            return Some(token);
+        let token = {
+            #[cfg(not(test))]
+            if let Ok(token) = std::env::var("RISE_TOKEN") {
+                Some(token)
+            } else {
+                self.token.clone()
+            }
+            #[cfg(test)]
+            {
+                self.token.clone()
+            }
+        };
+
+        if let Some(token) = token.as_deref() {
+            crate::login::token_utils::log_token_debug(token);
         }
-        self.token.clone()
+
+        token
     }
 
     /// Set the backend URL

--- a/src/cli/login/device_flow.rs
+++ b/src/cli/login/device_flow.rs
@@ -1,5 +1,5 @@
 use crate::config::{normalize_backend_url, Config};
-use crate::login::token_utils::format_token_expiration;
+use crate::login::token_utils::{format_token_expiration, log_token_debug};
 use anyhow::{Context, Result};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -168,6 +168,7 @@ pub async fn handle_device_flow(
                 }
 
                 // Store the token
+                log_token_debug(&token);
                 config
                     .set_token(token.clone())
                     .context("Failed to save authentication token")?;

--- a/src/cli/login/device_flow.rs
+++ b/src/cli/login/device_flow.rs
@@ -168,7 +168,7 @@ pub async fn handle_device_flow(
                 }
 
                 // Store the token
-                log_token_debug(&token);
+                log_token_debug(&token, "device flow response");
                 config
                     .set_token(token.clone())
                     .context("Failed to save authentication token")?;

--- a/src/cli/login/mod.rs
+++ b/src/cli/login/mod.rs
@@ -1,6 +1,6 @@
 pub mod device_flow;
 pub mod oauth_code;
-mod token_utils;
+pub(crate) mod token_utils;
 
 pub use device_flow::handle_device_flow;
 pub use oauth_code::handle_authorization_code_flow;

--- a/src/cli/login/oauth_code.rs
+++ b/src/cli/login/oauth_code.rs
@@ -323,7 +323,7 @@ pub async fn handle_authorization_code_flow(
     }
 
     // Store the token
-    log_token_debug(&exchange_response.token);
+    log_token_debug(&exchange_response.token, "OAuth login response");
     config
         .set_token(exchange_response.token.clone())
         .context("Failed to save authentication token")?;

--- a/src/cli/login/oauth_code.rs
+++ b/src/cli/login/oauth_code.rs
@@ -1,5 +1,5 @@
 use crate::config::{normalize_backend_url, Config};
-use crate::login::token_utils::format_token_expiration;
+use crate::login::token_utils::{format_token_expiration, log_token_debug};
 use anyhow::{Context, Result};
 use axum::{extract::Query, response::IntoResponse, routing::get, Router};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
@@ -323,6 +323,7 @@ pub async fn handle_authorization_code_flow(
     }
 
     // Store the token
+    log_token_debug(&exchange_response.token);
     config
         .set_token(exchange_response.token.clone())
         .context("Failed to save authentication token")?;

--- a/src/cli/login/token_utils.rs
+++ b/src/cli/login/token_utils.rs
@@ -1,7 +1,56 @@
 use anyhow::{Context, Result};
+use base64::{engine::general_purpose, Engine as _};
 use chrono::{DateTime, Utc};
 use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use serde::Deserialize;
+use serde_json::Value;
+
+#[derive(Debug)]
+struct JwtDebugParts {
+    header: Value,
+    claims: Value,
+}
+
+/// Log the JWT header and claims at debug level without exposing the signature.
+pub fn log_token_debug(token: &str) {
+    if !tracing::enabled!(tracing::Level::DEBUG) {
+        return;
+    }
+
+    match decode_jwt_debug_parts(token) {
+        Ok(parts) => tracing::debug!(
+            "CLI token header: {}\nCLI token claims: {}",
+            parts.header,
+            parts.claims
+        ),
+        Err(error) => tracing::debug!("Failed to decode CLI token for debug logging: {error}"),
+    }
+}
+
+fn decode_jwt_debug_parts(token: &str) -> Result<JwtDebugParts> {
+    let header = jsonwebtoken::decode_header(token).context("Failed to decode token header")?;
+    let header = serde_json::to_value(header).context("Failed to serialize token header")?;
+    let claims = decode_jwt_claims(token)?;
+
+    Ok(JwtDebugParts { header, claims })
+}
+
+fn decode_jwt_claims(token: &str) -> Result<Value> {
+    let mut parts = token.split('.');
+    let _header = parts
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("Token is missing JWT header"))?;
+    let claims = parts
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("Token is missing JWT claims"))?;
+
+    let decoded = general_purpose::URL_SAFE_NO_PAD
+        .decode(claims)
+        .or_else(|_| general_purpose::URL_SAFE.decode(claims))
+        .context("Failed to base64url-decode token claims")?;
+
+    serde_json::from_slice(&decoded).context("Failed to parse token claims JSON")
+}
 
 #[derive(Debug, Deserialize)]
 struct TokenClaims {
@@ -62,4 +111,43 @@ pub fn format_token_expiration(token: &str) -> Result<String> {
     };
 
     Ok(format!("{} ({})", formatted_date, relative))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn encode_segment(json: &str) -> String {
+        general_purpose::URL_SAFE_NO_PAD.encode(json)
+    }
+
+    #[test]
+    fn decode_jwt_debug_parts_reads_header_and_claims_without_signature() {
+        let token = format!(
+            "{}.{}.signature",
+            encode_segment(r#"{"alg":"RS256","typ":"JWT"}"#),
+            encode_segment(r#"{"sub":"service-account","aud":"demo-project"}"#),
+        );
+
+        let parts = decode_jwt_debug_parts(&token).expect("token should decode");
+
+        assert_eq!(parts.header["alg"], "RS256");
+        assert_eq!(parts.header["typ"], "JWT");
+        assert_eq!(parts.claims["sub"], "service-account");
+        assert_eq!(parts.claims["aud"], "demo-project");
+    }
+
+    #[test]
+    fn decode_jwt_debug_parts_rejects_invalid_claims() {
+        let token = format!(
+            "{}.{}.signature",
+            encode_segment(r#"{"alg":"RS256","typ":"JWT"}"#),
+            encode_segment("not-json"),
+        );
+
+        let error = decode_jwt_debug_parts(&token).expect_err("claims should fail to decode");
+        assert!(error
+            .to_string()
+            .contains("Failed to parse token claims JSON"));
+    }
 }

--- a/src/cli/login/token_utils.rs
+++ b/src/cli/login/token_utils.rs
@@ -12,24 +12,27 @@ struct JwtDebugParts {
 }
 
 /// Log the JWT header and claims at debug level without exposing the signature.
-pub fn log_token_debug(token: &str) {
+pub fn log_token_debug(token: &str, source: &str) {
     if !tracing::enabled!(tracing::Level::DEBUG) {
         return;
     }
 
+    tracing::debug!("Using token from {source}");
+
     match decode_jwt_debug_parts(token) {
-        Ok(parts) => tracing::debug!(
-            "CLI token header: {}\nCLI token claims: {}",
-            parts.header,
-            parts.claims
-        ),
-        Err(error) => tracing::debug!("Failed to decode CLI token for debug logging: {error}"),
+        Ok(parts) => tracing::debug!("Token header.claims is {}.{}", parts.header, parts.claims),
+        Err(error) => {
+            tracing::debug!("Failed to decode token header.claims for debug logging: {error}")
+        }
     }
 }
 
 fn decode_jwt_debug_parts(token: &str) -> Result<JwtDebugParts> {
     let header = jsonwebtoken::decode_header(token).context("Failed to decode token header")?;
-    let header = serde_json::to_value(header).context("Failed to serialize token header")?;
+    let mut header = serde_json::to_value(header).context("Failed to serialize token header")?;
+    if let Value::Object(header_obj) = &mut header {
+        header_obj.retain(|_, value| !value.is_null());
+    }
     let claims = decode_jwt_claims(token)?;
 
     Ok(JwtDebugParts { header, claims })
@@ -135,6 +138,20 @@ mod tests {
         assert_eq!(parts.header["typ"], "JWT");
         assert_eq!(parts.claims["sub"], "service-account");
         assert_eq!(parts.claims["aud"], "demo-project");
+    }
+
+    #[test]
+    fn token_header_claims_string_matches_expected_format() {
+        let token = format!(
+            "{}.{}.signature",
+            encode_segment(r#"{"alg":"RS256"}"#),
+            encode_segment(r#"{"sub":"service-account"}"#),
+        );
+
+        let parts = decode_jwt_debug_parts(&token).expect("token should decode");
+        let combined = format!("{}.{}", parts.header, parts.claims);
+
+        assert_eq!(combined, r#"{"alg":"RS256"}.{"sub":"service-account"}"#);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add debug logging for CLI JWT header and claims without exposing the signature
- log decoded token details when tokens are issued during login and when the CLI later reads the configured token
- add focused tests for valid and invalid JWT debug decoding

## Testing
- cargo fmt
- cargo test --features cli token_utils -- --nocapture
- cargo test --features cli cli::config -- --nocapture