### PR TITLE
fix: project-scoped deployment status endpoint

### DIFF
--- a/.sqlx/query-d89f6f7541619af29f944b05a74847cdee6f96b026ea72785c0c1a0b04c7ad0b.json
+++ b/.sqlx/query-d89f6f7541619af29f944b05a74847cdee6f96b026ea72785c0c1a0b04c7ad0b.json
@@ -1,0 +1,162 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            id, deployment_id, project_id, created_by_id,\n            status as \"status: DeploymentStatus\",\n            deployment_group, expires_at,\n            completed_at, error_message, build_logs,\n            controller_metadata as \"controller_metadata: serde_json::Value\",\n            image, image_digest, rolled_back_from_deployment_id,\n            http_port, needs_reconcile, is_active,\n            deploying_started_at,\n            first_healthy_at,\n            termination_reason as \"termination_reason: _\",\n            created_at, updated_at\n        FROM deployments\n        WHERE deployment_id = $1\n        ORDER BY created_at ASC\n        LIMIT $2\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "deployment_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "project_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "created_by_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 4,
+        "name": "status: DeploymentStatus",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "deployment_group",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "expires_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "build_logs",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "controller_metadata: serde_json::Value",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 11,
+        "name": "image",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "image_digest",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "rolled_back_from_deployment_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 14,
+        "name": "http_port",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 15,
+        "name": "needs_reconcile",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 16,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "deploying_started_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "first_healthy_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
+        "name": "termination_reason: _",
+        "type_info": {
+          "Custom": {
+            "name": "termination_reason",
+            "kind": {
+              "Enum": [
+                "UserStopped",
+                "Superseded",
+                "Cancelled",
+                "Failed",
+                "Expired"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "d89f6f7541619af29f944b05a74847cdee6f96b026ea72785c0c1a0b04c7ad0b"
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -164,6 +164,14 @@ cargo test
 
 Use conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`
 
+## Deprecated API Endpoints
+
+Endpoints listed here are kept for backward compatibility with older CLI versions. They should be removed in a future major release once all clients have migrated.
+
+| Endpoint | Replacement | Deprecated in | Reason |
+|----------|-------------|---------------|--------|
+| `PATCH /api/v1/deployments/{deployment_id}/status` | `PATCH /api/v1/projects/{project_name}/deployments/{deployment_id}/status` | v0.18.0 | `deployment_id` is not globally unique — two projects can share the same timestamp-based ID, causing status updates to hit the wrong deployment |
+
 ## Troubleshooting
 
 See [Troubleshooting](user-guide/troubleshooting.md) for common issues.

--- a/src/cli/deployment/core.rs
+++ b/src/cli/deployment/core.rs
@@ -508,6 +508,7 @@ pub async fn create_deployment(
     let backend_url_clone = backend_url.to_string();
     let http_client_clone = http_client.clone();
     let token_clone = token.to_string();
+    let project_name_clone = deploy_opts.project_name.to_string();
 
     tokio::spawn(async move {
         if let Ok(()) = tokio::signal::ctrl_c().await {
@@ -518,6 +519,7 @@ pub async fn create_deployment(
                 &http_client_clone,
                 &backend_url_clone,
                 &token_clone,
+                &project_name_clone,
                 &deployment_id_clone,
             )
             .await
@@ -551,6 +553,7 @@ pub async fn create_deployment(
             &token,
             &container_cli,
             &deployment_info.credentials,
+            deploy_opts.project_name,
             &deployment_info.deployment_id,
         )
         .await?;
@@ -561,6 +564,7 @@ pub async fn create_deployment(
                 http_client,
                 backend_url,
                 &token,
+                deploy_opts.project_name,
                 &deployment_info.deployment_id,
                 "Failed",
                 Some(&e.to_string()),
@@ -576,6 +580,7 @@ pub async fn create_deployment(
                 http_client,
                 backend_url,
                 &token,
+                deploy_opts.project_name,
                 &deployment_info.deployment_id,
                 "Failed",
                 Some(&e.to_string()),
@@ -589,6 +594,7 @@ pub async fn create_deployment(
             http_client,
             backend_url,
             &token,
+            deploy_opts.project_name,
             &deployment_info.deployment_id,
             "Building",
             None,
@@ -601,6 +607,7 @@ pub async fn create_deployment(
                 http_client,
                 backend_url,
                 &token,
+                deploy_opts.project_name,
                 &deployment_info.deployment_id,
                 "Failed",
                 Some(&e.to_string()),
@@ -614,6 +621,7 @@ pub async fn create_deployment(
             http_client,
             backend_url,
             &token,
+            deploy_opts.project_name,
             &deployment_info.deployment_id,
             "Pushed",
             None,
@@ -655,6 +663,7 @@ pub async fn create_deployment(
             &token,
             options.container_cli.command(),
             &deployment_info.credentials,
+            deploy_opts.project_name,
             &deployment_info.deployment_id,
         )
         .await?;
@@ -664,6 +673,7 @@ pub async fn create_deployment(
             http_client,
             backend_url,
             &token,
+            deploy_opts.project_name,
             &deployment_info.deployment_id,
             "Building",
             None,
@@ -678,6 +688,7 @@ pub async fn create_deployment(
                 http_client,
                 backend_url,
                 &token,
+                deploy_opts.project_name,
                 &deployment_info.deployment_id,
                 "Failed",
                 Some(&e.to_string()),
@@ -691,6 +702,7 @@ pub async fn create_deployment(
             http_client,
             backend_url,
             &token,
+            deploy_opts.project_name,
             &deployment_info.deployment_id,
             "Pushed",
             None,
@@ -726,6 +738,7 @@ async fn login_to_registry(
     token: &str,
     container_cli: &str,
     credentials: &RegistryCredentials,
+    project_name: &str,
     deployment_id: &str,
 ) -> Result<()> {
     let result = match credentials.auth_method {
@@ -760,6 +773,7 @@ async fn login_to_registry(
             http_client,
             backend_url,
             token,
+            project_name,
             deployment_id,
             "Failed",
             Some(&e.to_string()),
@@ -868,11 +882,12 @@ async fn cancel_deployment(
     http_client: &Client,
     backend_url: &str,
     token: &str,
+    project_name: &str,
     deployment_id: &str,
 ) -> Result<()> {
     let url = format!(
-        "{}/api/v1/deployments/{}/status",
-        backend_url, deployment_id
+        "{}/api/v1/projects/{}/deployments/{}/status",
+        backend_url, project_name, deployment_id
     );
 
     let payload = serde_json::json!({
@@ -903,13 +918,14 @@ async fn update_deployment_status(
     http_client: &Client,
     backend_url: &str,
     token: &str,
+    project_name: &str,
     deployment_id: &str,
     status: &str,
     error_message: Option<&str>,
 ) -> Result<()> {
     let url = format!(
-        "{}/api/v1/deployments/{}/status",
-        backend_url, deployment_id
+        "{}/api/v1/projects/{}/deployments/{}/status",
+        backend_url, project_name, deployment_id
     );
     let mut payload = serde_json::json!({
         "status": status,

--- a/src/db/deployments.rs
+++ b/src/db/deployments.rs
@@ -151,6 +151,45 @@ pub async fn find_by_deployment_id(
     Ok(deployment)
 }
 
+/// Find deployments by deployment_id across all projects (unscoped).
+///
+/// Returns up to `limit` matching deployments. Used by the deprecated unscoped
+/// status update endpoint to detect collisions.
+pub async fn find_by_deployment_id_unscoped(
+    pool: &PgPool,
+    deployment_id: &str,
+    limit: i64,
+) -> Result<Vec<Deployment>> {
+    let deployments = sqlx::query_as!(
+        Deployment,
+        r#"
+        SELECT
+            id, deployment_id, project_id, created_by_id,
+            status as "status: DeploymentStatus",
+            deployment_group, expires_at,
+            completed_at, error_message, build_logs,
+            controller_metadata as "controller_metadata: serde_json::Value",
+            image, image_digest, rolled_back_from_deployment_id,
+            http_port, needs_reconcile, is_active,
+            deploying_started_at,
+            first_healthy_at,
+            termination_reason as "termination_reason: _",
+            created_at, updated_at
+        FROM deployments
+        WHERE deployment_id = $1
+        ORDER BY created_at ASC
+        LIMIT $2
+        "#,
+        deployment_id,
+        limit
+    )
+    .fetch_all(pool)
+    .await
+    .context("Failed to find deployments by deployment_id (unscoped)")?;
+
+    Ok(deployments)
+}
+
 /// Create a new deployment
 pub async fn create(pool: &PgPool, params: CreateDeploymentParams<'_>) -> Result<Deployment> {
     let status_str = params.status.to_string();

--- a/src/server/deployment/handlers.rs
+++ b/src/server/deployment/handlers.rs
@@ -8,7 +8,7 @@ use axum::{
 use chrono::{DateTime, Utc};
 use futures::StreamExt;
 use regex::Regex;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use super::models::{self, *};
 use super::state_machine;
@@ -1133,57 +1133,20 @@ pub async fn create_deployment(
     }
 }
 
-/// PATCH /deployments/{deployment_id}/status - Update deployment status
-pub async fn update_deployment_status(
-    State(state): State<AppState>,
-    Extension(user): Extension<User>,
-    Path(deployment_id): Path<String>,
-    Json(payload): Json<UpdateDeploymentStatusRequest>,
+/// Shared logic for updating a deployment's status.
+///
+/// Given a resolved deployment and project, validates permissions and applies the status update.
+async fn perform_status_update(
+    state: &AppState,
+    user: &User,
+    deployment: crate::db::models::Deployment,
+    project: &crate::db::models::Project,
+    deployment_id: &str,
+    payload: UpdateDeploymentStatusRequest,
 ) -> Result<Json<Deployment>, (StatusCode, String)> {
-    info!(
-        "Updating deployment {} status to {:?}",
-        deployment_id, payload.status
-    );
-
-    // Find all deployments with this deployment_id (there should only be one)
-    // We need to find the project first to check the deployment_id
-    // For now, let's query by deployment_id across all projects
-    // We'll need to add a function to find by deployment_id only
-
-    // Query all projects to find the one with this deployment
-    let all_projects = projects::list(&state.db_pool, None).await.map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to list projects: {}", e),
-        )
-    })?;
-
-    let mut found_deployment: Option<crate::db::models::Deployment> = None;
-    let mut found_project: Option<crate::db::models::Project> = None;
-
-    for project in all_projects {
-        if let Ok(Some(deployment)) =
-            db_deployments::find_by_deployment_id(&state.db_pool, &deployment_id, project.id).await
-        {
-            found_deployment = Some(deployment);
-            found_project = Some(project);
-            break;
-        }
-    }
-
-    let deployment = found_deployment.ok_or((
-        StatusCode::NOT_FOUND,
-        format!("Deployment '{}' not found", deployment_id),
-    ))?;
-
-    let project = found_project.ok_or((
-        StatusCode::NOT_FOUND,
-        format!("Project for deployment '{}' not found", deployment_id),
-    ))?;
-
     // Check if user has permission (owns the project)
     // Return 404 instead of 403 to avoid revealing project existence
-    check_deploy_permission(&state, &project, &user)
+    check_deploy_permission(state, project, user)
         .await
         .map_err(|_| {
             (
@@ -1260,13 +1223,11 @@ pub async fn update_deployment_status(
     // Only calculate URLs for non-terminal deployments that could receive traffic
     let (primary_url, custom_domain_urls) =
         if state_machine::is_terminal(&updated_deployment.status) {
-            // Terminal deployments (Failed, Stopped, Cancelled, Superseded, Expired) cannot receive traffic
             (None, vec![])
         } else {
-            // Calculate deployment URLs dynamically for active deployments
             match state
                 .deployment_backend
-                .get_deployment_urls(&updated_deployment, &project)
+                .get_deployment_urls(&updated_deployment, project)
                 .await
             {
                 Ok(urls) => (Some(urls.primary_url), urls.custom_domain_urls),
@@ -1284,15 +1245,122 @@ pub async fn update_deployment_status(
         get_creator_email(&state.db_pool, updated_deployment.created_by_id).await;
     Ok(Json(
         convert_deployment(
-            &state,
+            state,
             updated_deployment,
-            &project,
+            project,
             created_by_email,
             primary_url,
             custom_domain_urls,
         )
         .await,
     ))
+}
+
+/// PATCH /projects/{project_name}/deployments/{deployment_id}/status - Update deployment status (project-scoped)
+pub async fn update_deployment_status_by_project(
+    State(state): State<AppState>,
+    Extension(user): Extension<User>,
+    Path((project_name, deployment_id)): Path<(String, String)>,
+    Json(payload): Json<UpdateDeploymentStatusRequest>,
+) -> Result<Json<Deployment>, (StatusCode, String)> {
+    info!(
+        "Updating deployment {} status to {:?} for project {}",
+        deployment_id, payload.status, project_name
+    );
+
+    // Find project by name
+    let project = projects::find_by_name(&state.db_pool, &project_name)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to find project: {}", e),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                format!("Project '{}' not found", project_name),
+            )
+        })?;
+
+    // Find deployment by deployment_id + project_id
+    let deployment =
+        db_deployments::find_by_deployment_id(&state.db_pool, &deployment_id, project.id)
+            .await
+            .map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to find deployment: {}", e),
+                )
+            })?
+            .ok_or_else(|| {
+                (
+                    StatusCode::NOT_FOUND,
+                    format!(
+                        "Deployment '{}' not found for project '{}'",
+                        deployment_id, project_name
+                    ),
+                )
+            })?;
+
+    perform_status_update(&state, &user, deployment, &project, &deployment_id, payload).await
+}
+
+/// PATCH /deployments/{deployment_id}/status - Update deployment status (deprecated, unscoped)
+///
+/// This endpoint is deprecated. Use `PATCH /projects/{project_name}/deployments/{deployment_id}/status` instead.
+/// Kept for backward compatibility with older CLI versions.
+pub async fn update_deployment_status(
+    State(state): State<AppState>,
+    Extension(user): Extension<User>,
+    Path(deployment_id): Path<String>,
+    Json(payload): Json<UpdateDeploymentStatusRequest>,
+) -> Result<Json<Deployment>, (StatusCode, String)> {
+    warn!(
+        "Deprecated endpoint called: PATCH /deployments/{}/status — use PATCH /projects/{{project_name}}/deployments/{}/status instead",
+        deployment_id, deployment_id
+    );
+
+    // Scan all projects to find the deployment (the original, buggy approach)
+    let all_projects = projects::list(&state.db_pool, None).await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to list projects: {}", e),
+        )
+    })?;
+
+    let mut matching_projects: Vec<(crate::db::models::Project, crate::db::models::Deployment)> =
+        Vec::new();
+
+    for project in all_projects {
+        if let Ok(Some(deployment)) =
+            db_deployments::find_by_deployment_id(&state.db_pool, &deployment_id, project.id).await
+        {
+            matching_projects.push((project, deployment));
+        }
+    }
+
+    if matching_projects.len() > 1 {
+        let project_names: Vec<&str> = matching_projects
+            .iter()
+            .map(|(p, _)| p.name.as_str())
+            .collect();
+        warn!(
+            "Deployment ID collision on deprecated endpoint: deployment_id={} matches {} projects: {:?}. Using first match. \
+             Clients should migrate to the project-scoped endpoint.",
+            deployment_id,
+            matching_projects.len(),
+            project_names,
+        );
+    }
+
+    let (project, deployment) = matching_projects.into_iter().next().ok_or((
+        StatusCode::NOT_FOUND,
+        format!("Deployment '{}' not found", deployment_id),
+    ))?;
+
+    perform_status_update(&state, &user, deployment, &project, &deployment_id, payload).await
 }
 
 /// Query parameters for listing deployments

--- a/src/server/deployment/handlers.rs
+++ b/src/server/deployment/handlers.rs
@@ -1311,6 +1311,9 @@ pub async fn update_deployment_status_by_project(
 ///
 /// This endpoint is deprecated. Use `PATCH /projects/{project_name}/deployments/{deployment_id}/status` instead.
 /// Kept for backward compatibility with older CLI versions.
+///
+/// Returns 409 Conflict when multiple projects have deployments with the same deployment_id,
+/// since we cannot determine which one the caller intended.
 pub async fn update_deployment_status(
     State(state): State<AppState>,
     Extension(user): Extension<User>,
@@ -1322,43 +1325,62 @@ pub async fn update_deployment_status(
         deployment_id, deployment_id
     );
 
-    // Scan all projects to find the deployment (the original, buggy approach)
-    let all_projects = projects::list(&state.db_pool, None).await.map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to list projects: {}", e),
-        )
-    })?;
+    // Single query to find matching deployments across all projects (LIMIT 2 to detect collisions)
+    let matching_deployments =
+        db_deployments::find_by_deployment_id_unscoped(&state.db_pool, &deployment_id, 2)
+            .await
+            .map_err(|e| {
+                error!(
+                    "Failed to query deployment '{}' (unscoped): {:?}",
+                    deployment_id, e
+                );
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to query deployment '{}': {}", deployment_id, e),
+                )
+            })?;
 
-    let mut matching_projects: Vec<(crate::db::models::Project, crate::db::models::Deployment)> =
-        Vec::new();
-
-    for project in all_projects {
-        if let Ok(Some(deployment)) =
-            db_deployments::find_by_deployment_id(&state.db_pool, &deployment_id, project.id).await
-        {
-            matching_projects.push((project, deployment));
-        }
-    }
-
-    if matching_projects.len() > 1 {
-        let project_names: Vec<&str> = matching_projects
+    if matching_deployments.len() > 1 {
+        let project_ids: Vec<String> = matching_deployments
             .iter()
-            .map(|(p, _)| p.name.as_str())
+            .map(|d| d.project_id.to_string())
             .collect();
         warn!(
-            "Deployment ID collision on deprecated endpoint: deployment_id={} matches {} projects: {:?}. Using first match. \
-             Clients should migrate to the project-scoped endpoint.",
+            "Deployment ID collision on deprecated endpoint: deployment_id={} matches {} projects: {:?}. \
+             Refusing to proceed. Clients should migrate to the project-scoped endpoint.",
             deployment_id,
-            matching_projects.len(),
-            project_names,
+            matching_deployments.len(),
+            project_ids,
         );
+        return Err((
+            StatusCode::CONFLICT,
+            format!(
+                "Ambiguous deployment_id '{}': matches multiple projects. \
+                 Use PATCH /api/v1/projects/{{project_name}}/deployments/{}/status instead.",
+                deployment_id, deployment_id
+            ),
+        ));
     }
 
-    let (project, deployment) = matching_projects.into_iter().next().ok_or((
+    let deployment = matching_deployments.into_iter().next().ok_or((
         StatusCode::NOT_FOUND,
         format!("Deployment '{}' not found", deployment_id),
     ))?;
+
+    let project = projects::find_by_id(&state.db_pool, deployment.project_id)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to find project: {}", e),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                format!("Project for deployment '{}' not found", deployment_id),
+            )
+        })?;
 
     perform_status_update(&state, &user, deployment, &project, &deployment_id, payload).await
 }

--- a/src/server/deployment/routes.rs
+++ b/src/server/deployment/routes.rs
@@ -28,6 +28,10 @@ pub fn deployment_routes() -> Router<AppState> {
             get(super::handlers::get_deployment_by_project),
         )
         .route(
+            "/projects/{project_name}/deployments/{deployment_id}/status",
+            patch(super::handlers::update_deployment_status_by_project),
+        )
+        .route(
             "/projects/{project_name}/deployments/{deployment_id}/stop",
             post(super::handlers::stop_deployment),
         )


### PR DESCRIPTION
## Summary

- Add `PATCH /projects/{project_name}/deployments/{deployment_id}/status` endpoint that scopes the lookup by project, fixing a bug where two deployments created at the same second would collide on the old unscoped endpoint
- Update the CLI to use the new project-scoped endpoint for all status updates and cancellations
- Keep the old `PATCH /deployments/{deployment_id}/status` endpoint with deprecation warnings for backward compatibility — returns **409 Conflict** on deployment ID collisions instead of silently updating the wrong deployment
- Replace N+1 project scan in the deprecated endpoint with a single `find_by_deployment_id_unscoped` DB query (`LIMIT 2` to detect collisions)
- Add a deprecated endpoints tracking table to `docs/development.md`

## Test plan

- [x] `cargo fmt --all` passes
- [x] `mise run lint` passes (clippy, fmt check, sqlx check, helm lint)
- [x] `cargo test --all-features` passes (234 tests)
- [x] Manual test: deploy to two different projects simultaneously and verify both deployments succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)