### PR TITLE
feat: add ArgoCD deployment controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ static/assets/app.css
 
 # Helm packages
 .helm-packages/
+dist/charts/
 
 # Cargo chef recipe (generated during Docker builds)
 **/recipe.json

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -31,6 +31,38 @@ rise deployment show my-app:latest --follow
 - Review application logs: `rise deployment logs my-app 20241205-1234`
 - Ensure health check endpoint responds
 
+### Temporarily Stop Rise Reconciliation
+
+For debugging, you can tell Rise to stop reconciling specific resources by adding this label:
+
+```yaml
+rise.dev/ignore-reconcile: "true"
+```
+
+When this label is present, Rise skips both reconcile updates and cleanup deletes for that resource.
+
+This is currently supported for ArgoCD deployment-controller resources managed by Rise:
+- `Application`
+- `AppProject`
+- destination `Namespace`
+- deployment-owned `Secret`s created by Rise
+
+Example:
+
+```bash
+kubectl -n argocd label application rise-hello-world-default rise.dev/ignore-reconcile=true
+```
+
+To resume normal Rise management, remove the label:
+
+```bash
+kubectl -n argocd label application rise-hello-world-default rise.dev/ignore-reconcile-
+```
+
+Use this carefully:
+- Rise will not revert or clean up ignored resources while the label is present.
+- If you label deployment-owned secrets or namespaces, Rise will also leave them behind during deployment cleanup.
+
 ## Build Issues
 
 ### Buildpack: CA Certificate Verification Errors

--- a/frontend/src/features/deployments.tsx
+++ b/frontend/src/features/deployments.tsx
@@ -1189,11 +1189,14 @@ function PodInfoRow({ pod }: { pod: PodInfo }) {
     );
 }
 
-function PodStatusSection({ podStatus }: { podStatus: PodStatus }) {
-    const replicasMismatch = podStatus.ready_replicas < podStatus.desired_replicas;
+function PodStatusSection({ podStatus, deploymentId }: { podStatus: PodStatus, deploymentId?: string }) {
+    const pods = Array.isArray(podStatus?.pods) ? podStatus.pods : [];
+    const desiredReplicas = typeof podStatus?.desired_replicas === 'number' ? podStatus.desired_replicas : 0;
+    const readyReplicas = typeof podStatus?.ready_replicas === 'number' ? podStatus.ready_replicas : 0;
+    const currentReplicas = typeof podStatus?.current_replicas === 'number' ? podStatus.current_replicas : pods.length;
+    const replicasMismatch = readyReplicas < desiredReplicas;
     const hasPodIssues =
-        podStatus.pods &&
-        podStatus.pods.some(
+        pods.some(
             (p) =>
                 (p.containers && p.containers.some(c => c.restart_count > 0)) ||
                 (p.events && p.events.length > 0)
@@ -1203,7 +1206,7 @@ function PodStatusSection({ podStatus }: { podStatus: PodStatus }) {
 
     // Determine tone based on replica counts and pod-level issues
     let tone = 'ok';
-    if (podStatus.ready_replicas === 0) {
+    if (readyReplicas === 0) {
         tone = 'bad';
     } else if (replicasMismatch || hasPodIssues) {
         tone = 'warn';
@@ -1236,23 +1239,23 @@ function PodStatusSection({ podStatus }: { podStatus: PodStatus }) {
             {/* Replica summary */}
             <div className="mono-inline-status mb-3" style={toneColors[tone]}>
                 <div className="flex items-center justify-between">
-                    <span>Pods: {podStatus.ready_replicas}/{podStatus.desired_replicas} ready</span>
+                    <span>Pods: {readyReplicas}/{desiredReplicas} ready</span>
                     <span className="text-xs" style={{ color: 'var(--mono-muted)' }}>
-                        {podStatus.current_replicas} total
+                        {currentReplicas} total
                     </span>
                 </div>
             </div>
 
             {/* Per-pod details */}
-            {podStatus.pods && podStatus.pods.length > 0 && (
+            {pods.length > 0 && (
                 <div className="border border-solid" style={{ borderColor: borderColors[tone], background: tone === 'ok' ? '#0a1210' : '#1a1212' }}>
                     <div className="p-3" style={{ borderBottom: `1px solid ${borderColors[tone]}` }}>
                         <h5 className="text-xs font-semibold" style={{ color: headerColors[tone] }}>
-                            Pods ({podStatus.pods.length})
+                            Pods ({pods.length})
                         </h5>
                     </div>
                     <div>
-                        {podStatus.pods.map((pod, idx) => (
+                        {pods.map((pod, idx) => (
                             <PodInfoRow key={pod.name || `pod-${idx}`} pod={pod} />
                         ))}
                     </div>
@@ -1260,8 +1263,250 @@ function PodStatusSection({ podStatus }: { podStatus: PodStatus }) {
             )}
 
             <p className="text-xs mt-2" style={{ color: 'var(--mono-muted)' }}>
-                Last checked: {formatRelativeTimeRounded(podStatus.last_checked)}
+                Last checked: {podStatus.last_checked ? formatRelativeTimeRounded(podStatus.last_checked) : '-'}
             </p>
+        </div>
+    );
+}
+
+function formatCompactObject(value) {
+    if (value === null || value === undefined) return '-';
+    if (typeof value === 'string') return value;
+    if (Array.isArray(value)) return value.map((item) => formatCompactObject(item)).join(', ');
+    if (typeof value === 'object') {
+        return Object.entries(value)
+            .filter(([_, entryValue]) => entryValue !== null && entryValue !== undefined && entryValue !== '')
+            .map(([key, entryValue]) => `${key}=${formatCompactObject(entryValue)}`)
+            .join(' • ');
+    }
+    return String(value);
+}
+
+function getArgoCdStatusTone(applicationStatus) {
+    const health = applicationStatus.health?.status;
+    const sync = applicationStatus.sync?.status;
+    const operation = applicationStatus.operationState?.phase;
+
+    if (health === 'Healthy' && sync === 'Synced') {
+        return 'ok';
+    }
+    if (['Degraded', 'Missing', 'Suspended'].includes(health) || ['Error', 'Failed'].includes(operation)) {
+        return 'bad';
+    }
+    return 'warn';
+}
+
+function ArgoCdApplicationStatusSection({ applicationStatus, deploymentId }) {
+    const tone = getArgoCdStatusTone(applicationStatus);
+    const configuredDeploymentId = applicationStatus.configuredDeploymentId || '-';
+    const expectedDeploymentId = applicationStatus.expectedDeploymentId || deploymentId || '-';
+    const deploymentMismatch = applicationStatus.deploymentMismatch ?? (
+        Boolean(applicationStatus.configuredDeploymentId) &&
+        Boolean(deploymentId) &&
+        applicationStatus.configuredDeploymentId !== deploymentId
+    );
+    const toneColors = {
+        ok: { color: '#b7ffce', borderColor: '#2e6c44', background: 'rgba(44, 105, 66, 0.2)' },
+        warn: { color: '#ffe3a8', borderColor: '#7b6333', background: 'rgba(139, 112, 57, 0.22)' },
+        bad: { color: '#ffc0c0', borderColor: '#7d4b4b', background: 'rgba(125, 75, 75, 0.24)' },
+    };
+
+    const borderColors = {
+        ok: '#2e6c44',
+        warn: '#7b6333',
+        bad: '#7d4b4b',
+    };
+
+    const headerColors = {
+        ok: '#b7ffce',
+        warn: '#ffe3a8',
+        bad: '#ffc0c0',
+    };
+
+    return (
+        <div className="mb-6">
+            <h4 className="text-sm font-semibold mb-2" style={{ color: 'var(--mono-muted)' }}>
+                ArgoCD Application Status
+            </h4>
+
+            <div className="mono-inline-status mb-3" style={toneColors[tone]}>
+                <div className="flex flex-col gap-1">
+                    <div className="flex items-center justify-between gap-4">
+                        <span>Application: {applicationStatus.application || '-'}</span>
+                        <span className="text-xs" style={{ color: 'var(--mono-muted)' }}>
+                            Namespace: {applicationStatus.namespace || '-'}
+                        </span>
+                    </div>
+                    <div className="text-xs" style={{ color: '#e8e8e8' }}>
+                        Health: {applicationStatus.health?.status || '-'} • Sync: {applicationStatus.sync?.status || '-'} • Operation: {applicationStatus.operationState?.phase || 'Idle'}
+                    </div>
+                </div>
+            </div>
+
+            {deploymentMismatch && (
+                <div className="mono-inline-status mb-3" style={toneColors.warn}>
+                    Application is configured for deployment {configuredDeploymentId}, not {expectedDeploymentId}.
+                </div>
+            )}
+
+            <div className="border border-solid mb-3" style={{ borderColor: borderColors[tone], background: tone === 'ok' ? '#0a1210' : '#1a1212' }}>
+                <div className="p-3" style={{ borderBottom: `1px solid ${borderColors[tone]}` }}>
+                    <h5 className="text-xs font-semibold" style={{ color: headerColors[tone] }}>
+                        Summary
+                    </h5>
+                </div>
+                <div className="p-3 grid gap-2 text-xs">
+                    <div><span style={{ color: 'var(--mono-muted)' }}>revision</span><div className="font-mono" style={{ color: '#e8e8e8' }}>{applicationStatus.sync?.revision || '-'}</div></div>
+                    <div><span style={{ color: 'var(--mono-muted)' }}>health message</span><div className="font-mono" style={{ color: '#e8e8e8' }}>{applicationStatus.health?.message || '-'}</div></div>
+                    <div><span style={{ color: 'var(--mono-muted)' }}>operation message</span><div className="font-mono" style={{ color: '#e8e8e8' }}>{applicationStatus.operationState?.message || '-'}</div></div>
+                    <div><span style={{ color: 'var(--mono-muted)' }}>configured deployment</span><div className="font-mono" style={{ color: '#e8e8e8' }}>{configuredDeploymentId}</div></div>
+                    <div><span style={{ color: 'var(--mono-muted)' }}>expected deployment</span><div className="font-mono" style={{ color: '#e8e8e8' }}>{expectedDeploymentId}</div></div>
+                    <div><span style={{ color: 'var(--mono-muted)' }}>last health transition</span><div style={{ color: '#e8e8e8' }}>{applicationStatus.health?.lastTransitionTime ? formatRelativeTimeRounded(applicationStatus.health.lastTransitionTime) : '-'}</div></div>
+                    <div><span style={{ color: 'var(--mono-muted)' }}>reconciled</span><div style={{ color: '#e8e8e8' }}>{applicationStatus.reconciledAt ? formatRelativeTimeRounded(applicationStatus.reconciledAt) : '-'}</div></div>
+                    <div><span style={{ color: 'var(--mono-muted)' }}>observed</span><div style={{ color: '#e8e8e8' }}>{applicationStatus.observedAt ? formatRelativeTimeRounded(applicationStatus.observedAt) : '-'}</div></div>
+                </div>
+            </div>
+
+            {applicationStatus.conditions && applicationStatus.conditions.length > 0 && (
+                <div className="border border-solid mb-3" style={{ borderColor: borderColors[tone], background: '#0a0a0a' }}>
+                    <div className="p-3" style={{ borderBottom: `1px solid ${borderColors[tone]}` }}>
+                        <h5 className="text-xs font-semibold" style={{ color: headerColors[tone] }}>
+                            Conditions
+                        </h5>
+                    </div>
+                    <div className="p-3 space-y-2">
+                        {applicationStatus.conditions.map((condition, idx) => (
+                            <div key={`condition-${idx}`} className="text-xs p-2" style={{ background: '#0f0f0f', border: '1px solid var(--mono-line)' }}>
+                                <div className="flex items-center justify-between gap-4 mb-1">
+                                    <span className="font-semibold" style={{ color: '#e8e8e8' }}>
+                                        {condition.type || '-'}
+                                    </span>
+                                    <span style={{ color: 'var(--mono-muted)' }}>
+                                        {condition.lastTransitionTime ? formatRelativeTimeRounded(condition.lastTransitionTime) : '-'}
+                                    </span>
+                                </div>
+                                <div className="font-mono" style={{ color: '#e8e8e8' }}>
+                                    {condition.message || '-'}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            )}
+
+            {((applicationStatus.summary?.externalURLs && applicationStatus.summary.externalURLs.length > 0) ||
+                (applicationStatus.summary?.images && applicationStatus.summary.images.length > 0)) && (
+                <div className="border border-solid mb-3" style={{ borderColor: borderColors[tone], background: '#0a0a0a' }}>
+                    <div className="p-3" style={{ borderBottom: `1px solid ${borderColors[tone]}` }}>
+                        <h5 className="text-xs font-semibold" style={{ color: headerColors[tone] }}>
+                            Application Summary
+                        </h5>
+                    </div>
+                    <div className="p-3 space-y-3 text-xs">
+                        {applicationStatus.summary?.externalURLs?.length > 0 && (
+                            <div>
+                                <div className="mb-1" style={{ color: 'var(--mono-muted)' }}>External URLs</div>
+                                <div className="space-y-1">
+                                    {applicationStatus.summary.externalURLs.map((url, idx) => (
+                                        <div key={`external-url-${idx}`} className="font-mono" style={{ color: '#e8e8e8' }}>
+                                            <a href={url} target="_blank" rel="noopener noreferrer" className="underline">
+                                                {url}
+                                            </a>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
+                        {applicationStatus.summary?.images?.length > 0 && (
+                            <div>
+                                <div className="mb-1" style={{ color: 'var(--mono-muted)' }}>Images</div>
+                                <div className="space-y-1">
+                                    {applicationStatus.summary.images.map((image, idx) => (
+                                        <div key={`image-${idx}`} className="font-mono" style={{ color: '#e8e8e8' }}>
+                                            {image}
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
+                    </div>
+                </div>
+            )}
+
+            {applicationStatus.resources && applicationStatus.resources.length > 0 && (
+                <div className="border border-solid mb-3" style={{ borderColor: borderColors[tone], background: '#0a0a0a' }}>
+                    <div className="p-3 flex items-center justify-between" style={{ borderBottom: `1px solid ${borderColors[tone]}` }}>
+                        <h5 className="text-xs font-semibold" style={{ color: headerColors[tone] }}>
+                            Managed Resources
+                        </h5>
+                        <span className="text-xs" style={{ color: 'var(--mono-muted)' }}>
+                            {applicationStatus.resourceCount || applicationStatus.resources.length} total
+                        </span>
+                    </div>
+                    <div>
+                        {applicationStatus.resources.map((resource, idx) => (
+                            <div key={`${resource.kind}-${resource.name}-${idx}`} className="p-3 border-b last:border-b-0" style={{ borderColor: 'var(--mono-line)' }}>
+                                <div className="flex items-center justify-between gap-4 text-xs mb-1">
+                                    <div className="font-mono" style={{ color: '#e8e8e8' }}>
+                                        {resource.kind}/{resource.name}
+                                    </div>
+                                    <div style={{ color: 'var(--mono-muted)' }}>
+                                        {resource.namespace || '-'}
+                                    </div>
+                                </div>
+                                <div className="text-xs mb-1" style={{ color: 'var(--mono-muted)' }}>
+                                    Sync: {resource.status || '-'} • Health: {resource.health?.status || '-'}
+                                    {resource.requiresPruning ? ' • prune pending' : ''}
+                                </div>
+                                {(resource.message || resource.health?.message) && (
+                                    <div className="font-mono text-xs" style={{ color: '#e8e8e8' }}>
+                                        {resource.message || resource.health?.message}
+                                    </div>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            )}
+
+            {applicationStatus.history && applicationStatus.history.length > 0 && (
+                <div className="border border-solid mb-3" style={{ borderColor: borderColors[tone], background: '#0a0a0a' }}>
+                    <div className="p-3" style={{ borderBottom: `1px solid ${borderColors[tone]}` }}>
+                        <h5 className="text-xs font-semibold" style={{ color: headerColors[tone] }}>
+                            Sync History
+                        </h5>
+                    </div>
+                    <div className="p-3 space-y-2">
+                        {applicationStatus.history.map((entry, idx) => (
+                            <div key={`history-${idx}`} className="text-xs p-2" style={{ background: '#0f0f0f', border: '1px solid var(--mono-line)' }}>
+                                <div className="font-mono mb-1" style={{ color: '#e8e8e8' }}>
+                                    {entry.revision || (entry.revisions && entry.revisions.join(', ')) || '-'}
+                                </div>
+                                <div style={{ color: 'var(--mono-muted)' }}>
+                                    Started: {entry.deployStartedAt ? formatRelativeTimeRounded(entry.deployStartedAt) : '-'} • Deployed: {entry.deployedAt ? formatRelativeTimeRounded(entry.deployedAt) : '-'}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            )}
+
+            {applicationStatus.transitions && applicationStatus.transitions.length > 0 && (
+                <div className="border border-solid" style={{ borderColor: borderColors[tone], background: '#0a0a0a' }}>
+                    <div className="p-3" style={{ borderBottom: `1px solid ${borderColors[tone]}` }}>
+                        <h5 className="text-xs font-semibold" style={{ color: headerColors[tone] }}>
+                            Status Transitions
+                        </h5>
+                    </div>
+                    <div className="p-3 space-y-2">
+                        {applicationStatus.transitions.map((transition, idx) => (
+                            <div key={`transition-${idx}`} className="text-xs p-2 font-mono" style={{ background: '#0f0f0f', border: '1px solid var(--mono-line)', color: '#e8e8e8' }}>
+                                {formatCompactObject(transition)}
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            )}
         </div>
     );
 }
@@ -1479,7 +1724,10 @@ export function DeploymentDetail({ projectName, deploymentId }) {
             )}
 
             {deployment.controller_metadata?.pod_status && (
-                <PodStatusSection podStatus={deployment.controller_metadata.pod_status} />
+                <PodStatusSection
+                    podStatus={deployment.controller_metadata.pod_status}
+                    deploymentId={deployment.deployment_id}
+                />
             )}
 
             {deployment.build_logs && (

--- a/helm/rise-app/.helmignore
+++ b/helm/rise-app/.helmignore
@@ -1,0 +1,5 @@
+.DS_Store
+.git/
+.gitignore
+*.swp
+*.bak

--- a/helm/rise-app/Chart.yaml
+++ b/helm/rise-app/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: rise-app
+description: Helm chart for Rise application workloads managed via ArgoCD
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/helm/rise-app/templates/_helpers.tpl
+++ b/helm/rise-app/templates/_helpers.tpl
@@ -1,0 +1,30 @@
+{{- define "rise-app.name" -}}
+{{- default .Chart.Name .Values.rise.argocd.applicationName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "rise-app.labels" -}}
+app.kubernetes.io/name: {{ include "rise-app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: rise
+{{ include "rise-app.riseLabels" . }}
+{{- end -}}
+
+{{- define "rise-app.riseLabels" -}}
+rise.dev/project: {{ .Values.rise.project.name | quote }}
+rise.dev/deployment-group: {{ .Values.rise.deployment.normalizedGroup | quote }}
+rise.dev/deployment-id: {{ .Values.rise.deployment.id | quote }}
+{{- end -}}
+
+{{- define "rise-app.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "rise-app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "rise-app.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "rise-app.name" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/helm/rise-app/templates/deployment.yaml
+++ b/helm/rise-app/templates/deployment.yaml
@@ -1,0 +1,120 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "rise-app.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rise-app.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.app.replicas }}
+  selector:
+    matchLabels:
+      {{- include "rise-app.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "rise-app.selectorLabels" . | nindent 8 }}
+        {{- include "rise-app.riseLabels" . | nindent 8 }}
+        {{- with .Values.app.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.app.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "rise-app.serviceAccountName" . }}
+      {{- if .Values.rise.image.pullSecretName }}
+      imagePullSecrets:
+        - name: {{ .Values.rise.image.pullSecretName }}
+      {{- end }}
+      {{- if .Values.app.podSecurity.enabled }}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      {{- end }}
+      {{- with .Values.app.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: app
+          image: {{ .Values.rise.image.ref | quote }}
+          imagePullPolicy: {{ .Values.app.imagePullPolicy }}
+          {{- with .Values.app.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.app.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.rise.deployment.httpPort }}
+              protocol: TCP
+          envFrom:
+            - secretRef:
+                name: {{ .Values.rise.env.secretName }}
+          {{- with .Values.app.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.app.podSecurity.enabled }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+          {{- end }}
+          resources:
+            {{- toYaml .Values.app.resources | nindent 12 }}
+          {{- if .Values.app.healthProbes.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.app.healthProbes.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.app.healthProbes.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.healthProbes.periodSeconds }}
+            timeoutSeconds: {{ .Values.app.healthProbes.timeoutSeconds }}
+            failureThreshold: {{ .Values.app.healthProbes.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.app.healthProbes.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.app.healthProbes.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.healthProbes.periodSeconds }}
+            timeoutSeconds: {{ .Values.app.healthProbes.timeoutSeconds }}
+            failureThreshold: {{ .Values.app.healthProbes.failureThreshold }}
+          {{- end }}
+          {{- if .Values.app.extraServiceTokenAudiences }}
+          volumeMounts:
+            - name: rise-extra-service-tokens
+              mountPath: /var/run/secrets/rise/tokens
+              readOnly: true
+          {{- end }}
+      {{- if .Values.app.extraServiceTokenAudiences }}
+      volumes:
+        - name: rise-extra-service-tokens
+          projected:
+            sources:
+              {{- range $name, $audience := .Values.app.extraServiceTokenAudiences }}
+              - serviceAccountToken:
+                  path: {{ $name | quote }}
+                  audience: {{ $audience | quote }}
+              {{- end }}
+      {{- end }}
+      {{- with .Values.app.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.app.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.app.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/rise-app/templates/ingress.yaml
+++ b/helm/rise-app/templates/ingress.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.ingress.enabled }}
+{{- $accessClass := (index .Values.rise.accessClasses .Values.rise.project.accessClass) | default dict }}
+{{- $annotations := merge (dict) (.Values.ingress.annotations | default dict) (($accessClass.customAnnotations) | default dict) }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "rise-app.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rise-app.labels" . | nindent 4 }}
+  {{- if $annotations }}
+  annotations:
+    {{- toYaml $annotations | nindent 4 }}
+  {{- end }}
+spec:
+  {{- $ingressClass := default .Values.ingress.className ($accessClass.ingressClass | default "") }}
+  {{- if $ingressClass }}
+  ingressClassName: {{ $ingressClass }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.rise.ingress.host | quote }}
+      http:
+        paths:
+          - path: {{ .Values.rise.ingress.path | quote }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "rise-app.name" . }}
+                port:
+                  name: http
+    {{- range .Values.rise.ingress.customDomainHosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "rise-app.name" $ }}
+                port:
+                  name: http
+    {{- end }}
+  {{- if and .Values.ingress.tls.enabled .Values.ingress.tls.secretName }}
+  tls:
+    - secretName: {{ .Values.ingress.tls.secretName }}
+      hosts:
+        - {{ .Values.rise.ingress.host | quote }}
+        {{- range .Values.rise.ingress.customDomainHosts }}
+        - {{ . | quote }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/rise-app/templates/networkpolicy.yaml
+++ b/helm/rise-app/templates/networkpolicy.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "rise-app.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rise-app.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "rise-app.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.ingressControllerNamespace | quote }}
+          podSelector:
+            matchLabels:
+              {{- toYaml .Values.networkPolicy.ingressControllerLabels | nindent 14 }}
+  egress:
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- if .Values.networkPolicy.allowKubeApiServer }}
+    {{- range .Values.networkPolicy.kubeApiServerCidrs }}
+    - to:
+        - ipBlock:
+            cidr: {{ . | quote }}
+      ports:
+        - protocol: TCP
+          port: 443
+    {{- end }}
+    {{- end }}
+    {{- range .Values.networkPolicy.egressAllowCidrs }}
+    - to:
+        - ipBlock:
+            cidr: {{ . | quote }}
+    {{- end }}
+{{- end }}

--- a/helm/rise-app/templates/service.yaml
+++ b/helm/rise-app/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "rise-app.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rise-app.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "rise-app.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.rise.deployment.httpPort }}
+      targetPort: http
+      protocol: TCP

--- a/helm/rise-app/templates/serviceaccount.yaml
+++ b/helm/rise-app/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "rise-app.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rise-app.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/rise-app/values.yaml
+++ b/helm/rise-app/values.yaml
@@ -1,0 +1,80 @@
+rise:
+  project:
+    id: ""
+    name: ""
+    accessClass: ""
+  deployment:
+    id: ""
+    group: ""
+    normalizedGroup: ""
+    namespace: ""
+    httpPort: 8080
+  ingress:
+    host: ""
+    path: "/"
+    customDomainHosts: []
+  image:
+    ref: ""
+    pullSecretName: ""
+  env:
+    secretName: ""
+  accessClasses: {}
+  argocd:
+    applicationName: ""
+    appProjectName: ""
+
+app:
+  replicas: 1
+  imagePullPolicy: IfNotPresent
+  command: []
+  args: []
+  extraEnv: []
+  podLabels: {}
+  podAnnotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  hostAliases: []
+  extraServiceTokenAudiences: {}
+  resources:
+    requests:
+      cpu: "10m"
+      memory: "64Mi"
+    limits:
+      memory: "512Mi"
+  podSecurity:
+    enabled: true
+  healthProbes:
+    enabled: true
+    path: /
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+service:
+  annotations: {}
+  type: ClusterIP
+
+ingress:
+  enabled: true
+  className: ""
+  annotations: {}
+  pathType: Prefix
+  tls:
+    enabled: false
+    secretName: ""
+
+networkPolicy:
+  enabled: true
+  ingressControllerNamespace: ingress-nginx
+  ingressControllerLabels:
+    app.kubernetes.io/name: ingress-nginx
+  allowKubeApiServer: false
+  kubeApiServerCidrs: []
+  egressAllowCidrs: []

--- a/mise.toml
+++ b/mise.toml
@@ -10,7 +10,7 @@ buildkit = "0.28.0"
 "cargo:sqlx-cli" = "latest"
 "cargo:cargo-all-features" = "latest"
 mdbook = "latest"
-helm = "latest"
+helm = "3"
 rust = { version = "1.91.1", profile = "default" }
 kubectl = "latest"
 k9s = "latest"
@@ -31,8 +31,24 @@ cargo all-features clippy --all-targets -- -D warnings
 cargo fmt --all -- --check
 mise sqlx:check
 helm lint helm/rise
+helm lint helm/rise-app
 """
 env.SQLX_OFFLINE = true
+
+[tasks."chart:app:package"]
+description = "Package the Rise app Helm chart into dist/charts."
+run = """
+mkdir -p dist/charts
+helm package helm/rise-app --destination dist/charts
+"""
+
+[tasks."chart:app:push-local"]
+description = "Package and push the Rise app Helm chart to the local development OCI registry."
+depends = ["backend:deps", "chart:app:package"]
+run = """
+CHART_PACKAGE=$(ls -t dist/charts/rise-app-*.tgz | head -n 1)
+helm push "$CHART_PACKAGE" oci://rise-registry:5000/helm-charts --plain-http
+"""
 
 [tasks."config:schema:generate"]
 description = "Generate the backend settings JSON schema."
@@ -203,4 +219,75 @@ run = "bash tests/e2e-build/run.sh"
 [tasks."k3s:down"]
 run = """
 sudo /usr/local/bin/k3s-uninstall.sh
+"""
+
+[tasks."argocd:install"]
+description = "Install ArgoCD into the current cluster and set the admin password to 'password'."
+run = """
+set -eu
+
+helm repo add argo https://argoproj.github.io/argo-helm >/dev/null 2>&1 || true
+helm repo update argo
+
+helm upgrade --install argocd argo/argo-cd \
+  --namespace argocd \
+  --create-namespace \
+  --wait \
+  --set configs.params."server\\.insecure"=true
+
+PASSWORD_HASH=$(docker run --rm --entrypoint htpasswd httpd:2.4-alpine -nbBC 10 "" password | tr -d ':\n' | sed 's/^\\$2y/\\$2a/')
+PASSWORD_MTIME=$(date -u +%FT%TZ)
+PATCH_FILE=$(mktemp)
+trap 'rm -f "$PATCH_FILE"' EXIT
+
+cat > "$PATCH_FILE" <<EOF
+stringData:
+  admin.password: "$PASSWORD_HASH"
+  admin.passwordMtime: "$PASSWORD_MTIME"
+EOF
+
+kubectl -n argocd patch secret argocd-secret \
+  --type merge \
+  --patch-file "$PATCH_FILE"
+
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rise-local-oci-repo
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: repository
+stringData:
+  name: rise-local-registry
+  url: oci://rise-registry:5000/helm-charts/rise-app
+  type: oci
+  insecureOCIForceHttp: "true"
+EOF
+
+kubectl -n argocd delete secret argocd-initial-admin-secret --ignore-not-found=true
+kubectl -n argocd rollout restart deployment argocd-server
+kubectl -n argocd rollout restart deployment argocd-repo-server
+kubectl -n argocd rollout status deployment argocd-server --timeout=180s
+kubectl -n argocd rollout status deployment argocd-repo-server --timeout=180s
+
+echo
+echo "ArgoCD installed."
+echo "Username: admin"
+echo "Password: password"
+echo "Local OCI Helm repo: rise-registry:5000 (insecure OCI enabled)"
+echo
+echo "Port-forward with:"
+echo "  kubectl -n argocd port-forward svc/argocd-server 8081:80"
+echo
+echo "Then open:"
+echo "  http://localhost:8081"
+"""
+
+[tasks."argocd:password"]
+description = "Print the current ArgoCD initial admin password if the secret exists."
+run = """
+set -eu
+kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d
+echo
 """

--- a/src/cli/deployment/core.rs
+++ b/src/cli/deployment/core.rs
@@ -5,7 +5,7 @@ use comfy_table::{
 use reqwest::Client;
 use serde::Deserialize;
 use std::time::Duration;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::build::{self, BuildOptions};
 use crate::config::Config;
@@ -287,11 +287,7 @@ pub async fn show_deployment(
 
         // Exit with error if deployment failed
         if deployment.status == DeploymentStatus::Failed {
-            if let Some(error) = deployment.error_message {
-                bail!("Deployment failed: {}", error);
-            } else {
-                bail!("Deployment failed");
-            }
+            return deployment_failed(deployment_id, deployment.error_message.as_deref());
         }
 
         Ok(())
@@ -310,14 +306,23 @@ pub async fn show_deployment(
 
         // Exit with error if deployment failed
         if deployment.status == DeploymentStatus::Failed {
-            if let Some(error) = deployment.error_message {
-                bail!("Deployment failed: {}", error);
-            } else {
-                bail!("Deployment failed");
-            }
+            return deployment_failed(deployment_id, deployment.error_message.as_deref());
         }
 
         Ok(())
+    }
+}
+
+fn deployment_failed(deployment_id: &str, error_message: Option<&str>) -> Result<()> {
+    match error_message {
+        Some(message) => {
+            error!(deployment_id, error = message, "Deployment failed");
+            bail!("Deployment failed: {}", message);
+        }
+        None => {
+            error!(deployment_id, "Deployment failed");
+            bail!("Deployment failed");
+        }
     }
 }
 

--- a/src/db/projects.rs
+++ b/src/db/projects.rs
@@ -397,8 +397,10 @@ pub async fn update_calculated_status(pool: &PgPool, project_id: Uuid) -> Result
                 | DeploymentStatus::Superseded
                 | DeploymentStatus::Expired => ProjectStatus::Stopped,
 
-                // Running states without being active (shouldn't happen, but treat as stopped)
-                DeploymentStatus::Healthy | DeploymentStatus::Unhealthy => ProjectStatus::Stopped,
+                // If the latest default deployment is already healthy/unhealthy but active
+                // promotion has not happened yet, reflect that state instead of showing Stopped.
+                DeploymentStatus::Healthy => ProjectStatus::Running,
+                DeploymentStatus::Unhealthy => ProjectStatus::Failed,
             }
         } else {
             // No deployments in default group at all
@@ -777,6 +779,53 @@ mod tests {
             project.status,
             ProjectStatus::Stopped,
             "Project should be Stopped when only failed deployment exists and no active deployment"
+        );
+    }
+
+    #[sqlx::test]
+    async fn test_project_status_with_healthy_default_deployment_without_active_flag(pool: PgPool) {
+        let user = crate::db::users::create(&pool, "test3@example.com")
+            .await
+            .expect("Failed to create test user");
+
+        let project = create(
+            &pool,
+            "test-project-3",
+            ProjectStatus::Stopped,
+            "default".to_string(),
+            Some(user.id),
+            None,
+        )
+        .await
+        .expect("Failed to create test project");
+
+        deployments::create(
+            &pool,
+            CreateDeploymentParams {
+                deployment_id: "20251220-130000",
+                project_id: project.id,
+                created_by_id: user.id,
+                status: DeploymentStatus::Healthy,
+                image: Some("test:v1"),
+                image_digest: None,
+                rolled_back_from_deployment_id: None,
+                deployment_group: DEFAULT_DEPLOYMENT_GROUP,
+                expires_at: None,
+                http_port: 8080,
+                is_active: false,
+            },
+        )
+        .await
+        .expect("Failed to create healthy deployment");
+
+        let project = update_calculated_status(&pool, project.id)
+            .await
+            .expect("Failed to update project status");
+
+        assert_eq!(
+            project.status,
+            ProjectStatus::Running,
+            "Project should be Running when the latest default deployment is healthy even if is_active is not set yet"
         );
     }
 }

--- a/src/server/deployment/controller/argocd.rs
+++ b/src/server/deployment/controller/argocd.rs
@@ -1,0 +1,2282 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
+use futures::{AsyncBufReadExt, StreamExt};
+use k8s_openapi::api::core::v1::{Namespace, Pod, Secret};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use kube::api::{Api, DeleteParams, ListParams, LogParams, Patch, PatchParams};
+use kube::{Client, CustomResource, ResourceExt};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::interval;
+use tracing::{info, warn};
+
+use super::{DeploymentBackend, DeploymentUrls, HealthStatus, ReconcileResult};
+use crate::db::custom_domains as db_custom_domains;
+use crate::db::deployments as db_deployments;
+use crate::db::models::{Deployment, DeploymentStatus, Project};
+use crate::db::projects as db_projects;
+use crate::server::deployment::models::{normalize_deployment_group, DEFAULT_DEPLOYMENT_GROUP};
+use crate::server::registry::{
+    models::{RegistryAuthMethod, RegistryCredentials},
+    ImageTagType, RegistryProvider,
+};
+use crate::server::settings::AccessClass;
+use crate::server::state::ControllerState;
+
+const LABEL_MANAGED_BY: &str = "rise.dev/managed-by";
+const LABEL_PROJECT: &str = "rise.dev/project";
+const LABEL_DEPLOYMENT_GROUP: &str = "rise.dev/deployment-group";
+const LABEL_DEPLOYMENT_ID: &str = "rise.dev/deployment-id";
+pub const LABEL_IGNORE_RECONCILE: &str = "rise.dev/ignore-reconcile";
+const ANNOTATION_SPEC_HASH: &str = "rise.dev/spec-hash";
+const ANNOTATION_LAST_APPLIED_AT: &str = "rise.dev/last-applied-at";
+const ANNOTATION_TARGET_IMAGE: &str = "rise.dev/target-image";
+const APPLICATION_RESOURCES_FINALIZER: &str = "resources-finalizer.argocd.argoproj.io";
+pub const ARGOCD_PROJECT_FINALIZER: &str = "argocd.rise.dev/resources";
+const MAX_STATUS_MESSAGE_CHARS: usize = 240;
+
+#[derive(Clone)]
+pub struct ArgoCdHelmChartConfig {
+    pub repo_url: String,
+    pub chart: String,
+    pub target_revision: String,
+    pub values: Value,
+}
+
+#[derive(Clone)]
+pub struct ArgoCdControllerConfig {
+    pub argocd_namespace: String,
+    pub production_ingress_url_template: String,
+    pub staging_ingress_url_template: Option<String>,
+    pub ingress_port: Option<u16>,
+    pub ingress_schema: String,
+    pub appproject_format: String,
+    pub application_format: String,
+    pub destination_namespace_format: String,
+    pub destination_server: String,
+    pub namespace_labels: HashMap<String, String>,
+    pub namespace_annotations: HashMap<String, String>,
+    pub helm_chart: ArgoCdHelmChartConfig,
+    pub sync_options: Vec<String>,
+    pub access_classes: HashMap<String, AccessClass>,
+    pub registry_provider: Arc<dyn RegistryProvider>,
+}
+
+pub struct ArgoCdController {
+    state: ControllerState,
+    kube_client: Client,
+    argocd_namespace: String,
+    production_ingress_url_template: String,
+    staging_ingress_url_template: Option<String>,
+    ingress_port: Option<u16>,
+    ingress_schema: String,
+    appproject_format: String,
+    application_format: String,
+    destination_namespace_format: String,
+    destination_server: String,
+    namespace_labels: HashMap<String, String>,
+    namespace_annotations: HashMap<String, String>,
+    helm_chart: ArgoCdHelmChartConfig,
+    sync_options: Vec<String>,
+    access_classes: HashMap<String, AccessClass>,
+    registry_provider: Arc<dyn RegistryProvider>,
+}
+
+#[derive(Serialize, Deserialize, Default, Clone)]
+struct ArgoCdMetadata {
+    argocd_namespace: Option<String>,
+    appproject_name: Option<String>,
+    application_name: Option<String>,
+    destination_namespace: Option<String>,
+    env_secret_name: Option<String>,
+    pull_secret_name: Option<String>,
+    target_image: Option<String>,
+    applied_spec_hash: Option<String>,
+    last_applied_at: Option<DateTime<Utc>>,
+    reverted_to_deployment_id: Option<String>,
+}
+
+#[derive(CustomResource, Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[kube(
+    group = "argoproj.io",
+    version = "v1alpha1",
+    kind = "Application",
+    plural = "applications",
+    namespaced,
+    status = "ApplicationStatus"
+)]
+#[serde(rename_all = "camelCase")]
+struct ApplicationSpec {
+    project: String,
+    source: ApplicationSource,
+    destination: ApplicationDestination,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sync_policy: Option<ApplicationSyncPolicy>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+struct ApplicationSource {
+    #[serde(rename = "repoURL")]
+    repo_url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    chart: Option<String>,
+    target_revision: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    helm: Option<ApplicationSourceHelm>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+struct ApplicationSourceHelm {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    release_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    values: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+struct ApplicationDestination {
+    server: String,
+    namespace: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+struct ApplicationSyncPolicy {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    automated: Option<ApplicationSyncPolicyAutomated>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sync_options: Option<Vec<String>>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+struct ApplicationSyncPolicyAutomated {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    enabled: Option<bool>,
+    #[serde(default)]
+    prune: bool,
+    #[serde(default)]
+    self_heal: bool,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+struct ApplicationStatus {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    health: Option<ApplicationHealthStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sync: Option<ApplicationSyncStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    operation_state: Option<ApplicationOperationState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    conditions: Option<Vec<ApplicationCondition>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    summary: Option<ApplicationSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    resources: Option<Vec<ApplicationResourceStatus>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    history: Option<Vec<ApplicationRevisionHistory>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    transitions: Option<Vec<Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reconciled_at: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+struct ApplicationHealthStatus {
+    status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_transition_time: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+struct ApplicationSyncStatus {
+    status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    revision: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+struct ApplicationOperationState {
+    phase: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    started_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    finished_at: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+struct ApplicationCondition {
+    #[serde(rename = "type")]
+    type_: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_transition_time: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+struct ApplicationSummary {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    external_urls: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    images: Option<Vec<String>>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+struct ApplicationResourceStatus {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    group: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    version: Option<String>,
+    kind: String,
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    namespace: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    health: Option<ApplicationHealthStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    requires_pruning: Option<bool>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+struct ApplicationRevisionHistory {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    revision: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    revisions: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    deployed_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    deploy_started_at: Option<String>,
+}
+
+#[derive(CustomResource, Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[kube(
+    group = "argoproj.io",
+    version = "v1alpha1",
+    kind = "AppProject",
+    plural = "appprojects",
+    namespaced
+)]
+#[serde(rename_all = "camelCase")]
+struct AppProjectSpec {
+    description: String,
+    source_repos: Vec<String>,
+    destinations: Vec<AppProjectDestination>,
+    cluster_resource_whitelist: Vec<AppProjectGroupKind>,
+    namespace_resource_whitelist: Vec<AppProjectGroupKind>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+struct AppProjectDestination {
+    server: String,
+    namespace: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+struct AppProjectGroupKind {
+    group: String,
+    kind: String,
+}
+
+struct DesiredApplication {
+    object: Application,
+    spec_hash: String,
+}
+
+struct ApplicationReadiness {
+    healthy: bool,
+    failed: bool,
+    message: Option<String>,
+    reconciled_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Serialize)]
+struct DeploymentPodStatus {
+    desired_replicas: i32,
+    ready_replicas: i32,
+    current_replicas: i32,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pods: Vec<DeploymentPodInfo>,
+    last_checked: DateTime<Utc>,
+}
+
+#[derive(Serialize)]
+struct DeploymentPodInfo {
+    name: String,
+    phase: String,
+    ready: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    conditions: Vec<DeploymentPodCondition>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    containers: Vec<DeploymentContainerStatus>,
+}
+
+#[derive(Serialize)]
+struct DeploymentPodCondition {
+    #[serde(rename = "type")]
+    type_: String,
+    status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<String>,
+}
+
+#[derive(Serialize)]
+struct DeploymentContainerStatus {
+    name: String,
+    ready: bool,
+    restart_count: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    state: Option<DeploymentContainerState>,
+}
+
+#[derive(Serialize)]
+struct DeploymentContainerState {
+    state_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    exit_code: Option<i32>,
+}
+
+struct MatchedPodHealth {
+    healthy: bool,
+    message: Option<String>,
+    status: Value,
+}
+
+fn truncate_text(input: &str, max_chars: usize) -> String {
+    if input.chars().count() <= max_chars {
+        return input.to_string();
+    }
+
+    let mut truncated: String = input.chars().take(max_chars).collect();
+    truncated.push_str("...");
+    truncated
+}
+
+fn truncate_optional_text(input: Option<&str>, max_chars: usize) -> Option<String> {
+    input.map(|text| truncate_text(text, max_chars))
+}
+
+fn application_configured_deployment_id(application: &Application) -> Option<String> {
+    application
+        .metadata
+        .labels
+        .as_ref()
+        .and_then(|labels| labels.get(LABEL_DEPLOYMENT_ID))
+        .cloned()
+}
+
+fn reconcile_ignored(metadata: &ObjectMeta) -> bool {
+    metadata
+        .labels
+        .as_ref()
+        .and_then(|labels| labels.get(LABEL_IGNORE_RECONCILE))
+        .map(|value| matches!(value.as_str(), "true" | "1" | "yes" | "on"))
+        .unwrap_or(false)
+}
+
+fn canonicalize_json(value: Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut entries: Vec<(String, Value)> = map
+                .into_iter()
+                .map(|(key, value)| (key, canonicalize_json(value)))
+                .collect();
+            entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+
+            let mut normalized = Map::new();
+            for (key, value) in entries {
+                normalized.insert(key, value);
+            }
+            Value::Object(normalized)
+        }
+        Value::Array(values) => Value::Array(values.into_iter().map(canonicalize_json).collect()),
+        other => other,
+    }
+}
+
+impl ArgoCdController {
+    pub fn new(
+        state: ControllerState,
+        kube_client: Client,
+        config: ArgoCdControllerConfig,
+    ) -> Result<Self> {
+        Ok(Self {
+            state,
+            kube_client,
+            argocd_namespace: config.argocd_namespace,
+            production_ingress_url_template: config.production_ingress_url_template,
+            staging_ingress_url_template: config.staging_ingress_url_template,
+            ingress_port: config.ingress_port,
+            ingress_schema: config.ingress_schema,
+            appproject_format: config.appproject_format,
+            application_format: config.application_format,
+            destination_namespace_format: config.destination_namespace_format,
+            destination_server: config.destination_server,
+            namespace_labels: config.namespace_labels,
+            namespace_annotations: config.namespace_annotations,
+            helm_chart: config.helm_chart,
+            sync_options: config.sync_options,
+            access_classes: config.access_classes,
+            registry_provider: config.registry_provider,
+        })
+    }
+
+    pub async fn test_connection(&self) -> Result<()> {
+        let namespaces: Api<Namespace> = Api::all(self.kube_client.clone());
+        namespaces
+            .get("default")
+            .await
+            .map(|_| ())
+            .map_err(|e| anyhow::anyhow!("Failed to connect to Kubernetes API: {}", e))
+    }
+
+    fn argocd_api_error(
+        &self,
+        resource_kind: &str,
+        operation: &str,
+        namespace: Option<&str>,
+        error: kube::Error,
+    ) -> anyhow::Error {
+        let namespace_suffix = namespace
+            .map(|value| format!(" in namespace '{}'", value))
+            .unwrap_or_default();
+
+        match &error {
+            kube::Error::Api(api_error) if api_error.code == 404 => {
+                if resource_kind == "Namespace" {
+                    return anyhow::anyhow!(
+                        "Failed to {} {}{}: namespace '{}' does not exist. \
+                         ArgoCD is likely not installed yet or is installed in a different namespace. \
+                         Configure deployment_controller.argocd_namespace to the correct namespace.",
+                        operation,
+                        resource_kind,
+                        namespace_suffix,
+                        namespace.unwrap_or(&self.argocd_namespace),
+                    );
+                }
+
+                return anyhow::anyhow!(
+                    "Failed to {} ArgoCD {}{}: Kubernetes returned 404 for argoproj.io/v1alpha1. \
+                     This usually means ArgoCD is not installed in the cluster or its CRDs are missing. \
+                     Expected ArgoCD Application/AppProject CRDs and namespace '{}'. Original error: {}",
+                    operation,
+                    resource_kind,
+                    namespace_suffix,
+                    self.argocd_namespace,
+                    api_error.message,
+                );
+            }
+            _ => {}
+        }
+
+        anyhow::anyhow!(
+            "Failed to {} {}{}: {}",
+            operation,
+            resource_kind,
+            namespace_suffix,
+            error
+        )
+    }
+
+    pub fn start(self: Arc<Self>) {
+        tokio::spawn(async move {
+            self.project_cleanup_loop().await;
+        });
+    }
+
+    async fn project_cleanup_loop(&self) {
+        let mut ticker = interval(Duration::from_secs(10));
+
+        loop {
+            ticker.tick().await;
+            if let Err(err) = self.process_deleting_projects().await {
+                warn!("ArgoCD project cleanup loop error: {}", err);
+            }
+        }
+    }
+
+    async fn process_deleting_projects(&self) -> Result<()> {
+        let projects = db_projects::find_deleting_with_finalizer(
+            &self.state.db_pool,
+            ARGOCD_PROJECT_FINALIZER,
+            20,
+        )
+        .await?;
+
+        for project in projects {
+            let groups = db_deployments::get_all_deployment_groups(&self.state.db_pool, project.id)
+                .await
+                .unwrap_or_default();
+
+            let mut all_deleted = true;
+
+            for group in groups {
+                let application_name = self.application_name(&project.name, &group);
+                if self.delete_application_if_exists(&application_name).await? {
+                    all_deleted = false;
+                }
+
+                let namespace = self.destination_namespace(&project.name, &group);
+                if self.delete_namespace_if_exists(&namespace).await? {
+                    all_deleted = false;
+                }
+            }
+
+            let appproject_name = self.appproject_name(&project.name);
+            if self.delete_appproject_if_exists(&appproject_name).await? {
+                all_deleted = false;
+            }
+
+            if all_deleted {
+                db_projects::remove_finalizer(
+                    &self.state.db_pool,
+                    project.id,
+                    ARGOCD_PROJECT_FINALIZER,
+                )
+                .await?;
+                info!(
+                    "Removed ArgoCD finalizer from project {}, cleanup complete",
+                    project.name
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn delete_application_if_exists(&self, name: &str) -> Result<bool> {
+        match self.get_application_opt(name).await? {
+            Some(_) => {
+                self.delete_application(name).await?;
+                Ok(true)
+            }
+            None => Ok(false),
+        }
+    }
+
+    async fn delete_appproject_if_exists(&self, name: &str) -> Result<bool> {
+        match self.get_appproject_opt(name).await? {
+            Some(_) => {
+                self.delete_appproject(name).await?;
+                Ok(true)
+            }
+            None => Ok(false),
+        }
+    }
+
+    async fn delete_namespace_if_exists(&self, name: &str) -> Result<bool> {
+        let api = self.namespace_api();
+        match api.get_opt(name).await? {
+            Some(existing) => {
+                if reconcile_ignored(&existing.metadata) {
+                    return Ok(false);
+                }
+                api.delete(name, &DeleteParams::default()).await?;
+                Ok(true)
+            }
+            None => Ok(false),
+        }
+    }
+
+    fn escaped_group_name(&self, deployment_group: &str) -> String {
+        if deployment_group == DEFAULT_DEPLOYMENT_GROUP {
+            "default".to_string()
+        } else {
+            normalize_deployment_group(deployment_group)
+        }
+    }
+
+    fn format_name(&self, template: &str, project_name: &str, deployment_group: &str) -> String {
+        template
+            .replace("{project_name}", project_name)
+            .replace("{deployment_group}", &self.escaped_group_name(deployment_group))
+    }
+
+    fn appproject_name(&self, project_name: &str) -> String {
+        self.format_name(&self.appproject_format, project_name, DEFAULT_DEPLOYMENT_GROUP)
+    }
+
+    fn application_name(&self, project_name: &str, deployment_group: &str) -> String {
+        self.format_name(&self.application_format, project_name, deployment_group)
+    }
+
+    fn destination_namespace(&self, project_name: &str, deployment_group: &str) -> String {
+        self.format_name(
+            &self.destination_namespace_format,
+            project_name,
+            deployment_group,
+        )
+    }
+
+    fn env_secret_name(&self, deployment: &Deployment) -> String {
+        format!("rise-env-{}", deployment.deployment_id)
+    }
+
+    fn pull_secret_name(&self, deployment: &Deployment) -> String {
+        format!("rise-pull-{}", deployment.deployment_id)
+    }
+
+    fn namespace_api(&self) -> Api<Namespace> {
+        Api::all(self.kube_client.clone())
+    }
+
+    fn applications_api(&self) -> Api<Application> {
+        Api::namespaced(self.kube_client.clone(), &self.argocd_namespace)
+    }
+
+    fn appprojects_api(&self) -> Api<AppProject> {
+        Api::namespaced(self.kube_client.clone(), &self.argocd_namespace)
+    }
+
+    fn secrets_api(&self, namespace: &str) -> Api<Secret> {
+        Api::namespaced(self.kube_client.clone(), namespace)
+    }
+
+    fn deployment_label_selector(&self, project_name: &str, deployment: &Deployment) -> String {
+        format!(
+            "{project_label}={project},{group_label}={group},{deployment_label}={deployment_id}",
+            project_label = LABEL_PROJECT,
+            project = project_name,
+            group_label = LABEL_DEPLOYMENT_GROUP,
+            group = self.escaped_group_name(&deployment.deployment_group),
+            deployment_label = LABEL_DEPLOYMENT_ID,
+            deployment_id = deployment.deployment_id,
+        )
+    }
+
+    async fn get_secret_opt(&self, namespace: &str, name: &str) -> Result<Option<Secret>> {
+        self.secrets_api(namespace)
+            .get_opt(name)
+            .await
+            .map_err(|e| self.argocd_api_error("Secret", "get", Some(namespace), e))
+    }
+
+    async fn collect_matched_pod_health(
+        &self,
+        namespace: &str,
+        project_name: &str,
+        deployment: &Deployment,
+    ) -> Result<MatchedPodHealth> {
+        let pod_api: Api<Pod> = Api::namespaced(self.kube_client.clone(), namespace);
+        let selector = self.deployment_label_selector(project_name, deployment);
+        let pods = pod_api
+            .list(&ListParams::default().labels(&selector))
+            .await?;
+
+        let current_replicas = pods.items.len() as i32;
+        let mut ready_replicas = 0;
+        let mut pod_infos = Vec::new();
+        let mut errors = Vec::new();
+
+        for pod in pods.items {
+            let pod_name = pod.metadata.name.unwrap_or_default();
+            let phase = pod
+                .status
+                .as_ref()
+                .and_then(|status| status.phase.clone())
+                .unwrap_or_else(|| "Unknown".to_string());
+            let conditions: Vec<DeploymentPodCondition> = pod
+                .status
+                .as_ref()
+                .and_then(|status| status.conditions.as_ref())
+                .map(|conditions| {
+                    conditions
+                        .iter()
+                        .map(|condition| DeploymentPodCondition {
+                            type_: condition.type_.clone(),
+                            status: condition.status.clone(),
+                            reason: condition.reason.clone(),
+                            message: truncate_optional_text(
+                                condition.message.as_deref(),
+                                MAX_STATUS_MESSAGE_CHARS,
+                            ),
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            let pod_ready = conditions
+                .iter()
+                .any(|condition| condition.type_ == "Ready" && condition.status == "True");
+
+            let containers: Vec<DeploymentContainerStatus> = pod
+                .status
+                .as_ref()
+                .and_then(|status| status.container_statuses.as_ref())
+                .map(|statuses| {
+                    statuses
+                        .iter()
+                        .map(|container| {
+                            let state = if let Some(waiting) =
+                                container.state.as_ref().and_then(|state| state.waiting.as_ref())
+                            {
+                                Some(DeploymentContainerState {
+                                    state_type: "waiting".to_string(),
+                                    reason: waiting.reason.clone(),
+                                    message: truncate_optional_text(
+                                        waiting.message.as_deref(),
+                                        MAX_STATUS_MESSAGE_CHARS,
+                                    ),
+                                    exit_code: None,
+                                })
+                            } else if container
+                                .state
+                                .as_ref()
+                                .and_then(|state| state.running.as_ref())
+                                .is_some()
+                            {
+                                Some(DeploymentContainerState {
+                                    state_type: "running".to_string(),
+                                    reason: None,
+                                    message: None,
+                                    exit_code: None,
+                                })
+                            } else {
+                                container
+                                    .state
+                                    .as_ref()
+                                    .and_then(|state| state.terminated.as_ref())
+                                    .map(|terminated| DeploymentContainerState {
+                                        state_type: "terminated".to_string(),
+                                        reason: terminated.reason.clone(),
+                                        message: truncate_optional_text(
+                                            terminated.message.as_deref(),
+                                            MAX_STATUS_MESSAGE_CHARS,
+                                        ),
+                                        exit_code: Some(terminated.exit_code),
+                                    })
+                            };
+
+                            DeploymentContainerStatus {
+                                name: container.name.clone(),
+                                ready: container.ready,
+                                restart_count: container.restart_count,
+                                state,
+                            }
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            let all_containers_ready = !containers.is_empty() && containers.iter().all(|c| c.ready);
+            let ready = pod_ready || all_containers_ready;
+            if ready {
+                ready_replicas += 1;
+            }
+
+            if phase == "Failed" {
+                errors.push(format!("pod {pod_name} failed"));
+            }
+
+            for container in &containers {
+                if let Some(state) = &container.state {
+                    if state.state_type == "waiting" {
+                        let reason = state.reason.as_deref().unwrap_or("waiting");
+                        if matches!(
+                            reason,
+                            "CrashLoopBackOff"
+                                | "ImagePullBackOff"
+                                | "ErrImagePull"
+                                | "CreateContainerConfigError"
+                                | "CreateContainerError"
+                                | "RunContainerError"
+                        ) {
+                            errors.push(format!(
+                                "pod {pod_name} container {} waiting: {reason}",
+                                container.name
+                            ));
+                        }
+                    }
+                    if state.state_type == "terminated" && state.exit_code.unwrap_or(0) != 0 {
+                        errors.push(format!(
+                            "pod {pod_name} container {} exited with {}",
+                            container.name,
+                            state.exit_code.unwrap_or_default()
+                        ));
+                    }
+                }
+            }
+
+            pod_infos.push(DeploymentPodInfo {
+                name: pod_name,
+                phase,
+                ready,
+                conditions,
+                containers,
+            });
+        }
+
+        let status = serde_json::to_value(DeploymentPodStatus {
+            desired_replicas: current_replicas.max(1),
+            ready_replicas,
+            current_replicas,
+            pods: pod_infos,
+            last_checked: Utc::now(),
+        })?;
+
+        let message = if !errors.is_empty() {
+            Some(errors.join(", "))
+        } else if current_replicas == 0 {
+            Some(format!(
+                "No pods found for deployment {} in namespace {}",
+                deployment.deployment_id, namespace
+            ))
+        } else if ready_replicas < current_replicas {
+            Some(format!("Pods ready: {ready_replicas}/{current_replicas}"))
+        } else {
+            None
+        };
+
+        Ok(MatchedPodHealth {
+            healthy: errors.is_empty() && current_replicas > 0 && ready_replicas == current_replicas,
+            message,
+            status,
+        })
+    }
+
+    async fn patch_secret(&self, namespace: &str, name: &str, secret: &Secret) -> Result<Secret> {
+        if let Some(existing) = self.get_secret_opt(namespace, name).await? {
+            if reconcile_ignored(&existing.metadata) {
+                return Ok(existing);
+            }
+        }
+
+        self.secrets_api(namespace)
+            .patch(
+                name,
+                &PatchParams::apply("rise-argocd").force(),
+                &Patch::Apply(secret),
+            )
+            .await
+            .map_err(|e| self.argocd_api_error("Secret", "patch", Some(namespace), e))
+    }
+
+    async fn get_application_opt(&self, name: &str) -> Result<Option<Application>> {
+        self.applications_api()
+            .get_opt(name)
+            .await
+            .map_err(|e| self.argocd_api_error("Application", "get", Some(&self.argocd_namespace), e))
+    }
+
+    async fn get_application(&self, name: &str) -> Result<Application> {
+        self.applications_api()
+            .get(name)
+            .await
+            .map_err(|e| self.argocd_api_error("Application", "get", Some(&self.argocd_namespace), e))
+    }
+
+    async fn patch_application(&self, name: &str, application: &Application) -> Result<Application> {
+        if let Some(existing) = self.get_application_opt(name).await? {
+            if reconcile_ignored(&existing.metadata) {
+                return Ok(existing);
+            }
+        }
+
+        self.applications_api()
+            .patch(
+                name,
+                &PatchParams::apply("rise-argocd").force(),
+                &Patch::Apply(application),
+            )
+            .await
+            .map_err(|e| self.argocd_api_error("Application", "patch", Some(&self.argocd_namespace), e))
+    }
+
+    async fn delete_application(&self, name: &str) -> Result<()> {
+        if let Some(existing) = self.get_application_opt(name).await? {
+            if reconcile_ignored(&existing.metadata) {
+                return Ok(());
+            }
+        }
+
+        self.applications_api()
+            .delete(name, &DeleteParams::default())
+            .await
+            .map(|_| ())
+            .map_err(|e| self.argocd_api_error("Application", "delete", Some(&self.argocd_namespace), e))
+    }
+
+    async fn get_appproject_opt(&self, name: &str) -> Result<Option<AppProject>> {
+        self.appprojects_api()
+            .get_opt(name)
+            .await
+            .map_err(|e| self.argocd_api_error("AppProject", "get", Some(&self.argocd_namespace), e))
+    }
+
+    async fn patch_appproject(&self, name: &str, appproject: &AppProject) -> Result<AppProject> {
+        if let Some(existing) = self.get_appproject_opt(name).await? {
+            if reconcile_ignored(&existing.metadata) {
+                return Ok(existing);
+            }
+        }
+
+        self.appprojects_api()
+            .patch(
+                name,
+                &PatchParams::apply("rise-argocd").force(),
+                &Patch::Apply(appproject),
+            )
+            .await
+            .map_err(|e| self.argocd_api_error("AppProject", "patch", Some(&self.argocd_namespace), e))
+    }
+
+    async fn delete_appproject(&self, name: &str) -> Result<()> {
+        if let Some(existing) = self.get_appproject_opt(name).await? {
+            if reconcile_ignored(&existing.metadata) {
+                return Ok(());
+            }
+        }
+
+        self.appprojects_api()
+            .delete(name, &DeleteParams::default())
+            .await
+            .map(|_| ())
+            .map_err(|e| self.argocd_api_error("AppProject", "delete", Some(&self.argocd_namespace), e))
+    }
+
+    async fn ensure_destination_namespace(
+        &self,
+        project: &Project,
+        deployment_group: &str,
+    ) -> Result<String> {
+        let namespace_name = self.destination_namespace(&project.name, deployment_group);
+        if let Some(existing) = self.namespace_api().get_opt(&namespace_name).await? {
+            if reconcile_ignored(&existing.metadata) {
+                return Ok(namespace_name);
+            }
+        }
+
+        let mut labels = BTreeMap::new();
+        labels.insert(LABEL_MANAGED_BY.to_string(), "rise-argocd".to_string());
+        labels.insert(LABEL_PROJECT.to_string(), project.name.clone());
+        labels.insert(
+            LABEL_DEPLOYMENT_GROUP.to_string(),
+            self.escaped_group_name(deployment_group),
+        );
+        for (key, value) in &self.namespace_labels {
+            labels.insert(key.clone(), value.clone());
+        }
+
+        let mut annotations = BTreeMap::new();
+        for (key, value) in &self.namespace_annotations {
+            annotations.insert(key.clone(), value.clone());
+        }
+
+        let namespace = Namespace {
+            metadata: ObjectMeta {
+                name: Some(namespace_name.clone()),
+                labels: Some(labels),
+                annotations: Some(annotations),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        self.namespace_api()
+            .patch(
+                &namespace_name,
+                &PatchParams::apply("rise-argocd").force(),
+                &Patch::Apply(&namespace),
+            )
+            .await?;
+
+        Ok(namespace_name)
+    }
+
+    async fn ensure_appproject(&self, project: &Project) -> Result<String> {
+        let appproject_name = self.appproject_name(&project.name);
+        let (source_repo_url, _, _) = self.application_source_reference();
+        let appproject = AppProject::new(
+            &appproject_name,
+            AppProjectSpec {
+                description: format!("Rise-managed ArgoCD project for {}", project.name),
+                source_repos: vec![source_repo_url],
+                destinations: vec![AppProjectDestination {
+                    server: self.destination_server.clone(),
+                    namespace: format!("rise-{}-*", project.name),
+                }],
+                cluster_resource_whitelist: vec![AppProjectGroupKind {
+                    group: "*".to_string(),
+                    kind: "*".to_string(),
+                }],
+                namespace_resource_whitelist: vec![AppProjectGroupKind {
+                    group: "*".to_string(),
+                    kind: "*".to_string(),
+                }],
+            },
+        );
+
+        self.patch_appproject(&appproject_name, &appproject).await?;
+
+        if !project
+            .finalizers
+            .contains(&ARGOCD_PROJECT_FINALIZER.to_string())
+        {
+            db_projects::add_finalizer(
+                &self.state.db_pool,
+                project.id,
+                ARGOCD_PROJECT_FINALIZER,
+            )
+            .await?;
+        }
+
+        Ok(appproject_name)
+    }
+
+    async fn load_env_vars(&self, deployment: &Deployment) -> Result<Vec<(String, String)>> {
+        crate::db::env_vars::load_deployment_env_vars_decrypted(
+            &self.state.db_pool,
+            deployment.id,
+            self.state.encryption_provider.as_deref(),
+        )
+        .await
+    }
+
+    fn create_env_secret(
+        &self,
+        name: &str,
+        project: &Project,
+        deployment: &Deployment,
+        env_vars: &[(String, String)],
+    ) -> Secret {
+        let mut data = BTreeMap::new();
+        for (key, value) in env_vars {
+            data.insert(key.clone(), k8s_openapi::ByteString(value.as_bytes().to_vec()));
+        }
+
+        let mut labels = BTreeMap::new();
+        labels.insert(LABEL_MANAGED_BY.to_string(), "rise-argocd".to_string());
+        labels.insert(LABEL_PROJECT.to_string(), project.name.clone());
+        labels.insert(
+            LABEL_DEPLOYMENT_GROUP.to_string(),
+            self.escaped_group_name(&deployment.deployment_group),
+        );
+        labels.insert(LABEL_DEPLOYMENT_ID.to_string(), deployment.deployment_id.clone());
+
+        Secret {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                labels: Some(labels),
+                ..Default::default()
+            },
+            type_: Some("Opaque".to_string()),
+            data: Some(data),
+            ..Default::default()
+        }
+    }
+
+    fn create_dockerconfigjson_secret(
+        &self,
+        name: &str,
+        project: &Project,
+        deployment: &Deployment,
+        registry_host: &str,
+        credentials: &RegistryCredentials,
+    ) -> Result<Secret> {
+        use base64::Engine;
+
+        let auths_entry = match credentials.auth_method {
+            RegistryAuthMethod::LoginCredentials => {
+                let auth = base64::engine::general_purpose::STANDARD
+                    .encode(format!("{}:{}", credentials.username, credentials.password));
+                json!({
+                    "username": credentials.username,
+                    "password": credentials.password,
+                    "auth": auth,
+                })
+            }
+            RegistryAuthMethod::RegistryToken => json!({ "registrytoken": credentials.password }),
+        };
+
+        let docker_config = json!({ "auths": { registry_host: auths_entry } });
+        let docker_config_bytes = docker_config.to_string().into_bytes();
+
+        let mut data = BTreeMap::new();
+        data.insert(
+            ".dockerconfigjson".to_string(),
+            k8s_openapi::ByteString(docker_config_bytes),
+        );
+
+        let mut labels = BTreeMap::new();
+        labels.insert(LABEL_MANAGED_BY.to_string(), "rise-argocd".to_string());
+        labels.insert(LABEL_PROJECT.to_string(), project.name.clone());
+        labels.insert(
+            LABEL_DEPLOYMENT_GROUP.to_string(),
+            self.escaped_group_name(&deployment.deployment_group),
+        );
+        labels.insert(LABEL_DEPLOYMENT_ID.to_string(), deployment.deployment_id.clone());
+
+        Ok(Secret {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                labels: Some(labels),
+                ..Default::default()
+            },
+            type_: Some("kubernetes.io/dockerconfigjson".to_string()),
+            data: Some(data),
+            ..Default::default()
+        })
+    }
+
+    async fn ensure_deployment_secrets(
+        &self,
+        project: &Project,
+        deployment: &Deployment,
+        metadata: &mut ArgoCdMetadata,
+    ) -> Result<()> {
+        let destination_namespace =
+            self.ensure_destination_namespace(project, &deployment.deployment_group)
+                .await?;
+        metadata.destination_namespace = Some(destination_namespace.clone());
+        metadata.argocd_namespace = Some(self.argocd_namespace.clone());
+
+        let env_secret_name = self.env_secret_name(deployment);
+        let env_vars = self.load_env_vars(deployment).await?;
+        let env_secret = self.create_env_secret(&env_secret_name, project, deployment, &env_vars);
+        self.patch_secret(&destination_namespace, &env_secret_name, &env_secret)
+            .await?;
+        metadata.env_secret_name = Some(env_secret_name);
+
+        if self.registry_provider.requires_pull_secret() {
+            let pull_secret_name = self.pull_secret_name(deployment);
+            let credentials = self
+                .registry_provider
+                .get_k8s_pull_credentials(&project.name)
+                .await?;
+            let pull_secret = self.create_dockerconfigjson_secret(
+                &pull_secret_name,
+                project,
+                deployment,
+                self.registry_provider.registry_host(),
+                &credentials,
+            )?;
+            self.patch_secret(&destination_namespace, &pull_secret_name, &pull_secret)
+                .await?;
+            metadata.pull_secret_name = Some(pull_secret_name);
+        } else {
+            metadata.pull_secret_name = None;
+        }
+
+        Ok(())
+    }
+
+    async fn get_image_ref(&self, deployment: &Deployment, project: &Project) -> Result<String> {
+        if let Some(digest) = &deployment.image_digest {
+            return Ok(digest.clone());
+        }
+
+        let tag = if let Some(source_deployment_id) = deployment.rolled_back_from_deployment_id {
+            match db_deployments::find_by_id(&self.state.db_pool, source_deployment_id).await? {
+                Some(source) => source.deployment_id,
+                None => deployment.deployment_id.clone(),
+            }
+        } else {
+            deployment.deployment_id.clone()
+        };
+
+        Ok(self
+            .registry_provider
+            .get_image_tag(&project.name, &tag, ImageTagType::Internal))
+    }
+
+    fn merge_json(base: &mut Value, overlay: Value) {
+        match (base, overlay) {
+            (Value::Object(base_map), Value::Object(overlay_map)) => {
+                for (key, value) in overlay_map {
+                    Self::merge_json(base_map.entry(key).or_insert(Value::Null), value);
+                }
+            }
+            (base_value, overlay_value) => *base_value = overlay_value,
+        }
+    }
+
+    fn application_source_reference(&self) -> (String, Option<String>, Option<String>) {
+        if let Some(repo_url) = self.helm_chart.repo_url.strip_prefix("oci://") {
+            let repo_url = format!(
+                "oci://{}/{}",
+                repo_url.trim_end_matches('/'),
+                self.helm_chart.chart.trim_start_matches('/')
+            );
+            return (repo_url, None, Some(".".to_string()));
+        }
+
+        (
+            self.helm_chart.repo_url.clone(),
+            Some(self.helm_chart.chart.clone()),
+            None,
+        )
+    }
+
+    async fn desired_application_for_deployment(
+        &self,
+        project: &Project,
+        deployment: &Deployment,
+        metadata: &mut ArgoCdMetadata,
+    ) -> Result<DesiredApplication> {
+        let (source_repo_url, source_chart, source_path) = self.application_source_reference();
+        let appproject_name = self.ensure_appproject(project).await?;
+        self.ensure_deployment_secrets(project, deployment, metadata).await?;
+
+        let application_name = self.application_name(&project.name, &deployment.deployment_group);
+        let destination_namespace = metadata
+            .destination_namespace
+            .clone()
+            .unwrap_or_else(|| self.destination_namespace(&project.name, &deployment.deployment_group));
+        let target_image = self.get_image_ref(deployment, project).await?;
+        let resolved_ingress =
+            self.resolved_ingress_url_for_group(project, &deployment.deployment_group);
+        let (ingress_host, ingress_path) = Self::parse_ingress_target(&resolved_ingress);
+        let custom_domain_hosts = if deployment.deployment_group == DEFAULT_DEPLOYMENT_GROUP {
+            db_custom_domains::list_project_custom_domains(&self.state.db_pool, project.id)
+                .await?
+                .into_iter()
+                .map(|domain| domain.domain)
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
+
+        let generated_values = json!({
+            "rise": {
+                "project": {
+                    "id": project.id.to_string(),
+                    "name": project.name,
+                    "accessClass": project.access_class,
+                },
+                "deployment": {
+                    "id": deployment.deployment_id,
+                    "group": deployment.deployment_group,
+                    "normalizedGroup": self.escaped_group_name(&deployment.deployment_group),
+                    "namespace": destination_namespace,
+                    "httpPort": deployment.http_port,
+                },
+                "ingress": {
+                    "host": ingress_host,
+                    "path": ingress_path,
+                    "customDomainHosts": custom_domain_hosts,
+                },
+                "image": {
+                    "ref": target_image,
+                    "pullSecretName": metadata.pull_secret_name,
+                },
+                "env": {
+                    "secretName": metadata.env_secret_name,
+                },
+                "accessClasses": self.access_classes,
+                "argocd": {
+                    "applicationName": application_name,
+                    "appProjectName": appproject_name,
+                }
+            }
+        });
+
+        let mut merged_values = canonicalize_json(self.helm_chart.values.clone());
+        Self::merge_json(&mut merged_values, generated_values);
+        merged_values = canonicalize_json(merged_values);
+        let values_string = serde_json::to_string_pretty(&merged_values)?;
+
+        let application = Application::new(
+            &application_name,
+            ApplicationSpec {
+                project: appproject_name.clone(),
+                source: ApplicationSource {
+                    repo_url: source_repo_url,
+                    chart: source_chart,
+                    target_revision: self.helm_chart.target_revision.clone(),
+                    path: source_path,
+                    helm: Some(ApplicationSourceHelm {
+                        release_name: Some(application_name.clone()),
+                        values: Some(values_string),
+                    }),
+                },
+                destination: ApplicationDestination {
+                    server: self.destination_server.clone(),
+                    namespace: destination_namespace.clone(),
+                },
+                sync_policy: Some(ApplicationSyncPolicy {
+                    automated: Some(ApplicationSyncPolicyAutomated {
+                        enabled: Some(true),
+                        prune: true,
+                        self_heal: true,
+                    }),
+                    sync_options: Some(self.sync_options.clone()),
+                }),
+            },
+        );
+
+        let spec_hash = {
+            let mut hasher = Sha256::new();
+            hasher.update(serde_json::to_vec(&application.spec)?);
+            format!("{:x}", hasher.finalize())
+        };
+
+        let mut labels = BTreeMap::new();
+        labels.insert(LABEL_MANAGED_BY.to_string(), "rise-argocd".to_string());
+        labels.insert(LABEL_PROJECT.to_string(), project.name.clone());
+        labels.insert(
+            LABEL_DEPLOYMENT_GROUP.to_string(),
+            self.escaped_group_name(&deployment.deployment_group),
+        );
+        labels.insert(LABEL_DEPLOYMENT_ID.to_string(), deployment.deployment_id.clone());
+
+        let mut annotations = BTreeMap::new();
+        annotations.insert(ANNOTATION_SPEC_HASH.to_string(), spec_hash.clone());
+        annotations.insert(ANNOTATION_TARGET_IMAGE.to_string(), target_image.clone());
+
+        let mut object = application;
+        object.metadata.namespace = Some(self.argocd_namespace.clone());
+        object.metadata.labels = Some(labels);
+        object.metadata.annotations = Some(annotations);
+        object.metadata.finalizers = Some(vec![APPLICATION_RESOURCES_FINALIZER.to_string()]);
+
+        metadata.appproject_name = Some(appproject_name);
+        metadata.application_name = Some(application_name);
+        metadata.target_image = Some(target_image);
+
+        Ok(DesiredApplication {
+            object,
+            spec_hash,
+        })
+    }
+
+    async fn ensure_application(
+        &self,
+        desired: &DesiredApplication,
+        metadata: &mut ArgoCdMetadata,
+    ) -> Result<Application> {
+        let application_name = desired.object.name_any();
+        let existing = self.get_application_opt(&application_name).await?;
+        let current_hash = existing.as_ref().and_then(|app| {
+            app.metadata
+                .annotations
+                .as_ref()
+                .and_then(|map| map.get(ANNOTATION_SPEC_HASH))
+                .cloned()
+        });
+
+        if current_hash.as_deref() != Some(desired.spec_hash.as_str()) {
+            let mut object = desired.object.clone();
+            let now = Utc::now();
+            object
+                .metadata
+                .annotations
+                .get_or_insert_with(BTreeMap::new)
+                .insert(ANNOTATION_LAST_APPLIED_AT.to_string(), now.to_rfc3339());
+
+            let applied = self.patch_application(&application_name, &object).await?;
+            metadata.applied_spec_hash = Some(desired.spec_hash.clone());
+            metadata.last_applied_at = Some(now);
+            metadata.reverted_to_deployment_id = None;
+            Ok(applied)
+        } else {
+            Ok(existing.unwrap())
+        }
+    }
+
+    fn evaluate_application_status(&self, application: &Application) -> ApplicationReadiness {
+        let mut message_parts = Vec::new();
+
+        let health_status = application
+            .status
+            .as_ref()
+            .and_then(|status| status.health.as_ref());
+        let sync_status = application
+            .status
+            .as_ref()
+            .and_then(|status| status.sync.as_ref());
+        let operation_state = application
+            .status
+            .as_ref()
+            .and_then(|status| status.operation_state.as_ref());
+        let reconciled_at = application
+            .status
+            .as_ref()
+            .and_then(|status| status.reconciled_at.as_deref())
+            .and_then(parse_rfc3339);
+
+        if let Some(health) = health_status {
+            message_parts.push(format!("health={}", health.status));
+            if let Some(msg) = &health.message {
+                message_parts.push(truncate_text(msg, MAX_STATUS_MESSAGE_CHARS));
+            }
+            if let Some(last_transition_time) = &health.last_transition_time {
+                message_parts.push(format!("lastTransition={}", last_transition_time));
+            }
+        }
+        if let Some(sync) = sync_status {
+            message_parts.push(format!("sync={}", sync.status));
+            if let Some(revision) = &sync.revision {
+                message_parts.push(format!("revision={}", revision));
+            }
+        }
+        if let Some(operation) = operation_state {
+            message_parts.push(format!("operation={}", operation.phase));
+            if let Some(msg) = &operation.message {
+                message_parts.push(truncate_text(msg, MAX_STATUS_MESSAGE_CHARS));
+            }
+        }
+        if let Some(conditions) = application
+            .status
+            .as_ref()
+            .and_then(|status| status.conditions.as_ref())
+        {
+            if let Some(condition) = conditions.iter().find(|condition| condition.message.is_some()) {
+                message_parts.push(format!(
+                    "condition={}{}",
+                    condition.type_,
+                    condition
+                        .message
+                        .as_deref()
+                        .map(|message| format!(
+                            ": {}",
+                            truncate_text(message, MAX_STATUS_MESSAGE_CHARS)
+                        ))
+                        .unwrap_or_default()
+                ));
+            }
+        }
+
+        if let Some(status) = &application.status {
+            if let Some(resources) = &status.resources {
+                let unhealthy_resources: Vec<String> = resources
+                    .iter()
+                    .filter_map(|resource| {
+                        let sync_status = resource.status.as_deref();
+                        let health_status = resource.health.as_ref().map(|health| health.status.as_str());
+                        let needs_attention = !matches!(sync_status, None | Some("Synced"))
+                            || matches!(health_status, Some("Degraded" | "Missing" | "Suspended"));
+
+                        if needs_attention {
+                            Some(format!(
+                                "{}/{}{}",
+                                resource.kind,
+                                resource.name,
+                                resource
+                                    .status
+                                    .as_ref()
+                                    .map(|status| format!(" [{}]", status))
+                                    .unwrap_or_default()
+                            ))
+                        } else {
+                            None
+                        }
+                    })
+                    .take(3)
+                    .collect();
+
+                if !unhealthy_resources.is_empty() {
+                    message_parts.push(format!("resources={}", unhealthy_resources.join(", ")));
+                }
+            }
+
+            if let Some(transitions) = &status.transitions {
+                if let Some(last_transition) = transitions.last() {
+                    message_parts.push(format!(
+                        "transition={}",
+                        truncate_text(&last_transition.to_string(), MAX_STATUS_MESSAGE_CHARS)
+                    ));
+                }
+            }
+        }
+
+        let health_is_healthy =
+            matches!(health_status.map(|status| status.status.as_str()), Some("Healthy"));
+        let sync_is_synced =
+            matches!(sync_status.map(|status| status.status.as_str()), Some("Synced"));
+        let failed = matches!(
+            health_status.map(|status| status.status.as_str()),
+            Some("Degraded" | "Missing")
+        ) || matches!(
+            operation_state.map(|status| status.phase.as_str()),
+            Some("Error" | "Failed")
+        );
+
+        ApplicationReadiness {
+            healthy: health_is_healthy && sync_is_synced,
+            failed,
+            message: if message_parts.is_empty() {
+                None
+            } else {
+                Some(message_parts.join(", "))
+            },
+            reconciled_at,
+        }
+    }
+
+    fn controller_metadata_with_status(
+        &self,
+        metadata: &ArgoCdMetadata,
+        pods: Option<Value>,
+    ) -> Result<Value> {
+        let mut controller_metadata = serde_json::to_value(metadata)?;
+        if let Some(obj) = controller_metadata.as_object_mut() {
+            if let Some(pods) = pods {
+                obj.insert("pod_status".to_string(), pods);
+            }
+        }
+        Ok(controller_metadata)
+    }
+
+    async fn group_reconcile_owner(&self, deployment: &Deployment) -> Result<Option<Deployment>> {
+        let deployments = db_deployments::find_non_terminal_for_project_and_group(
+            &self.state.db_pool,
+            deployment.project_id,
+            &deployment.deployment_group,
+        )
+        .await?;
+
+        Ok(deployments.into_iter().next())
+    }
+
+    async fn should_defer_to_newer_deployment(&self, deployment: &Deployment) -> Result<bool> {
+        Ok(self
+            .group_reconcile_owner(deployment)
+            .await?
+            .map(|owner| owner.id != deployment.id)
+            .unwrap_or(false))
+    }
+
+    async fn rollback_to_active_deployment(
+        &self,
+        project: &Project,
+        deployment: &Deployment,
+        metadata: &mut ArgoCdMetadata,
+    ) -> Result<()> {
+        let active = db_deployments::find_active_for_project_and_group(
+            &self.state.db_pool,
+            project.id,
+            &deployment.deployment_group,
+        )
+        .await?;
+
+        match active {
+            Some(active) if active.id != deployment.id => {
+                let mut rollback_metadata = ArgoCdMetadata::default();
+                let desired = self
+                    .desired_application_for_deployment(project, &active, &mut rollback_metadata)
+                    .await?;
+                let _ = self
+                    .patch_application(&desired.object.name_any(), &desired.object)
+                    .await?;
+                metadata.reverted_to_deployment_id = Some(active.deployment_id);
+            }
+            _ => {
+                self.delete_group_application(project, &deployment.deployment_group)
+                    .await?;
+                metadata.reverted_to_deployment_id = None;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn delete_group_application(&self, project: &Project, deployment_group: &str) -> Result<()> {
+        let application_name = self.application_name(&project.name, deployment_group);
+        if self.get_application_opt(&application_name).await?.is_some() {
+            self.delete_application(&application_name).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn delete_secret_if_exists(&self, namespace: &str, name: &str) -> Result<()> {
+        if let Some(existing) = self.get_secret_opt(namespace, name).await? {
+            if reconcile_ignored(&existing.metadata) {
+                return Ok(());
+            }
+        }
+
+        match self
+            .secrets_api(namespace)
+            .delete(name, &DeleteParams::default())
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(kube::Error::Api(ae)) if ae.code == 404 => Ok(()),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    async fn cleanup_deployment_secrets(&self, metadata: &ArgoCdMetadata) -> Result<()> {
+        if let Some(namespace) = &metadata.destination_namespace {
+            if let Some(env_secret) = &metadata.env_secret_name {
+                self.delete_secret_if_exists(namespace, env_secret).await?;
+            }
+            if let Some(pull_secret) = &metadata.pull_secret_name {
+                self.delete_secret_if_exists(namespace, pull_secret).await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn reconcile_group_to_active_or_delete(&self, deployment: &Deployment) -> Result<()> {
+        if self.should_defer_to_newer_deployment(deployment).await? {
+            return Ok(());
+        }
+
+        let project = db_projects::find_by_id(&self.state.db_pool, deployment.project_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Project not found"))?;
+
+        let active = db_deployments::find_active_for_project_and_group(
+            &self.state.db_pool,
+            project.id,
+            &deployment.deployment_group,
+        )
+        .await?;
+
+        match active {
+            Some(active) if active.id != deployment.id => {
+                let mut metadata = ArgoCdMetadata::default();
+                let desired = self
+                    .desired_application_for_deployment(&project, &active, &mut metadata)
+                    .await?;
+                let _ = self
+                    .patch_application(&desired.object.name_any(), &desired.object)
+                    .await?;
+            }
+            _ => {
+                self.delete_group_application(&project, &deployment.deployment_group)
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn resolved_ingress_url_for_group(&self, project: &Project, deployment_group: &str) -> String {
+        if deployment_group == DEFAULT_DEPLOYMENT_GROUP {
+            self.production_ingress_url_template
+                .replace("{project_name}", &project.name)
+        } else if let Some(staging_template) = &self.staging_ingress_url_template {
+            staging_template
+                .replace("{project_name}", &project.name)
+                .replace("{deployment_group}", &self.escaped_group_name(deployment_group))
+        } else {
+            let base = self
+                .production_ingress_url_template
+                .replace("{project_name}", &project.name);
+            if let Some(dot_index) = base.find('.') {
+                format!(
+                    "{}-{}{}",
+                    &base[..dot_index],
+                    self.escaped_group_name(deployment_group),
+                    &base[dot_index..]
+                )
+            } else {
+                format!("{}-{}", base, self.escaped_group_name(deployment_group))
+            }
+        }
+    }
+
+    fn full_ingress_url_from_host(&self, host_or_path: &str) -> String {
+        if let Some(port) = self.ingress_port {
+            match host_or_path.find('/') {
+                Some(slash) => format!(
+                    "{}:{}{}",
+                    &host_or_path[..slash],
+                    port,
+                    &host_or_path[slash..]
+                ),
+                None => format!("{}:{}", host_or_path, port),
+            }
+        } else {
+            host_or_path.to_string()
+        }
+    }
+
+    fn parse_ingress_target(url: &str) -> (String, String) {
+        match url.find('/') {
+            Some(slash) => (url[..slash].to_string(), url[slash..].to_string()),
+            None => (url.to_string(), "/".to_string()),
+        }
+    }
+
+    async fn build_urls(&self, project: &Project, deployment_group: &str) -> Result<DeploymentUrls> {
+        let default_url = format!(
+            "{}://{}",
+            self.ingress_schema,
+            self.full_ingress_url_from_host(&self.resolved_ingress_url_for_group(
+                project,
+                deployment_group,
+            ))
+        );
+
+        let mut custom_domain_urls = Vec::new();
+        let mut primary_url = default_url.clone();
+
+        if deployment_group == DEFAULT_DEPLOYMENT_GROUP {
+            let custom_domains =
+                db_custom_domains::list_project_custom_domains(&self.state.db_pool, project.id)
+                    .await?;
+            for domain in &custom_domains {
+                let host = if let Some(port) = self.ingress_port {
+                    format!("{}:{}", domain.domain, port)
+                } else {
+                    domain.domain.clone()
+                };
+                let url = format!("{}://{}", self.ingress_schema, host);
+                if domain.is_primary {
+                    primary_url = url.clone();
+                }
+                custom_domain_urls.push(url);
+            }
+        }
+
+        Ok(DeploymentUrls {
+            default_url,
+            primary_url,
+            custom_domain_urls,
+        })
+    }
+}
+
+#[async_trait]
+impl DeploymentBackend for ArgoCdController {
+    async fn reconcile(
+        &self,
+        deployment: &Deployment,
+        project: &Project,
+    ) -> Result<ReconcileResult> {
+        if !matches!(
+            deployment.status,
+            DeploymentStatus::Pushed
+                | DeploymentStatus::Deploying
+                | DeploymentStatus::Unhealthy
+                | DeploymentStatus::Healthy
+        ) {
+            return Ok(ReconcileResult {
+                status: deployment.status.clone(),
+                controller_metadata: deployment.controller_metadata.clone(),
+                error_message: None,
+            });
+        }
+
+        if self.should_defer_to_newer_deployment(deployment).await? {
+            return Ok(ReconcileResult {
+                status: deployment.status.clone(),
+                controller_metadata: deployment.controller_metadata.clone(),
+                error_message: None,
+            });
+        }
+
+        let mut metadata: ArgoCdMetadata =
+            serde_json::from_value(deployment.controller_metadata.clone()).unwrap_or_default();
+        let desired = self
+            .desired_application_for_deployment(project, deployment, &mut metadata)
+            .await?;
+        let application = self.ensure_application(&desired, &mut metadata).await?;
+        let readiness = self.evaluate_application_status(&application);
+        let pod_health = if let Some(namespace) = metadata.destination_namespace.as_deref() {
+            self.collect_matched_pod_health(namespace, &project.name, deployment)
+                .await
+                .ok()
+        } else {
+            None
+        };
+        let rollout_healthy = readiness.healthy
+            && pod_health
+                .as_ref()
+                .map(|pods| pods.healthy)
+                .unwrap_or(false);
+
+        let last_applied_at = metadata.last_applied_at;
+        let reconciled_after_apply = match (last_applied_at, readiness.reconciled_at) {
+            (Some(applied_at), Some(reconciled_at)) => reconciled_at >= applied_at,
+            (None, _) => true,
+            _ => false,
+        };
+
+        if !reconciled_after_apply {
+            return Ok(ReconcileResult {
+                status: if deployment.first_healthy_at.is_some() {
+                    DeploymentStatus::Unhealthy
+                } else {
+                    DeploymentStatus::Deploying
+                },
+                controller_metadata: self.controller_metadata_with_status(
+                    &metadata,
+                    pod_health.as_ref().map(|pods| pods.status.clone()),
+                )?,
+                error_message: pod_health
+                    .as_ref()
+                    .and_then(|pods| pods.message.clone())
+                    .or(readiness.message),
+            });
+        }
+
+        let status = if rollout_healthy {
+            DeploymentStatus::Healthy
+        } else if readiness.failed {
+            self.rollback_to_active_deployment(project, deployment, &mut metadata)
+                .await?;
+            DeploymentStatus::Failed
+        } else if deployment.first_healthy_at.is_some() {
+            DeploymentStatus::Unhealthy
+        } else {
+            DeploymentStatus::Deploying
+        };
+
+        Ok(ReconcileResult {
+            status,
+            controller_metadata: self.controller_metadata_with_status(
+                &metadata,
+                pod_health.as_ref().map(|pods| pods.status.clone()),
+            )?,
+            error_message: pod_health
+                .as_ref()
+                .and_then(|pods| pods.message.clone())
+                .or(readiness.message),
+        })
+    }
+
+    async fn health_check(&self, deployment: &Deployment) -> Result<HealthStatus> {
+        let metadata: ArgoCdMetadata = serde_json::from_value(deployment.controller_metadata.clone())
+            .map_err(|err| anyhow::anyhow!("Invalid ArgoCD metadata: {}", err))?;
+        let application_name = metadata
+            .application_name
+            .ok_or_else(|| anyhow::anyhow!("No application_name in ArgoCD metadata"))?;
+        let application = self.get_application(&application_name).await?;
+        let readiness = self.evaluate_application_status(&application);
+        let project = db_projects::find_by_id(&self.state.db_pool, deployment.project_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Project not found"))?;
+        let configured_deployment_id = application_configured_deployment_id(&application);
+        let deployment_mismatch = configured_deployment_id.as_deref() != Some(&deployment.deployment_id);
+        let defer_to_newer = if deployment_mismatch {
+            self.should_defer_to_newer_deployment(deployment).await?
+        } else {
+            false
+        };
+
+        if defer_to_newer {
+            return Ok(HealthStatus {
+                healthy: true,
+                message: Some(format!(
+                    "Application is currently configured for newer deployment {}",
+                    configured_deployment_id.as_deref().unwrap_or("unknown")
+                )),
+                last_check: Utc::now(),
+                pod_status: None,
+            });
+        }
+
+        let destination_namespace = metadata
+            .destination_namespace
+            .ok_or_else(|| anyhow::anyhow!("No destination namespace in ArgoCD metadata"))?;
+        let pod_health = self
+            .collect_matched_pod_health(&destination_namespace, &project.name, deployment)
+            .await?;
+
+        let message = match (
+            pod_health.message.as_deref(),
+            readiness.message.as_deref(),
+            deployment_mismatch,
+        ) {
+            (Some(pod_message), Some(app_message), true) => Some(format!(
+                "{pod_message}, {app_message}, configuredDeploymentId={}",
+                configured_deployment_id.as_deref().unwrap_or("unknown")
+            )),
+            (Some(pod_message), Some(app_message), false) => {
+                Some(format!("{pod_message}, {app_message}"))
+            }
+            (Some(pod_message), None, true) => Some(format!(
+                "{pod_message}, configuredDeploymentId={}",
+                configured_deployment_id.as_deref().unwrap_or("unknown")
+            )),
+            (Some(pod_message), None, false) => Some(pod_message.to_string()),
+            (None, Some(app_message), true) => Some(format!(
+                "{app_message}, configuredDeploymentId={}",
+                configured_deployment_id.as_deref().unwrap_or("unknown")
+            )),
+            (None, Some(app_message), false) => Some(app_message.to_string()),
+            (None, None, true) => Some(format!(
+                "Application is currently configured for deployment {}",
+                configured_deployment_id.as_deref().unwrap_or("unknown")
+            )),
+            (None, None, false) => None,
+        };
+
+        Ok(HealthStatus {
+            healthy: readiness.healthy && pod_health.healthy,
+            message,
+            last_check: Utc::now(),
+            pod_status: Some(pod_health.status),
+        })
+    }
+
+    async fn cancel(&self, deployment: &Deployment) -> Result<()> {
+        let metadata: ArgoCdMetadata =
+            serde_json::from_value(deployment.controller_metadata.clone()).unwrap_or_default();
+        self.cleanup_deployment_secrets(&metadata).await?;
+        self.reconcile_group_to_active_or_delete(deployment).await?;
+        Ok(())
+    }
+
+    async fn terminate(&self, deployment: &Deployment) -> Result<()> {
+        let metadata: ArgoCdMetadata =
+            serde_json::from_value(deployment.controller_metadata.clone()).unwrap_or_default();
+        self.cleanup_deployment_secrets(&metadata).await?;
+        self.reconcile_group_to_active_or_delete(deployment).await?;
+        Ok(())
+    }
+
+    async fn get_deployment_urls(
+        &self,
+        deployment: &Deployment,
+        project: &Project,
+    ) -> Result<DeploymentUrls> {
+        self.build_urls(project, &deployment.deployment_group).await
+    }
+
+    async fn get_project_urls(
+        &self,
+        project: &Project,
+        deployment_group: &str,
+    ) -> Result<DeploymentUrls> {
+        self.build_urls(project, deployment_group).await
+    }
+
+    async fn stream_logs(
+        &self,
+        deployment: &Deployment,
+        follow: bool,
+        tail_lines: Option<i64>,
+        timestamps: bool,
+        since_seconds: Option<i64>,
+    ) -> Result<futures::stream::BoxStream<'static, Result<bytes::Bytes, anyhow::Error>>> {
+        let metadata: ArgoCdMetadata =
+            serde_json::from_value(deployment.controller_metadata.clone()).unwrap_or_default();
+        let namespace = metadata
+            .destination_namespace
+            .ok_or_else(|| anyhow::anyhow!("No destination namespace in ArgoCD metadata"))?;
+        let project = db_projects::find_by_id(&self.state.db_pool, deployment.project_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Project not found"))?;
+        let normalized_group = self.escaped_group_name(&deployment.deployment_group);
+
+        let pod_api: Api<Pod> = Api::namespaced(self.kube_client.clone(), &namespace);
+        let label_selector = format!(
+            "{project_label}={project},{group_label}={group},{deployment_label}={deployment_id}",
+            project_label = LABEL_PROJECT,
+            project = project.name,
+            group_label = LABEL_DEPLOYMENT_GROUP,
+            group = normalized_group,
+            deployment_label = LABEL_DEPLOYMENT_ID,
+            deployment_id = deployment.deployment_id,
+        );
+        let pods = pod_api.list(&ListParams::default().labels(&label_selector)).await?;
+
+        let pod_names: Vec<String> = pods
+            .items
+            .into_iter()
+            .filter_map(|pod| pod.metadata.name)
+            .collect();
+
+        if pod_names.is_empty() {
+            return Err(anyhow::anyhow!(
+                "No pods found for deployment {} in namespace {}",
+                deployment.deployment_id,
+                namespace
+            ));
+        }
+
+        let multiple_pods = pod_names.len() > 1;
+        let mut streams = futures::stream::SelectAll::new();
+
+        for pod_name in pod_names {
+            let pod_api = pod_api.clone();
+            let pod_name_for_stream = pod_name.clone();
+            let mut log_params = LogParams {
+                follow,
+                timestamps,
+                ..Default::default()
+            };
+            log_params.tail_lines = tail_lines;
+            log_params.since_seconds = since_seconds;
+
+            let log_stream = pod_api.log_stream(&pod_name, &log_params).await?;
+            let stream = async_stream::stream! {
+                let mut lines = log_stream.lines();
+                loop {
+                    match lines.next().await {
+                        Some(Ok(line)) => {
+                            let rendered = if multiple_pods {
+                                format!("[{}] {}\n", pod_name_for_stream, line)
+                            } else {
+                                format!("{}\n", line)
+                            };
+                            yield Ok(Bytes::from(rendered));
+                        }
+                        Some(Err(err)) => {
+                            yield Err(anyhow::anyhow!(
+                                "Log stream error for pod {}: {}",
+                                pod_name_for_stream,
+                                err
+                            ));
+                            break;
+                        }
+                        None => break,
+                    }
+                }
+            };
+            streams.push(stream.boxed());
+        }
+
+        Ok(streams.boxed())
+    }
+}
+
+fn parse_rfc3339(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|timestamp| timestamp.with_timezone(&Utc))
+        .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_config() -> ArgoCdControllerConfig {
+        ArgoCdControllerConfig {
+            argocd_namespace: "argocd".to_string(),
+            production_ingress_url_template: "{project_name}.apps.example.com".to_string(),
+            staging_ingress_url_template: None,
+            ingress_port: None,
+            ingress_schema: "https".to_string(),
+            appproject_format: "rise-{project_name}".to_string(),
+            application_format: "rise-{project_name}-{deployment_group}".to_string(),
+            destination_namespace_format: "rise-{project_name}-{deployment_group}".to_string(),
+            destination_server: "https://kubernetes.default.svc".to_string(),
+            namespace_labels: HashMap::new(),
+            namespace_annotations: HashMap::new(),
+            helm_chart: ArgoCdHelmChartConfig {
+                repo_url: "https://charts.example.com".to_string(),
+                chart: "app".to_string(),
+                target_revision: "1.2.3".to_string(),
+                values: json!({}),
+            },
+            sync_options: vec![
+                "ServerSideApply=true".to_string(),
+                "ApplyOutOfSyncOnly=true".to_string(),
+            ],
+            access_classes: HashMap::new(),
+            registry_provider: Arc::new(crate::server::registry::providers::OciClientAuthProvider::new(
+                crate::server::registry::models::OciClientAuthConfig {
+                    registry_url: "registry.example.com".to_string(),
+                    namespace: String::new(),
+                    client_registry_url: None,
+                },
+            ).expect("provider")),
+        }
+    }
+
+    fn test_kube_client() -> kube::Client {
+        rustls::crypto::ring::default_provider()
+            .install_default()
+            .ok();
+
+        kube::Client::try_from(kube::Config::new(axum::http::Uri::from_static(
+            "http://127.0.0.1",
+        )))
+        .expect("client")
+    }
+
+    #[tokio::test]
+    async fn naming_templates_use_normalized_group_names() {
+        let controller = ArgoCdController::new(
+            ControllerState {
+                db_pool: sqlx::PgPool::connect_lazy("postgres://unused").expect("pool"),
+                encryption_provider: None,
+            },
+            test_kube_client(),
+            sample_config(),
+        )
+        .expect("controller");
+
+        assert_eq!(controller.appproject_name("hello-world"), "rise-hello-world");
+        assert_eq!(
+            controller.application_name("hello-world", "mr/42"),
+            "rise-hello-world-mr--42"
+        );
+        assert_eq!(
+            controller.destination_namespace("hello-world", "mr/42"),
+            "rise-hello-world-mr--42"
+        );
+    }
+
+    #[tokio::test]
+    async fn builds_oci_application_source_reference() {
+        let controller = ArgoCdController::new(
+            ControllerState {
+                db_pool: sqlx::PgPool::connect_lazy("postgres://unused").expect("pool"),
+                encryption_provider: None,
+            },
+            test_kube_client(),
+            ArgoCdControllerConfig {
+                helm_chart: ArgoCdHelmChartConfig {
+                    repo_url: "oci://rise-registry:5000".to_string(),
+                    chart: "helm-charts/rise-app".to_string(),
+                    target_revision: "0.1.0".to_string(),
+                    values: json!({}),
+                },
+                ..sample_config()
+            },
+        )
+        .expect("controller");
+
+        let (repo_url, chart, path) = controller.application_source_reference();
+        assert_eq!(repo_url, "oci://rise-registry:5000/helm-charts/rise-app");
+        assert_eq!(chart, None);
+        assert_eq!(path, Some(".".to_string()));
+    }
+
+    #[test]
+    fn canonicalize_json_sorts_object_keys_recursively() {
+        let input = json!({
+            "z": 1,
+            "a": {
+                "d": 4,
+                "b": 2
+            }
+        });
+
+        let output = canonicalize_json(input);
+        assert_eq!(
+            serde_json::to_string(&output).unwrap(),
+            r#"{"a":{"b":2,"d":4},"z":1}"#
+        );
+    }
+
+    #[test]
+    fn reconcile_ignored_recognizes_true_label() {
+        let metadata = ObjectMeta {
+            labels: Some(BTreeMap::from([(
+                LABEL_IGNORE_RECONCILE.to_string(),
+                "true".to_string(),
+            )])),
+            ..Default::default()
+        };
+
+        assert!(reconcile_ignored(&metadata));
+    }
+
+    #[tokio::test]
+    async fn evaluate_application_status_marks_degraded_as_failed() {
+        let application = Application {
+            status: Some(ApplicationStatus {
+                health: Some(ApplicationHealthStatus {
+                    status: "Degraded".to_string(),
+                    message: Some("deployment failed".to_string()),
+                    last_transition_time: None,
+                }),
+                sync: Some(ApplicationSyncStatus {
+                    status: "OutOfSync".to_string(),
+                    revision: None,
+                }),
+                operation_state: Some(ApplicationOperationState {
+                    phase: "Failed".to_string(),
+                    message: Some("sync failed".to_string()),
+                    started_at: None,
+                    finished_at: None,
+                }),
+                conditions: Some(vec![ApplicationCondition {
+                    type_: "ComparisonError".to_string(),
+                    message: Some("failed to generate manifest".to_string()),
+                    last_transition_time: Some("2026-03-16T23:54:06Z".to_string()),
+                }]),
+                summary: None,
+                resources: None,
+                history: None,
+                transitions: None,
+                reconciled_at: Some(Utc::now().to_rfc3339()),
+            }),
+            ..Application::new(
+                "rise-hello-world-default",
+                ApplicationSpec {
+                    project: "rise-hello-world".to_string(),
+                    source: ApplicationSource::default(),
+                    destination: ApplicationDestination::default(),
+                    sync_policy: None,
+                },
+            )
+        };
+
+        let controller = ArgoCdController {
+            state: ControllerState {
+                db_pool: sqlx::PgPool::connect_lazy("postgres://unused").expect("pool"),
+                encryption_provider: None,
+            },
+            kube_client: test_kube_client(),
+            argocd_namespace: "argocd".to_string(),
+            production_ingress_url_template: "{project_name}.apps.example.com".to_string(),
+            staging_ingress_url_template: None,
+            ingress_port: None,
+            ingress_schema: "https".to_string(),
+            appproject_format: "rise-{project_name}".to_string(),
+            application_format: "rise-{project_name}-{deployment_group}".to_string(),
+            destination_namespace_format: "rise-{project_name}-{deployment_group}".to_string(),
+            destination_server: "https://kubernetes.default.svc".to_string(),
+            namespace_labels: HashMap::new(),
+            namespace_annotations: HashMap::new(),
+            helm_chart: ArgoCdHelmChartConfig {
+                repo_url: "https://charts.example.com".to_string(),
+                chart: "app".to_string(),
+                target_revision: "1.2.3".to_string(),
+                values: json!({}),
+            },
+            sync_options: vec![],
+            access_classes: HashMap::new(),
+            registry_provider: Arc::new(crate::server::registry::providers::OciClientAuthProvider::new(
+                crate::server::registry::models::OciClientAuthConfig {
+                    registry_url: "registry.example.com".to_string(),
+                    namespace: String::new(),
+                    client_registry_url: None,
+                },
+            ).expect("provider")),
+        };
+
+        let readiness = controller.evaluate_application_status(&application);
+        assert!(readiness.failed);
+        assert!(!readiness.healthy);
+    }
+
+}

--- a/src/server/deployment/controller/mod.rs
+++ b/src/server/deployment/controller/mod.rs
@@ -1,5 +1,11 @@
 #[cfg(feature = "backend")]
+mod argocd;
+
+#[cfg(feature = "backend")]
 mod kubernetes;
+
+#[cfg(feature = "backend")]
+pub use argocd::{ArgoCdController, ArgoCdControllerConfig, ArgoCdHelmChartConfig};
 
 #[cfg(feature = "backend")]
 pub use kubernetes::{KubernetesController, KubernetesControllerConfig};
@@ -192,6 +198,73 @@ pub struct DeploymentController {
 }
 
 impl DeploymentController {
+    async fn promote_healthy_deployment(
+        &self,
+        deployment: &Deployment,
+        project: &Project,
+    ) -> anyhow::Result<()> {
+        // Find active deployment IN THIS GROUP before marking the new deployment healthy.
+        // This prevents a race where the query could otherwise return the newly-promoted deployment.
+        let active_in_group = db_deployments::find_active_for_project_and_group(
+            &self.state.db_pool,
+            deployment.project_id,
+            &deployment.deployment_group,
+        )
+        .await?;
+
+        db_deployments::mark_healthy(&self.state.db_pool, deployment.id).await?;
+
+        if let Some(old_active) = active_in_group {
+            if old_active.id != deployment.id && !state_machine::is_terminal(&old_active.status) {
+                info!(
+                    "Deployment {} replacing {} in group '{}', marking old as Terminating",
+                    deployment.deployment_id, old_active.deployment_id, deployment.deployment_group
+                );
+                db_deployments::mark_terminating(
+                    &self.state.db_pool,
+                    old_active.id,
+                    crate::db::models::TerminationReason::Superseded,
+                )
+                .await?;
+            }
+        }
+
+        let other_in_group = db_deployments::find_non_terminal_for_project_and_group(
+            &self.state.db_pool,
+            project.id,
+            &deployment.deployment_group,
+        )
+        .await?;
+
+        for other in other_in_group {
+            if other.id != deployment.id
+                && state_machine::is_active(&other.status)
+                && !state_machine::is_terminal(&other.status)
+            {
+                info!(
+                    "Cleaning up non-active deployment {} in group '{}', marking as Terminating",
+                    other.deployment_id, deployment.deployment_group
+                );
+                db_deployments::mark_terminating(
+                    &self.state.db_pool,
+                    other.id,
+                    crate::db::models::TerminationReason::Superseded,
+                )
+                .await?;
+            }
+        }
+
+        db_deployments::mark_as_active(
+            &self.state.db_pool,
+            deployment.id,
+            project.id,
+            &deployment.deployment_group,
+        )
+        .await?;
+
+        Ok(())
+    }
+
     /// Create a new deployment controller
     ///
     /// # Arguments
@@ -409,81 +482,20 @@ impl DeploymentController {
         )
         .await?;
 
-        if let Some(error) = result.error_message {
-            if new_status == DeploymentStatus::Failed {
-                db_deployments::mark_failed(&self.state.db_pool, deployment.id, &error).await?;
-            } else if new_status == DeploymentStatus::Unhealthy {
-                db_deployments::mark_unhealthy(&self.state.db_pool, deployment.id, error).await?;
-            }
-        } else if new_status == DeploymentStatus::Healthy {
-            // Find active deployment IN THIS GROUP *before* marking new as Healthy
-            // This prevents a race condition where the query would return the new deployment
-            let active_in_group = db_deployments::find_active_for_project_and_group(
-                &self.state.db_pool,
-                deployment.project_id,
-                &deployment.deployment_group,
-            )
-            .await?;
-
-            // Now mark the new deployment as healthy
-            db_deployments::mark_healthy(&self.state.db_pool, deployment.id).await?;
-
-            // Supersede old active deployment in this group
-            if let Some(old_active) = active_in_group {
-                if old_active.id != deployment.id && !state_machine::is_terminal(&old_active.status)
-                {
-                    info!(
-                        "Deployment {} replacing {} in group '{}', marking old as Terminating",
-                        deployment.deployment_id,
-                        old_active.deployment_id,
-                        deployment.deployment_group
-                    );
-                    db_deployments::mark_terminating(
-                        &self.state.db_pool,
-                        old_active.id,
-                        crate::db::models::TerminationReason::Superseded,
-                    )
-                    .await?;
-                }
-            }
-
-            // Clean up other ACTIVE (Healthy/Unhealthy) deployments in this group
-            // Do NOT clean up deployments that are still being deployed (Pushed, Deploying, etc.)
-            let other_in_group = db_deployments::find_non_terminal_for_project_and_group(
-                &self.state.db_pool,
-                project.id,
-                &deployment.deployment_group,
-            )
-            .await?;
-
-            for other in other_in_group {
-                // Only clean up OTHER deployments that are in ACTIVE running states
-                // Don't clean up deployments that are still being deployed (Pending, Building, Pushing, Pushed, Deploying)
-                if other.id != deployment.id
-                    && state_machine::is_active(&other.status)
-                    && !state_machine::is_terminal(&other.status)
-                {
-                    info!(
-                        "Cleaning up non-active deployment {} in group '{}', marking as Terminating",
-                        other.deployment_id, deployment.deployment_group
-                    );
-                    db_deployments::mark_terminating(
-                        &self.state.db_pool,
-                        other.id,
-                        crate::db::models::TerminationReason::Superseded,
-                    )
-                    .await?;
-                }
-            }
-
-            // Mark deployment as active
-            db_deployments::mark_as_active(
-                &self.state.db_pool,
-                deployment.id,
-                project.id,
-                &deployment.deployment_group,
-            )
-            .await?;
+        if new_status == DeploymentStatus::Failed {
+            let error = result
+                .error_message
+                .unwrap_or_else(|| "Deployment failed".to_string());
+            db_deployments::mark_failed(&self.state.db_pool, deployment.id, &error).await?;
+        } else if new_status == DeploymentStatus::Unhealthy {
+            let error = result
+                .error_message
+                .unwrap_or_else(|| "Deployment became unhealthy".to_string());
+            db_deployments::mark_unhealthy(&self.state.db_pool, deployment.id, error).await?;
+        } else if new_status == DeploymentStatus::Healthy
+            && deployment.status != DeploymentStatus::Healthy
+        {
+            self.promote_healthy_deployment(&deployment, &project).await?;
         }
 
         // Update project status
@@ -631,7 +643,10 @@ impl DeploymentController {
                             "Deployment {} has recovered, marking as Healthy",
                             deployment.deployment_id
                         );
-                        db_deployments::mark_healthy(&self.state.db_pool, deployment.id).await?;
+                        let project = projects::find_by_id(&self.state.db_pool, deployment.project_id)
+                            .await?
+                            .ok_or_else(|| anyhow::anyhow!("Project not found"))?;
+                        self.promote_healthy_deployment(&deployment, &project).await?;
                         projects::update_calculated_status(
                             &self.state.db_pool,
                             deployment.project_id,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -40,8 +40,8 @@ pub async fn run_server(settings: settings::Settings) -> Result<()> {
     // Spawn enabled controllers as background tasks
     let mut controller_handles = vec![];
 
-    // Start Kubernetes deployment controller
-    info!("Starting Kubernetes deployment controller");
+    // Start deployment controller
+    info!("Starting deployment controller");
 
     let settings_clone = settings.clone();
     let controller_state_clone = controller_state.clone();
@@ -49,20 +49,36 @@ pub async fn run_server(settings: settings::Settings) -> Result<()> {
     let handle = tokio::spawn(async move {
         #[cfg(feature = "backend")]
         {
-            if let Err(e) = run_kubernetes_controller_loop(
-                controller_state_clone,
-                registry_provider,
-                settings_clone,
-            )
-            .await
-            {
+            let result = match &settings_clone.deployment_controller {
+                Some(settings::DeploymentControllerSettings::Kubernetes { .. }) => {
+                    run_kubernetes_controller_loop(
+                        controller_state_clone,
+                        registry_provider,
+                        settings_clone,
+                    )
+                    .await
+                }
+                Some(settings::DeploymentControllerSettings::ArgoCd { .. }) => {
+                    run_argocd_controller_loop(
+                        controller_state_clone,
+                        registry_provider,
+                        settings_clone,
+                    )
+                    .await
+                }
+                None => Err(anyhow::anyhow!(
+                    "Deployment controller not configured. Please add deployment_controller configuration"
+                )),
+            };
+
+            if let Err(e) = result {
                 tracing::error!("Deployment controller error: {:#}", e);
             }
         }
         #[cfg(not(feature = "backend"))]
         {
             tracing::error!(
-                "Kubernetes deployment controller is required but the 'backend' feature is not enabled. \
+                "A deployment controller is configured but the 'backend' feature is not enabled. \
                  Please rebuild with --features backend"
             );
         }
@@ -410,6 +426,11 @@ async fn run_kubernetes_controller_loop(
             pod_resources,
             health_probes,
         ),
+        Some(settings::DeploymentControllerSettings::ArgoCd { .. }) => {
+            anyhow::bail!(
+                "Deployment controller configuration mismatch: expected type kubernetes but found argocd"
+            )
+        }
         None => {
             anyhow::bail!("Deployment controller not configured. Please add deployment_controller configuration with type: kubernetes")
         }
@@ -500,6 +521,137 @@ async fn run_kubernetes_controller_loop(
     // Wait for shutdown signal
     shutdown_signal().await;
     info!("Kubernetes deployment controller shutdown complete");
+    Ok(())
+}
+
+/// Run the ArgoCD deployment controller loop (for embedding in server process)
+#[cfg(feature = "backend")]
+async fn run_argocd_controller_loop(
+    controller_state: ControllerState,
+    registry_provider: Arc<dyn crate::server::registry::RegistryProvider>,
+    settings: settings::Settings,
+) -> Result<()> {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .ok();
+
+    let (
+        kubeconfig,
+        argocd_namespace,
+        production_ingress_url_template,
+        staging_ingress_url_template,
+        ingress_port,
+        ingress_schema,
+        appproject_format,
+        application_format,
+        destination_namespace_format,
+        destination_server,
+        namespace_labels,
+        namespace_annotations,
+        helm_chart,
+        sync_options,
+        access_classes,
+    ) = match settings.deployment_controller.clone() {
+        Some(settings::DeploymentControllerSettings::ArgoCd {
+            kubeconfig,
+            argocd_namespace,
+            production_ingress_url_template,
+            staging_ingress_url_template,
+            ingress_port,
+            ingress_schema,
+            appproject_format,
+            application_format,
+            destination_namespace_format,
+            destination_server,
+            namespace_labels,
+            namespace_annotations,
+            helm_chart,
+            sync_options,
+            access_classes,
+            ..
+        }) => (
+            kubeconfig,
+            argocd_namespace,
+            production_ingress_url_template,
+            staging_ingress_url_template,
+            ingress_port,
+            ingress_schema,
+            appproject_format,
+            application_format,
+            destination_namespace_format,
+            destination_server,
+            namespace_labels,
+            namespace_annotations,
+            helm_chart,
+            sync_options,
+            access_classes,
+        ),
+        _ => anyhow::bail!(
+            "Deployment controller not configured. Please add deployment_controller configuration with type: argocd"
+        ),
+    };
+
+    let kube_config = if kubeconfig.is_some() {
+        kube::Config::from_kubeconfig(&kube::config::KubeConfigOptions {
+            context: None,
+            cluster: None,
+            user: None,
+        })
+        .await?
+    } else {
+        kube::Config::infer().await?
+    };
+    let kube_client = kube::Client::try_from(kube_config)?;
+
+    let backend = Arc::new(deployment::controller::ArgoCdController::new(
+        controller_state.clone(),
+        kube_client,
+        deployment::controller::ArgoCdControllerConfig {
+            argocd_namespace,
+            production_ingress_url_template,
+            staging_ingress_url_template,
+            ingress_port,
+            ingress_schema,
+            appproject_format,
+            application_format,
+            destination_namespace_format,
+            destination_server,
+            namespace_labels,
+            namespace_annotations,
+            helm_chart: deployment::controller::ArgoCdHelmChartConfig {
+                repo_url: helm_chart.repo_url,
+                chart: helm_chart.chart,
+                target_revision: helm_chart.target_revision,
+                values: helm_chart.values,
+            },
+            sync_options,
+            access_classes: access_classes
+                .into_iter()
+                .filter_map(|(key, value)| value.map(|access_class| (key, access_class)))
+                .collect(),
+            registry_provider,
+        },
+    )?);
+
+    backend.test_connection().await?;
+
+    let controller = Arc::new(deployment::controller::DeploymentController::new(
+        Arc::new(controller_state),
+        backend.clone(),
+        Duration::from_secs(settings.controller.reconcile_interval_secs),
+        Duration::from_secs(settings.controller.health_check_interval_secs),
+        Duration::from_secs(settings.controller.termination_interval_secs),
+        Duration::from_secs(settings.controller.cancellation_interval_secs),
+        Duration::from_secs(settings.controller.expiration_interval_secs),
+    )?);
+    controller.start();
+    info!("ArgoCD deployment controller started");
+
+    Arc::clone(&backend).start();
+    info!("ArgoCD project cleanup loop started");
+
+    shutdown_signal().await;
+    info!("ArgoCD deployment controller shutdown complete");
     Ok(())
 }
 

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -246,6 +246,33 @@ fn default_namespace_format() -> String {
     "rise-{project_name}".to_string()
 }
 
+fn default_argocd_namespace() -> String {
+    "argocd".to_string()
+}
+
+fn default_argocd_appproject_format() -> String {
+    "rise-{project_name}".to_string()
+}
+
+fn default_argocd_application_format() -> String {
+    "rise-{project_name}-{deployment_group}".to_string()
+}
+
+fn default_argocd_destination_namespace_format() -> String {
+    "rise-{project_name}-{deployment_group}".to_string()
+}
+
+fn default_argocd_destination_server() -> String {
+    "https://kubernetes.default.svc".to_string()
+}
+
+fn default_argocd_sync_options() -> Vec<String> {
+    vec![
+        "ServerSideApply=true".to_string(),
+        "ApplyOutOfSyncOnly=true".to_string(),
+    ]
+}
+
 fn default_node_selector() -> std::collections::HashMap<String, String> {
     let mut selector = std::collections::HashMap::new();
     selector.insert("kubernetes.io/arch".to_string(), "amd64".to_string());
@@ -455,6 +482,23 @@ fn default_failure_threshold() -> i32 {
     3
 }
 
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct ArgoCdHelmChartSettings {
+    /// Helm repository URL used by ArgoCD for the managed application
+    pub repo_url: String,
+    /// Chart name within the repository
+    pub chart: String,
+    /// Chart version or revision to deploy
+    pub target_revision: String,
+    /// Static values merged with the Rise-generated values contract
+    #[serde(default = "default_chart_values")]
+    pub values: serde_json::Value,
+}
+
+fn default_chart_values() -> serde_json::Value {
+    serde_json::Value::Object(serde_json::Map::new())
+}
+
 /// Deployment controller configuration
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "kebab-case")]
@@ -633,6 +677,73 @@ pub enum DeploymentControllerSettings {
         /// If not set, uses defaults (HTTP probes on app port at "/" path)
         #[serde(default)]
         health_probes: Option<HealthProbeConfig>,
+    },
+    /// ArgoCD deployment controller
+    #[cfg(feature = "backend")]
+    #[serde(alias = "argocd")]
+    ArgoCd {
+        /// Optional kubeconfig path (defaults to in-cluster or ~/.kube/config)
+        #[serde(default)]
+        kubeconfig: Option<String>,
+
+        /// Namespace where ArgoCD stores Application and AppProject objects
+        #[serde(default = "default_argocd_namespace")]
+        argocd_namespace: String,
+
+        /// Ingress URL template for production (default) deployment group
+        /// Must contain {project_name}
+        production_ingress_url_template: String,
+
+        /// Ingress URL template for non-default deployment groups
+        /// Must contain {project_name} and {deployment_group} when set
+        #[serde(default)]
+        staging_ingress_url_template: Option<String>,
+
+        /// Optional port number to append to generated application URLs
+        #[serde(default)]
+        ingress_port: Option<u16>,
+
+        /// URL scheme for generated application URLs
+        #[serde(default = "default_ingress_schema")]
+        ingress_schema: String,
+
+        /// Naming format for per-project ArgoCD AppProjects
+        /// Required placeholders: {project_name}
+        #[serde(default = "default_argocd_appproject_format")]
+        appproject_format: String,
+
+        /// Naming format for per-group ArgoCD Applications
+        /// Required placeholders: {project_name}, {deployment_group}
+        #[serde(default = "default_argocd_application_format")]
+        application_format: String,
+
+        /// Destination namespace format for deployed workloads
+        /// Required placeholders: {project_name}, {deployment_group}
+        #[serde(default = "default_argocd_destination_namespace_format")]
+        destination_namespace_format: String,
+
+        /// Kubernetes API destination server for ArgoCD Applications
+        #[serde(default = "default_argocd_destination_server")]
+        destination_server: String,
+
+        /// Labels to apply to destination namespaces created by Rise
+        #[serde(default)]
+        namespace_labels: std::collections::HashMap<String, String>,
+
+        /// Annotations to apply to destination namespaces created by Rise
+        #[serde(default)]
+        namespace_annotations: std::collections::HashMap<String, String>,
+
+        /// Helm chart configuration used by ArgoCD Applications
+        helm_chart: ArgoCdHelmChartSettings,
+
+        /// syncOptions applied to every managed Application
+        #[serde(default = "default_argocd_sync_options")]
+        sync_options: Vec<String>,
+
+        /// Access classes exposed by the backend
+        /// Use `null` in YAML to remove an inherited access class from parent configs
+        access_classes: std::collections::HashMap<String, Option<AccessClass>>,
     },
 }
 
@@ -926,69 +1037,116 @@ impl Settings {
         }
 
         // Validate deployment controller settings if configured
-        if let Some(DeploymentControllerSettings::Kubernetes {
-            ref namespace_format,
-            ref production_ingress_url_template,
-            ref staging_ingress_url_template,
-            ref access_classes,
-            ref extra_service_token_audiences,
-            ..
-        }) = settings.deployment_controller
-        {
-            Self::validate_format_string(namespace_format, "namespace_format", "{project_name}")?;
-            Self::validate_format_string(
-                production_ingress_url_template,
-                "production_ingress_url_template",
-                "{project_name}",
-            )?;
+        if let Some(ref deployment_controller) = settings.deployment_controller {
+            match deployment_controller {
+                DeploymentControllerSettings::Kubernetes {
+                    namespace_format,
+                    production_ingress_url_template,
+                    staging_ingress_url_template,
+                    access_classes,
+                    extra_service_token_audiences,
+                    ..
+                } => {
+                    Self::validate_format_string(
+                        namespace_format,
+                        "namespace_format",
+                        "{project_name}",
+                    )?;
+                    Self::validate_format_string(
+                        production_ingress_url_template,
+                        "production_ingress_url_template",
+                        "{project_name}",
+                    )?;
 
-            if let Some(ref staging_template) = staging_ingress_url_template {
-                Self::validate_format_string(
-                    staging_template,
-                    "staging_ingress_url_template",
-                    "{project_name}",
-                )?;
-                Self::validate_format_string(
-                    staging_template,
-                    "staging_ingress_url_template",
-                    "{deployment_group}",
-                )?;
-            }
+                    if let Some(staging_template) = staging_ingress_url_template {
+                        Self::validate_format_string(
+                            staging_template,
+                            "staging_ingress_url_template",
+                            "{project_name}",
+                        )?;
+                        Self::validate_format_string(
+                            staging_template,
+                            "staging_ingress_url_template",
+                            "{deployment_group}",
+                        )?;
+                    }
 
-            Self::validate_extra_service_token_audiences(extra_service_token_audiences)?;
-
-            // Filter out null access classes (used to remove inherited entries)
-            // and validate the remaining ones
-            let active_classes: Vec<_> = access_classes
-                .iter()
-                .filter_map(|(id, class)| class.as_ref().map(|c| (id, c)))
-                .collect();
-
-            if active_classes.is_empty() {
-                return Err(ConfigError::Message(
-                    "Kubernetes deployment_controller requires at least one access class to be configured. \
-                     Add access_classes to your configuration file.".to_string()
-                ));
-            }
-
-            for (id, class) in active_classes {
-                if class.display_name.is_empty() {
-                    return Err(ConfigError::Message(format!(
-                        "Access class '{}' has empty display_name",
-                        id
-                    )));
+                    Self::validate_extra_service_token_audiences(extra_service_token_audiences)?;
+                    Self::validate_access_classes(access_classes, "Kubernetes")?;
                 }
-                if class.description.is_empty() {
-                    return Err(ConfigError::Message(format!(
-                        "Access class '{}' has empty description",
-                        id
-                    )));
-                }
-                if class.ingress_class.is_empty() {
-                    return Err(ConfigError::Message(format!(
-                        "Access class '{}' has empty ingress_class",
-                        id
-                    )));
+                DeploymentControllerSettings::ArgoCd {
+                    production_ingress_url_template,
+                    staging_ingress_url_template,
+                    appproject_format,
+                    application_format,
+                    destination_namespace_format,
+                    helm_chart,
+                    sync_options,
+                    access_classes,
+                    ..
+                } => {
+                    Self::validate_format_string(
+                        production_ingress_url_template,
+                        "production_ingress_url_template",
+                        "{project_name}",
+                    )?;
+
+                    if let Some(staging_template) = staging_ingress_url_template {
+                        Self::validate_format_string(
+                            staging_template,
+                            "staging_ingress_url_template",
+                            "{project_name}",
+                        )?;
+                        Self::validate_format_string(
+                            staging_template,
+                            "staging_ingress_url_template",
+                            "{deployment_group}",
+                        )?;
+                    }
+
+                    Self::validate_format_string(
+                        appproject_format,
+                        "appproject_format",
+                        "{project_name}",
+                    )?;
+                    Self::validate_format_string(
+                        application_format,
+                        "application_format",
+                        "{project_name}",
+                    )?;
+                    Self::validate_format_string(
+                        application_format,
+                        "application_format",
+                        "{deployment_group}",
+                    )?;
+                    Self::validate_format_string(
+                        destination_namespace_format,
+                        "destination_namespace_format",
+                        "{project_name}",
+                    )?;
+                    Self::validate_format_string(
+                        destination_namespace_format,
+                        "destination_namespace_format",
+                        "{deployment_group}",
+                    )?;
+
+                    if helm_chart.repo_url.is_empty()
+                        || helm_chart.chart.is_empty()
+                        || helm_chart.target_revision.is_empty()
+                    {
+                        return Err(ConfigError::Message(
+                            "ArgoCD deployment_controller requires helm_chart.repo_url, helm_chart.chart, and helm_chart.target_revision".to_string(),
+                        ));
+                    }
+
+                    if !sync_options.iter().all(|item| item.contains('=')) {
+                        return Err(ConfigError::Message(
+                            "ArgoCD deployment_controller sync_options must use KEY=VALUE format"
+                                .to_string(),
+                        ));
+                    }
+
+                    Self::validate_access_classes(access_classes, "ArgoCD")?;
                 }
             }
         }
@@ -1008,6 +1166,46 @@ impl Settings {
                 field_name, required_placeholder, format_str
             )));
         }
+        Ok(())
+    }
+
+    fn validate_access_classes(
+        access_classes: &std::collections::HashMap<String, Option<AccessClass>>,
+        controller_name: &str,
+    ) -> Result<(), ConfigError> {
+        let active_classes: Vec<_> = access_classes
+            .iter()
+            .filter_map(|(id, class)| class.as_ref().map(|c| (id, c)))
+            .collect();
+
+        if active_classes.is_empty() {
+            return Err(ConfigError::Message(format!(
+                "{} deployment_controller requires at least one access class to be configured. Add access_classes to your configuration file.",
+                controller_name
+            )));
+        }
+
+        for (id, class) in active_classes {
+            if class.display_name.is_empty() {
+                return Err(ConfigError::Message(format!(
+                    "Access class '{}' has empty display_name",
+                    id
+                )));
+            }
+            if class.description.is_empty() {
+                return Err(ConfigError::Message(format!(
+                    "Access class '{}' has empty description",
+                    id
+                )));
+            }
+            if class.ingress_class.is_empty() {
+                return Err(ConfigError::Message(format!(
+                    "Access class '{}' has empty ingress_class",
+                    id
+                )));
+            }
+        }
+
         Ok(())
     }
 }
@@ -1205,6 +1403,67 @@ deployment_controller:
         assert_eq!(
             extra_service_token_audiences.get("vault"),
             Some(&"https://vault.example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_argocd_sync_options_default() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("development.yaml");
+
+        fs::write(
+            &config_path,
+            r#"
+server:
+  host: "0.0.0.0"
+  port: 3000
+  public_url: "http://localhost:3000"
+  jwt_signing_secret: "test-secret-key-for-testing-123456"
+
+database:
+  url: "postgres://test@localhost/test"
+
+auth:
+  issuer: "http://localhost:5556"
+  client_id: "test"
+  client_secret: "test"
+
+deployment_controller:
+  type: "argo-cd"
+  production_ingress_url_template: "{project_name}.test.local"
+  helm_chart:
+    repo_url: "https://charts.example.com"
+    chart: "test"
+    target_revision: "1.0.0"
+  access_classes:
+    public:
+      display_name: "Public"
+      description: "Test public access"
+      ingress_class: "nginx"
+      access_requirement: None
+"#,
+        )
+        .unwrap();
+
+        let settings =
+            Settings::new_with_env(temp_dir.path().to_str().unwrap(), "development", &|_| None)
+                .expect("argocd config should load");
+
+        let Some(DeploymentControllerSettings::ArgoCd { sync_options, .. }) =
+            settings.deployment_controller
+        else {
+            panic!("expected argocd deployment_controller");
+        };
+
+        assert_eq!(
+            sync_options,
+            vec![
+                "ServerSideApply=true".to_string(),
+                "ApplyOutOfSyncOnly=true".to_string()
+            ]
         );
     }
 

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -26,7 +26,8 @@ use std::time::Duration;
 
 #[cfg(feature = "backend")]
 use crate::server::deployment::controller::{
-    DeploymentBackend, KubernetesController, KubernetesControllerConfig,
+    ArgoCdController, ArgoCdControllerConfig, ArgoCdHelmChartConfig, DeploymentBackend,
+    KubernetesController, KubernetesControllerConfig,
 };
 
 /// Minimal state for controllers - database access and encryption
@@ -263,6 +264,93 @@ async fn init_kubernetes_backend(
         Ok(Arc::new(k8s_backend) as Arc<dyn DeploymentBackend>)
     } else {
         anyhow::bail!("Deployment controller not configured. Please add deployment_controller configuration with type: kubernetes")
+    }
+}
+
+/// Initialize ArgoCD deployment backend from settings
+#[cfg(feature = "backend")]
+async fn init_argocd_backend(
+    settings: &Settings,
+    controller_state: Arc<ControllerState>,
+    registry_provider: Arc<dyn RegistryProvider>,
+) -> Result<Arc<dyn DeploymentBackend>> {
+    use crate::server::settings::DeploymentControllerSettings;
+
+    if let Some(DeploymentControllerSettings::ArgoCd {
+        kubeconfig,
+        argocd_namespace,
+        production_ingress_url_template,
+        staging_ingress_url_template,
+        ingress_port,
+        ingress_schema,
+        appproject_format,
+        application_format,
+        destination_namespace_format,
+        destination_server,
+        namespace_labels,
+        namespace_annotations,
+        helm_chart,
+        sync_options,
+        access_classes,
+        ..
+    }) = &settings.deployment_controller
+    {
+        let filtered_access_classes: std::collections::HashMap<_, _> = access_classes
+            .iter()
+            .filter_map(|(key, value)| value.as_ref().map(|access_class| (key.clone(), access_class.clone())))
+            .collect();
+
+        rustls::crypto::ring::default_provider()
+            .install_default()
+            .ok();
+
+        let kube_config = if kubeconfig.is_some() {
+            kube::Config::from_kubeconfig(&kube::config::KubeConfigOptions {
+                context: None,
+                cluster: None,
+                user: None,
+            })
+            .await?
+        } else {
+            kube::Config::infer().await?
+        };
+        let kube_client = kube::Client::try_from(kube_config)?;
+
+        let argocd_backend = ArgoCdController::new(
+            (*controller_state).clone(),
+            kube_client,
+            ArgoCdControllerConfig {
+                argocd_namespace: argocd_namespace.clone(),
+                production_ingress_url_template: production_ingress_url_template.clone(),
+                staging_ingress_url_template: staging_ingress_url_template.clone(),
+                ingress_port: *ingress_port,
+                ingress_schema: ingress_schema.clone(),
+                appproject_format: appproject_format.clone(),
+                application_format: application_format.clone(),
+                destination_namespace_format: destination_namespace_format.clone(),
+                destination_server: destination_server.clone(),
+                namespace_labels: namespace_labels.clone(),
+                namespace_annotations: namespace_annotations.clone(),
+                helm_chart: ArgoCdHelmChartConfig {
+                    repo_url: helm_chart.repo_url.clone(),
+                    chart: helm_chart.chart.clone(),
+                    target_revision: helm_chart.target_revision.clone(),
+                    values: helm_chart.values.clone(),
+                },
+                sync_options: sync_options.clone(),
+                access_classes: filtered_access_classes,
+                registry_provider,
+            },
+        )?;
+
+        argocd_backend.test_connection().await?;
+        tracing::info!("✓ ArgoCD deployment backend initialized and connection tested");
+
+        Ok(Arc::new(argocd_backend) as Arc<dyn DeploymentBackend>)
+    } else {
+        anyhow::bail!(
+            "Deployment controller not configured. Please add deployment_controller configuration with type: argocd"
+        )
     }
 }
 
@@ -531,7 +619,19 @@ impl AppState {
                 db_pool: db_pool.clone(),
                 encryption_provider: encryption_provider.clone(),
             });
-            init_kubernetes_backend(settings, controller_state, registry_provider.clone()).await?
+            match &settings.deployment_controller {
+                Some(crate::server::settings::DeploymentControllerSettings::Kubernetes { .. }) => {
+                    init_kubernetes_backend(settings, controller_state, registry_provider.clone())
+                        .await?
+                }
+                Some(crate::server::settings::DeploymentControllerSettings::ArgoCd { .. }) => {
+                    init_argocd_backend(settings, controller_state, registry_provider.clone())
+                        .await?
+                }
+                None => anyhow::bail!(
+                    "Deployment controller not configured. Please add deployment_controller configuration"
+                ),
+            }
         };
 
         // Initialize extension registry
@@ -737,24 +837,30 @@ impl AppState {
         // Extract access_classes from deployment controller settings
         // Filter out null values (used to remove inherited access classes)
         let (access_classes, production_ingress_url_template, staging_ingress_url_template) =
-            if let Some(crate::server::settings::DeploymentControllerSettings::Kubernetes {
-                access_classes,
-                production_ingress_url_template,
-                staging_ingress_url_template,
-                ..
-            }) = &settings.deployment_controller
-            {
-                let filtered: std::collections::HashMap<_, _> = access_classes
-                    .iter()
-                    .filter_map(|(k, v)| v.as_ref().map(|ac| (k.clone(), ac.clone())))
-                    .collect();
-                (
-                    Arc::new(filtered),
-                    Some(production_ingress_url_template.clone()),
-                    staging_ingress_url_template.clone(),
-                )
-            } else {
-                (Arc::new(std::collections::HashMap::new()), None, None)
+            match &settings.deployment_controller {
+                Some(crate::server::settings::DeploymentControllerSettings::Kubernetes {
+                    access_classes,
+                    production_ingress_url_template,
+                    staging_ingress_url_template,
+                    ..
+                })
+                | Some(crate::server::settings::DeploymentControllerSettings::ArgoCd {
+                    access_classes,
+                    production_ingress_url_template,
+                    staging_ingress_url_template,
+                    ..
+                }) => {
+                    let filtered: std::collections::HashMap<_, _> = access_classes
+                        .iter()
+                        .filter_map(|(k, v)| v.as_ref().map(|ac| (k.clone(), ac.clone())))
+                        .collect();
+                    (
+                        Arc::new(filtered),
+                        Some(production_ingress_url_template.clone()),
+                        staging_ingress_url_template.clone(),
+                    )
+                }
+                None => (Arc::new(std::collections::HashMap::new()), None, None),
             };
 
         Ok(Self {


### PR DESCRIPTION
## Summary
- add an ArgoCD-backed deployment controller and backend settings
- add the local rise-app Helm chart and mise tasks for local ArgoCD/chart workflows
- wire rollout, rollback, pod-based health, logs, and deployment UI updates for the new controller

## Validation
- `SQLX_OFFLINE=true cargo check --features backend`
- `cd frontend && npm run build`
