### PR TITLE
feat: runtime env vars on deploy + rename build-time flags

### DIFF
--- a/.sqlx/query-6723a084174e8bff5782dd9224fcc7cab8e3ffac62ad5a08f24ededfe0e7a48a.json
+++ b/.sqlx/query-6723a084174e8bff5782dd9224fcc7cab8e3ffac62ad5a08f24ededfe0e7a48a.json
@@ -1,0 +1,65 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, deployment_id, key, value, is_secret, is_protected, created_at, updated_at\n        FROM deployment_env_vars\n        WHERE deployment_id = $1 AND key = $2\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "deployment_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "key",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "value",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "is_secret",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 5,
+        "name": "is_protected",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "6723a084174e8bff5782dd9224fcc7cab8e3ffac62ad5a08f24ededfe0e7a48a"
+}

--- a/docs/user-guide/builds.md
+++ b/docs/user-guide/builds.md
@@ -149,19 +149,19 @@ If builds fail with the error `requested experimental feature mergeop has been d
 docker buildx create --use
 ```
 
-## Build-Time Environment Variables
+## Build-Time Arguments
 
-Pass variables to the build process with `-e`:
+Pass build arguments with `-b` / `--build-arg`:
 
 ```bash
-rise build myapp:latest -e NODE_ENV=production -e BUILD_VERSION=1.2.3
+rise build myapp:latest -b NODE_ENV=production -b BUILD_VERSION=1.2.3
 ```
 
 Or in `rise.toml`:
 
 ```toml
 [build]
-env = ["NODE_ENV=production", "BUILD_VERSION"]
+args = ["NODE_ENV=production", "BUILD_VERSION"]
 ```
 
 Using `KEY` without `=VALUE` reads the variable from your shell environment (useful for CI metadata like git SHAs).
@@ -172,7 +172,7 @@ Using `KEY` without `=VALUE` reads the variable from your shell environment (use
 - **Pack**: Passed as `--env` to pack CLI
 - **Railpack**: Passed as BuildKit secrets
 
-Build-time variables are for build configuration only (compiler flags, tool versions). For runtime secrets, use `rise env set --secret`. See [Environment Variables](environment-variables.md) for the distinction.
+Build args are for build configuration only (compiler flags, tool versions). For runtime variables, use `-e` / `--env` on `rise deploy`, or `rise env set`. See [Environment Variables](environment-variables.md) for the distinction.
 
 ## Build Cache Control
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -31,7 +31,7 @@ LOG_LEVEL = "info"
 [build]
 backend = "docker"
 dockerfile = "Dockerfile.prod"
-env = ["NODE_ENV=production", "BUILD_VERSION"]
+args = ["NODE_ENV=production", "BUILD_VERSION"]
 ```
 
 | Field | Type | Description |
@@ -42,7 +42,7 @@ env = ["NODE_ENV=production", "BUILD_VERSION"]
 | `build_contexts` | Object | Named build contexts for multi-stage Docker builds (format: `{ "name" = "path" }`) |
 | `builder` | String | Buildpack builder image (pack backend only) |
 | `buildpacks` | Array | Buildpacks to use (pack backend only) |
-| `env` | Array | Build-time environment variables (format: `KEY=VALUE` or `KEY` to read from shell) |
+| `args` | Array | Build-time arguments (format: `KEY=VALUE` or `KEY` to read from shell). Alias: `env` for backward compat. |
 | `container_cli` | String | Container CLI: `docker` or `podman` |
 | `managed_buildkit` | Boolean | Enable/disable managed BuildKit daemon (auto-enables when `SSL_CERT_FILE` is set) |
 | `no_cache` | Boolean | Disable build cache |
@@ -63,7 +63,7 @@ APP_MODE = "production"
 backend = "pack"
 builder = "heroku/builder:24"
 buildpacks = ["heroku/nodejs", "heroku/procfile"]
-env = ["BP_NODE_VERSION=20"]
+args = ["BP_NODE_VERSION=20"]
 ```
 
 ## Project Creation Modes
@@ -106,7 +106,7 @@ Settings are resolved in this order (highest to lowest priority):
 4. **Global config** (`~/.config/rise/config.json`)
 5. **Auto-detection / defaults**
 
-For array fields (`buildpacks`, `env`), CLI values are **appended** to config file values rather than replacing them.
+For array fields (`buildpacks`, `args`), CLI values are **appended** to config file values rather than replacing them.
 
 ## Global CLI Config
 

--- a/docs/user-guide/environment-variables.md
+++ b/docs/user-guide/environment-variables.md
@@ -89,17 +89,37 @@ Rise automatically injects these variables into every deployment:
 
 `PORT` defaults to 8080. Override it per-deployment with `--http-port` on `rise deploy`, or set it permanently with `rise env set my-app PORT 3000`.
 
+## Deploy-Time Environment Overrides
+
+You can pass runtime environment variables directly when deploying:
+
+```bash
+# Plain text variable
+rise deploy -e DATABASE_URL=postgres://user:pass@db/mydb
+
+# Secret variable (encrypted, retrievable via `rise env get`)
+rise deploy --secret-env API_KEY=sk-xxx
+
+# Protected secret (encrypted, NOT retrievable)
+rise deploy --protected-env MASTER_KEY=xxx
+
+# From a file (same format as `rise env import`)
+rise deploy --env-file .env.production
+```
+
+These overrides are applied after copying project env vars, so they take precedence over existing values. They are stored as deployment-level env vars.
+
 ## Build-Time vs Runtime Variables
 
 | Aspect | Build-Time | Runtime |
 |--------|-----------|---------|
 | **Purpose** | Configure build process (compiler flags, tool versions) | Configure running application |
-| **Set via** | `-e` flag or `[build] env` in `rise.toml` | `rise env set` |
+| **Set via** | `-b` / `--build-arg` flag or `[build] args` in `rise.toml` | `rise env set`, or `-e` / `--env` on deploy |
 | **Available during** | Image build only | Container runtime |
 | **Storage** | Ephemeral (not persisted) | Database (encrypted for secrets) |
 | **Examples** | `NODE_ENV`, `BUILD_VERSION` | `DATABASE_URL`, `API_KEY` |
 
-See [Building Images](builds.md#build-time-environment-variables) for build-time variable details.
+See [Building Images](builds.md#build-time-arguments) for build-time variable details.
 
 ## Variables in rise.toml
 

--- a/docs/user-guide/local-development.md
+++ b/docs/user-guide/local-development.md
@@ -50,10 +50,10 @@ For OAuth extension support during local development, see [OAuth — Local Devel
 Set or override environment variables for the local run:
 
 ```bash
-rise run --run-env DATABASE_URL=postgres://localhost/mydb --run-env DEBUG=true
+rise run -e DATABASE_URL=postgres://localhost/mydb -e DEBUG=true
 ```
 
-`--run-env` values take precedence over project environment variables.
+`--env` / `-e` values take precedence over project environment variables.
 
 ## Build Backend Selection
 

--- a/example/hello-world-js/rise.toml
+++ b/example/hello-world-js/rise.toml
@@ -7,7 +7,7 @@ custom_domains = []
 
 [project.env]
 
-# Build-time environment variables (optional)
+# Build-time arguments (optional)
 # These are passed to the build process and can configure build behavior
 # Uncomment to configure Node.js version and npm version:
 # [build]

--- a/example/hello-world/rise.toml
+++ b/example/hello-world/rise.toml
@@ -7,8 +7,8 @@ custom_domains = []
 
 [project.env]
 
-# Build-time environment variables (optional)
+# Build-time arguments (optional)
 # These are passed to the build process and can configure build behavior
 # Uncomment to use:
 # [build]
-# env = ["BUILD_VERSION=1.0.0", "NODE_ENV=production"]
+# args = ["BUILD_VERSION=1.0.0", "NODE_ENV=production"]

--- a/frontend/src/features/resources.tsx
+++ b/frontend/src/features/resources.tsx
@@ -818,7 +818,9 @@ export function EnvVarsList({ projectName, deploymentId }) {
                                             <button
                                                 onClick={async () => {
                                                     try {
-                                                        const response = await api.getEnvVarValue(projectName, env.key);
+                                                        const response = deploymentId
+                                                            ? await api.getDeploymentEnvVarValue(projectName, deploymentId, env.key)
+                                                            : await api.getEnvVarValue(projectName, env.key);
                                                         await copyToClipboard(response.value);
                                                         showToast('Secret copied to clipboard!', 'success');
                                                     } catch (err) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -204,6 +204,12 @@ class RiseAPI {
         return this.request(`/projects/${projectName}/env/${encodeURIComponent(key)}/value`);
     }
 
+    async getDeploymentEnvVarValue(projectName, deploymentId, key) {
+        return this.request(
+            `/projects/${projectName}/deployments/${deploymentId}/env/${encodeURIComponent(key)}/value`
+        );
+    }
+
     async deleteEnvVar(projectName, key) {
         return this.request(`/projects/${projectName}/env/${encodeURIComponent(key)}`, {
             method: 'DELETE'

--- a/src/build/config.rs
+++ b/src/build/config.rs
@@ -56,9 +56,10 @@ pub struct BuildConfig {
     /// Buildpack(s) to use (only for pack backend)
     pub buildpacks: Option<Vec<String>>,
 
-    /// Environment variables to pass to the build
+    /// Build arguments to pass to the build
     /// Format: KEY=VALUE or KEY (to pass from environment)
-    pub env: Option<Vec<String>>,
+    #[serde(alias = "env")]
+    pub args: Option<Vec<String>>,
 
     /// Container CLI to use (docker or podman)
     pub container_cli: Option<String>,

--- a/src/build/method.rs
+++ b/src/build/method.rs
@@ -33,24 +33,24 @@ pub struct BuildArgs {
     pub builder: Option<String>,
 
     /// Buildpack(s) to use (only for pack backend). Can be specified multiple times.
-    #[arg(long = "buildpack", short = 'b')]
+    #[arg(long = "buildpack", short = 'B')]
     pub buildpacks: Vec<String>,
 
-    /// Build-time environment variables (for build configuration only).
+    /// Build-time arguments (for build configuration only).
     /// Format: KEY=VALUE (with explicit value) or KEY (reads from current environment).
     ///
     /// Examples:
-    ///   -e NODE_ENV=production -e API_VERSION=1.2.3
-    ///   -e DATABASE_URL  (reads DATABASE_URL from current environment)
+    ///   -b NODE_ENV=production -b API_VERSION=1.2.3
+    ///   -b DATABASE_URL  (reads DATABASE_URL from current environment)
     ///
-    /// Can also be configured in rise.toml under [build] section.
+    /// Can also be configured in rise.toml under [build] section as `args`.
     /// CLI values are merged with rise.toml values.
     ///
-    /// WARNING: Build-time variables are for build configuration (compiler flags,
+    /// WARNING: Build args are for build configuration (compiler flags,
     /// tool versions, feature toggles), NOT runtime secrets. For runtime secrets,
-    /// use 'rise env set --secret' instead.
-    #[arg(long = "env", short = 'e', value_name = "KEY=VALUE")]
-    pub env: Vec<String>,
+    /// use '-e' / '--env' on deploy, or 'rise env set --secret'.
+    #[arg(long = "build-arg", short = 'b', value_name = "KEY=VALUE")]
+    pub build_env: Vec<String>,
 
     /// Container CLI to use (docker or podman)
     #[arg(long)]
@@ -186,9 +186,9 @@ impl BuildOptions {
             env: {
                 let mut env = project_config
                     .as_ref()
-                    .and_then(|c| c.env.clone())
+                    .and_then(|c| c.args.clone())
                     .unwrap_or_default();
-                env.extend(build_args.env.clone());
+                env.extend(build_args.build_env.clone());
                 env
             },
 

--- a/src/cli/deployment/core.rs
+++ b/src/cli/deployment/core.rs
@@ -421,6 +421,15 @@ struct CreateDeploymentResponse {
     credentials: RegistryCredentials,
 }
 
+/// A runtime environment variable override for a deployment
+#[derive(Debug, Clone)]
+pub struct EnvOverride {
+    pub key: String,
+    pub value: String,
+    pub is_secret: bool,
+    pub is_protected: bool,
+}
+
 /// Options for creating a deployment
 pub struct DeploymentOptions<'a> {
     pub project_name: &'a str,
@@ -436,6 +445,8 @@ pub struct DeploymentOptions<'a> {
     pub use_source_env_vars: bool,
     /// When true with --image, pull the image locally and push to Rise registry.
     pub push_image: bool,
+    /// Runtime environment variable overrides to apply to the deployment.
+    pub env_overrides: Vec<EnvOverride>,
 }
 
 pub async fn create_deployment(
@@ -485,6 +496,7 @@ pub async fn create_deployment(
         deploy_opts.from_deployment,
         deploy_opts.use_source_env_vars,
         deploy_opts.push_image,
+        &deploy_opts.env_overrides,
     )
     .await?;
 
@@ -771,6 +783,7 @@ async fn call_create_deployment_api(
     from_deployment: Option<&str>,
     use_source_env_vars: bool,
     push_image: bool,
+    env_overrides: &[EnvOverride],
 ) -> Result<CreateDeploymentResponse> {
     let url = format!("{}/api/v1/deployments", backend_url);
     let mut payload = serde_json::json!({
@@ -807,6 +820,22 @@ async fn call_create_deployment_api(
     // Add push_image field if set
     if push_image {
         payload["push_image"] = serde_json::json!(true);
+    }
+
+    // Add env_overrides if any
+    if !env_overrides.is_empty() {
+        let overrides: Vec<serde_json::Value> = env_overrides
+            .iter()
+            .map(|o| {
+                serde_json::json!({
+                    "key": o.key,
+                    "value": o.value,
+                    "is_secret": o.is_secret,
+                    "is_protected": o.is_protected,
+                })
+            })
+            .collect();
+        payload["env_overrides"] = serde_json::json!(overrides);
     }
 
     let response = http_client

--- a/src/cli/deployment/mod.rs
+++ b/src/cli/deployment/mod.rs
@@ -3,5 +3,5 @@ mod follow_ui;
 
 pub use core::{
     create_deployment, get_logs, list_deployments, show_deployment, stop_deployments_by_group,
-    DeploymentOptions, GetLogsParams,
+    DeploymentOptions, EnvOverride, GetLogsParams,
 };

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -341,6 +341,69 @@ pub async fn unset_env(
     Ok(())
 }
 
+/// A parsed environment variable from a file or string
+#[derive(Debug, Clone)]
+pub struct ParsedEnvVar {
+    pub key: String,
+    pub value: String,
+    pub is_secret: bool,
+}
+
+/// Parse a single KEY=VALUE or KEY=secret:VALUE string
+pub fn parse_env_string(s: &str) -> anyhow::Result<ParsedEnvVar> {
+    let parts: Vec<&str> = s.splitn(2, '=').collect();
+    if parts.len() != 2 {
+        anyhow::bail!("Invalid format (expected KEY=value): {}", s);
+    }
+
+    let key = parts[0].trim();
+    let value_part = parts[1];
+
+    // Validate key name
+    if !key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        anyhow::bail!(
+            "Invalid key name '{}' (must be alphanumeric with underscores)",
+            key
+        );
+    }
+
+    let (value, is_secret) = if let Some(stripped) = value_part.strip_prefix("secret:") {
+        (stripped, true)
+    } else {
+        (value_part, false)
+    };
+
+    Ok(ParsedEnvVar {
+        key: key.to_string(),
+        value: value.to_string(),
+        is_secret,
+    })
+}
+
+/// Parse a multi-line env file (same format as `rise env import`)
+///
+/// Lines starting with # are comments, empty lines are ignored.
+/// Format: KEY=value (plain text) or KEY=secret:value (secret)
+pub fn parse_env_file(contents: &str) -> anyhow::Result<Vec<ParsedEnvVar>> {
+    let mut vars = Vec::new();
+
+    for (line_num, line) in contents.lines().enumerate() {
+        let line = line.trim();
+
+        // Skip comments and empty lines
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        match parse_env_string(line) {
+            Ok(var) => vars.push(var),
+            Err(e) => anyhow::bail!("Line {}: {}", line_num + 1, e),
+        }
+    }
+
+    Ok(vars)
+}
+
 /// Import environment variables from a file
 ///
 /// File format:

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -485,38 +485,6 @@ pub async fn import_env(
     Ok(())
 }
 
-#[cfg(test)]
-mod tests {
-    use super::{parse_env_file, parse_env_string};
-
-    #[test]
-    fn parse_env_string_rejects_empty_keys() {
-        let err = parse_env_string("=value").unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "Invalid key name '' (must be alphanumeric with underscores)"
-        );
-    }
-
-    #[test]
-    fn parse_env_file_reports_original_line_numbers() {
-        let err = parse_env_file("\n# comment\n=value").unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "Line 3: Invalid key name '' (must be alphanumeric with underscores)"
-        );
-    }
-
-    #[test]
-    fn parse_env_string_supports_secret_values() {
-        let parsed = parse_env_string("API_KEY=secret:value").unwrap();
-
-        assert_eq!(parsed.key, "API_KEY");
-        assert_eq!(parsed.value, "value");
-        assert!(parsed.is_secret);
-    }
-}
-
 /// List environment variables for a deployment (read-only)
 pub async fn list_deployment_env(
     http_client: &Client,
@@ -589,4 +557,36 @@ pub async fn list_deployment_env(
     println!("Note: Deployment environment variables are read-only snapshots");
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_env_file, parse_env_string};
+
+    #[test]
+    fn parse_env_string_rejects_empty_keys() {
+        let err = parse_env_string("=value").unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Invalid key name '' (must be alphanumeric with underscores)"
+        );
+    }
+
+    #[test]
+    fn parse_env_file_reports_original_line_numbers() {
+        let err = parse_env_file("\n# comment\n=value").unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Line 3: Invalid key name '' (must be alphanumeric with underscores)"
+        );
+    }
+
+    #[test]
+    fn parse_env_string_supports_secret_values() {
+        let parsed = parse_env_string("API_KEY=secret:value").unwrap();
+
+        assert_eq!(parsed.key, "API_KEY");
+        assert_eq!(parsed.value, "value");
+        assert!(parsed.is_secret);
+    }
 }

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -349,6 +349,17 @@ pub struct ParsedEnvVar {
     pub is_secret: bool,
 }
 
+fn iter_env_file_lines(contents: &str) -> impl Iterator<Item = (usize, &str)> {
+    contents.lines().enumerate().filter_map(|(line_num, line)| {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            None
+        } else {
+            Some((line_num + 1, line))
+        }
+    })
+}
+
 /// Parse a single KEY=VALUE or KEY=secret:VALUE string
 pub fn parse_env_string(s: &str) -> anyhow::Result<ParsedEnvVar> {
     let parts: Vec<&str> = s.splitn(2, '=').collect();
@@ -360,6 +371,10 @@ pub fn parse_env_string(s: &str) -> anyhow::Result<ParsedEnvVar> {
     let value_part = parts[1];
 
     // Validate key name
+    if key.is_empty() {
+        anyhow::bail!("Invalid key name '' (must be alphanumeric with underscores)");
+    }
+
     if !key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
         anyhow::bail!(
             "Invalid key name '{}' (must be alphanumeric with underscores)",
@@ -387,17 +402,10 @@ pub fn parse_env_string(s: &str) -> anyhow::Result<ParsedEnvVar> {
 pub fn parse_env_file(contents: &str) -> anyhow::Result<Vec<ParsedEnvVar>> {
     let mut vars = Vec::new();
 
-    for (line_num, line) in contents.lines().enumerate() {
-        let line = line.trim();
-
-        // Skip comments and empty lines
-        if line.is_empty() || line.starts_with('#') {
-            continue;
-        }
-
+    for (line_num, line) in iter_env_file_lines(contents) {
         match parse_env_string(line) {
             Ok(var) => vars.push(var),
-            Err(e) => anyhow::bail!("Line {}: {}", line_num + 1, e),
+            Err(e) => anyhow::bail!("Line {}: {}", line_num, e),
         }
     }
 
@@ -429,58 +437,27 @@ pub async fn import_env(
     let mut success_count = 0;
     let mut error_count = 0;
 
-    for (line_num, line) in contents.lines().enumerate() {
-        let line = line.trim();
-
-        // Skip comments and empty lines
-        if line.is_empty() || line.starts_with('#') {
-            continue;
-        }
-
-        // Parse KEY=value
-        let parts: Vec<&str> = line.splitn(2, '=').collect();
-        if parts.len() != 2 {
-            eprintln!(
-                "Warning: Line {} has invalid format (expected KEY=value): {}",
-                line_num + 1,
-                line
-            );
-            error_count += 1;
-            continue;
-        }
-
-        let key = parts[0].trim();
-        let value_part = parts[1];
-
-        // Check if value is secret
-        let (value, is_secret) = if let Some(stripped) = value_part.strip_prefix("secret:") {
-            (stripped, true)
-        } else {
-            (value_part, false)
+    for (line_num, line) in iter_env_file_lines(&contents) {
+        let parsed = match parse_env_string(line) {
+            Ok(parsed) => parsed,
+            Err(e) => {
+                eprintln!("Warning: Line {}: {}", line_num, e);
+                error_count += 1;
+                continue;
+            }
         };
-
-        // Validate key name (alphanumeric and underscore only)
-        if !key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
-            eprintln!(
-                "Warning: Line {} has invalid key name '{}' (must be alphanumeric with underscores)",
-                line_num + 1,
-                key
-            );
-            error_count += 1;
-            continue;
-        }
 
         // Set the variable
         // Protected defaults to true for secrets, false for non-secrets
-        let is_protected = is_secret;
+        let is_protected = parsed.is_secret;
         match set_env(
             http_client,
             backend_url,
             token,
             project,
-            key,
-            value,
-            is_secret,
+            &parsed.key,
+            &parsed.value,
+            parsed.is_secret,
             is_protected,
         )
         .await
@@ -489,9 +466,7 @@ pub async fn import_env(
             Err(e) => {
                 eprintln!(
                     "Warning: Failed to set variable '{}' from line {}: {}",
-                    key,
-                    line_num + 1,
-                    e
+                    parsed.key, line_num, e
                 );
                 error_count += 1;
             }
@@ -508,6 +483,38 @@ pub async fn import_env(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_env_file, parse_env_string};
+
+    #[test]
+    fn parse_env_string_rejects_empty_keys() {
+        let err = parse_env_string("=value").unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Invalid key name '' (must be alphanumeric with underscores)"
+        );
+    }
+
+    #[test]
+    fn parse_env_file_reports_original_line_numbers() {
+        let err = parse_env_file("\n# comment\n=value").unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Line 3: Invalid key name '' (must be alphanumeric with underscores)"
+        );
+    }
+
+    #[test]
+    fn parse_env_string_supports_secret_values() {
+        let parsed = parse_env_string("API_KEY=secret:value").unwrap();
+
+        assert_eq!(parsed.key, "API_KEY");
+        assert_eq!(parsed.value, "value");
+        assert!(parsed.is_secret);
+    }
 }
 
 /// List environment variables for a deployment (read-only)

--- a/src/db/env_vars.rs
+++ b/src/db/env_vars.rs
@@ -169,6 +169,29 @@ pub async fn list_deployment_env_vars(
     Ok(env_vars)
 }
 
+/// Get a specific deployment environment variable by key
+pub async fn get_deployment_env_var(
+    pool: &PgPool,
+    deployment_id: Uuid,
+    key: &str,
+) -> Result<Option<DeploymentEnvVar>> {
+    let env_var = sqlx::query_as!(
+        DeploymentEnvVar,
+        r#"
+        SELECT id, deployment_id, key, value, is_secret, is_protected, created_at, updated_at
+        FROM deployment_env_vars
+        WHERE deployment_id = $1 AND key = $2
+        "#,
+        deployment_id,
+        key
+    )
+    .fetch_optional(pool)
+    .await
+    .context("Failed to get deployment environment variable")?;
+
+    Ok(env_var)
+}
+
 /// Create or update a deployment environment variable (upsert)
 pub async fn upsert_deployment_env_var(
     pool: &PgPool,
@@ -251,4 +274,63 @@ pub async fn load_deployment_env_vars_decrypted(
     }
 
     Ok(env_vars)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::deployments::{self, CreateDeploymentParams};
+    use crate::db::models::{DeploymentStatus, ProjectStatus};
+    use crate::server::deployment::models::DEFAULT_DEPLOYMENT_GROUP;
+
+    #[sqlx::test]
+    async fn get_deployment_env_var_returns_matching_variable(pool: PgPool) {
+        let user = crate::db::users::create(&pool, "env-vars-test@example.com")
+            .await
+            .expect("Failed to create test user");
+
+        let project = crate::db::projects::create(
+            &pool,
+            "env-vars-test-project",
+            ProjectStatus::Stopped,
+            "default".to_string(),
+            Some(user.id),
+            None,
+        )
+        .await
+        .expect("Failed to create test project");
+
+        let deployment = deployments::create(
+            &pool,
+            CreateDeploymentParams {
+                deployment_id: "20260316-120000",
+                project_id: project.id,
+                created_by_id: user.id,
+                status: DeploymentStatus::Healthy,
+                image: Some("test:v1"),
+                image_digest: None,
+                rolled_back_from_deployment_id: None,
+                deployment_group: DEFAULT_DEPLOYMENT_GROUP,
+                expires_at: None,
+                http_port: 8080,
+                is_active: false,
+            },
+        )
+        .await
+        .expect("Failed to create test deployment");
+
+        upsert_deployment_env_var(&pool, deployment.id, "BAZ", "secret-value", true, false)
+            .await
+            .expect("Failed to insert deployment env var");
+
+        let env_var = get_deployment_env_var(&pool, deployment.id, "BAZ")
+            .await
+            .expect("Failed to fetch deployment env var")
+            .expect("Expected deployment env var to exist");
+
+        assert_eq!(env_var.key, "BAZ");
+        assert_eq!(env_var.value, "secret-value");
+        assert!(env_var.is_secret);
+        assert!(!env_var.is_protected);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,22 @@ struct DeployArgs {
     /// Pulls the image locally (platform linux/amd64) and pushes to the internal registry.
     #[arg(long)]
     push_image: bool,
+    /// Runtime environment variables (format: KEY=VALUE, can be specified multiple times).
+    /// These are set on the deployment and available to the running container.
+    #[arg(long = "env", short = 'e', value_name = "KEY=VALUE", value_parser = parse_key_val::<String, String>)]
+    env: Vec<(String, String)>,
+    /// Secret runtime environment variables (encrypted at rest, retrievable via `rise env get`).
+    /// Format: KEY=VALUE, can be specified multiple times.
+    #[arg(long, value_name = "KEY=VALUE", value_parser = parse_key_val::<String, String>)]
+    secret_env: Vec<(String, String)>,
+    /// Protected secret runtime environment variables (encrypted at rest, NOT retrievable).
+    /// Format: KEY=VALUE, can be specified multiple times.
+    #[arg(long, value_name = "KEY=VALUE", value_parser = parse_key_val::<String, String>)]
+    protected_env: Vec<(String, String)>,
+    /// File with runtime environment variables (same format as `rise env import`).
+    /// Lines: KEY=value (plain) or KEY=secret:value (protected secret).
+    #[arg(long)]
+    env_file: Option<String>,
     #[command(flatten)]
     build_args: build::BuildArgs,
 }
@@ -157,7 +173,7 @@ enum Commands {
         #[arg(long)]
         expose: Option<u16>,
         /// Runtime environment variables (format: KEY=VALUE, can be specified multiple times)
-        #[arg(long = "run-env", short, value_parser = parse_key_val::<String, String>)]
+        #[arg(long = "env", short = 'e', value_parser = parse_key_val::<String, String>)]
         run_env: Vec<(String, String)>,
         #[command(flatten)]
         build_args: build::BuildArgs,
@@ -1012,6 +1028,55 @@ async fn main() -> Result<()> {
                     }
                 }
 
+                // Collect runtime env overrides
+                let mut env_overrides = Vec::new();
+
+                // --env KEY=VALUE → plain text
+                for (key, value) in &args.env {
+                    env_overrides.push(deployment::EnvOverride {
+                        key: key.clone(),
+                        value: value.clone(),
+                        is_secret: false,
+                        is_protected: false,
+                    });
+                }
+
+                // --secret-env KEY=VALUE → secret, retrievable
+                for (key, value) in &args.secret_env {
+                    env_overrides.push(deployment::EnvOverride {
+                        key: key.clone(),
+                        value: value.clone(),
+                        is_secret: true,
+                        is_protected: false,
+                    });
+                }
+
+                // --protected-env KEY=VALUE → secret, NOT retrievable
+                for (key, value) in &args.protected_env {
+                    env_overrides.push(deployment::EnvOverride {
+                        key: key.clone(),
+                        value: value.clone(),
+                        is_secret: true,
+                        is_protected: true,
+                    });
+                }
+
+                // --env-file → parse file
+                if let Some(ref env_file_path) = args.env_file {
+                    let contents = std::fs::read_to_string(env_file_path)
+                        .with_context(|| format!("Failed to read env file: {}", env_file_path))?;
+                    let parsed = cli::env::parse_env_file(&contents)
+                        .with_context(|| format!("Failed to parse env file: {}", env_file_path))?;
+                    for var in parsed {
+                        env_overrides.push(deployment::EnvOverride {
+                            key: var.key,
+                            value: var.value,
+                            is_secret: var.is_secret,
+                            is_protected: var.is_secret, // secrets from file are protected by default
+                        });
+                    }
+                }
+
                 // Pass through the http_port option - server will resolve from:
                 // 1. Explicit http_port (if provided)
                 // 2. Source deployment's http_port (if --from is used)
@@ -1032,6 +1097,7 @@ async fn main() -> Result<()> {
                         from_deployment: args.from.as_deref(),
                         use_source_env_vars: args.use_source_env_vars,
                         push_image: args.push_image,
+                        env_overrides,
                     },
                 )
                 .await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1063,7 +1063,8 @@ async fn main() -> Result<()> {
 
                 // --env-file → parse file
                 if let Some(ref env_file_path) = args.env_file {
-                    let contents = std::fs::read_to_string(env_file_path)
+                    let contents = tokio::fs::read_to_string(env_file_path)
+                        .await
                         .with_context(|| format!("Failed to read env file: {}", env_file_path))?;
                     let parsed = cli::env::parse_env_file(&contents)
                         .with_context(|| format!("Failed to parse env file: {}", env_file_path))?;

--- a/src/server/deployment/handlers.rs
+++ b/src/server/deployment/handlers.rs
@@ -299,6 +299,87 @@ async fn insert_rise_env_vars(
     Ok(())
 }
 
+/// Apply env var overrides from the deployment request.
+///
+/// Encrypts secret values and upserts each override into the deployment's env vars.
+/// Called after copying project/source env vars and before upserting PORT.
+async fn apply_env_overrides(
+    state: &AppState,
+    deployment_id: uuid::Uuid,
+    overrides: &[models::EnvOverride],
+) -> Result<(), (StatusCode, String)> {
+    if overrides.is_empty() {
+        return Ok(());
+    }
+
+    info!(
+        "Applying {} env override(s) to deployment {}",
+        overrides.len(),
+        deployment_id
+    );
+
+    for env_override in overrides {
+        // Validate key
+        if !env_override
+            .key
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_')
+        {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                format!(
+                    "Invalid env var key '{}' (must be alphanumeric with underscores)",
+                    env_override.key
+                ),
+            ));
+        }
+
+        // Encrypt if secret
+        let value_to_store = if env_override.is_secret {
+            let provider = state.encryption_provider.as_ref().ok_or_else(|| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    "Cannot store secret variables: no encryption provider configured".to_string(),
+                )
+            })?;
+            provider.encrypt(&env_override.value).await.map_err(|e| {
+                error!(
+                    "Failed to encrypt env override '{}': {:?}",
+                    env_override.key, e
+                );
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to encrypt secret '{}': {}", env_override.key, e),
+                )
+            })?
+        } else {
+            env_override.value.clone()
+        };
+
+        crate::db::env_vars::upsert_deployment_env_var(
+            &state.db_pool,
+            deployment_id,
+            &env_override.key,
+            &value_to_store,
+            env_override.is_secret,
+            env_override.is_protected,
+        )
+        .await
+        .map_err(|e| {
+            error!(
+                "Failed to upsert env override '{}': {}",
+                env_override.key, e
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to set env override '{}': {}", env_override.key, e),
+            )
+        })?;
+    }
+
+    Ok(())
+}
+
 /// Convert DB DeploymentStatus to API DeploymentStatus
 fn convert_status_from_db(status: DbDeploymentStatus) -> DeploymentStatus {
     match status {
@@ -651,6 +732,9 @@ pub async fn create_deployment(
             })?;
         }
 
+        // Apply env overrides from the request
+        apply_env_overrides(&state, new_deployment.id, &payload.env_overrides).await?;
+
         // Upsert PORT env var with the final http_port value
         crate::db::env_vars::upsert_deployment_env_var(
             &state.db_pool,
@@ -772,6 +856,9 @@ pub async fn create_deployment(
                 )
             })?;
 
+            // Apply env overrides from the request
+            apply_env_overrides(&state, deployment.id, &payload.env_overrides).await?;
+
             crate::db::env_vars::upsert_deployment_env_var(
                 &state.db_pool,
                 deployment.id,
@@ -872,6 +959,9 @@ pub async fn create_deployment(
             )
         })?;
 
+        // Apply env overrides from the request
+        apply_env_overrides(&state, deployment.id, &payload.env_overrides).await?;
+
         // Upsert PORT env var with the resolved effective value
         // This overwrites any user-set PORT with the resolved value (which may be the same)
         crate::db::env_vars::upsert_deployment_env_var(
@@ -971,6 +1061,9 @@ pub async fn create_deployment(
                 format!("Failed to copy environment variables: {}", e),
             )
         })?;
+
+        // Apply env overrides from the request
+        apply_env_overrides(&state, deployment.id, &payload.env_overrides).await?;
 
         // Upsert PORT env var with the resolved effective value
         // This overwrites any user-set PORT with the resolved value (which may be the same)

--- a/src/server/deployment/handlers.rs
+++ b/src/server/deployment/handlers.rs
@@ -319,7 +319,7 @@ async fn apply_env_overrides(
     );
 
     for env_override in overrides {
-        validate_env_override(env_override)?;
+        let is_protected = validate_env_override(env_override)?;
 
         // Encrypt if secret
         let value_to_store = if env_override.is_secret {
@@ -349,7 +349,7 @@ async fn apply_env_overrides(
             &env_override.key,
             &value_to_store,
             env_override.is_secret,
-            env_override.is_protected,
+            is_protected,
         )
         .await
         .map_err(|e| {
@@ -371,7 +371,11 @@ fn validate_env_override_key(key: &str) -> bool {
     !key.is_empty() && key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
-fn validate_env_override(env_override: &models::EnvOverride) -> Result<(), (StatusCode, String)> {
+fn normalize_env_override_is_protected(env_override: &models::EnvOverride) -> bool {
+    env_override.is_protected.unwrap_or(env_override.is_secret)
+}
+
+fn validate_env_override(env_override: &models::EnvOverride) -> Result<bool, (StatusCode, String)> {
     if !validate_env_override_key(&env_override.key) {
         return Err((
             StatusCode::BAD_REQUEST,
@@ -389,7 +393,8 @@ fn validate_env_override(env_override: &models::EnvOverride) -> Result<(), (Stat
         ));
     }
 
-    if env_override.is_protected && !env_override.is_secret {
+    let is_protected = normalize_env_override_is_protected(env_override);
+    if is_protected && !env_override.is_secret {
         return Err((
             StatusCode::BAD_REQUEST,
             format!(
@@ -399,7 +404,7 @@ fn validate_env_override(env_override: &models::EnvOverride) -> Result<(), (Stat
         ));
     }
 
-    Ok(())
+    Ok(is_protected)
 }
 
 fn validate_env_overrides(overrides: &[models::EnvOverride]) -> Result<(), (StatusCode, String)> {
@@ -1946,7 +1951,9 @@ pub async fn stream_deployment_logs(
 
 #[cfg(test)]
 mod tests {
-    use super::{validate_env_override, validate_env_override_key};
+    use super::{
+        normalize_env_override_is_protected, validate_env_override, validate_env_override_key,
+    };
     use crate::server::deployment::models::EnvOverride;
     use axum::http::StatusCode;
 
@@ -1962,7 +1969,7 @@ mod tests {
             key: "PORT".to_string(),
             value: "3000".to_string(),
             is_secret: false,
-            is_protected: false,
+            is_protected: Some(false),
         })
         .unwrap_err();
 
@@ -1979,7 +1986,7 @@ mod tests {
             key: "API_KEY".to_string(),
             value: "value".to_string(),
             is_secret: false,
-            is_protected: true,
+            is_protected: Some(true),
         })
         .unwrap_err();
 
@@ -1996,7 +2003,7 @@ mod tests {
             key: String::new(),
             value: "value".to_string(),
             is_secret: false,
-            is_protected: false,
+            is_protected: Some(false),
         })
         .unwrap_err();
 
@@ -2005,5 +2012,30 @@ mod tests {
             err.1,
             "Invalid env var key '' (must be alphanumeric with underscores)"
         );
+    }
+
+    #[test]
+    fn env_override_validation_defaults_secret_overrides_to_protected() {
+        let is_protected = validate_env_override(&EnvOverride {
+            key: "API_KEY".to_string(),
+            value: "secret".to_string(),
+            is_secret: true,
+            is_protected: None,
+        })
+        .unwrap();
+
+        assert!(is_protected);
+    }
+
+    #[test]
+    fn env_override_normalization_preserves_explicit_unprotected_secret() {
+        let is_protected = normalize_env_override_is_protected(&EnvOverride {
+            key: "API_KEY".to_string(),
+            value: "secret".to_string(),
+            is_secret: true,
+            is_protected: Some(false),
+        });
+
+        assert!(!is_protected);
     }
 }

--- a/src/server/deployment/handlers.rs
+++ b/src/server/deployment/handlers.rs
@@ -319,20 +319,7 @@ async fn apply_env_overrides(
     );
 
     for env_override in overrides {
-        // Validate key
-        if !env_override
-            .key
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '_')
-        {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                format!(
-                    "Invalid env var key '{}' (must be alphanumeric with underscores)",
-                    env_override.key
-                ),
-            ));
-        }
+        validate_env_override(env_override)?;
 
         // Encrypt if secret
         let value_to_store = if env_override.is_secret {
@@ -375,6 +362,49 @@ async fn apply_env_overrides(
                 format!("Failed to set env override '{}': {}", env_override.key, e),
             )
         })?;
+    }
+
+    Ok(())
+}
+
+fn validate_env_override_key(key: &str) -> bool {
+    !key.is_empty() && key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+fn validate_env_override(env_override: &models::EnvOverride) -> Result<(), (StatusCode, String)> {
+    if !validate_env_override_key(&env_override.key) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "Invalid env var key '{}' (must be alphanumeric with underscores)",
+                env_override.key
+            ),
+        ));
+    }
+
+    if env_override.key == "PORT" {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "PORT cannot be set via env overrides. Use http_port/--http-port instead.".to_string(),
+        ));
+    }
+
+    if env_override.is_protected && !env_override.is_secret {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "Env override '{}' cannot be protected unless it is also secret.",
+                env_override.key
+            ),
+        ));
+    }
+
+    Ok(())
+}
+
+fn validate_env_overrides(overrides: &[models::EnvOverride]) -> Result<(), (StatusCode, String)> {
+    for env_override in overrides {
+        validate_env_override(env_override)?;
     }
 
     Ok(())
@@ -529,6 +559,8 @@ pub async fn create_deployment(
             ));
         }
     }
+
+    validate_env_overrides(&payload.env_overrides)?;
 
     // Parse expiration duration if provided
     let expires_at = if let Some(ref expires_in) = payload.expires_in {
@@ -1910,4 +1942,68 @@ pub async fn stream_deployment_logs(
     });
 
     Ok(Sse::new(sse_stream).keep_alive(KeepAlive::default()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{validate_env_override, validate_env_override_key};
+    use crate::server::deployment::models::EnvOverride;
+    use axum::http::StatusCode;
+
+    #[test]
+    fn env_override_key_validation_rejects_empty_keys() {
+        assert!(!validate_env_override_key(""));
+        assert!(validate_env_override_key("VALID_KEY_123"));
+    }
+
+    #[test]
+    fn env_override_validation_rejects_port_overrides() {
+        let err = validate_env_override(&EnvOverride {
+            key: "PORT".to_string(),
+            value: "3000".to_string(),
+            is_secret: false,
+            is_protected: false,
+        })
+        .unwrap_err();
+
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            err.1,
+            "PORT cannot be set via env overrides. Use http_port/--http-port instead."
+        );
+    }
+
+    #[test]
+    fn env_override_validation_rejects_protected_non_secrets() {
+        let err = validate_env_override(&EnvOverride {
+            key: "API_KEY".to_string(),
+            value: "value".to_string(),
+            is_secret: false,
+            is_protected: true,
+        })
+        .unwrap_err();
+
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            err.1,
+            "Env override 'API_KEY' cannot be protected unless it is also secret."
+        );
+    }
+
+    #[test]
+    fn env_override_validation_rejects_empty_keys() {
+        let err = validate_env_override(&EnvOverride {
+            key: String::new(),
+            value: "value".to_string(),
+            is_secret: false,
+            is_protected: false,
+        })
+        .unwrap_err();
+
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            err.1,
+            "Invalid env var key '' (must be alphanumeric with underscores)"
+        );
+    }
 }

--- a/src/server/deployment/models.rs
+++ b/src/server/deployment/models.rs
@@ -174,8 +174,8 @@ pub struct EnvOverride {
     pub value: String,
     #[serde(default)]
     pub is_secret: bool,
-    #[serde(default)]
-    pub is_protected: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_protected: Option<bool>,
 }
 
 // Request to create a deployment
@@ -222,6 +222,7 @@ pub struct UpdateDeploymentStatusRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn test_normalize_deployment_group() {
@@ -289,5 +290,31 @@ mod tests {
         );
         assert_eq!(map["RISE_DEPLOYMENT_GROUP"], "mr/42");
         assert_eq!(map["RISE_DEPLOYMENT_GROUP_NORMALIZED"], "mr--42");
+    }
+
+    #[test]
+    fn test_env_override_deserialization_defaults_is_protected_to_none() {
+        let env_override: EnvOverride = serde_json::from_value(json!({
+            "key": "API_KEY",
+            "value": "secret",
+            "is_secret": true
+        }))
+        .unwrap();
+
+        assert!(env_override.is_secret);
+        assert_eq!(env_override.is_protected, None);
+    }
+
+    #[test]
+    fn test_env_override_deserialization_keeps_explicit_is_protected() {
+        let env_override: EnvOverride = serde_json::from_value(json!({
+            "key": "API_KEY",
+            "value": "secret",
+            "is_secret": true,
+            "is_protected": false
+        }))
+        .unwrap();
+
+        assert_eq!(env_override.is_protected, Some(false));
     }
 }

--- a/src/server/deployment/models.rs
+++ b/src/server/deployment/models.rs
@@ -167,6 +167,17 @@ pub fn rise_system_env_vars(
     ]
 }
 
+/// A runtime environment variable override included in a deployment request
+#[derive(Debug, Deserialize, Serialize)]
+pub struct EnvOverride {
+    pub key: String,
+    pub value: String,
+    #[serde(default)]
+    pub is_secret: bool,
+    #[serde(default)]
+    pub is_protected: bool,
+}
+
 // Request to create a deployment
 #[derive(Debug, Deserialize)]
 pub struct CreateDeploymentRequest {
@@ -187,6 +198,9 @@ pub struct CreateDeploymentRequest {
     pub use_source_env_vars: bool, // If true and from_deployment is set, copy env vars from source (default: false = use current project env vars)
     #[serde(default)]
     pub push_image: bool, // If true with image, CLI will pull and push image to Rise registry
+    /// Runtime environment variable overrides applied after copying project/source env vars
+    #[serde(default)]
+    pub env_overrides: Vec<EnvOverride>,
 }
 
 // Response from creating a deployment

--- a/src/server/env_vars/handlers.rs
+++ b/src/server/env_vars/handlers.rs
@@ -524,6 +524,110 @@ pub async fn get_project_env_var_value(
     }))
 }
 
+/// Get the decrypted value of a specific retrievable deployment secret
+pub async fn get_deployment_env_var_value(
+    State(state): State<AppState>,
+    Extension(user): Extension<User>,
+    Path((project_id_or_name, deployment_id, key)): Path<(String, String, String)>,
+) -> Result<Json<EnvVarValueResponse>, (StatusCode, String)> {
+    // Find project by ID or name
+    let project = if let Ok(uuid) = project_id_or_name.parse() {
+        projects::find_by_id(&state.db_pool, uuid)
+            .await
+            .map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to get project: {}", e),
+                )
+            })?
+    } else {
+        projects::find_by_name(&state.db_pool, &project_id_or_name)
+            .await
+            .map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to get project: {}", e),
+                )
+            })?
+    }
+    .ok_or_else(|| (StatusCode::NOT_FOUND, "Project not found".to_string()))?;
+
+    // Check permission (admin bypass)
+    ensure_project_access_or_admin(&state, &user, &project).await?;
+
+    // Get deployment by deployment_id within the project
+    let deployment =
+        crate::db::deployments::find_by_deployment_id(&state.db_pool, &deployment_id, project.id)
+            .await
+            .map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to get deployment: {}", e),
+                )
+            })?
+            .ok_or_else(|| (StatusCode::NOT_FOUND, "Deployment not found".to_string()))?;
+
+    // Get the specific environment variable
+    let env_var = db_env_vars::get_deployment_env_var(&state.db_pool, deployment.id, &key)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to get environment variable: {}", e),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                format!("Environment variable '{}' not found", key),
+            )
+        })?;
+
+    // Validate: must be an unprotected secret
+    if !env_var.is_secret || env_var.is_protected {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "Environment variable '{}' is a protected secret and cannot be retrieved. \
+                 Update it with --protected=false to allow retrieval.",
+                key
+            ),
+        ));
+    }
+
+    // Decrypt the value
+    let decrypted_value = match &state.encryption_provider {
+        Some(provider) => provider.decrypt(&env_var.value).await.map_err(|e| {
+            tracing::error!(
+                "Failed to decrypt unprotected deployment secret '{}': {:?}",
+                key,
+                e
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to decrypt secret '{}': {}", key, e),
+            )
+        })?,
+        None => {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Cannot decrypt secrets: no encryption provider configured".to_string(),
+            ))
+        }
+    };
+
+    tracing::info!(
+        "Retrieved decrypted value for secret '{}' in deployment '{}' by user '{}'",
+        key,
+        deployment.deployment_id,
+        user.email
+    );
+
+    Ok(Json(EnvVarValueResponse {
+        value: decrypted_value,
+    }))
+}
+
 /// Preview the full set of environment variables a deployment would receive.
 ///
 /// Returns:

--- a/src/server/env_vars/routes.rs
+++ b/src/server/env_vars/routes.rs
@@ -31,4 +31,8 @@ pub fn routes() -> Router<AppState> {
             "/projects/{project_id_or_name}/deployments/{deployment_id}/env",
             get(handlers::list_deployment_env_vars),
         )
+        .route(
+            "/projects/{project_id_or_name}/deployments/{deployment_id}/env/{key}/value",
+            get(handlers::get_deployment_env_var_value),
+        )
 }


### PR DESCRIPTION
## Summary

- **Reclaim `-e`/`--env` for runtime env vars** on `rise deploy` and `rise run`, renaming build-time flags to `-b`/`--build-arg` (Docker-familiar conventions)
- **New deploy-time env override flags**: `--env`/`-e` (plain), `--secret-env` (encrypted, retrievable), `--protected-env` (encrypted, not retrievable), `--env-file` (bulk import)
- **Server-side `apply_env_overrides`** in all 4 deployment creation paths (from-deployment, push-image, pre-built image, build-from-source), applied after copying project env vars and before PORT upsert
- **Backward compat**: `[build] env` still works in rise.toml via serde alias

### Flag changes

| Command | Before | After |
|---------|--------|-------|
| Build-time vars | `--env` / `-e` | `--build-arg` / `-b` |
| `--buildpack` short | `-b` | `-B` |
| `rise deploy` runtime | _(none)_ | `-e`/`--env`, `--secret-env`, `--protected-env`, `--env-file` |
| `rise run` runtime | `--run-env` | `--env` / `-e` |
| rise.toml build vars | `[build] env` | `[build] args` (alias `env` for back-compat) |

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all-features -- -D warnings` — clean
- [x] `cargo test --all-features` — 221 tests pass
- [x] Smoke test: `rise build --build-arg NODE_ENV=production -B heroku/buildpack-nodejs myapp:latest`
- [x] Smoke test: `rise deploy -e DATABASE_URL=postgres://... --secret-env API_KEY=sk-xxx`
- [ ] Smoke test: `rise deploy --env-file .env.production`
- [x] Smoke test: `rise run -e DEBUG=true --build-arg NODE_ENV=dev`
- [ ] Verify old `rise.toml` with `[build] env = [...]` still parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)