### PR TITLE
fix: retry startup log streams and widen rollback sources

### DIFF
--- a/frontend/src/features/deployments.tsx
+++ b/frontend/src/features/deployments.tsx
@@ -326,8 +326,8 @@ export function DeploymentsList({ projectName }) {
         return ['Cancelled', 'Stopped', 'Superseded', 'Failed', 'Expired'].includes(status);
     };
 
-    const isRollbackable = (status) => {
-        return ['Healthy', 'Superseded'].includes(status);
+    const isRollbackable = (deployment) => {
+        return Boolean(deployment?.can_rollback);
     };
 
     const handleStopClick = (deployment) => {
@@ -482,7 +482,7 @@ export function DeploymentsList({ projectName }) {
                                         </MonoTd>
                                         <MonoTd className="px-6 py-4 whitespace-nowrap text-sm">
                                             <div className="mono-table-action-slot">
-                                                {isRollbackable(d.status) && (
+                                                {isRollbackable(d) && (
                                                     <Button
                                                         variant="primary"
                                                         size="sm"
@@ -1349,7 +1349,7 @@ export function DeploymentDetail({ projectName, deploymentId }) {
     return (
         <section>
             <div className="flex justify-end items-center mb-4">
-                {(deployment.status === 'Healthy' || deployment.status === 'Superseded') && (
+                {deployment.can_rollback && (
                     <Button
                         variant="secondary"
                         size="sm"

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -97,6 +97,8 @@ mod client_models {
         #[serde(default)]
         pub http_port: u16,
         #[serde(default)]
+        pub can_rollback: bool,
+        #[serde(default)]
         pub created: String,
         #[serde(default)]
         pub updated: String,

--- a/src/cli/deployment/follow_ui.rs
+++ b/src/cli/deployment/follow_ui.rs
@@ -434,6 +434,9 @@ async fn stream_logs_with_status_polling(
     // Try initial connection
     match open_log_stream(http_client, backend_url, token, project, deployment_id, 100).await {
         Ok(s) => log_stream = Some(s),
+        Err(LogStreamError::NotReady) => {
+            debug!("Initial log stream connection deferred: deployment logs are not ready yet");
+        }
         Err(LogStreamError::Gone) => {
             return fetch_deployment(http_client, backend_url, token, project, deployment_id).await;
         }
@@ -494,7 +497,6 @@ async fn stream_logs_with_status_polling(
 
             tokio::select! {
                 _ = tokio::time::sleep(RETRY_DELAY) => {
-                    retry_count += 1;
                     match open_log_stream(
                         http_client, backend_url, token, project, deployment_id, 100,
                     ).await {
@@ -502,12 +504,16 @@ async fn stream_logs_with_status_polling(
                             log_stream = Some(s);
                             retry_count = 0;
                         }
+                        Err(LogStreamError::NotReady) => {
+                            debug!("Log stream not ready yet; will retry");
+                        }
                         Err(LogStreamError::Gone) => {
                             return fetch_deployment(
                                 http_client, backend_url, token, project, deployment_id,
                             ).await;
                         }
                         Err(e) => {
+                            retry_count += 1;
                             debug!("Log stream reconnect failed (attempt {}): {:?}", retry_count, e);
                         }
                     }

--- a/src/server/deployment/handlers.rs
+++ b/src/server/deployment/handlers.rs
@@ -347,6 +347,7 @@ async fn convert_deployment(
     } else {
         Some(super::utils::get_deployment_image_tag(state, &deployment, project).await)
     };
+    let can_rollback = state_machine::can_create_from(&deployment);
 
     Deployment {
         id: deployment.id.to_string(),
@@ -367,6 +368,7 @@ async fn convert_deployment(
         image_digest: deployment.image_digest,
         http_port: deployment.http_port as u16,
         is_active: deployment.is_active,
+        can_rollback,
         created: deployment.created_at.to_rfc3339(),
         updated: deployment.updated_at.to_rfc3339(),
     }
@@ -547,10 +549,15 @@ pub async fn create_deployment(
             )
         })?;
 
-        // Verify source deployment is in a valid state for creating from
-        // Allow Healthy (currently active), Superseded (previously active), and Stopped
-        if !state_machine::is_rollbackable(&source_deployment.status) {
-            return Err((StatusCode::BAD_REQUEST, format!("Cannot create deployment from '{}' with status '{:?}'. Only Healthy, Superseded, or Stopped deployments can be used as source.", from_deployment_id, source_deployment.status)));
+        // Verify the source deployment already has a reusable image.
+        if !state_machine::can_create_from(&source_deployment) {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                format!(
+                    "Cannot create deployment from '{}' because its image is not available yet (status '{}').",
+                    from_deployment_id, source_deployment.status
+                ),
+            ));
         }
 
         // For chained redeployments, follow the chain to find the original source
@@ -1769,7 +1776,12 @@ pub async fn stream_deployment_logs(
         .await
         .map_err(|e| {
             let error_msg = e.to_string();
-            if error_msg.contains("Pod not found") || error_msg.contains("not ready yet") {
+            if error_msg.contains("Pod not found")
+                || error_msg.contains("not ready yet")
+                || error_msg.contains("waiting to start")
+                || error_msg.contains("ContainerCreating")
+                || error_msg.contains("PodInitializing")
+            {
                 (
                     StatusCode::SERVICE_UNAVAILABLE,
                     "Deployment pod not ready yet. Please try again in a moment.".to_string(),

--- a/src/server/deployment/models.rs
+++ b/src/server/deployment/models.rs
@@ -85,6 +85,8 @@ pub struct Deployment {
     #[serde(default)]
     pub is_active: bool,
     #[serde(default)]
+    pub can_rollback: bool,
+    #[serde(default)]
     pub created: String,
     #[serde(default)]
     pub updated: String,

--- a/src/server/deployment/state_machine.rs
+++ b/src/server/deployment/state_machine.rs
@@ -1,4 +1,4 @@
-use crate::db::models::DeploymentStatus;
+use crate::db::models::{Deployment, DeploymentStatus};
 use anyhow::{bail, Result};
 
 /// Check if a deployment status is terminal (no further transitions allowed)
@@ -45,13 +45,36 @@ pub fn is_terminable(status: &DeploymentStatus) -> bool {
     )
 }
 
-/// Check if a deployment can be used as a rollback source
-/// Only Healthy and Superseded deployments can be rolled back to
-pub fn is_rollbackable(status: &DeploymentStatus) -> bool {
+/// Check if a deployment can be used as the source for a new rollback/redeploy.
+///
+/// A deployment is reusable once its image is known to be available:
+/// - digest-pinned images are reusable immediately
+/// - rollback deployments are reusable because they point at an earlier image
+/// - locally built images become reusable once they reached `Pushed`
+/// - failed/cancelled deployments are reusable only after rollout actually started
+pub fn can_create_from(deployment: &Deployment) -> bool {
+    if deployment.image_digest.is_some() || deployment.rolled_back_from_deployment_id.is_some() {
+        return true;
+    }
+
+    if matches!(
+        deployment.status,
+        DeploymentStatus::Pushed
+            | DeploymentStatus::Deploying
+            | DeploymentStatus::Healthy
+            | DeploymentStatus::Unhealthy
+            | DeploymentStatus::Terminating
+            | DeploymentStatus::Stopped
+            | DeploymentStatus::Superseded
+            | DeploymentStatus::Expired
+    ) {
+        return true;
+    }
+
     matches!(
-        status,
-        DeploymentStatus::Healthy | DeploymentStatus::Superseded
-    )
+        deployment.status,
+        DeploymentStatus::Cancelling | DeploymentStatus::Cancelled | DeploymentStatus::Failed
+    ) && deployment.deploying_started_at.is_some()
 }
 
 /// Check if a state transition is valid
@@ -114,7 +137,35 @@ pub fn validate_transition(from: &DeploymentStatus, to: &DeploymentStatus) -> Re
 #[cfg(test)]
 mod tests {
     use super::*;
+    use uuid::Uuid;
     use DeploymentStatus::*;
+
+    fn deployment(status: DeploymentStatus) -> Deployment {
+        Deployment {
+            id: Uuid::nil(),
+            deployment_id: "20260315-000000".to_string(),
+            project_id: Uuid::nil(),
+            created_by_id: Uuid::nil(),
+            status,
+            deployment_group: "default".to_string(),
+            expires_at: None,
+            termination_reason: None,
+            completed_at: None,
+            error_message: None,
+            build_logs: None,
+            controller_metadata: serde_json::Value::Null,
+            image: None,
+            image_digest: None,
+            rolled_back_from_deployment_id: None,
+            http_port: 8080,
+            needs_reconcile: false,
+            is_active: false,
+            deploying_started_at: None,
+            first_healthy_at: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
 
     #[test]
     fn test_terminal_states() {
@@ -157,6 +208,46 @@ mod tests {
 
         assert!(!is_terminable(&Deploying));
         assert!(!is_terminable(&Stopped));
+    }
+
+    #[test]
+    fn test_can_create_from_when_image_is_known_available() {
+        assert!(can_create_from(&deployment(Pushed)));
+        assert!(can_create_from(&deployment(Healthy)));
+        assert!(can_create_from(&deployment(Stopped)));
+        assert!(can_create_from(&deployment(Superseded)));
+    }
+
+    #[test]
+    fn test_can_create_from_rejects_pre_push_states_without_image() {
+        assert!(!can_create_from(&deployment(Pending)));
+        assert!(!can_create_from(&deployment(Building)));
+        assert!(!can_create_from(&deployment(Pushing)));
+    }
+
+    #[test]
+    fn test_can_create_from_requires_rollout_for_failed_or_cancelled_builds() {
+        let failed_before_rollout = deployment(Failed);
+        assert!(!can_create_from(&failed_before_rollout));
+
+        let mut failed_after_rollout = deployment(Failed);
+        failed_after_rollout.deploying_started_at = Some(chrono::Utc::now());
+        assert!(can_create_from(&failed_after_rollout));
+
+        let mut cancelled_after_rollout = deployment(Cancelled);
+        cancelled_after_rollout.deploying_started_at = Some(chrono::Utc::now());
+        assert!(can_create_from(&cancelled_after_rollout));
+    }
+
+    #[test]
+    fn test_can_create_from_allows_digest_and_rollback_sources_immediately() {
+        let mut digest_pinned = deployment(Pending);
+        digest_pinned.image_digest = Some("registry.example/app@sha256:abc".to_string());
+        assert!(can_create_from(&digest_pinned));
+
+        let mut rollback_source = deployment(Failed);
+        rollback_source.rolled_back_from_deployment_id = Some(Uuid::new_v4());
+        assert!(can_create_from(&rollback_source));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- keep retrying deployment log streaming while pods are still starting instead of falling back early to status-only polling
- return retryable log-stream responses from the backend when Kubernetes reports ContainerCreating or similar startup states
- allow rollback/redeploy actions for any deployment whose image is already reusable, and drive the UI from that API flag

## Testing
- cargo test
- npm run typecheck

Co-authored-by: Codex <codex@openai.com>