### PR TITLE
fix: preserve healthy deployments during recovery

### DIFF
--- a/.sqlx/query-0c7d65d8069d48fa4bead8ae92b09288faaf4a30061130709ff88c9ed182cedd.json
+++ b/.sqlx/query-0c7d65d8069d48fa4bead8ae92b09288faaf4a30061130709ff88c9ed182cedd.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n                        deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            created_at, updated_at\n        FROM deployments\n        WHERE expires_at IS NOT NULL\n          AND expires_at <= NOW()\n          AND NOT is_terminal(status)\n        ORDER BY expires_at ASC\n        LIMIT $1\n        ",
+  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n                        deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            first_healthy_at,\n            created_at, updated_at\n        FROM deployments\n        WHERE project_id = $1\n          AND deployment_group = $2\n          AND NOT is_terminal(status)\n        ORDER BY created_at DESC\n        ",
   "describe": {
     "columns": [
       {
@@ -113,18 +113,24 @@
       },
       {
         "ordinal": 19,
-        "name": "created_at",
+        "name": "first_healthy_at",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
-        "Int8"
+        "Uuid",
+        "Text"
       ]
     },
     "nullable": [
@@ -147,9 +153,10 @@
       false,
       false,
       true,
+      true,
       false,
       false
     ]
   },
-  "hash": "450dc2df5e601cf0ce8321c8f2e15be516371d9fb2f4437d6cf5b8d642d3c534"
+  "hash": "0c7d65d8069d48fa4bead8ae92b09288faaf4a30061130709ff88c9ed182cedd"
 }

--- a/.sqlx/query-122fbaba1369aab5cb73fe2e94a1d0349b77877c526e30c684907a96c89c1a2d.json
+++ b/.sqlx/query-122fbaba1369aab5cb73fe2e94a1d0349b77877c526e30c684907a96c89c1a2d.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n                        deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            created_at, updated_at\n        FROM deployments\n        WHERE project_id = $1\n          AND deployment_group = $2\n          AND NOT is_terminal(status)\n        ORDER BY created_at DESC\n        ",
+  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            first_healthy_at,\n            created_at, updated_at\n        FROM deployments\n        WHERE project_id = $1\n          AND deployment_group = $2\n        ORDER BY created_at DESC\n        LIMIT 1\n        ",
   "describe": {
     "columns": [
       {
@@ -113,11 +113,16 @@
       },
       {
         "ordinal": 19,
-        "name": "created_at",
+        "name": "first_healthy_at",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
@@ -148,9 +153,10 @@
       false,
       false,
       true,
+      true,
       false,
       false
     ]
   },
-  "hash": "1ebd45cb119f63028e46c931770da9f7f9e6e27cb0d0cf61819bfd2e17006800"
+  "hash": "122fbaba1369aab5cb73fe2e94a1d0349b77877c526e30c684907a96c89c1a2d"
 }

--- a/.sqlx/query-16b19f20b7c5b464668a88f2f91b99438178d9992c4a8e98813a5de630096379.json
+++ b/.sqlx/query-16b19f20b7c5b464668a88f2f91b99438178d9992c4a8e98813a5de630096379.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            created_at, updated_at\n        FROM deployments\n        WHERE project_id = $1\n          AND deployment_group = $2\n        ORDER BY created_at DESC\n        LIMIT 1\n        ",
+  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            first_healthy_at,\n            termination_reason as \"termination_reason: _\",\n            created_at, updated_at\n        FROM deployments\n        WHERE id = ANY($1)\n        ",
   "describe": {
     "columns": [
       {
@@ -40,6 +40,66 @@
       },
       {
         "ordinal": 7,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "build_logs",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "controller_metadata: serde_json::Value",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 11,
+        "name": "image",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "image_digest",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "rolled_back_from_deployment_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 14,
+        "name": "http_port",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 15,
+        "name": "needs_reconcile",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 16,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "deploying_started_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "first_healthy_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
         "name": "termination_reason: _",
         "type_info": {
           "Custom": {
@@ -57,75 +117,19 @@
         }
       },
       {
-        "ordinal": 8,
-        "name": "completed_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 9,
-        "name": "error_message",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 10,
-        "name": "build_logs",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 11,
-        "name": "controller_metadata: serde_json::Value",
-        "type_info": "Jsonb"
-      },
-      {
-        "ordinal": 12,
-        "name": "image",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 13,
-        "name": "image_digest",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 14,
-        "name": "rolled_back_from_deployment_id",
-        "type_info": "Uuid"
-      },
-      {
-        "ordinal": 15,
-        "name": "http_port",
-        "type_info": "Int4"
-      },
-      {
-        "ordinal": 16,
-        "name": "needs_reconcile",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 17,
-        "name": "is_active",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 18,
-        "name": "deploying_started_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 19,
+        "ordinal": 20,
         "name": "created_at",
         "type_info": "Timestamptz"
       },
       {
-        "ordinal": 20,
+        "ordinal": 21,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
-        "Uuid",
-        "Text"
+        "UuidArray"
       ]
     },
     "nullable": [
@@ -143,14 +147,15 @@
       true,
       true,
       true,
+      false,
+      false,
+      false,
       true,
-      false,
-      false,
-      false,
+      true,
       true,
       false,
       false
     ]
   },
-  "hash": "5be7c0777193040029785febd7612b6b7e1fbedfc764026afb120bb8023faf3f"
+  "hash": "16b19f20b7c5b464668a88f2f91b99438178d9992c4a8e98813a5de630096379"
 }

--- a/.sqlx/query-19a0e9e5ce59b26abe560fb8567050052701a2f0bb5a901c7b23e8839be4fcd2.json
+++ b/.sqlx/query-19a0e9e5ce59b26abe560fb8567050052701a2f0bb5a901c7b23e8839be4fcd2.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            termination_reason as \"termination_reason: _\",\n            created_at, updated_at\n        FROM deployments\n        WHERE id = ANY($1)\n        ",
+  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            first_healthy_at,\n            created_at, updated_at\n        FROM deployments\n        WHERE project_id = $1\n          AND deployment_group = $2\n          AND is_active = TRUE\n        LIMIT 1\n        ",
   "describe": {
     "columns": [
       {
@@ -40,61 +40,6 @@
       },
       {
         "ordinal": 7,
-        "name": "completed_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 8,
-        "name": "error_message",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 9,
-        "name": "build_logs",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 10,
-        "name": "controller_metadata: serde_json::Value",
-        "type_info": "Jsonb"
-      },
-      {
-        "ordinal": 11,
-        "name": "image",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 12,
-        "name": "image_digest",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 13,
-        "name": "rolled_back_from_deployment_id",
-        "type_info": "Uuid"
-      },
-      {
-        "ordinal": 14,
-        "name": "http_port",
-        "type_info": "Int4"
-      },
-      {
-        "ordinal": 15,
-        "name": "needs_reconcile",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 16,
-        "name": "is_active",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 17,
-        "name": "deploying_started_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 18,
         "name": "termination_reason: _",
         "type_info": {
           "Custom": {
@@ -112,19 +57,80 @@
         }
       },
       {
+        "ordinal": 8,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "build_logs",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "controller_metadata: serde_json::Value",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 12,
+        "name": "image",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "image_digest",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "rolled_back_from_deployment_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 15,
+        "name": "http_port",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "needs_reconcile",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 18,
+        "name": "deploying_started_at",
+        "type_info": "Timestamptz"
+      },
+      {
         "ordinal": 19,
-        "name": "created_at",
+        "name": "first_healthy_at",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
-        "UuidArray"
+        "Uuid",
+        "Text"
       ]
     },
     "nullable": [
@@ -142,6 +148,7 @@
       true,
       true,
       true,
+      true,
       false,
       false,
       false,
@@ -151,5 +158,5 @@
       false
     ]
   },
-  "hash": "95da5cb8d7a3d2018a775b2829e5af9a9d7808634cbd3bb139356bde93ba7ab6"
+  "hash": "19a0e9e5ce59b26abe560fb8567050052701a2f0bb5a901c7b23e8839be4fcd2"
 }

--- a/.sqlx/query-1e114a35bf5348ae5a3eb438884a2f5c497f39cafc74dddd7f41663ea8d94590.json
+++ b/.sqlx/query-1e114a35bf5348ae5a3eb438884a2f5c497f39cafc74dddd7f41663ea8d94590.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        UPDATE deployments\n        SET\n            status = 'Terminating',\n            termination_reason = $2,\n            updated_at = NOW()\n        WHERE id = $1\n        RETURNING\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            created_at, updated_at\n        ",
+  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n                        deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            first_healthy_at,\n            created_at, updated_at\n        FROM deployments\n        WHERE project_id = $1\n          AND deployment_group = $2\n          AND status = 'Healthy'\n        ORDER BY created_at DESC\n        LIMIT 1\n        ",
   "describe": {
     "columns": [
       {
@@ -113,11 +113,16 @@
       },
       {
         "ordinal": 19,
-        "name": "created_at",
+        "name": "first_healthy_at",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
@@ -125,20 +130,7 @@
     "parameters": {
       "Left": [
         "Uuid",
-        {
-          "Custom": {
-            "name": "termination_reason",
-            "kind": {
-              "Enum": [
-                "UserStopped",
-                "Superseded",
-                "Cancelled",
-                "Failed",
-                "Expired"
-              ]
-            }
-          }
-        }
+        "Text"
       ]
     },
     "nullable": [
@@ -161,9 +153,10 @@
       false,
       false,
       true,
+      true,
       false,
       false
     ]
   },
-  "hash": "d2d30a463d9391fe58907916d88c4fdf497acc0d6f7495ea4729950165265727"
+  "hash": "1e114a35bf5348ae5a3eb438884a2f5c497f39cafc74dddd7f41663ea8d94590"
 }

--- a/.sqlx/query-26e0907f62f455796775f3a9f0271276e51864b71e37c3488ccf6a31e3bf0eac.json
+++ b/.sqlx/query-26e0907f62f455796775f3a9f0271276e51864b71e37c3488ccf6a31e3bf0eac.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        UPDATE deployments\n        SET status = $2,\n            deploying_started_at = CASE\n                WHEN $2 = 'Deploying' AND deploying_started_at IS NULL THEN NOW()\n                ELSE deploying_started_at\n            END\n        WHERE id = $1\n        RETURNING\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            termination_reason as \"termination_reason: _\",\n            created_at, updated_at\n        ",
+  "query": "\n            SELECT\n                id, deployment_id, project_id, created_by_id,\n                status as \"status: DeploymentStatus\",\n                deployment_group, expires_at,\n                termination_reason as \"termination_reason: _\",\n                completed_at, error_message, build_logs,\n                controller_metadata as \"controller_metadata: serde_json::Value\",\n                image, image_digest, rolled_back_from_deployment_id,\n                http_port, needs_reconcile, is_active,\n                deploying_started_at,\n                first_healthy_at,\n                created_at, updated_at\n            FROM deployments\n            WHERE project_id = $1\n            ORDER BY created_at DESC\n            LIMIT $2 OFFSET $3\n            ",
   "describe": {
     "columns": [
       {
@@ -40,61 +40,6 @@
       },
       {
         "ordinal": 7,
-        "name": "completed_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 8,
-        "name": "error_message",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 9,
-        "name": "build_logs",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 10,
-        "name": "controller_metadata: serde_json::Value",
-        "type_info": "Jsonb"
-      },
-      {
-        "ordinal": 11,
-        "name": "image",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 12,
-        "name": "image_digest",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 13,
-        "name": "rolled_back_from_deployment_id",
-        "type_info": "Uuid"
-      },
-      {
-        "ordinal": 14,
-        "name": "http_port",
-        "type_info": "Int4"
-      },
-      {
-        "ordinal": 15,
-        "name": "needs_reconcile",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 16,
-        "name": "is_active",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 17,
-        "name": "deploying_started_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 18,
         "name": "termination_reason: _",
         "type_info": {
           "Custom": {
@@ -112,12 +57,72 @@
         }
       },
       {
+        "ordinal": 8,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "build_logs",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "controller_metadata: serde_json::Value",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 12,
+        "name": "image",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "image_digest",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "rolled_back_from_deployment_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 15,
+        "name": "http_port",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "needs_reconcile",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 18,
+        "name": "deploying_started_at",
+        "type_info": "Timestamptz"
+      },
+      {
         "ordinal": 19,
-        "name": "created_at",
+        "name": "first_healthy_at",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
@@ -125,7 +130,8 @@
     "parameters": {
       "Left": [
         "Uuid",
-        "Text"
+        "Int8",
+        "Int8"
       ]
     },
     "nullable": [
@@ -143,6 +149,7 @@
       true,
       true,
       true,
+      true,
       false,
       false,
       false,
@@ -152,5 +159,5 @@
       false
     ]
   },
-  "hash": "9d7d9fd92beec26e3aac697dd04738b5a05c6b219d3145ca1018b02514d545cf"
+  "hash": "26e0907f62f455796775f3a9f0271276e51864b71e37c3488ccf6a31e3bf0eac"
 }

--- a/.sqlx/query-2bb33eff67a63efbd62ea4227d8c6ba19e89c062a8a33bfec3fd93926d6b6094.json
+++ b/.sqlx/query-2bb33eff67a63efbd62ea4227d8c6ba19e89c062a8a33bfec3fd93926d6b6094.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        UPDATE deployments\n        SET\n            status = 'Superseded',\n            termination_reason = 'Superseded',\n            controller_metadata = '{}',\n            updated_at = NOW()\n        WHERE id = $1\n        RETURNING\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            created_at, updated_at\n        ",
+  "query": "\n        UPDATE deployments\n        SET controller_metadata = $2\n        WHERE id = $1\n        RETURNING\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            first_healthy_at,\n            termination_reason as \"termination_reason: _\",\n            created_at, updated_at\n        ",
   "describe": {
     "columns": [
       {
@@ -40,6 +40,66 @@
       },
       {
         "ordinal": 7,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "build_logs",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "controller_metadata: serde_json::Value",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 11,
+        "name": "image",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "image_digest",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "rolled_back_from_deployment_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 14,
+        "name": "http_port",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 15,
+        "name": "needs_reconcile",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 16,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "deploying_started_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "first_healthy_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
         "name": "termination_reason: _",
         "type_info": {
           "Custom": {
@@ -57,74 +117,20 @@
         }
       },
       {
-        "ordinal": 8,
-        "name": "completed_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 9,
-        "name": "error_message",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 10,
-        "name": "build_logs",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 11,
-        "name": "controller_metadata: serde_json::Value",
-        "type_info": "Jsonb"
-      },
-      {
-        "ordinal": 12,
-        "name": "image",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 13,
-        "name": "image_digest",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 14,
-        "name": "rolled_back_from_deployment_id",
-        "type_info": "Uuid"
-      },
-      {
-        "ordinal": 15,
-        "name": "http_port",
-        "type_info": "Int4"
-      },
-      {
-        "ordinal": 16,
-        "name": "needs_reconcile",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 17,
-        "name": "is_active",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 18,
-        "name": "deploying_started_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 19,
+        "ordinal": 20,
         "name": "created_at",
         "type_info": "Timestamptz"
       },
       {
-        "ordinal": 20,
+        "ordinal": 21,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
-        "Uuid"
+        "Uuid",
+        "Jsonb"
       ]
     },
     "nullable": [
@@ -142,14 +148,15 @@
       true,
       true,
       true,
+      false,
+      false,
+      false,
       true,
-      false,
-      false,
-      false,
+      true,
       true,
       false,
       false
     ]
   },
-  "hash": "1778867848593fe193bacb6e9b2e16c0846695cf2ffe360467d786920cc252dc"
+  "hash": "2bb33eff67a63efbd62ea4227d8c6ba19e89c062a8a33bfec3fd93926d6b6094"
 }

--- a/.sqlx/query-2dd8fe743f1b5a2bde798ec11dde0186bc267eaf223934a65f71ce4e908a4c74.json
+++ b/.sqlx/query-2dd8fe743f1b5a2bde798ec11dde0186bc267eaf223934a65f71ce4e908a4c74.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        UPDATE deployments\n        SET\n            status = 'Cancelled',\n            termination_reason = 'Cancelled',\n            controller_metadata = '{}',\n            updated_at = NOW()\n        WHERE id = $1\n        RETURNING\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            created_at, updated_at\n        ",
+  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            first_healthy_at,\n            termination_reason as \"termination_reason: _\",\n            created_at, updated_at\n        FROM deployments\n        WHERE status = $1\n        ORDER BY created_at DESC\n        ",
   "describe": {
     "columns": [
       {
@@ -40,6 +40,66 @@
       },
       {
         "ordinal": 7,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "build_logs",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "controller_metadata: serde_json::Value",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 11,
+        "name": "image",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "image_digest",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "rolled_back_from_deployment_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 14,
+        "name": "http_port",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 15,
+        "name": "needs_reconcile",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 16,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "deploying_started_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "first_healthy_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
         "name": "termination_reason: _",
         "type_info": {
           "Custom": {
@@ -57,74 +117,19 @@
         }
       },
       {
-        "ordinal": 8,
-        "name": "completed_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 9,
-        "name": "error_message",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 10,
-        "name": "build_logs",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 11,
-        "name": "controller_metadata: serde_json::Value",
-        "type_info": "Jsonb"
-      },
-      {
-        "ordinal": 12,
-        "name": "image",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 13,
-        "name": "image_digest",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 14,
-        "name": "rolled_back_from_deployment_id",
-        "type_info": "Uuid"
-      },
-      {
-        "ordinal": 15,
-        "name": "http_port",
-        "type_info": "Int4"
-      },
-      {
-        "ordinal": 16,
-        "name": "needs_reconcile",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 17,
-        "name": "is_active",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 18,
-        "name": "deploying_started_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 19,
+        "ordinal": 20,
         "name": "created_at",
         "type_info": "Timestamptz"
       },
       {
-        "ordinal": 20,
+        "ordinal": 21,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
-        "Uuid"
+        "Text"
       ]
     },
     "nullable": [
@@ -142,14 +147,15 @@
       true,
       true,
       true,
+      false,
+      false,
+      false,
       true,
-      false,
-      false,
-      false,
+      true,
       true,
       false,
       false
     ]
   },
-  "hash": "491a165327a64261eaf043a7e41d23861af35f4e691cf44df5986f9c453cee96"
+  "hash": "2dd8fe743f1b5a2bde798ec11dde0186bc267eaf223934a65f71ce4e908a4c74"
 }

--- a/.sqlx/query-3cf05dbfa2f2cffce157f430066230d7a7e471af364fd2aa8430902ecfcf30ea.json
+++ b/.sqlx/query-3cf05dbfa2f2cffce157f430066230d7a7e471af364fd2aa8430902ecfcf30ea.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        UPDATE deployments\n        SET controller_metadata = $2\n        WHERE id = $1\n        RETURNING\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            termination_reason as \"termination_reason: _\",\n            created_at, updated_at\n        ",
+  "query": "\n        UPDATE deployments\n        SET\n            status = 'Cancelled',\n            termination_reason = 'Cancelled',\n            controller_metadata = '{}',\n            updated_at = NOW()\n        WHERE id = $1\n        RETURNING\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            first_healthy_at,\n            created_at, updated_at\n        ",
   "describe": {
     "columns": [
       {
@@ -40,61 +40,6 @@
       },
       {
         "ordinal": 7,
-        "name": "completed_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 8,
-        "name": "error_message",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 9,
-        "name": "build_logs",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 10,
-        "name": "controller_metadata: serde_json::Value",
-        "type_info": "Jsonb"
-      },
-      {
-        "ordinal": 11,
-        "name": "image",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 12,
-        "name": "image_digest",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 13,
-        "name": "rolled_back_from_deployment_id",
-        "type_info": "Uuid"
-      },
-      {
-        "ordinal": 14,
-        "name": "http_port",
-        "type_info": "Int4"
-      },
-      {
-        "ordinal": 15,
-        "name": "needs_reconcile",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 16,
-        "name": "is_active",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 17,
-        "name": "deploying_started_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 18,
         "name": "termination_reason: _",
         "type_info": {
           "Custom": {
@@ -112,20 +57,79 @@
         }
       },
       {
+        "ordinal": 8,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "build_logs",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "controller_metadata: serde_json::Value",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 12,
+        "name": "image",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "image_digest",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "rolled_back_from_deployment_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 15,
+        "name": "http_port",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "needs_reconcile",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 18,
+        "name": "deploying_started_at",
+        "type_info": "Timestamptz"
+      },
+      {
         "ordinal": 19,
-        "name": "created_at",
+        "name": "first_healthy_at",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
-        "Uuid",
-        "Jsonb"
+        "Uuid"
       ]
     },
     "nullable": [
@@ -143,6 +147,7 @@
       true,
       true,
       true,
+      true,
       false,
       false,
       false,
@@ -152,5 +157,5 @@
       false
     ]
   },
-  "hash": "fa54f9c5db85cb124bfb6c6ae0ab04547cf6971f01e95b6704d3114a0a861b51"
+  "hash": "3cf05dbfa2f2cffce157f430066230d7a7e471af364fd2aa8430902ecfcf30ea"
 }

--- a/.sqlx/query-3e5ecaf9833999b631329d7bd6f1755c39effca778b7dd56c70585494e43c37b.json
+++ b/.sqlx/query-3e5ecaf9833999b631329d7bd6f1755c39effca778b7dd56c70585494e43c37b.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        UPDATE deployments\n        SET\n            status = 'Cancelling',\n            termination_reason = 'Cancelled',\n            updated_at = NOW()\n        WHERE id = $1\n        RETURNING\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            created_at, updated_at\n        ",
+  "query": "\n        UPDATE deployments\n        SET status = 'Failed', completed_at = NOW(), error_message = $2\n        WHERE id = $1\n        RETURNING\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            first_healthy_at,\n            termination_reason as \"termination_reason: _\",\n            created_at, updated_at\n        ",
   "describe": {
     "columns": [
       {
@@ -40,6 +40,66 @@
       },
       {
         "ordinal": 7,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "build_logs",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "controller_metadata: serde_json::Value",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 11,
+        "name": "image",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "image_digest",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "rolled_back_from_deployment_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 14,
+        "name": "http_port",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 15,
+        "name": "needs_reconcile",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 16,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "deploying_started_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "first_healthy_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
         "name": "termination_reason: _",
         "type_info": {
           "Custom": {
@@ -57,74 +117,20 @@
         }
       },
       {
-        "ordinal": 8,
-        "name": "completed_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 9,
-        "name": "error_message",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 10,
-        "name": "build_logs",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 11,
-        "name": "controller_metadata: serde_json::Value",
-        "type_info": "Jsonb"
-      },
-      {
-        "ordinal": 12,
-        "name": "image",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 13,
-        "name": "image_digest",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 14,
-        "name": "rolled_back_from_deployment_id",
-        "type_info": "Uuid"
-      },
-      {
-        "ordinal": 15,
-        "name": "http_port",
-        "type_info": "Int4"
-      },
-      {
-        "ordinal": 16,
-        "name": "needs_reconcile",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 17,
-        "name": "is_active",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 18,
-        "name": "deploying_started_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 19,
+        "ordinal": 20,
         "name": "created_at",
         "type_info": "Timestamptz"
       },
       {
-        "ordinal": 20,
+        "ordinal": 21,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
-        "Uuid"
+        "Uuid",
+        "Text"
       ]
     },
     "nullable": [
@@ -142,14 +148,15 @@
       true,
       true,
       true,
+      false,
+      false,
+      false,
       true,
-      false,
-      false,
-      false,
+      true,
       true,
       false,
       false
     ]
   },
-  "hash": "f96c6c7273088e0bf7f26796a119f3b5a2859b415aa0602bcd96b8516ac9c6cb"
+  "hash": "3e5ecaf9833999b631329d7bd6f1755c39effca778b7dd56c70585494e43c37b"
 }

--- a/.sqlx/query-3eda5f125a39e56ee0ecbeb0cb49bda30765b1e6e7029ccbca5d02e31b9fbf29.json
+++ b/.sqlx/query-3eda5f125a39e56ee0ecbeb0cb49bda30765b1e6e7029ccbca5d02e31b9fbf29.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            termination_reason as \"termination_reason: _\",\n            created_at, updated_at\n        FROM deployments\n        WHERE project_id = $1\n        ORDER BY created_at DESC\n        ",
+  "query": "\n            SELECT\n                id, deployment_id, project_id, created_by_id,\n                status as \"status: DeploymentStatus\",\n                deployment_group, expires_at,\n                termination_reason as \"termination_reason: _\",\n                completed_at, error_message, build_logs,\n                controller_metadata as \"controller_metadata: serde_json::Value\",\n                image, image_digest, rolled_back_from_deployment_id,\n                http_port, needs_reconcile, is_active,\n                deploying_started_at,\n                first_healthy_at,\n                created_at, updated_at\n            FROM deployments\n            WHERE project_id = $1 AND deployment_group = $2\n            ORDER BY created_at DESC\n            LIMIT $3 OFFSET $4\n            ",
   "describe": {
     "columns": [
       {
@@ -40,61 +40,6 @@
       },
       {
         "ordinal": 7,
-        "name": "completed_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 8,
-        "name": "error_message",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 9,
-        "name": "build_logs",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 10,
-        "name": "controller_metadata: serde_json::Value",
-        "type_info": "Jsonb"
-      },
-      {
-        "ordinal": 11,
-        "name": "image",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 12,
-        "name": "image_digest",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 13,
-        "name": "rolled_back_from_deployment_id",
-        "type_info": "Uuid"
-      },
-      {
-        "ordinal": 14,
-        "name": "http_port",
-        "type_info": "Int4"
-      },
-      {
-        "ordinal": 15,
-        "name": "needs_reconcile",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 16,
-        "name": "is_active",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 17,
-        "name": "deploying_started_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 18,
         "name": "termination_reason: _",
         "type_info": {
           "Custom": {
@@ -112,19 +57,82 @@
         }
       },
       {
+        "ordinal": 8,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "build_logs",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "controller_metadata: serde_json::Value",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 12,
+        "name": "image",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "image_digest",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "rolled_back_from_deployment_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 15,
+        "name": "http_port",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "needs_reconcile",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 18,
+        "name": "deploying_started_at",
+        "type_info": "Timestamptz"
+      },
+      {
         "ordinal": 19,
-        "name": "created_at",
+        "name": "first_healthy_at",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
-        "Uuid"
+        "Uuid",
+        "Text",
+        "Int8",
+        "Int8"
       ]
     },
     "nullable": [
@@ -142,6 +150,7 @@
       true,
       true,
       true,
+      true,
       false,
       false,
       false,
@@ -151,5 +160,5 @@
       false
     ]
   },
-  "hash": "1cbd4cef53136e19f6a6649e5e9361f8d0ccdd862921d8523d8b91efb63d758a"
+  "hash": "3eda5f125a39e56ee0ecbeb0cb49bda30765b1e6e7029ccbca5d02e31b9fbf29"
 }

--- a/.sqlx/query-4b5915caef31537ff4326989c7c9b870fe040eda334c06715164df4ae2f03ec1.json
+++ b/.sqlx/query-4b5915caef31537ff4326989c7c9b870fe040eda334c06715164df4ae2f03ec1.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        UPDATE deployments\n        SET\n            status = 'Expired',\n            termination_reason = 'Expired',\n            controller_metadata = '{}',\n            updated_at = NOW()\n        WHERE id = $1\n        RETURNING\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            created_at, updated_at\n        ",
+  "query": "\n        UPDATE deployments\n        SET status = $2,\n            deploying_started_at = CASE\n                WHEN $2 = 'Deploying' AND deploying_started_at IS NULL THEN NOW()\n                ELSE deploying_started_at\n            END,\n            first_healthy_at = CASE\n                WHEN $2 = 'Healthy' AND first_healthy_at IS NULL THEN NOW()\n                ELSE first_healthy_at\n            END\n        WHERE id = $1\n        RETURNING\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            first_healthy_at,\n            termination_reason as \"termination_reason: _\",\n            created_at, updated_at\n        ",
   "describe": {
     "columns": [
       {
@@ -40,6 +40,66 @@
       },
       {
         "ordinal": 7,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "build_logs",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "controller_metadata: serde_json::Value",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 11,
+        "name": "image",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "image_digest",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "rolled_back_from_deployment_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 14,
+        "name": "http_port",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 15,
+        "name": "needs_reconcile",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 16,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "deploying_started_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "first_healthy_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
         "name": "termination_reason: _",
         "type_info": {
           "Custom": {
@@ -57,74 +117,20 @@
         }
       },
       {
-        "ordinal": 8,
-        "name": "completed_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 9,
-        "name": "error_message",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 10,
-        "name": "build_logs",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 11,
-        "name": "controller_metadata: serde_json::Value",
-        "type_info": "Jsonb"
-      },
-      {
-        "ordinal": 12,
-        "name": "image",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 13,
-        "name": "image_digest",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 14,
-        "name": "rolled_back_from_deployment_id",
-        "type_info": "Uuid"
-      },
-      {
-        "ordinal": 15,
-        "name": "http_port",
-        "type_info": "Int4"
-      },
-      {
-        "ordinal": 16,
-        "name": "needs_reconcile",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 17,
-        "name": "is_active",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 18,
-        "name": "deploying_started_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 19,
+        "ordinal": 20,
         "name": "created_at",
         "type_info": "Timestamptz"
       },
       {
-        "ordinal": 20,
+        "ordinal": 21,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
-        "Uuid"
+        "Uuid",
+        "Text"
       ]
     },
     "nullable": [
@@ -142,14 +148,15 @@
       true,
       true,
       true,
+      false,
+      false,
+      false,
       true,
-      false,
-      false,
-      false,
+      true,
       true,
       false,
       false
     ]
   },
-  "hash": "2904ccc72f71cc5bd0f6ab42ad015ba8a940e1091731263840ba154e89194cb8"
+  "hash": "4b5915caef31537ff4326989c7c9b870fe040eda334c06715164df4ae2f03ec1"
 }

--- a/.sqlx/query-58e9cc73002c21daf0ec5f78542f1332da358fc0b35ce4fd98647041367dc07d.json
+++ b/.sqlx/query-58e9cc73002c21daf0ec5f78542f1332da358fc0b35ce4fd98647041367dc07d.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT\n                id, deployment_id, project_id, created_by_id,\n                status as \"status: DeploymentStatus\",\n                deployment_group, expires_at,\n                termination_reason as \"termination_reason: _\",\n                completed_at, error_message, build_logs,\n                controller_metadata as \"controller_metadata: serde_json::Value\",\n                image, image_digest, rolled_back_from_deployment_id,\n                http_port, needs_reconcile, is_active,\n                deploying_started_at,\n                created_at, updated_at\n            FROM deployments\n            WHERE project_id = $1\n            ORDER BY created_at DESC\n            LIMIT $2 OFFSET $3\n            ",
+  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            error_message, completed_at, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            first_healthy_at,\n            termination_reason as \"termination_reason: _\",\n            created_at, updated_at\n        FROM deployments\n        WHERE status IN ('Pending', 'Building', 'Pushing')\n          AND created_at < $1\n          AND NOT is_protected(status)\n        LIMIT $2\n        ",
   "describe": {
     "columns": [
       {
@@ -40,6 +40,66 @@
       },
       {
         "ordinal": 7,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "build_logs",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "controller_metadata: serde_json::Value",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 11,
+        "name": "image",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "image_digest",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "rolled_back_from_deployment_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 14,
+        "name": "http_port",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 15,
+        "name": "needs_reconcile",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 16,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "deploying_started_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "first_healthy_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
         "name": "termination_reason: _",
         "type_info": {
           "Custom": {
@@ -57,75 +117,19 @@
         }
       },
       {
-        "ordinal": 8,
-        "name": "completed_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 9,
-        "name": "error_message",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 10,
-        "name": "build_logs",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 11,
-        "name": "controller_metadata: serde_json::Value",
-        "type_info": "Jsonb"
-      },
-      {
-        "ordinal": 12,
-        "name": "image",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 13,
-        "name": "image_digest",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 14,
-        "name": "rolled_back_from_deployment_id",
-        "type_info": "Uuid"
-      },
-      {
-        "ordinal": 15,
-        "name": "http_port",
-        "type_info": "Int4"
-      },
-      {
-        "ordinal": 16,
-        "name": "needs_reconcile",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 17,
-        "name": "is_active",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 18,
-        "name": "deploying_started_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 19,
+        "ordinal": 20,
         "name": "created_at",
         "type_info": "Timestamptz"
       },
       {
-        "ordinal": 20,
+        "ordinal": 21,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
-        "Uuid",
-        "Int8",
+        "Timestamptz",
         "Int8"
       ]
     },
@@ -144,14 +148,15 @@
       true,
       true,
       true,
+      false,
+      false,
+      false,
       true,
-      false,
-      false,
-      false,
+      true,
       true,
       false,
       false
     ]
   },
-  "hash": "2336d0e686f0ba526663903be2cf4be0ca1537430868a19542312fa406a6c670"
+  "hash": "58e9cc73002c21daf0ec5f78542f1332da358fc0b35ce4fd98647041367dc07d"
 }

--- a/.sqlx/query-5ee2ab19a3fe4a4424a0e9550dad8d2822cf58cdcff8039d7705a01778171111.json
+++ b/.sqlx/query-5ee2ab19a3fe4a4424a0e9550dad8d2822cf58cdcff8039d7705a01778171111.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        UPDATE deployments\n        SET\n            status = 'Unhealthy',\n            error_message = $2,\n            updated_at = NOW()\n        WHERE id = $1\n        RETURNING\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            created_at, updated_at\n        ",
+  "query": "\n        UPDATE deployments\n        SET\n            status = 'Healthy',\n            error_message = NULL,\n            first_healthy_at = COALESCE(first_healthy_at, NOW()),\n            updated_at = NOW()\n        WHERE id = $1\n        RETURNING\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            first_healthy_at,\n            created_at, updated_at\n        ",
   "describe": {
     "columns": [
       {
@@ -113,19 +113,23 @@
       },
       {
         "ordinal": 19,
-        "name": "created_at",
+        "name": "first_healthy_at",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
-        "Uuid",
-        "Text"
+        "Uuid"
       ]
     },
     "nullable": [
@@ -148,9 +152,10 @@
       false,
       false,
       true,
+      true,
       false,
       false
     ]
   },
-  "hash": "aa1eb6ae99d5e5fafaf7c7b75b40ca9adb7069b8d85e6da5e256730c2bf39560"
+  "hash": "5ee2ab19a3fe4a4424a0e9550dad8d2822cf58cdcff8039d7705a01778171111"
 }

--- a/.sqlx/query-710be1b9d983c25da96676d19c44346ddb82f378a72f53a5585386527bd2fde6.json
+++ b/.sqlx/query-710be1b9d983c25da96676d19c44346ddb82f378a72f53a5585386527bd2fde6.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        UPDATE deployments\n        SET status = 'Failed', completed_at = NOW(), error_message = $2\n        WHERE id = $1\n        RETURNING\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            termination_reason as \"termination_reason: _\",\n            created_at, updated_at\n        ",
+  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            first_healthy_at,\n            termination_reason as \"termination_reason: _\",\n            created_at, updated_at\n        FROM deployments\n        WHERE project_id = $1\n        ORDER BY created_at DESC\n        ",
   "describe": {
     "columns": [
       {
@@ -95,6 +95,11 @@
       },
       {
         "ordinal": 18,
+        "name": "first_healthy_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
         "name": "termination_reason: _",
         "type_info": {
           "Custom": {
@@ -112,20 +117,19 @@
         }
       },
       {
-        "ordinal": 19,
+        "ordinal": 20,
         "name": "created_at",
         "type_info": "Timestamptz"
       },
       {
-        "ordinal": 20,
+        "ordinal": 21,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
-        "Uuid",
-        "Text"
+        "Uuid"
       ]
     },
     "nullable": [
@@ -148,9 +152,10 @@
       false,
       true,
       true,
+      true,
       false,
       false
     ]
   },
-  "hash": "b2eeaa29c746bded1124e1a1217de80605567ab4820fa2ad965b8a6cc701f78c"
+  "hash": "710be1b9d983c25da96676d19c44346ddb82f378a72f53a5585386527bd2fde6"
 }

--- a/.sqlx/query-725bbcdc7319aa5339612bce7c4741118871d8812c98f42453df852270afa2f7.json
+++ b/.sqlx/query-725bbcdc7319aa5339612bce7c4741118871d8812c98f42453df852270afa2f7.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        UPDATE deployments\n        SET\n            status = 'Healthy',\n            error_message = NULL,\n            updated_at = NOW()\n        WHERE id = $1\n        RETURNING\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            created_at, updated_at\n        ",
+  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            first_healthy_at,\n            created_at, updated_at\n        FROM deployments\n        WHERE needs_reconcile = TRUE\n          AND status IN ('Healthy', 'Unhealthy')\n        ORDER BY updated_at ASC\n        LIMIT $1\n        ",
   "describe": {
     "columns": [
       {
@@ -113,18 +113,23 @@
       },
       {
         "ordinal": 19,
-        "name": "created_at",
+        "name": "first_healthy_at",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
-        "Uuid"
+        "Int8"
       ]
     },
     "nullable": [
@@ -147,9 +152,10 @@
       false,
       false,
       true,
+      true,
       false,
       false
     ]
   },
-  "hash": "32ab3a0dd18d26ee8338a85368a6331afe5b9982c8fed6087b916e4becf0645c"
+  "hash": "725bbcdc7319aa5339612bce7c4741118871d8812c98f42453df852270afa2f7"
 }

--- a/.sqlx/query-75f4c3594efc9b5231348668089cdb378a57660f125293f6701e23ec902d4c20.json
+++ b/.sqlx/query-75f4c3594efc9b5231348668089cdb378a57660f125293f6701e23ec902d4c20.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            termination_reason as \"termination_reason: _\",\n            created_at, updated_at\n        FROM deployments\n        WHERE id = $1\n        ",
+  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            first_healthy_at,\n            termination_reason as \"termination_reason: _\",\n            created_at, updated_at\n        FROM deployments\n        WHERE NOT is_terminal(status)\n        ORDER BY updated_at ASC\n        LIMIT $1\n        ",
   "describe": {
     "columns": [
       {
@@ -95,6 +95,11 @@
       },
       {
         "ordinal": 18,
+        "name": "first_healthy_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
         "name": "termination_reason: _",
         "type_info": {
           "Custom": {
@@ -112,19 +117,19 @@
         }
       },
       {
-        "ordinal": 19,
+        "ordinal": 20,
         "name": "created_at",
         "type_info": "Timestamptz"
       },
       {
-        "ordinal": 20,
+        "ordinal": 21,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
-        "Uuid"
+        "Int8"
       ]
     },
     "nullable": [
@@ -147,9 +152,10 @@
       false,
       true,
       true,
+      true,
       false,
       false
     ]
   },
-  "hash": "2b3b663bd1d86cacd209eaf0ecfdd0a10e7ef56de79c7c53da79787326c53b6a"
+  "hash": "75f4c3594efc9b5231348668089cdb378a57660f125293f6701e23ec902d4c20"
 }

--- a/.sqlx/query-7b8af8b7d27931d79ddcdb618b11097eb94eaa53d539c56162e4104ca3c901af.json
+++ b/.sqlx/query-7b8af8b7d27931d79ddcdb618b11097eb94eaa53d539c56162e4104ca3c901af.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            termination_reason as \"termination_reason: _\",\n            created_at, updated_at\n        FROM deployments\n        WHERE status = $1\n        ORDER BY created_at DESC\n        ",
+  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n                        deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            first_healthy_at,\n            created_at, updated_at\n        FROM deployments\n        WHERE expires_at IS NOT NULL\n          AND expires_at <= NOW()\n          AND NOT is_terminal(status)\n        ORDER BY expires_at ASC\n        LIMIT $1\n        ",
   "describe": {
     "columns": [
       {
@@ -40,61 +40,6 @@
       },
       {
         "ordinal": 7,
-        "name": "completed_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 8,
-        "name": "error_message",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 9,
-        "name": "build_logs",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 10,
-        "name": "controller_metadata: serde_json::Value",
-        "type_info": "Jsonb"
-      },
-      {
-        "ordinal": 11,
-        "name": "image",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 12,
-        "name": "image_digest",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 13,
-        "name": "rolled_back_from_deployment_id",
-        "type_info": "Uuid"
-      },
-      {
-        "ordinal": 14,
-        "name": "http_port",
-        "type_info": "Int4"
-      },
-      {
-        "ordinal": 15,
-        "name": "needs_reconcile",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 16,
-        "name": "is_active",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 17,
-        "name": "deploying_started_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 18,
         "name": "termination_reason: _",
         "type_info": {
           "Custom": {
@@ -112,19 +57,79 @@
         }
       },
       {
+        "ordinal": 8,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "build_logs",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "controller_metadata: serde_json::Value",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 12,
+        "name": "image",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "image_digest",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "rolled_back_from_deployment_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 15,
+        "name": "http_port",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "needs_reconcile",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 18,
+        "name": "deploying_started_at",
+        "type_info": "Timestamptz"
+      },
+      {
         "ordinal": 19,
-        "name": "created_at",
+        "name": "first_healthy_at",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
-        "Text"
+        "Int8"
       ]
     },
     "nullable": [
@@ -142,6 +147,7 @@
       true,
       true,
       true,
+      true,
       false,
       false,
       false,
@@ -151,5 +157,5 @@
       false
     ]
   },
-  "hash": "3050384c3c97d46ae37496ce39bf016629c7f91658dfbc85e4c0945cc1f1b2f5"
+  "hash": "7b8af8b7d27931d79ddcdb618b11097eb94eaa53d539c56162e4104ca3c901af"
 }

--- a/.sqlx/query-96ec6c14f7aa7a767a2f2698275d798182e4c9aecd29767122b20c9f12aa6ef0.json
+++ b/.sqlx/query-96ec6c14f7aa7a767a2f2698275d798182e4c9aecd29767122b20c9f12aa6ef0.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            termination_reason as \"termination_reason: _\",\n            created_at, updated_at\n        FROM deployments\n        WHERE deployment_id = $1 AND project_id = $2\n        ",
+  "query": "\n        UPDATE deployments\n        SET\n            status = 'Expired',\n            termination_reason = 'Expired',\n            controller_metadata = '{}',\n            updated_at = NOW()\n        WHERE id = $1\n        RETURNING\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            first_healthy_at,\n            created_at, updated_at\n        ",
   "describe": {
     "columns": [
       {
@@ -40,61 +40,6 @@
       },
       {
         "ordinal": 7,
-        "name": "completed_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 8,
-        "name": "error_message",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 9,
-        "name": "build_logs",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 10,
-        "name": "controller_metadata: serde_json::Value",
-        "type_info": "Jsonb"
-      },
-      {
-        "ordinal": 11,
-        "name": "image",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 12,
-        "name": "image_digest",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 13,
-        "name": "rolled_back_from_deployment_id",
-        "type_info": "Uuid"
-      },
-      {
-        "ordinal": 14,
-        "name": "http_port",
-        "type_info": "Int4"
-      },
-      {
-        "ordinal": 15,
-        "name": "needs_reconcile",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 16,
-        "name": "is_active",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 17,
-        "name": "deploying_started_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 18,
         "name": "termination_reason: _",
         "type_info": {
           "Custom": {
@@ -112,19 +57,78 @@
         }
       },
       {
+        "ordinal": 8,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "build_logs",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "controller_metadata: serde_json::Value",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 12,
+        "name": "image",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "image_digest",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "rolled_back_from_deployment_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 15,
+        "name": "http_port",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "needs_reconcile",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 18,
+        "name": "deploying_started_at",
+        "type_info": "Timestamptz"
+      },
+      {
         "ordinal": 19,
-        "name": "created_at",
+        "name": "first_healthy_at",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
-        "Text",
         "Uuid"
       ]
     },
@@ -143,6 +147,7 @@
       true,
       true,
       true,
+      true,
       false,
       false,
       false,
@@ -152,5 +157,5 @@
       false
     ]
   },
-  "hash": "175959877ce0bb860c2544d2eddafd24846af1353317d734b2e558f88fab5be7"
+  "hash": "96ec6c14f7aa7a767a2f2698275d798182e4c9aecd29767122b20c9f12aa6ef0"
 }

--- a/.sqlx/query-a72a7db0c5b00eef8db5c0a6fcfab8714c581ad0fa765fae3866897a59ff18fa.json
+++ b/.sqlx/query-a72a7db0c5b00eef8db5c0a6fcfab8714c581ad0fa765fae3866897a59ff18fa.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            termination_reason as \"termination_reason: _\",\n            created_at, updated_at\n        FROM deployments\n        WHERE project_id = $1 AND is_active = TRUE\n        ORDER BY deployment_group, created_at DESC\n        ",
+  "query": "\n        UPDATE deployments\n        SET\n            status = 'Terminating',\n            termination_reason = $2,\n            updated_at = NOW()\n        WHERE id = $1\n        RETURNING\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            first_healthy_at,\n            created_at, updated_at\n        ",
   "describe": {
     "columns": [
       {
@@ -40,61 +40,6 @@
       },
       {
         "ordinal": 7,
-        "name": "completed_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 8,
-        "name": "error_message",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 9,
-        "name": "build_logs",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 10,
-        "name": "controller_metadata: serde_json::Value",
-        "type_info": "Jsonb"
-      },
-      {
-        "ordinal": 11,
-        "name": "image",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 12,
-        "name": "image_digest",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 13,
-        "name": "rolled_back_from_deployment_id",
-        "type_info": "Uuid"
-      },
-      {
-        "ordinal": 14,
-        "name": "http_port",
-        "type_info": "Int4"
-      },
-      {
-        "ordinal": 15,
-        "name": "needs_reconcile",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 16,
-        "name": "is_active",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 17,
-        "name": "deploying_started_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 18,
         "name": "termination_reason: _",
         "type_info": {
           "Custom": {
@@ -112,19 +57,93 @@
         }
       },
       {
+        "ordinal": 8,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "build_logs",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "controller_metadata: serde_json::Value",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 12,
+        "name": "image",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "image_digest",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "rolled_back_from_deployment_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 15,
+        "name": "http_port",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "needs_reconcile",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 18,
+        "name": "deploying_started_at",
+        "type_info": "Timestamptz"
+      },
+      {
         "ordinal": 19,
-        "name": "created_at",
+        "name": "first_healthy_at",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
-        "Uuid"
+        "Uuid",
+        {
+          "Custom": {
+            "name": "termination_reason",
+            "kind": {
+              "Enum": [
+                "UserStopped",
+                "Superseded",
+                "Cancelled",
+                "Failed",
+                "Expired"
+              ]
+            }
+          }
+        }
       ]
     },
     "nullable": [
@@ -142,6 +161,7 @@
       true,
       true,
       true,
+      true,
       false,
       false,
       false,
@@ -151,5 +171,5 @@
       false
     ]
   },
-  "hash": "40c9ddf77a43eec514d9b1ab887f03a586aad6c02d87310921763777976d7d1e"
+  "hash": "a72a7db0c5b00eef8db5c0a6fcfab8714c581ad0fa765fae3866897a59ff18fa"
 }

--- a/.sqlx/query-b4d56f5170c5fbffa7e0d576344c3bbee2bff23f028e2ff22b2fc23db8291bd0.json
+++ b/.sqlx/query-b4d56f5170c5fbffa7e0d576344c3bbee2bff23f028e2ff22b2fc23db8291bd0.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            created_at, updated_at\n        FROM deployments\n        WHERE needs_reconcile = TRUE\n          AND status IN ('Healthy', 'Unhealthy')\n        ORDER BY updated_at ASC\n        LIMIT $1\n        ",
+  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            first_healthy_at,\n            termination_reason as \"termination_reason: _\",\n            created_at, updated_at\n        FROM deployments\n        WHERE id = $1\n        ",
   "describe": {
     "columns": [
       {
@@ -40,6 +40,66 @@
       },
       {
         "ordinal": 7,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "build_logs",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "controller_metadata: serde_json::Value",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 11,
+        "name": "image",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "image_digest",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "rolled_back_from_deployment_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 14,
+        "name": "http_port",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 15,
+        "name": "needs_reconcile",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 16,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "deploying_started_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "first_healthy_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
         "name": "termination_reason: _",
         "type_info": {
           "Custom": {
@@ -57,74 +117,19 @@
         }
       },
       {
-        "ordinal": 8,
-        "name": "completed_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 9,
-        "name": "error_message",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 10,
-        "name": "build_logs",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 11,
-        "name": "controller_metadata: serde_json::Value",
-        "type_info": "Jsonb"
-      },
-      {
-        "ordinal": 12,
-        "name": "image",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 13,
-        "name": "image_digest",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 14,
-        "name": "rolled_back_from_deployment_id",
-        "type_info": "Uuid"
-      },
-      {
-        "ordinal": 15,
-        "name": "http_port",
-        "type_info": "Int4"
-      },
-      {
-        "ordinal": 16,
-        "name": "needs_reconcile",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 17,
-        "name": "is_active",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 18,
-        "name": "deploying_started_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 19,
+        "ordinal": 20,
         "name": "created_at",
         "type_info": "Timestamptz"
       },
       {
-        "ordinal": 20,
+        "ordinal": 21,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
-        "Int8"
+        "Uuid"
       ]
     },
     "nullable": [
@@ -142,14 +147,15 @@
       true,
       true,
       true,
+      false,
+      false,
+      false,
       true,
-      false,
-      false,
-      false,
+      true,
       true,
       false,
       false
     ]
   },
-  "hash": "ab73ea995f1386c7a55dc78662f46976e6acf4b9f32001a1d1e097f5c1beace6"
+  "hash": "b4d56f5170c5fbffa7e0d576344c3bbee2bff23f028e2ff22b2fc23db8291bd0"
 }

--- a/.sqlx/query-b8935cd8fe6c4bc5650c4344ea29f80cb653e4fb63bee72068c923783bd81b39.json
+++ b/.sqlx/query-b8935cd8fe6c4bc5650c4344ea29f80cb653e4fb63bee72068c923783bd81b39.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT\n                id, deployment_id, project_id, created_by_id,\n                status as \"status: DeploymentStatus\",\n                deployment_group, expires_at,\n                termination_reason as \"termination_reason: _\",\n                completed_at, error_message, build_logs,\n                controller_metadata as \"controller_metadata: serde_json::Value\",\n                image, image_digest, rolled_back_from_deployment_id,\n                http_port, needs_reconcile, is_active,\n                deploying_started_at,\n                created_at, updated_at\n            FROM deployments\n            WHERE project_id = $1 AND deployment_group = $2\n            ORDER BY created_at DESC\n            LIMIT $3 OFFSET $4\n            ",
+  "query": "\n        UPDATE deployments\n        SET\n            status = 'Stopped',\n            termination_reason = 'UserStopped',\n            controller_metadata = '{}',\n            updated_at = NOW()\n        WHERE id = $1\n        RETURNING\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            first_healthy_at,\n            created_at, updated_at\n        ",
   "describe": {
     "columns": [
       {
@@ -113,21 +113,23 @@
       },
       {
         "ordinal": 19,
-        "name": "created_at",
+        "name": "first_healthy_at",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
-        "Uuid",
-        "Text",
-        "Int8",
-        "Int8"
+        "Uuid"
       ]
     },
     "nullable": [
@@ -150,9 +152,10 @@
       false,
       false,
       true,
+      true,
       false,
       false
     ]
   },
-  "hash": "2b36b44ab517ba1632a4534c0117d8cc4453b60a9aaa6625ee514efab37e4ff5"
+  "hash": "b8935cd8fe6c4bc5650c4344ea29f80cb653e4fb63bee72068c923783bd81b39"
 }

--- a/.sqlx/query-bb0a04d74ffcfcff7464f0896081b35a346d0a3f4b3b8c856cfaa19c7bcbd9ac.json
+++ b/.sqlx/query-bb0a04d74ffcfcff7464f0896081b35a346d0a3f4b3b8c856cfaa19c7bcbd9ac.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        INSERT INTO deployments (deployment_id, project_id, created_by_id, status, image, image_digest, rolled_back_from_deployment_id, deployment_group, expires_at, http_port, is_active)\n        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)\n        RETURNING\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n                        deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            created_at, updated_at\n        ",
+  "query": "\n        UPDATE deployments\n        SET\n            status = 'Unhealthy',\n            error_message = $2,\n            updated_at = NOW()\n        WHERE id = $1\n        RETURNING\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            first_healthy_at,\n            created_at, updated_at\n        ",
   "describe": {
     "columns": [
       {
@@ -113,28 +113,24 @@
       },
       {
         "ordinal": 19,
-        "name": "created_at",
+        "name": "first_healthy_at",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
-        "Text",
         "Uuid",
-        "Uuid",
-        "Text",
-        "Text",
-        "Text",
-        "Uuid",
-        "Text",
-        "Timestamptz",
-        "Int4",
-        "Bool"
+        "Text"
       ]
     },
     "nullable": [
@@ -157,9 +153,10 @@
       false,
       false,
       true,
+      true,
       false,
       false
     ]
   },
-  "hash": "32ded4ab60b9803138d62bffdd18a73d5e047bf220e51125dd02a2ad01f76b09"
+  "hash": "bb0a04d74ffcfcff7464f0896081b35a346d0a3f4b3b8c856cfaa19c7bcbd9ac"
 }

--- a/.sqlx/query-bedc704b16c7b7a3ec05c1497e825fe343bb6f538d35dae77c2d8dbb6a1fa421.json
+++ b/.sqlx/query-bedc704b16c7b7a3ec05c1497e825fe343bb6f538d35dae77c2d8dbb6a1fa421.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            termination_reason as \"termination_reason: _\",\n            created_at, updated_at\n        FROM deployments\n        WHERE NOT is_terminal(status)\n        ORDER BY updated_at ASC\n        LIMIT $1\n        ",
+  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            first_healthy_at,\n            termination_reason as \"termination_reason: _\",\n            created_at, updated_at\n        FROM deployments\n        WHERE deployment_id = $1 AND project_id = $2\n        ",
   "describe": {
     "columns": [
       {
@@ -95,6 +95,11 @@
       },
       {
         "ordinal": 18,
+        "name": "first_healthy_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
         "name": "termination_reason: _",
         "type_info": {
           "Custom": {
@@ -112,19 +117,20 @@
         }
       },
       {
-        "ordinal": 19,
+        "ordinal": 20,
         "name": "created_at",
         "type_info": "Timestamptz"
       },
       {
-        "ordinal": 20,
+        "ordinal": 21,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
-        "Int8"
+        "Text",
+        "Uuid"
       ]
     },
     "nullable": [
@@ -147,9 +153,10 @@
       false,
       true,
       true,
+      true,
       false,
       false
     ]
   },
-  "hash": "af54458b787ce11aee5084634e08da65c59ace6658c7efa93392303152a8d52d"
+  "hash": "bedc704b16c7b7a3ec05c1497e825fe343bb6f538d35dae77c2d8dbb6a1fa421"
 }

--- a/.sqlx/query-c9b1152445ccdcbe7b22d5bebf4504e1e08805f056abd17944977a1b703cda9d.json
+++ b/.sqlx/query-c9b1152445ccdcbe7b22d5bebf4504e1e08805f056abd17944977a1b703cda9d.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        UPDATE deployments\n        SET\n            status = 'Stopped',\n            termination_reason = 'UserStopped',\n            controller_metadata = '{}',\n            updated_at = NOW()\n        WHERE id = $1\n        RETURNING\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            created_at, updated_at\n        ",
+  "query": "\n        UPDATE deployments\n        SET\n            status = 'Superseded',\n            termination_reason = 'Superseded',\n            controller_metadata = '{}',\n            updated_at = NOW()\n        WHERE id = $1\n        RETURNING\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            first_healthy_at,\n            created_at, updated_at\n        ",
   "describe": {
     "columns": [
       {
@@ -113,11 +113,16 @@
       },
       {
         "ordinal": 19,
-        "name": "created_at",
+        "name": "first_healthy_at",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
@@ -147,9 +152,10 @@
       false,
       false,
       true,
+      true,
       false,
       false
     ]
   },
-  "hash": "b45864deabb647bd09fc2d4583683f98a9ceb4da76d9081eb3e9bf0bd5a93857"
+  "hash": "c9b1152445ccdcbe7b22d5bebf4504e1e08805f056abd17944977a1b703cda9d"
 }

--- a/.sqlx/query-d8abd8a6958925bfdc79b806b0d4da328f4889ae2f0a21a844a702ab574ab950.json
+++ b/.sqlx/query-d8abd8a6958925bfdc79b806b0d4da328f4889ae2f0a21a844a702ab574ab950.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            created_at, updated_at\n        FROM deployments\n        WHERE project_id = $1\n          AND deployment_group = $2\n          AND is_active = TRUE\n        LIMIT 1\n        ",
+  "query": "\n        INSERT INTO deployments (deployment_id, project_id, created_by_id, status, image, image_digest, rolled_back_from_deployment_id, deployment_group, expires_at, http_port, is_active)\n        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)\n        RETURNING\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n                        deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            first_healthy_at,\n            created_at, updated_at\n        ",
   "describe": {
     "columns": [
       {
@@ -113,19 +113,33 @@
       },
       {
         "ordinal": 19,
-        "name": "created_at",
+        "name": "first_healthy_at",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
+        "Text",
         "Uuid",
-        "Text"
+        "Uuid",
+        "Text",
+        "Text",
+        "Text",
+        "Uuid",
+        "Text",
+        "Timestamptz",
+        "Int4",
+        "Bool"
       ]
     },
     "nullable": [
@@ -148,9 +162,10 @@
       false,
       false,
       true,
+      true,
       false,
       false
     ]
   },
-  "hash": "e5d667a47d8e037854a4d513524054a58c34c07331e3ba0dc683285aa238275c"
+  "hash": "d8abd8a6958925bfdc79b806b0d4da328f4889ae2f0a21a844a702ab574ab950"
 }

--- a/.sqlx/query-f3f46619f81ab62267329596433d33bcb8efd2fd49f4b199966e9b308fdc5913.json
+++ b/.sqlx/query-f3f46619f81ab62267329596433d33bcb8efd2fd49f4b199966e9b308fdc5913.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            error_message, completed_at, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            termination_reason as \"termination_reason: _\",\n            created_at, updated_at\n        FROM deployments\n        WHERE status IN ('Pending', 'Building', 'Pushing')\n          AND created_at < $1\n          AND NOT is_protected(status)\n        LIMIT $2\n        ",
+  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            first_healthy_at,\n            termination_reason as \"termination_reason: _\",\n            created_at, updated_at\n        FROM deployments\n        WHERE project_id = $1 AND is_active = TRUE\n        ORDER BY deployment_group, created_at DESC\n        ",
   "describe": {
     "columns": [
       {
@@ -40,13 +40,13 @@
       },
       {
         "ordinal": 7,
-        "name": "error_message",
-        "type_info": "Text"
+        "name": "completed_at",
+        "type_info": "Timestamptz"
       },
       {
         "ordinal": 8,
-        "name": "completed_at",
-        "type_info": "Timestamptz"
+        "name": "error_message",
+        "type_info": "Text"
       },
       {
         "ordinal": 9,
@@ -95,6 +95,11 @@
       },
       {
         "ordinal": 18,
+        "name": "first_healthy_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
         "name": "termination_reason: _",
         "type_info": {
           "Custom": {
@@ -112,20 +117,19 @@
         }
       },
       {
-        "ordinal": 19,
+        "ordinal": 20,
         "name": "created_at",
         "type_info": "Timestamptz"
       },
       {
-        "ordinal": 20,
+        "ordinal": 21,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
-        "Timestamptz",
-        "Int8"
+        "Uuid"
       ]
     },
     "nullable": [
@@ -148,9 +152,10 @@
       false,
       true,
       true,
+      true,
       false,
       false
     ]
   },
-  "hash": "3bcfb03761ac356f8d6a5c9715fc6c5993ea6b888dee0eba7c7392c8f40ffece"
+  "hash": "f3f46619f81ab62267329596433d33bcb8efd2fd49f4b199966e9b308fdc5913"
 }

--- a/.sqlx/query-fa0e3ce7cd88b0ab654ac3f07a75a396d2356a6d59a8aaceed7964a93800da3a.json
+++ b/.sqlx/query-fa0e3ce7cd88b0ab654ac3f07a75a396d2356a6d59a8aaceed7964a93800da3a.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n                        deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            created_at, updated_at\n        FROM deployments\n        WHERE project_id = $1\n          AND deployment_group = $2\n          AND status = 'Healthy'\n        ORDER BY created_at DESC\n        LIMIT 1\n        ",
+  "query": "\n        UPDATE deployments\n        SET\n            status = 'Cancelling',\n            termination_reason = 'Cancelled',\n            updated_at = NOW()\n        WHERE id = $1\n        RETURNING\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            termination_reason as \"termination_reason: _\",\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            first_healthy_at,\n            created_at, updated_at\n        ",
   "describe": {
     "columns": [
       {
@@ -113,19 +113,23 @@
       },
       {
         "ordinal": 19,
-        "name": "created_at",
+        "name": "first_healthy_at",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
-        "Uuid",
-        "Text"
+        "Uuid"
       ]
     },
     "nullable": [
@@ -148,9 +152,10 @@
       false,
       false,
       true,
+      true,
       false,
       false
     ]
   },
-  "hash": "b96b686763d9c9ff00ae1af78d46df690a35d64c155e7c8fb962b55ac8c56a7d"
+  "hash": "fa0e3ce7cd88b0ab654ac3f07a75a396d2356a6d59a8aaceed7964a93800da3a"
 }

--- a/migrations/20260315000001_add_first_healthy_at_to_deployments.sql
+++ b/migrations/20260315000001_add_first_healthy_at_to_deployments.sql
@@ -1,2 +1,7 @@
 ALTER TABLE deployments
 ADD COLUMN first_healthy_at TIMESTAMPTZ;
+
+UPDATE deployments
+SET first_healthy_at = COALESCE(updated_at, created_at, NOW())
+WHERE first_healthy_at IS NULL
+  AND status IN ('Healthy', 'Unhealthy');

--- a/migrations/20260315000001_add_first_healthy_at_to_deployments.sql
+++ b/migrations/20260315000001_add_first_healthy_at_to_deployments.sql
@@ -1,0 +1,2 @@
+ALTER TABLE deployments
+ADD COLUMN first_healthy_at TIMESTAMPTZ;

--- a/src/db/deployments.rs
+++ b/src/db/deployments.rs
@@ -35,6 +35,7 @@ pub async fn list_for_project(pool: &PgPool, project_id: Uuid) -> Result<Vec<Dep
             image, image_digest, rolled_back_from_deployment_id,
             http_port, needs_reconcile, is_active,
             deploying_started_at,
+            first_healthy_at,
             termination_reason as "termination_reason: _",
             created_at, updated_at
         FROM deployments
@@ -68,6 +69,7 @@ pub async fn get_deployments_batch(
             image, image_digest, rolled_back_from_deployment_id,
             http_port, needs_reconcile, is_active,
             deploying_started_at,
+            first_healthy_at,
             termination_reason as "termination_reason: _",
             created_at, updated_at
         FROM deployments
@@ -101,6 +103,7 @@ pub async fn find_by_id(pool: &PgPool, id: Uuid) -> Result<Option<Deployment>> {
             image, image_digest, rolled_back_from_deployment_id,
             http_port, needs_reconcile, is_active,
             deploying_started_at,
+            first_healthy_at,
             termination_reason as "termination_reason: _",
             created_at, updated_at
         FROM deployments
@@ -132,6 +135,7 @@ pub async fn find_by_deployment_id(
             image, image_digest, rolled_back_from_deployment_id,
             http_port, needs_reconcile, is_active,
             deploying_started_at,
+            first_healthy_at,
             termination_reason as "termination_reason: _",
             created_at, updated_at
         FROM deployments
@@ -166,6 +170,7 @@ pub async fn create(pool: &PgPool, params: CreateDeploymentParams<'_>) -> Result
             image, image_digest, rolled_back_from_deployment_id,
             http_port, needs_reconcile, is_active,
             deploying_started_at,
+            first_healthy_at,
             created_at, updated_at
         "#,
         params.deployment_id,
@@ -209,6 +214,7 @@ pub async fn update_status(
             image, image_digest, rolled_back_from_deployment_id,
             http_port, needs_reconcile, is_active,
             deploying_started_at,
+            first_healthy_at,
             termination_reason as "termination_reason: _",
             created_at, updated_at
         FROM deployments
@@ -236,6 +242,10 @@ pub async fn update_status(
             deploying_started_at = CASE
                 WHEN $2 = 'Deploying' AND deploying_started_at IS NULL THEN NOW()
                 ELSE deploying_started_at
+            END,
+            first_healthy_at = CASE
+                WHEN $2 = 'Healthy' AND first_healthy_at IS NULL THEN NOW()
+                ELSE first_healthy_at
             END
         WHERE id = $1
         RETURNING
@@ -247,6 +257,7 @@ pub async fn update_status(
             image, image_digest, rolled_back_from_deployment_id,
             http_port, needs_reconcile, is_active,
             deploying_started_at,
+            first_healthy_at,
             termination_reason as "termination_reason: _",
             created_at, updated_at
         "#,
@@ -288,6 +299,7 @@ pub async fn mark_failed(pool: &PgPool, id: Uuid, error_message: &str) -> Result
             image, image_digest, rolled_back_from_deployment_id,
             http_port, needs_reconcile, is_active,
             deploying_started_at,
+            first_healthy_at,
             termination_reason as "termination_reason: _",
             created_at, updated_at
         "#,
@@ -317,6 +329,7 @@ pub async fn find_non_terminal(pool: &PgPool, limit: i64) -> Result<Vec<Deployme
             image, image_digest, rolled_back_from_deployment_id,
             http_port, needs_reconcile, is_active,
             deploying_started_at,
+            first_healthy_at,
             termination_reason as "termination_reason: _",
             created_at, updated_at
         FROM deployments
@@ -350,6 +363,7 @@ pub async fn find_by_status(pool: &PgPool, status: DeploymentStatus) -> Result<V
             image, image_digest, rolled_back_from_deployment_id,
             http_port, needs_reconcile, is_active,
             deploying_started_at,
+            first_healthy_at,
             termination_reason as "termination_reason: _",
             created_at, updated_at
         FROM deployments
@@ -387,6 +401,7 @@ pub async fn update_controller_metadata(
             image, image_digest, rolled_back_from_deployment_id,
             http_port, needs_reconcile, is_active,
             deploying_started_at,
+            first_healthy_at,
             termination_reason as "termination_reason: _",
             created_at, updated_at
         "#,
@@ -433,6 +448,7 @@ pub async fn mark_cancelled(pool: &PgPool, id: Uuid) -> Result<Deployment> {
             image, image_digest, rolled_back_from_deployment_id,
             http_port, needs_reconcile, is_active,
             deploying_started_at,
+            first_healthy_at,
             created_at, updated_at
         "#,
         id
@@ -467,6 +483,7 @@ pub async fn mark_stopped(pool: &PgPool, id: Uuid) -> Result<Deployment> {
             image, image_digest, rolled_back_from_deployment_id,
             http_port, needs_reconcile, is_active,
             deploying_started_at,
+            first_healthy_at,
             created_at, updated_at
         "#,
         id
@@ -501,6 +518,7 @@ pub async fn mark_superseded(pool: &PgPool, id: Uuid) -> Result<Deployment> {
             image, image_digest, rolled_back_from_deployment_id,
             http_port, needs_reconcile, is_active,
             deploying_started_at,
+            first_healthy_at,
             created_at, updated_at
         "#,
         id
@@ -535,6 +553,7 @@ pub async fn mark_expired(pool: &PgPool, id: Uuid) -> Result<Deployment> {
             image, image_digest, rolled_back_from_deployment_id,
             http_port, needs_reconcile, is_active,
             deploying_started_at,
+            first_healthy_at,
             created_at, updated_at
         "#,
         id
@@ -556,6 +575,7 @@ pub async fn mark_healthy(pool: &PgPool, id: Uuid) -> Result<Deployment> {
         SET
             status = 'Healthy',
             error_message = NULL,
+            first_healthy_at = COALESCE(first_healthy_at, NOW()),
             updated_at = NOW()
         WHERE id = $1
         RETURNING
@@ -568,6 +588,7 @@ pub async fn mark_healthy(pool: &PgPool, id: Uuid) -> Result<Deployment> {
             image, image_digest, rolled_back_from_deployment_id,
             http_port, needs_reconcile, is_active,
             deploying_started_at,
+            first_healthy_at,
             created_at, updated_at
         "#,
         id
@@ -601,6 +622,7 @@ pub async fn mark_unhealthy(pool: &PgPool, id: Uuid, reason: String) -> Result<D
             image, image_digest, rolled_back_from_deployment_id,
             http_port, needs_reconcile, is_active,
             deploying_started_at,
+            first_healthy_at,
             created_at, updated_at
         "#,
         id,
@@ -638,6 +660,7 @@ pub async fn mark_terminating(
             image, image_digest, rolled_back_from_deployment_id,
             http_port, needs_reconcile, is_active,
             deploying_started_at,
+            first_healthy_at,
             created_at, updated_at
         "#,
         id,
@@ -671,6 +694,7 @@ pub async fn mark_cancelling(pool: &PgPool, id: Uuid) -> Result<Deployment> {
             image, image_digest, rolled_back_from_deployment_id,
             http_port, needs_reconcile, is_active,
             deploying_started_at,
+            first_healthy_at,
             created_at, updated_at
         "#,
         id
@@ -730,6 +754,7 @@ pub async fn find_needing_reconcile(pool: &PgPool, limit: i64) -> Result<Vec<Dep
             image, image_digest, rolled_back_from_deployment_id,
             http_port, needs_reconcile, is_active,
             deploying_started_at,
+            first_healthy_at,
             created_at, updated_at
         FROM deployments
         WHERE needs_reconcile = TRUE
@@ -767,6 +792,7 @@ pub async fn find_active_for_project_and_group(
             image, image_digest, rolled_back_from_deployment_id,
             http_port, needs_reconcile, is_active,
             deploying_started_at,
+            first_healthy_at,
             created_at, updated_at
         FROM deployments
         WHERE project_id = $1
@@ -804,6 +830,7 @@ pub async fn find_non_terminal_for_project_and_group(
             image, image_digest, rolled_back_from_deployment_id,
             http_port, needs_reconcile, is_active,
             deploying_started_at,
+            first_healthy_at,
             created_at, updated_at
         FROM deployments
         WHERE project_id = $1
@@ -841,6 +868,7 @@ pub async fn find_active_deployment_for_group(
             image, image_digest, rolled_back_from_deployment_id,
             http_port, needs_reconcile, is_active,
             deploying_started_at,
+            first_healthy_at,
             created_at, updated_at
         FROM deployments
         WHERE project_id = $1
@@ -878,6 +906,7 @@ pub async fn find_last_for_project_and_group(
             image, image_digest, rolled_back_from_deployment_id,
             http_port, needs_reconcile, is_active,
             deploying_started_at,
+            first_healthy_at,
             created_at, updated_at
         FROM deployments
         WHERE project_id = $1
@@ -911,6 +940,7 @@ pub async fn find_expired(pool: &PgPool, limit: i64) -> Result<Vec<Deployment>> 
             image, image_digest, rolled_back_from_deployment_id,
             http_port, needs_reconcile, is_active,
             deploying_started_at,
+            first_healthy_at,
             created_at, updated_at
         FROM deployments
         WHERE expires_at IS NOT NULL
@@ -953,6 +983,7 @@ pub async fn list_for_project_and_group(
                 image, image_digest, rolled_back_from_deployment_id,
                 http_port, needs_reconcile, is_active,
                 deploying_started_at,
+                first_healthy_at,
                 created_at, updated_at
             FROM deployments
             WHERE project_id = $1 AND deployment_group = $2
@@ -981,6 +1012,7 @@ pub async fn list_for_project_and_group(
                 image, image_digest, rolled_back_from_deployment_id,
                 http_port, needs_reconcile, is_active,
                 deploying_started_at,
+                first_healthy_at,
                 created_at, updated_at
             FROM deployments
             WHERE project_id = $1
@@ -1134,6 +1166,7 @@ pub async fn get_active_deployments_for_project(
             image, image_digest, rolled_back_from_deployment_id,
             http_port, needs_reconcile, is_active,
             deploying_started_at,
+            first_healthy_at,
             termination_reason as "termination_reason: _",
             created_at, updated_at
         FROM deployments
@@ -1168,6 +1201,7 @@ pub async fn find_stuck_pre_pushed_before(
             image, image_digest, rolled_back_from_deployment_id,
             http_port, needs_reconcile, is_active,
             deploying_started_at,
+            first_healthy_at,
             termination_reason as "termination_reason: _",
             created_at, updated_at
         FROM deployments
@@ -1464,5 +1498,69 @@ mod tests {
 
         // Verify deploying_started_at remains unchanged across valid non-Deploying transitions
         assert_eq!(deployment.deploying_started_at, Some(first_timestamp));
+    }
+
+    #[cfg(feature = "backend")]
+    #[sqlx::test]
+    async fn first_healthy_at_set_once_on_healthy_transition(pool: PgPool) {
+        use uuid::Uuid;
+
+        let project_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+
+        sqlx::query!(
+            "INSERT INTO users (id, email) VALUES ($1, $2)",
+            user_id,
+            "test@example.com"
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query!(
+            "INSERT INTO projects (id, name, owner_user_id, access_class, status) VALUES ($1, $2, $3, $4, $5)",
+            project_id,
+            "test-project",
+            user_id,
+            "public",
+            "Stopped"
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let deployment = create(
+            &pool,
+            CreateDeploymentParams {
+                deployment_id: "test-deploy",
+                project_id,
+                created_by_id: user_id,
+                status: DeploymentStatus::Deploying,
+                image: None,
+                image_digest: None,
+                rolled_back_from_deployment_id: None,
+                deployment_group: "default",
+                expires_at: None,
+                http_port: 8080,
+                is_active: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(deployment.first_healthy_at.is_none());
+
+        let deployment = mark_healthy(&pool, deployment.id).await.unwrap();
+        let first_healthy_at = deployment.first_healthy_at.unwrap();
+
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        let deployment = mark_unhealthy(&pool, deployment.id, "temporary failure".to_string())
+            .await
+            .unwrap();
+        assert_eq!(deployment.first_healthy_at, Some(first_healthy_at));
+
+        let deployment = mark_healthy(&pool, deployment.id).await.unwrap();
+        assert_eq!(deployment.first_healthy_at, Some(first_healthy_at));
     }
 }

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -129,6 +129,7 @@ pub struct Deployment {
     pub needs_reconcile: bool,
     pub is_active: bool,
     pub deploying_started_at: Option<DateTime<Utc>>,
+    pub first_healthy_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }

--- a/src/server/deployment/controller/kubernetes.rs
+++ b/src/server/deployment/controller/kubernetes.rs
@@ -5329,6 +5329,7 @@ mod tests {
             needs_reconcile: false,
             is_active: false,
             deploying_started_at: None,
+            first_healthy_at: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         }
@@ -5501,6 +5502,7 @@ mod tests {
             needs_reconcile: false,
             is_active: false,
             deploying_started_at: None,
+            first_healthy_at: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -5572,6 +5574,7 @@ mod tests {
             needs_reconcile: false,
             is_active: false,
             deploying_started_at: None,
+            first_healthy_at: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -5625,6 +5628,7 @@ mod tests {
             needs_reconcile: false,
             is_active: false,
             deploying_started_at: None,
+            first_healthy_at: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -5710,6 +5714,7 @@ mod tests {
             needs_reconcile: false,
             is_active: false,
             deploying_started_at: None,
+            first_healthy_at: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -5815,6 +5820,7 @@ mod tests {
             needs_reconcile: false,
             is_active: false,
             deploying_started_at: None,
+            first_healthy_at: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -5969,6 +5975,7 @@ mod tests {
             needs_reconcile: false,
             is_active: false,
             deploying_started_at: None,
+            first_healthy_at: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };

--- a/src/server/deployment/controller/kubernetes.rs
+++ b/src/server/deployment/controller/kubernetes.rs
@@ -97,6 +97,14 @@ fn truncate_optional_text(input: Option<String>, max_chars: usize) -> Option<Str
     input.map(|text| truncate_text(&text, max_chars))
 }
 
+fn reconcile_in_progress_status(deployment: &Deployment) -> DeploymentStatus {
+    if deployment.first_healthy_at.is_some() {
+        DeploymentStatus::Unhealthy
+    } else {
+        DeploymentStatus::Deploying
+    }
+}
+
 /// Kubernetes-specific metadata stored in deployment.controller_metadata
 #[derive(Serialize, Deserialize, Default, Clone)]
 struct KubernetesMetadata {
@@ -3367,12 +3375,8 @@ impl DeploymentBackend for KubernetesController {
             deployment.deployment_id, deployment.status, metadata.reconcile_phase
         );
 
-        // Determine status (preserve Unhealthy during recovery, otherwise Deploying)
-        let status = if deployment.status == DeploymentStatus::Unhealthy {
-            DeploymentStatus::Unhealthy
-        } else {
-            DeploymentStatus::Deploying
-        };
+        // Once a deployment has been healthy, recovery/recreate progress must stay post-deploy.
+        let status = reconcile_in_progress_status(deployment);
 
         // Recovery logic: If deployment is Unhealthy and Deployment is missing, reset to recreate it
         if deployment.status == DeploymentStatus::Unhealthy
@@ -4436,7 +4440,7 @@ impl DeploymentBackend for KubernetesController {
                             .await?;
 
                             return Ok(ReconcileResult {
-                                status: DeploymentStatus::Deploying,
+                                status,
                                 controller_metadata: serde_json::to_value(&metadata)?,
                                 error_message: None,
                             });
@@ -5980,6 +5984,28 @@ mod tests {
             updated_at: chrono::Utc::now(),
         };
         (project, deployment)
+    }
+
+    #[test]
+    fn reconcile_in_progress_status_stays_post_deploy_after_first_healthy() {
+        let (_, mut deployment) = create_test_project_and_deployment();
+        deployment.status = DeploymentStatus::Healthy;
+        deployment.first_healthy_at = Some(Utc::now());
+
+        assert_eq!(
+            reconcile_in_progress_status(&deployment),
+            DeploymentStatus::Unhealthy
+        );
+    }
+
+    #[test]
+    fn reconcile_in_progress_status_uses_deploying_before_first_healthy() {
+        let (_, deployment) = create_test_project_and_deployment();
+
+        assert_eq!(
+            reconcile_in_progress_status(&deployment),
+            DeploymentStatus::Deploying
+        );
     }
 
     #[tokio::test]

--- a/src/server/deployment/controller/mod.rs
+++ b/src/server/deployment/controller/mod.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 use tokio::time::interval;
 use tracing::{debug, error, info, warn};
 
-use crate::db::models::{Deployment, DeploymentStatus, Project};
+use crate::db::models::{Deployment, DeploymentStatus, Project, TerminationReason};
 use crate::db::{deployments as db_deployments, projects};
 use crate::server::deployment::state_machine;
 use crate::server::state::ControllerState;
@@ -29,6 +29,30 @@ pub struct HealthStatus {
     pub message: Option<String>,
     pub last_check: DateTime<Utc>,
     pub pod_status: Option<serde_json::Value>,
+}
+
+fn has_been_healthy(deployment: &Deployment) -> bool {
+    deployment.first_healthy_at.is_some()
+}
+
+fn normalize_reconcile_result_for_recovery(
+    deployment: &Deployment,
+    mut result: ReconcileResult,
+) -> ReconcileResult {
+    if has_been_healthy(deployment) && result.status == DeploymentStatus::Failed {
+        warn!(
+            "Deployment {} was healthy before; preserving it as Unhealthy instead of auto-failing",
+            deployment.deployment_id
+        );
+        result.status = DeploymentStatus::Unhealthy;
+    }
+
+    result
+}
+
+fn should_queue_failed_cleanup(deployment: &Deployment) -> bool {
+    deployment.termination_reason != Some(TerminationReason::Failed)
+        && !has_been_healthy(deployment)
 }
 
 /// URLs where a deployment can be accessed
@@ -353,7 +377,10 @@ impl DeploymentController {
             .ok_or_else(|| anyhow::anyhow!("Project not found"))?;
 
         // Call backend reconcile
-        let result = self.backend.reconcile(&deployment, &project).await?;
+        let result = normalize_reconcile_result_for_recovery(
+            &deployment,
+            self.backend.reconcile(&deployment, &project).await?,
+        );
 
         // Store status for later comparison
         let new_status = result.status.clone();
@@ -381,7 +408,11 @@ impl DeploymentController {
         .await?;
 
         if let Some(error) = result.error_message {
-            db_deployments::mark_failed(&self.state.db_pool, deployment.id, &error).await?;
+            if new_status == DeploymentStatus::Failed {
+                db_deployments::mark_failed(&self.state.db_pool, deployment.id, &error).await?;
+            } else if new_status == DeploymentStatus::Unhealthy {
+                db_deployments::mark_unhealthy(&self.state.db_pool, deployment.id, error).await?;
+            }
         } else if new_status == DeploymentStatus::Healthy {
             // Find active deployment IN THIS GROUP *before* marking new as Healthy
             // This prevents a race condition where the query would return the new deployment
@@ -717,11 +748,7 @@ impl DeploymentController {
             db_deployments::find_by_status(&self.state.db_pool, DeploymentStatus::Failed).await?;
 
         for deployment in failed {
-            // Failed deployments that already came through termination have this reason set.
-            if matches!(
-                deployment.termination_reason,
-                Some(crate::db::models::TerminationReason::Failed)
-            ) {
+            if !should_queue_failed_cleanup(&deployment) {
                 continue;
             }
 
@@ -885,5 +912,64 @@ impl DeploymentController {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    fn sample_deployment(first_healthy_at: Option<DateTime<Utc>>) -> Deployment {
+        Deployment {
+            id: Uuid::new_v4(),
+            deployment_id: "deploy-123".to_string(),
+            project_id: Uuid::new_v4(),
+            created_by_id: Uuid::new_v4(),
+            status: DeploymentStatus::Unhealthy,
+            deployment_group: "default".to_string(),
+            expires_at: None,
+            termination_reason: None,
+            completed_at: None,
+            error_message: None,
+            build_logs: None,
+            controller_metadata: serde_json::json!({}),
+            image: None,
+            image_digest: None,
+            rolled_back_from_deployment_id: None,
+            http_port: 8080,
+            needs_reconcile: false,
+            is_active: false,
+            deploying_started_at: None,
+            first_healthy_at,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn normalize_reconcile_result_keeps_previously_healthy_deployments_recoverable() {
+        let deployment = sample_deployment(Some(Utc::now()));
+        let result = normalize_reconcile_result_for_recovery(
+            &deployment,
+            ReconcileResult {
+                status: DeploymentStatus::Failed,
+                controller_metadata: serde_json::json!({}),
+                error_message: Some("pod crash loop".to_string()),
+            },
+        );
+
+        assert_eq!(result.status, DeploymentStatus::Unhealthy);
+        assert_eq!(result.error_message.as_deref(), Some("pod crash loop"));
+    }
+
+    #[test]
+    fn failed_cleanup_only_queues_never_healthy_deployments() {
+        let never_healthy = sample_deployment(None);
+        let previously_healthy = sample_deployment(Some(Utc::now()));
+
+        assert!(should_queue_failed_cleanup(&never_healthy));
+        assert!(!should_queue_failed_cleanup(&previously_healthy));
     }
 }

--- a/src/server/deployment/controller/mod.rs
+++ b/src/server/deployment/controller/mod.rs
@@ -39,7 +39,10 @@ fn normalize_reconcile_result_for_recovery(
     deployment: &Deployment,
     mut result: ReconcileResult,
 ) -> ReconcileResult {
-    if has_been_healthy(deployment) && result.status == DeploymentStatus::Failed {
+    if has_been_healthy(deployment)
+        && result.status == DeploymentStatus::Failed
+        && state_machine::is_valid_transition(&deployment.status, &DeploymentStatus::Unhealthy)
+    {
         warn!(
             "Deployment {} was healthy before; preserving it as Unhealthy instead of auto-failing",
             deployment.deployment_id
@@ -921,13 +924,16 @@ mod tests {
     use chrono::Utc;
     use uuid::Uuid;
 
-    fn sample_deployment(first_healthy_at: Option<DateTime<Utc>>) -> Deployment {
+    fn sample_deployment(
+        status: DeploymentStatus,
+        first_healthy_at: Option<DateTime<Utc>>,
+    ) -> Deployment {
         Deployment {
             id: Uuid::new_v4(),
             deployment_id: "deploy-123".to_string(),
             project_id: Uuid::new_v4(),
             created_by_id: Uuid::new_v4(),
-            status: DeploymentStatus::Unhealthy,
+            status,
             deployment_group: "default".to_string(),
             expires_at: None,
             termination_reason: None,
@@ -950,7 +956,7 @@ mod tests {
 
     #[test]
     fn normalize_reconcile_result_keeps_previously_healthy_deployments_recoverable() {
-        let deployment = sample_deployment(Some(Utc::now()));
+        let deployment = sample_deployment(DeploymentStatus::Healthy, Some(Utc::now()));
         let result = normalize_reconcile_result_for_recovery(
             &deployment,
             ReconcileResult {
@@ -965,9 +971,25 @@ mod tests {
     }
 
     #[test]
+    fn normalize_reconcile_result_preserves_failed_during_recreated_deployments() {
+        let deployment = sample_deployment(DeploymentStatus::Deploying, Some(Utc::now()));
+        let result = normalize_reconcile_result_for_recovery(
+            &deployment,
+            ReconcileResult {
+                status: DeploymentStatus::Failed,
+                controller_metadata: serde_json::json!({}),
+                error_message: Some("image pull backoff".to_string()),
+            },
+        );
+
+        assert_eq!(result.status, DeploymentStatus::Failed);
+        assert_eq!(result.error_message.as_deref(), Some("image pull backoff"));
+    }
+
+    #[test]
     fn failed_cleanup_only_queues_never_healthy_deployments() {
-        let never_healthy = sample_deployment(None);
-        let previously_healthy = sample_deployment(Some(Utc::now()));
+        let never_healthy = sample_deployment(DeploymentStatus::Failed, None);
+        let previously_healthy = sample_deployment(DeploymentStatus::Failed, Some(Utc::now()));
 
         assert!(should_queue_failed_cleanup(&never_healthy));
         assert!(!should_queue_failed_cleanup(&previously_healthy));

--- a/src/server/deployment/controller/mod.rs
+++ b/src/server/deployment/controller/mod.rs
@@ -55,7 +55,6 @@ fn normalize_reconcile_result_for_recovery(
 
 fn should_queue_failed_cleanup(deployment: &Deployment) -> bool {
     deployment.termination_reason != Some(TerminationReason::Failed)
-        && !has_been_healthy(deployment)
 }
 
 /// URLs where a deployment can be accessed
@@ -971,7 +970,7 @@ mod tests {
     }
 
     #[test]
-    fn normalize_reconcile_result_preserves_failed_during_recreated_deployments() {
+    fn normalize_reconcile_result_preserves_failed_for_invalid_transition_states() {
         let deployment = sample_deployment(DeploymentStatus::Deploying, Some(Utc::now()));
         let result = normalize_reconcile_result_for_recovery(
             &deployment,
@@ -987,11 +986,11 @@ mod tests {
     }
 
     #[test]
-    fn failed_cleanup_only_queues_never_healthy_deployments() {
+    fn failed_cleanup_queues_deployments_regardless_of_health_history() {
         let never_healthy = sample_deployment(DeploymentStatus::Failed, None);
         let previously_healthy = sample_deployment(DeploymentStatus::Failed, Some(Utc::now()));
 
         assert!(should_queue_failed_cleanup(&never_healthy));
-        assert!(!should_queue_failed_cleanup(&previously_healthy));
+        assert!(should_queue_failed_cleanup(&previously_healthy));
     }
 }


### PR DESCRIPTION
## Summary
- track when a deployment first becomes healthy
- keep previously healthy deployments recoverable by downgrading later fatal reconcile results to Unhealthy
- skip automatic failed cleanup for deployments that were healthy before and refresh the SQLx cache

Fixes #174

## Verification
- cargo fmt --all
- DATABASE_URL=postgres://rise:rise123@localhost:5432/rise cargo sqlx migrate run
- DATABASE_URL=postgres://rise:rise123@localhost:5432/rise cargo sqlx prepare -- --features cli,backend --all-targets
- SQLX_OFFLINE=true cargo test --features cli,backend --no-run
- cargo test --features cli,backend normalize_reconcile_result_keeps_previously_healthy_deployments_recoverable -- --nocapture
- cargo test --features cli,backend failed_cleanup_only_queues_never_healthy_deployments -- --nocapture
- cargo test --features cli,backend first_healthy_at_set_once_on_healthy_transition -- --nocapture