### PR TITLE
refactor: migrate server handlers to ServerError

### DIFF
--- a/src/server/custom_domains/handlers.rs
+++ b/src/server/custom_domains/handlers.rs
@@ -3,6 +3,7 @@ use super::validation;
 use crate::db::models::User;
 use crate::db::{custom_domains as db_custom_domains, deployments as db_deployments, projects};
 use crate::server::deployment::models::DEFAULT_DEPLOYMENT_GROUP;
+use crate::server::error::{ServerError, ServerErrorExt};
 use crate::server::state::AppState;
 use axum::{
     extract::{Extension, Path, State},
@@ -11,39 +12,7 @@ use axum::{
 };
 use tracing::info;
 
-/// Check if user has access to a project (admin bypass)
-///
-/// Admins always have access. Non-admins must pass the project ownership/team membership check.
-async fn ensure_project_access_or_admin(
-    state: &AppState,
-    user: &User,
-    project: &crate::db::models::Project,
-) -> Result<(), (StatusCode, String)> {
-    // Admins bypass all access checks
-    if state.is_admin(&user.email) {
-        return Ok(());
-    }
-
-    // Check if user has access via ownership or team membership
-    let can_access = projects::user_can_access(&state.db_pool, project.id, user.id)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to check project access: {:#}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Database error".to_string(),
-            )
-        })?;
-
-    if !can_access {
-        return Err((
-            StatusCode::FORBIDDEN,
-            "You do not have access to this project".to_string(),
-        ));
-    }
-
-    Ok(())
-}
+use crate::server::project::handlers::ensure_project_access_or_admin;
 
 /// Add a custom domain to a project
 pub async fn add_custom_domain(
@@ -51,28 +20,18 @@ pub async fn add_custom_domain(
     Extension(user): Extension<User>,
     Path(project_id_or_name): Path<String>,
     Json(payload): Json<AddCustomDomainRequest>,
-) -> Result<(StatusCode, Json<CustomDomainResponse>), (StatusCode, String)> {
+) -> Result<(StatusCode, Json<CustomDomainResponse>), ServerError> {
     // Find project by ID or name
     let project = if let Ok(uuid) = project_id_or_name.parse() {
         projects::find_by_id(&state.db_pool, uuid)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get project: {}", e),
-                )
-            })?
+            .internal_err("Failed to get project")?
     } else {
         projects::find_by_name(&state.db_pool, &project_id_or_name)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get project: {}", e),
-                )
-            })?
+            .internal_err("Failed to get project")?
     }
-    .ok_or_else(|| (StatusCode::NOT_FOUND, "Project not found".to_string()))?;
+    .ok_or_else(|| ServerError::not_found("Project not found"))?;
 
     // Check permission (admin bypass)
     ensure_project_access_or_admin(&state, &user, &project).await?;
@@ -85,7 +44,7 @@ pub async fn add_custom_domain(
             state.staging_ingress_url_template.as_deref(),
             Some(&state.public_url),
         ) {
-            return Err((StatusCode::BAD_REQUEST, reason));
+            return Err(ServerError::bad_request(reason));
         }
     }
 
@@ -98,20 +57,11 @@ pub async fn add_custom_domain(
             if error_message.contains("duplicate key")
                 || error_message.contains("unique constraint")
             {
-                (
-                    StatusCode::CONFLICT,
-                    format!("Domain '{}' is already in use", payload.domain),
-                )
+                ServerError::conflict(format!("Domain '{}' is already in use", payload.domain))
             } else if error_message.contains("check constraint") {
-                (
-                    StatusCode::BAD_REQUEST,
-                    format!("Invalid domain format: {}", payload.domain),
-                )
+                ServerError::bad_request(format!("Invalid domain format: {}", payload.domain))
             } else {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to add custom domain: {}", e),
-                )
+                ServerError::internal_anyhow(e, "Failed to add custom domain")
             }
         })?;
 
@@ -170,50 +120,34 @@ pub async fn list_custom_domains(
     State(state): State<AppState>,
     Extension(user): Extension<User>,
     Path(project_id_or_name): Path<String>,
-) -> Result<Json<CustomDomainsResponse>, (StatusCode, String)> {
+) -> Result<Json<CustomDomainsResponse>, ServerError> {
     // Find project by ID or name
     let project = if let Ok(uuid) = project_id_or_name.parse() {
         projects::find_by_id(&state.db_pool, uuid)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get project: {}", e),
-                )
-            })?
+            .internal_err("Failed to get project")?
     } else {
         projects::find_by_name(&state.db_pool, &project_id_or_name)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get project: {}", e),
-                )
-            })?
+            .internal_err("Failed to get project")?
     }
-    .ok_or_else(|| (StatusCode::NOT_FOUND, "Project not found".to_string()))?;
+    .ok_or_else(|| ServerError::not_found("Project not found"))?;
 
     // Check permission (admin bypass)
     ensure_project_access_or_admin(&state, &user, &project)
         .await
-        .map_err(|(status, msg)| {
-            // Map FORBIDDEN to NOT_FOUND for consistency with original behavior
-            if status == StatusCode::FORBIDDEN {
-                (StatusCode::NOT_FOUND, "Project not found".to_string())
+        .map_err(|e| {
+            if e.status == StatusCode::FORBIDDEN {
+                ServerError::not_found("Project not found")
             } else {
-                (status, msg)
+                e
             }
         })?;
 
     // Get all custom domains for the project
     let domains = db_custom_domains::list_project_custom_domains(&state.db_pool, project.id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to list custom domains: {}", e),
-            )
-        })?;
+        .internal_err("Failed to list custom domains")?;
 
     Ok(Json(CustomDomainsResponse {
         domains: domains
@@ -228,51 +162,35 @@ pub async fn get_custom_domain(
     State(state): State<AppState>,
     Extension(user): Extension<User>,
     Path((project_id_or_name, domain)): Path<(String, String)>,
-) -> Result<Json<CustomDomainResponse>, (StatusCode, String)> {
+) -> Result<Json<CustomDomainResponse>, ServerError> {
     // Find project by ID or name
     let project = if let Ok(uuid) = project_id_or_name.parse() {
         projects::find_by_id(&state.db_pool, uuid)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get project: {}", e),
-                )
-            })?
+            .internal_err("Failed to get project")?
     } else {
         projects::find_by_name(&state.db_pool, &project_id_or_name)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get project: {}", e),
-                )
-            })?
+            .internal_err("Failed to get project")?
     }
-    .ok_or_else(|| (StatusCode::NOT_FOUND, "Project not found".to_string()))?;
+    .ok_or_else(|| ServerError::not_found("Project not found"))?;
 
     // Check permission (admin bypass)
     ensure_project_access_or_admin(&state, &user, &project)
         .await
-        .map_err(|(status, msg)| {
-            // Map FORBIDDEN to NOT_FOUND for consistency with original behavior
-            if status == StatusCode::FORBIDDEN {
-                (StatusCode::NOT_FOUND, "Project not found".to_string())
+        .map_err(|e| {
+            if e.status == StatusCode::FORBIDDEN {
+                ServerError::not_found("Project not found")
             } else {
-                (status, msg)
+                e
             }
         })?;
 
     // Get the custom domain
     let domain = db_custom_domains::get_custom_domain(&state.db_pool, project.id, &domain)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to get custom domain: {}", e),
-            )
-        })?
-        .ok_or_else(|| (StatusCode::NOT_FOUND, "Custom domain not found".to_string()))?;
+        .internal_err("Failed to get custom domain")?
+        .ok_or_else(|| ServerError::not_found("Custom domain not found"))?;
 
     Ok(Json(CustomDomainResponse::from_db_model(&domain)))
 }
@@ -282,28 +200,18 @@ pub async fn delete_custom_domain(
     State(state): State<AppState>,
     Extension(user): Extension<User>,
     Path((project_id_or_name, domain)): Path<(String, String)>,
-) -> Result<StatusCode, (StatusCode, String)> {
+) -> Result<StatusCode, ServerError> {
     // Find project by ID or name
     let project = if let Ok(uuid) = project_id_or_name.parse() {
         projects::find_by_id(&state.db_pool, uuid)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get project: {}", e),
-                )
-            })?
+            .internal_err("Failed to get project")?
     } else {
         projects::find_by_name(&state.db_pool, &project_id_or_name)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get project: {}", e),
-                )
-            })?
+            .internal_err("Failed to get project")?
     }
-    .ok_or_else(|| (StatusCode::NOT_FOUND, "Project not found".to_string()))?;
+    .ok_or_else(|| ServerError::not_found("Project not found"))?;
 
     // Check permission (admin bypass)
     ensure_project_access_or_admin(&state, &user, &project).await?;
@@ -311,15 +219,10 @@ pub async fn delete_custom_domain(
     // Delete the custom domain
     let deleted = db_custom_domains::delete_custom_domain(&state.db_pool, project.id, &domain)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to delete custom domain: {}", e),
-            )
-        })?;
+        .internal_err("Failed to delete custom domain")?;
 
     if !deleted {
-        return Err((StatusCode::NOT_FOUND, "Custom domain not found".to_string()));
+        return Err(ServerError::not_found("Custom domain not found"));
     }
 
     // Trigger reconciliation of the active deployment in the default group
@@ -374,28 +277,18 @@ pub async fn set_primary_domain(
     State(state): State<AppState>,
     Extension(user): Extension<User>,
     Path((project_id_or_name, domain)): Path<(String, String)>,
-) -> Result<Json<CustomDomainResponse>, (StatusCode, String)> {
+) -> Result<Json<CustomDomainResponse>, ServerError> {
     // Find project by ID or name
     let project = if let Ok(uuid) = project_id_or_name.parse() {
         projects::find_by_id(&state.db_pool, uuid)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get project: {}", e),
-                )
-            })?
+            .internal_err("Failed to get project")?
     } else {
         projects::find_by_name(&state.db_pool, &project_id_or_name)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get project: {}", e),
-                )
-            })?
+            .internal_err("Failed to get project")?
     }
-    .ok_or_else(|| (StatusCode::NOT_FOUND, "Project not found".to_string()))?;
+    .ok_or_else(|| ServerError::not_found("Project not found"))?;
 
     // Check permission (admin bypass)
     ensure_project_access_or_admin(&state, &user, &project).await?;
@@ -406,12 +299,9 @@ pub async fn set_primary_domain(
         .map_err(|e| {
             let error_message = e.to_string();
             if error_message.contains("no rows") {
-                (StatusCode::NOT_FOUND, "Custom domain not found".to_string())
+                ServerError::not_found("Custom domain not found")
             } else {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to set primary domain: {}", e),
-                )
+                ServerError::internal_anyhow(e, "Failed to set primary domain")
             }
         })?;
 
@@ -465,28 +355,18 @@ pub async fn unset_primary_domain(
     State(state): State<AppState>,
     Extension(user): Extension<User>,
     Path((project_id_or_name, domain)): Path<(String, String)>,
-) -> Result<StatusCode, (StatusCode, String)> {
+) -> Result<StatusCode, ServerError> {
     // Find project by ID or name
     let project = if let Ok(uuid) = project_id_or_name.parse() {
         projects::find_by_id(&state.db_pool, uuid)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get project: {}", e),
-                )
-            })?
+            .internal_err("Failed to get project")?
     } else {
         projects::find_by_name(&state.db_pool, &project_id_or_name)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get project: {}", e),
-                )
-            })?
+            .internal_err("Failed to get project")?
     }
-    .ok_or_else(|| (StatusCode::NOT_FOUND, "Project not found".to_string()))?;
+    .ok_or_else(|| ServerError::not_found("Project not found"))?;
 
     // Check permission (admin bypass)
     ensure_project_access_or_admin(&state, &user, &project).await?;
@@ -494,17 +374,11 @@ pub async fn unset_primary_domain(
     // Unset the primary status
     let unset = db_custom_domains::unset_primary_domain(&state.db_pool, project.id, &domain)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to unset primary domain: {}", e),
-            )
-        })?;
+        .internal_err("Failed to unset primary domain")?;
 
     if !unset {
-        return Err((
-            StatusCode::NOT_FOUND,
-            "Custom domain not found or is not primary".to_string(),
+        return Err(ServerError::not_found(
+            "Custom domain not found or is not primary",
         ));
     }
 

--- a/src/server/deployment/handlers.rs
+++ b/src/server/deployment/handlers.rs
@@ -61,7 +61,12 @@ async fn check_deploy_permission(
         let team = db_teams::find_by_id(&state.db_pool, team_id)
             .await
             .internal_err("Failed to fetch team")?
-            .ok_or_else(|| ServerError::not_found("Team not found"))?;
+            .ok_or_else(|| {
+                ServerError::internal(format!(
+                    "Data integrity error: project {} references non-existent team {}",
+                    project.id, team_id
+                ))
+            })?;
 
         return Err(ServerError::forbidden(format!(
             "You must be a member of team '{}' to deploy to this project",

--- a/src/server/deployment/handlers.rs
+++ b/src/server/deployment/handlers.rs
@@ -1,7 +1,6 @@
 use anyhow::Context;
 use axum::{
     extract::{Extension, Path, Query, State},
-    http::StatusCode,
     response::sse::{Event, KeepAlive, Sse},
     Json,
 };
@@ -17,6 +16,7 @@ use crate::db::models::{DeploymentStatus as DbDeploymentStatus, User};
 use crate::db::{
     deployments as db_deployments, projects, service_accounts, teams as db_teams, users,
 };
+use crate::server::error::{ServerError, ServerErrorExt};
 use crate::server::registry::ImageTagType;
 use crate::server::state::AppState;
 
@@ -25,7 +25,7 @@ async fn check_deploy_permission(
     state: &AppState,
     project: &crate::db::models::Project,
     user: &User,
-) -> Result<(), String> {
+) -> Result<(), ServerError> {
     // Admins have full access
     if state.is_admin(&user.email) {
         return Ok(());
@@ -34,7 +34,7 @@ async fn check_deploy_permission(
     // Check if user is a service account for this project
     let is_sa = service_accounts::find_by_user_and_project(&state.db_pool, user.id, project.id)
         .await
-        .map_err(|e| format!("Failed to check service account status: {}", e))?
+        .internal_err("Failed to check service account status")?
         .is_some();
 
     if is_sa {
@@ -52,7 +52,7 @@ async fn check_deploy_permission(
     if let Some(team_id) = project.owner_team_id {
         let is_member = db_teams::is_member(&state.db_pool, team_id, user.id)
             .await
-            .map_err(|e| format!("Failed to check team membership: {}", e))?;
+            .internal_err("Failed to check team membership")?;
 
         if is_member {
             return Ok(());
@@ -60,16 +60,18 @@ async fn check_deploy_permission(
 
         let team = db_teams::find_by_id(&state.db_pool, team_id)
             .await
-            .map_err(|e| format!("Failed to fetch team: {}", e))?
-            .ok_or_else(|| "Team not found".to_string())?;
+            .internal_err("Failed to fetch team")?
+            .ok_or_else(|| ServerError::not_found("Team not found"))?;
 
-        return Err(format!(
+        return Err(ServerError::forbidden(format!(
             "You must be a member of team '{}' to deploy to this project",
             team.name
-        ));
+        )));
     }
 
-    Err("You do not have permission to deploy to this project".to_string())
+    Err(ServerError::forbidden(
+        "You do not have permission to deploy to this project",
+    ))
 }
 
 /// Validate group name format: must be 'default' or match [a-z0-9][a-z0-9/-]*[a-z0-9]
@@ -254,18 +256,12 @@ async fn insert_rise_env_vars(
     state: &AppState,
     deployment: &crate::db::models::Deployment,
     project: &crate::db::models::Project,
-) -> Result<(), (StatusCode, String)> {
+) -> Result<(), ServerError> {
     let deployment_urls = state
         .deployment_backend
         .get_deployment_urls(deployment, project)
         .await
-        .map_err(|e| {
-            error!("Failed to get deployment URLs: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to get deployment URLs: {}", e),
-            )
-        })?;
+        .internal_err("Failed to get deployment URLs")?;
 
     let vars = models::rise_system_env_vars(
         &state.public_url,
@@ -283,13 +279,7 @@ async fn insert_rise_env_vars(
             false, // is_protected
         )
         .await
-        .map_err(|e| {
-            error!("Failed to insert {} env var: {}", key, e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to insert {}: {}", key, e),
-            )
-        })?;
+        .internal_err(format!("Failed to insert {}", key))?;
     }
 
     info!(
@@ -307,7 +297,7 @@ async fn apply_env_overrides(
     state: &AppState,
     deployment_id: uuid::Uuid,
     overrides: &[models::EnvOverride],
-) -> Result<(), (StatusCode, String)> {
+) -> Result<(), ServerError> {
     if overrides.is_empty() {
         return Ok(());
     }
@@ -324,21 +314,14 @@ async fn apply_env_overrides(
         // Encrypt if secret
         let value_to_store = if env_override.is_secret {
             let provider = state.encryption_provider.as_ref().ok_or_else(|| {
-                (
-                    StatusCode::BAD_REQUEST,
-                    "Cannot store secret variables: no encryption provider configured".to_string(),
+                ServerError::bad_request(
+                    "Cannot store secret variables: no encryption provider configured",
                 )
             })?;
-            provider.encrypt(&env_override.value).await.map_err(|e| {
-                error!(
-                    "Failed to encrypt env override '{}': {:?}",
-                    env_override.key, e
-                );
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to encrypt secret '{}': {}", env_override.key, e),
-                )
-            })?
+            provider
+                .encrypt(&env_override.value)
+                .await
+                .internal_err(format!("Failed to encrypt secret '{}'", env_override.key))?
         } else {
             env_override.value.clone()
         };
@@ -352,16 +335,7 @@ async fn apply_env_overrides(
             is_protected,
         )
         .await
-        .map_err(|e| {
-            error!(
-                "Failed to upsert env override '{}': {}",
-                env_override.key, e
-            );
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to set env override '{}': {}", env_override.key, e),
-            )
-        })?;
+        .internal_err(format!("Failed to set env override '{}'", env_override.key))?;
     }
 
     Ok(())
@@ -375,39 +349,32 @@ fn normalize_env_override_is_protected(env_override: &models::EnvOverride) -> bo
     env_override.is_protected.unwrap_or(env_override.is_secret)
 }
 
-fn validate_env_override(env_override: &models::EnvOverride) -> Result<bool, (StatusCode, String)> {
+fn validate_env_override(env_override: &models::EnvOverride) -> Result<bool, ServerError> {
     if !validate_env_override_key(&env_override.key) {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            format!(
-                "Invalid env var key '{}' (must be alphanumeric with underscores)",
-                env_override.key
-            ),
-        ));
+        return Err(ServerError::bad_request(format!(
+            "Invalid env var key '{}' (must be alphanumeric with underscores)",
+            env_override.key
+        )));
     }
 
     if env_override.key == "PORT" {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "PORT cannot be set via env overrides. Use http_port/--http-port instead.".to_string(),
+        return Err(ServerError::bad_request(
+            "PORT cannot be set via env overrides. Use http_port/--http-port instead.",
         ));
     }
 
     let is_protected = normalize_env_override_is_protected(env_override);
     if is_protected && !env_override.is_secret {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            format!(
-                "Env override '{}' cannot be protected unless it is also secret.",
-                env_override.key
-            ),
-        ));
+        return Err(ServerError::bad_request(format!(
+            "Env override '{}' cannot be protected unless it is also secret.",
+            env_override.key
+        )));
     }
 
     Ok(is_protected)
 }
 
-fn validate_env_overrides(overrides: &[models::EnvOverride]) -> Result<(), (StatusCode, String)> {
+fn validate_env_overrides(overrides: &[models::EnvOverride]) -> Result<(), ServerError> {
     for env_override in overrides {
         validate_env_override(env_override)?;
     }
@@ -500,7 +467,7 @@ async fn resolve_effective_http_port(
     state: &AppState,
     project_id: uuid::Uuid,
     explicit_port: Option<u16>,
-) -> Result<u16, (StatusCode, String)> {
+) -> Result<u16, ServerError> {
     // 1. Explicit port takes precedence
     if let Some(port) = explicit_port {
         return Ok(port);
@@ -509,13 +476,7 @@ async fn resolve_effective_http_port(
     // 2. Check project's PORT env var
     let project_env_vars = crate::db::env_vars::list_project_env_vars(&state.db_pool, project_id)
         .await
-        .map_err(|e| {
-            error!("Failed to list project env vars: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to list project environment variables: {}", e),
-            )
-        })?;
+        .internal_err("Failed to list project environment variables")?;
 
     if let Some(port_var) = project_env_vars.iter().find(|v| v.key == "PORT") {
         if let Ok(port) = port_var.value.parse::<u16>() {
@@ -541,26 +502,22 @@ pub async fn create_deployment(
     State(state): State<AppState>,
     Extension(user): Extension<User>,
     Json(payload): Json<CreateDeploymentRequest>,
-) -> Result<Json<CreateDeploymentResponse>, (StatusCode, String)> {
+) -> Result<Json<CreateDeploymentResponse>, ServerError> {
     info!("Creating deployment for project '{}'", payload.project);
 
     // Validate deployment group name
     if !is_valid_group_name(&payload.group) {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            format!(
-                "Invalid group name '{}'. Must be 'default' or match pattern [a-z0-9][a-z0-9/-]*[a-z0-9] (no consecutive hyphens, normalized length max 63 chars)",
-                payload.group
-            ),
-        ));
+        return Err(ServerError::bad_request(format!(
+            "Invalid group name '{}'. Must be 'default' or match pattern [a-z0-9][a-z0-9/-]*[a-z0-9] (no consecutive hyphens, normalized length max 63 chars)",
+            payload.group
+        )));
     }
 
     // Validate http_port if provided (should be 1-65535)
     if let Some(port) = payload.http_port {
         if port == 0 {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                "HTTP port must be between 1 and 65535".to_string(),
+            return Err(ServerError::bad_request(
+                "HTTP port must be between 1 and 65535",
             ));
         }
     }
@@ -570,10 +527,10 @@ pub async fn create_deployment(
     // Parse expiration duration if provided
     let expires_at = if let Some(ref expires_in) = payload.expires_in {
         Some(parse_expiration(expires_in).map_err(|e| {
-            (
-                StatusCode::BAD_REQUEST,
-                format!("Invalid expiration duration '{}': {}", expires_in, e),
-            )
+            ServerError::bad_request(format!(
+                "Invalid expiration duration '{}': {}",
+                expires_in, e
+            ))
         })?)
     } else {
         None
@@ -582,17 +539,9 @@ pub async fn create_deployment(
     // Query project by name
     let project = projects::find_by_name(&state.db_pool, &payload.project)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to query project: {}", e),
-            )
-        })?
+        .internal_err("Failed to query project")?
         .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                format!("Project '{}' not found", payload.project),
-            )
+            ServerError::not_found(format!("Project '{}' not found", payload.project))
         })?;
 
     // Prevent deployments on projects in deletion lifecycle
@@ -601,25 +550,17 @@ pub async fn create_deployment(
         project.status,
         crate::db::models::ProjectStatus::Deleting | crate::db::models::ProjectStatus::Terminated
     ) {
-        return Err((
-            StatusCode::CONFLICT,
-            format!(
-                "Cannot create deployment for project in {:?} state",
-                project.status
-            ),
-        ));
+        return Err(ServerError::conflict(format!(
+            "Cannot create deployment for project in {:?} state",
+            project.status
+        )));
     }
 
     // Check deployment permissions
     // Return 404 instead of 403 to avoid revealing project existence
     check_deploy_permission(&state, &project, &user)
         .await
-        .map_err(|_| {
-            (
-                StatusCode::NOT_FOUND,
-                format!("Project '{}' not found", payload.project),
-            )
-        })?;
+        .map_err(|_| ServerError::not_found(format!("Project '{}' not found", payload.project)))?;
 
     // Generate deployment ID
     let deployment_id = generate_deployment_id();
@@ -651,31 +592,20 @@ pub async fn create_deployment(
             from_deployment_id,
         )
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to find source deployment: {}", e),
-            )
-        })?
+        .internal_err("Failed to find source deployment")?
         .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                format!(
-                    "Source deployment '{}' not found for project '{}'",
-                    from_deployment_id, payload.project
-                ),
-            )
+            ServerError::not_found(format!(
+                "Source deployment '{}' not found for project '{}'",
+                from_deployment_id, payload.project
+            ))
         })?;
 
         // Verify the source deployment already has a reusable image.
         if !state_machine::can_create_from(&source_deployment) {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                format!(
-                    "Cannot create deployment from '{}' because its image is not available yet (status '{}').",
-                    from_deployment_id, source_deployment.status
-                ),
-            ));
+            return Err(ServerError::bad_request(format!(
+                "Cannot create deployment from '{}' because its image is not available yet (status '{}').",
+                from_deployment_id, source_deployment.status
+            )));
         }
 
         // For chained redeployments, follow the chain to find the original source
@@ -738,16 +668,7 @@ pub async fn create_deployment(
                 new_deployment.id,
             )
             .await
-            .map_err(|e| {
-                error!(
-                    "Failed to copy environment variables from deployment {}: {}",
-                    from_deployment_id, e
-                );
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to copy environment variables: {}", e),
-                )
-            })?;
+            .internal_err("Failed to copy environment variables")?;
         } else {
             // Copy current project environment variables to deployment
             info!("Using current project environment variables");
@@ -757,16 +678,7 @@ pub async fn create_deployment(
                 new_deployment.id,
             )
             .await
-            .map_err(|e| {
-                error!(
-                    "Failed to copy environment variables for deployment {}: {}",
-                    deployment_id, e
-                );
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to copy environment variables: {}", e),
-                )
-            })?;
+            .internal_err("Failed to copy environment variables")?;
         }
 
         // Apply env overrides from the request
@@ -782,13 +694,7 @@ pub async fn create_deployment(
             false, // is_protected
         )
         .await
-        .map_err(|e| {
-            error!("Failed to insert PORT env var: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to insert PORT env var: {}", e),
-            )
-        })?;
+        .internal_err("Failed to insert PORT env var")?;
 
         // Insert Rise-provided environment variables
         insert_rise_env_vars(&state, &new_deployment, &project).await?;
@@ -839,12 +745,7 @@ pub async fn create_deployment(
                 .registry_provider
                 .get_credentials(&payload.project)
                 .await
-                .map_err(|e| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Failed to get credentials: {}", e),
-                    )
-                })?;
+                .internal_err("Failed to get credentials")?;
             let image_tag = state.registry_provider.get_image_tag(
                 &payload.project,
                 &deployment_id,
@@ -882,16 +783,7 @@ pub async fn create_deployment(
                 deployment.id,
             )
             .await
-            .map_err(|e| {
-                error!(
-                    "Failed to copy environment variables for deployment {}: {}",
-                    deployment_id, e
-                );
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to copy environment variables: {}", e),
-                )
-            })?;
+            .internal_err("Failed to copy environment variables")?;
 
             // Apply env overrides from the request
             apply_env_overrides(&state, deployment.id, &payload.env_overrides).await?;
@@ -905,13 +797,7 @@ pub async fn create_deployment(
                 false,
             )
             .await
-            .map_err(|e| {
-                error!("Failed to insert PORT env var: {}", e);
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to insert PORT env var: {}", e),
-                )
-            })?;
+            .internal_err("Failed to insert PORT env var")?;
 
             insert_rise_env_vars(&state, &deployment, &project).await?;
 
@@ -941,14 +827,7 @@ pub async fn create_deployment(
         )
         .await
         .map_err(|e| {
-            error!(
-                "Failed to resolve image '{}' (normalized from '{}'): {}",
-                normalized_image, user_image, e
-            );
-            (
-                StatusCode::BAD_REQUEST,
-                format!("Failed to resolve image '{}': {}", user_image, e),
-            )
+            ServerError::bad_request(format!("Failed to resolve image '{}': {}", user_image, e))
         })?;
 
         info!("Successfully resolved image to digest: {}", image_digest);
@@ -985,16 +864,7 @@ pub async fn create_deployment(
             deployment.id,
         )
         .await
-        .map_err(|e| {
-            error!(
-                "Failed to copy environment variables for deployment {}: {}",
-                deployment_id, e
-            );
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to copy environment variables: {}", e),
-            )
-        })?;
+        .internal_err("Failed to copy environment variables")?;
 
         // Apply env overrides from the request
         apply_env_overrides(&state, deployment.id, &payload.env_overrides).await?;
@@ -1010,13 +880,7 @@ pub async fn create_deployment(
             false, // is_protected
         )
         .await
-        .map_err(|e| {
-            error!("Failed to insert PORT env var: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to insert PORT env var: {}", e),
-            )
-        })?;
+        .internal_err("Failed to insert PORT env var")?;
 
         // Insert Rise-provided environment variables
         insert_rise_env_vars(&state, &deployment, &project).await?;
@@ -1040,12 +904,7 @@ pub async fn create_deployment(
             .registry_provider
             .get_credentials(&payload.project)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get credentials: {}", e),
-                )
-            })?;
+            .internal_err("Failed to get credentials")?;
 
         // Get full image tag from provider for CLI client (uses client_registry_url if configured)
         let image_tag = state.registry_provider.get_image_tag(
@@ -1088,16 +947,7 @@ pub async fn create_deployment(
             deployment.id,
         )
         .await
-        .map_err(|e| {
-            error!(
-                "Failed to copy environment variables for deployment {}: {}",
-                deployment_id, e
-            );
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to copy environment variables: {}", e),
-            )
-        })?;
+        .internal_err("Failed to copy environment variables")?;
 
         // Apply env overrides from the request
         apply_env_overrides(&state, deployment.id, &payload.env_overrides).await?;
@@ -1113,13 +963,7 @@ pub async fn create_deployment(
             false, // is_protected
         )
         .await
-        .map_err(|e| {
-            error!("Failed to insert PORT env var: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to insert PORT env var: {}", e),
-            )
-        })?;
+        .internal_err("Failed to insert PORT env var")?;
 
         // Insert Rise-provided environment variables
         insert_rise_env_vars(&state, &deployment, &project).await?;
@@ -1143,17 +987,12 @@ async fn perform_status_update(
     project: &crate::db::models::Project,
     deployment_id: &str,
     payload: UpdateDeploymentStatusRequest,
-) -> Result<Json<Deployment>, (StatusCode, String)> {
+) -> Result<Json<Deployment>, ServerError> {
     // Check if user has permission (owns the project)
     // Return 404 instead of 403 to avoid revealing project existence
     check_deploy_permission(state, project, user)
         .await
-        .map_err(|_| {
-            (
-                StatusCode::NOT_FOUND,
-                format!("Deployment '{}' not found", deployment_id),
-            )
-        })?;
+        .map_err(|_| ServerError::not_found(format!("Deployment '{}' not found", deployment_id)))?;
 
     // Update status in database
     let status_copy = payload.status.clone();
@@ -1162,22 +1001,12 @@ async fn perform_status_update(
             let error_msg = payload.error_message.as_deref().unwrap_or("Unknown error");
             let deployment = db_deployments::mark_failed(&state.db_pool, deployment.id, error_msg)
                 .await
-                .map_err(|e| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Failed to update deployment: {}", e),
-                    )
-                })?;
+                .internal_err("Failed to update deployment")?;
 
             // Update project status to Failed
             projects::update_calculated_status(&state.db_pool, project.id)
                 .await
-                .map_err(|e| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Failed to update project status: {}", e),
-                    )
-                })?;
+                .internal_err("Failed to update project status")?;
 
             deployment
         }
@@ -1192,24 +1021,16 @@ async fn perform_status_update(
                         // Return BAD_REQUEST for validation errors, INTERNAL_SERVER_ERROR otherwise
                         let error_msg = e.to_string();
                         if error_msg.contains("Invalid deployment state transition") {
-                            (StatusCode::BAD_REQUEST, error_msg)
+                            ServerError::bad_request(error_msg)
                         } else {
-                            (
-                                StatusCode::INTERNAL_SERVER_ERROR,
-                                format!("Failed to update deployment: {}", e),
-                            )
+                            ServerError::internal_anyhow(e, "Failed to update deployment")
                         }
                     })?;
 
             // Update project status (e.g., to Deploying)
             projects::update_calculated_status(&state.db_pool, project.id)
                 .await
-                .map_err(|e| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Failed to update project status: {}", e),
-                    )
-                })?;
+                .internal_err("Failed to update project status")?;
 
             deployment
         }
@@ -1262,7 +1083,7 @@ pub async fn update_deployment_status_by_project(
     Extension(user): Extension<User>,
     Path((project_name, deployment_id)): Path<(String, String)>,
     Json(payload): Json<UpdateDeploymentStatusRequest>,
-) -> Result<Json<Deployment>, (StatusCode, String)> {
+) -> Result<Json<Deployment>, ServerError> {
     info!(
         "Updating deployment {} status to {:?} for project {}",
         deployment_id, payload.status, project_name
@@ -1271,37 +1092,19 @@ pub async fn update_deployment_status_by_project(
     // Find project by name
     let project = projects::find_by_name(&state.db_pool, &project_name)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to find project: {}", e),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                format!("Project '{}' not found", project_name),
-            )
-        })?;
+        .internal_err("Failed to find project")?
+        .ok_or_else(|| ServerError::not_found(format!("Project '{}' not found", project_name)))?;
 
     // Find deployment by deployment_id + project_id
     let deployment =
         db_deployments::find_by_deployment_id(&state.db_pool, &deployment_id, project.id)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to find deployment: {}", e),
-                )
-            })?
+            .internal_err("Failed to find deployment")?
             .ok_or_else(|| {
-                (
-                    StatusCode::NOT_FOUND,
-                    format!(
-                        "Deployment '{}' not found for project '{}'",
-                        deployment_id, project_name
-                    ),
-                )
+                ServerError::not_found(format!(
+                    "Deployment '{}' not found for project '{}'",
+                    deployment_id, project_name
+                ))
             })?;
 
     perform_status_update(&state, &user, deployment, &project, &deployment_id, payload).await
@@ -1319,7 +1122,7 @@ pub async fn update_deployment_status(
     Extension(user): Extension<User>,
     Path(deployment_id): Path<String>,
     Json(payload): Json<UpdateDeploymentStatusRequest>,
-) -> Result<Json<Deployment>, (StatusCode, String)> {
+) -> Result<Json<Deployment>, ServerError> {
     warn!(
         "Deprecated endpoint called: PATCH /deployments/{}/status — use PATCH /projects/{{project_name}}/deployments/{}/status instead",
         deployment_id, deployment_id
@@ -1329,16 +1132,7 @@ pub async fn update_deployment_status(
     let matching_deployments =
         db_deployments::find_by_deployment_id_unscoped(&state.db_pool, &deployment_id, 2)
             .await
-            .map_err(|e| {
-                error!(
-                    "Failed to query deployment '{}' (unscoped): {:?}",
-                    deployment_id, e
-                );
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to query deployment '{}': {}", deployment_id, e),
-                )
-            })?;
+            .internal_err(format!("Failed to query deployment '{}'", deployment_id))?;
 
     if matching_deployments.len() > 1 {
         let project_ids: Vec<String> = matching_deployments
@@ -1352,34 +1146,25 @@ pub async fn update_deployment_status(
             matching_deployments.len(),
             project_ids,
         );
-        return Err((
-            StatusCode::CONFLICT,
-            format!(
-                "Ambiguous deployment_id '{}': matches multiple projects. \
-                 Use PATCH /api/v1/projects/{{project_name}}/deployments/{}/status instead.",
-                deployment_id, deployment_id
-            ),
-        ));
+        return Err(ServerError::conflict(format!(
+            "Ambiguous deployment_id '{}': matches multiple projects. \
+             Use PATCH /api/v1/projects/{{project_name}}/deployments/{}/status instead.",
+            deployment_id, deployment_id
+        )));
     }
 
-    let deployment = matching_deployments.into_iter().next().ok_or((
-        StatusCode::NOT_FOUND,
-        format!("Deployment '{}' not found", deployment_id),
-    ))?;
+    let deployment = matching_deployments.into_iter().next().ok_or_else(|| {
+        ServerError::not_found(format!("Deployment '{}' not found", deployment_id))
+    })?;
 
     let project = projects::find_by_id(&state.db_pool, deployment.project_id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to find project: {}", e),
-            )
-        })?
+        .internal_err("Failed to find project")?
         .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                format!("Project for deployment '{}' not found", deployment_id),
-            )
+            ServerError::not_found(format!(
+                "Project for deployment '{}' not found",
+                deployment_id
+            ))
         })?;
 
     perform_status_update(&state, &user, deployment, &project, &deployment_id, payload).await
@@ -1400,7 +1185,7 @@ pub async fn list_deployments(
     Extension(user): Extension<User>,
     Path(project_name): Path<String>,
     Query(query): Query<ListDeploymentsQuery>,
-) -> Result<Json<Vec<Deployment>>, (StatusCode, String)> {
+) -> Result<Json<Vec<Deployment>>, ServerError> {
     debug!(
         "Listing deployments for project: {} (group: {:?})",
         project_name, query.deployment_group
@@ -1409,29 +1194,14 @@ pub async fn list_deployments(
     // Find the project by name
     let project = projects::find_by_name(&state.db_pool, &project_name)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to find project: {}", e),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                format!("Project '{}' not found", project_name),
-            )
-        })?;
+        .internal_err("Failed to find project")?
+        .ok_or_else(|| ServerError::not_found(format!("Project '{}' not found", project_name)))?;
 
     // Check if user has permission to view deployments
     // Return 404 instead of 403 to avoid revealing project existence
     check_deploy_permission(&state, &project, &user)
         .await
-        .map_err(|_| {
-            (
-                StatusCode::NOT_FOUND,
-                format!("Project '{}' not found", project_name),
-            )
-        })?;
+        .map_err(|_| ServerError::not_found(format!("Project '{}' not found", project_name)))?;
 
     // Get deployments from database (optionally filtered by group, with pagination)
     let db_deployments = db_deployments::list_for_project_and_group(
@@ -1442,12 +1212,7 @@ pub async fn list_deployments(
         query.offset,
     )
     .await
-    .map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to list deployments: {}", e),
-        )
-    })?;
+    .internal_err("Failed to list deployments")?;
 
     // Convert to API models (fetch creator emails and calculate URLs)
     let mut deployments = Vec::with_capacity(db_deployments.len());
@@ -1512,7 +1277,7 @@ pub async fn stop_deployments_by_group(
     Extension(user): Extension<User>,
     Path(project_name): Path<String>,
     Query(query): Query<StopDeploymentsQuery>,
-) -> Result<Json<StopDeploymentsResponse>, (StatusCode, String)> {
+) -> Result<Json<StopDeploymentsResponse>, ServerError> {
     info!(
         "Stopping all deployments in group '{}' for project '{}'",
         query.group, project_name
@@ -1520,41 +1285,23 @@ pub async fn stop_deployments_by_group(
 
     // Validate group name
     if !is_valid_group_name(&query.group) {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            format!(
-                "Invalid group name '{}'. Must be 'default' or match pattern [a-z0-9][a-z0-9/-]*[a-z0-9] (no consecutive hyphens, normalized length max 63 chars)",
-                query.group
-            ),
-        ));
+        return Err(ServerError::bad_request(format!(
+            "Invalid group name '{}'. Must be 'default' or match pattern [a-z0-9][a-z0-9/-]*[a-z0-9] (no consecutive hyphens, normalized length max 63 chars)",
+            query.group
+        )));
     }
 
     // Find the project by name
     let project = projects::find_by_name(&state.db_pool, &project_name)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to find project: {}", e),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                format!("Project '{}' not found", project_name),
-            )
-        })?;
+        .internal_err("Failed to find project")?
+        .ok_or_else(|| ServerError::not_found(format!("Project '{}' not found", project_name)))?;
 
     // Check if user has permission to stop deployments (owns the project)
     // Return 404 instead of 403 to avoid revealing project existence
     check_deploy_permission(&state, &project, &user)
         .await
-        .map_err(|_| {
-            (
-                StatusCode::NOT_FOUND,
-                format!("Project '{}' not found", project_name),
-            )
-        })?;
+        .map_err(|_| ServerError::not_found(format!("Project '{}' not found", project_name)))?;
 
     // Find all non-terminal deployments in this group
     let deployments = db_deployments::find_non_terminal_for_project_and_group(
@@ -1563,12 +1310,7 @@ pub async fn stop_deployments_by_group(
         &query.group,
     )
     .await
-    .map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to find deployments: {}", e),
-        )
-    })?;
+    .internal_err("Failed to find deployments")?;
 
     let mut stopped_ids = Vec::new();
 
@@ -1600,12 +1342,7 @@ pub async fn stop_deployments_by_group(
     // Update project status
     projects::update_calculated_status(&state.db_pool, project.id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to update project status: {}", e),
-            )
-        })?;
+        .internal_err("Failed to update project status")?;
 
     info!(
         "Stopped {} deployments in group '{}' for project '{}'",
@@ -1625,7 +1362,7 @@ pub async fn stop_deployment(
     State(state): State<AppState>,
     Extension(user): Extension<User>,
     Path((project_name, deployment_id)): Path<(String, String)>,
-) -> Result<Json<Deployment>, (StatusCode, String)> {
+) -> Result<Json<Deployment>, ServerError> {
     info!(
         "Stopping deployment '{}' for project '{}'",
         deployment_id, project_name
@@ -1634,56 +1371,30 @@ pub async fn stop_deployment(
     // Find the project by name
     let project = projects::find_by_name(&state.db_pool, &project_name)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to find project: {}", e),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                format!("Project '{}' not found", project_name),
-            )
-        })?;
+        .internal_err("Failed to find project")?
+        .ok_or_else(|| ServerError::not_found(format!("Project '{}' not found", project_name)))?;
 
     // Check if user has permission to stop deployments
     // Return 404 instead of 403 to avoid revealing project existence
     check_deploy_permission(&state, &project, &user)
         .await
-        .map_err(|_| {
-            (
-                StatusCode::NOT_FOUND,
-                format!("Project '{}' not found", project_name),
-            )
-        })?;
+        .map_err(|_| ServerError::not_found(format!("Project '{}' not found", project_name)))?;
 
     // Find the specific deployment
     let deployment =
         db_deployments::find_by_deployment_id(&state.db_pool, &deployment_id, project.id)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to find deployment: {}", e),
-                )
-            })?
+            .internal_err("Failed to find deployment")?
             .ok_or_else(|| {
-                (
-                    StatusCode::NOT_FOUND,
-                    format!("Deployment '{}' not found", deployment_id),
-                )
+                ServerError::not_found(format!("Deployment '{}' not found", deployment_id))
             })?;
 
     // Check if deployment is already in a terminal state
     if state_machine::is_terminal(&deployment.status) {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            format!(
-                "Deployment '{}' is already in terminal state: {}",
-                deployment_id, deployment.status
-            ),
-        ));
+        return Err(ServerError::bad_request(format!(
+            "Deployment '{}' is already in terminal state: {}",
+            deployment_id, deployment.status
+        )));
     }
 
     // Mark deployment as Terminating with UserStopped reason
@@ -1693,24 +1404,14 @@ pub async fn stop_deployment(
         crate::db::models::TerminationReason::UserStopped,
     )
     .await
-    .map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to stop deployment: {}", e),
-        )
-    })?;
+    .internal_err("Failed to stop deployment")?;
 
     info!("Marked deployment {} as Terminating", deployment_id);
 
     // Update project status
     projects::update_calculated_status(&state.db_pool, project.id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to update project status: {}", e),
-            )
-        })?;
+        .internal_err("Failed to update project status")?;
 
     // Calculate deployment URLs dynamically
     let (primary_url, custom_domain_urls) = match state
@@ -1749,7 +1450,7 @@ pub async fn get_deployment_by_project(
     State(state): State<AppState>,
     Extension(user): Extension<User>,
     Path((project_name, deployment_id)): Path<(String, String)>,
-) -> Result<Json<Deployment>, (StatusCode, String)> {
+) -> Result<Json<Deployment>, ServerError> {
     debug!(
         "Getting deployment {} for project {}",
         deployment_id, project_name
@@ -1758,29 +1459,14 @@ pub async fn get_deployment_by_project(
     // Find the project by name
     let project = projects::find_by_name(&state.db_pool, &project_name)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to find project: {}", e),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                format!("Project '{}' not found", project_name),
-            )
-        })?;
+        .internal_err("Failed to find project")?
+        .ok_or_else(|| ServerError::not_found(format!("Project '{}' not found", project_name)))?;
 
     // Check if user has permission to view deployments
     // Return 404 instead of 403 to avoid revealing project existence
     check_deploy_permission(&state, &project, &user)
         .await
-        .map_err(|_| {
-            (
-                StatusCode::NOT_FOUND,
-                format!("Project '{}' not found", project_name),
-            )
-        })?;
+        .map_err(|_| ServerError::not_found(format!("Project '{}' not found", project_name)))?;
 
     // Find deployment by project_id and deployment_id
     let deployment = db_deployments::find_by_project_and_deployment_id(
@@ -1789,20 +1475,12 @@ pub async fn get_deployment_by_project(
         &deployment_id,
     )
     .await
-    .map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to find deployment: {}", e),
-        )
-    })?
+    .internal_err("Failed to find deployment")?
     .ok_or_else(|| {
-        (
-            StatusCode::NOT_FOUND,
-            format!(
-                "Deployment '{}' not found for project '{}'",
-                deployment_id, project_name
-            ),
-        )
+        ServerError::not_found(format!(
+            "Deployment '{}' not found for project '{}'",
+            deployment_id, project_name
+        ))
     })?;
 
     // Only calculate URLs for non-terminal deployments that could receive traffic
@@ -1846,45 +1524,25 @@ pub async fn list_deployment_groups(
     State(state): State<AppState>,
     Extension(user): Extension<User>,
     Path(project_name): Path<String>,
-) -> Result<Json<Vec<String>>, (StatusCode, String)> {
+) -> Result<Json<Vec<String>>, ServerError> {
     debug!("Listing deployment groups for project: {}", project_name);
 
     // Find the project by name
     let project = projects::find_by_name(&state.db_pool, &project_name)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to find project: {}", e),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                format!("Project '{}' not found", project_name),
-            )
-        })?;
+        .internal_err("Failed to find project")?
+        .ok_or_else(|| ServerError::not_found(format!("Project '{}' not found", project_name)))?;
 
     // Check if user has permission to view deployment groups
     // Return 404 instead of 403 to avoid revealing project existence
     check_deploy_permission(&state, &project, &user)
         .await
-        .map_err(|_| {
-            (
-                StatusCode::NOT_FOUND,
-                format!("Project '{}' not found", project_name),
-            )
-        })?;
+        .map_err(|_| ServerError::not_found(format!("Project '{}' not found", project_name)))?;
 
     // Get deployment groups from database
     let groups = db_deployments::get_all_deployment_groups(&state.db_pool, project.id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to list deployment groups: {}", e),
-            )
-        })?;
+        .internal_err("Failed to list deployment groups")?;
 
     Ok(Json(groups))
 }
@@ -1912,27 +1570,15 @@ pub async fn stream_deployment_logs(
     Extension(user): Extension<User>,
     Path((project_name, deployment_id)): Path<(String, String)>,
     Query(params): Query<LogStreamParams>,
-) -> Result<Sse<impl futures::Stream<Item = Result<Event, anyhow::Error>>>, (StatusCode, String)> {
+) -> Result<Sse<impl futures::Stream<Item = Result<Event, anyhow::Error>>>, ServerError> {
     // Fetch project
     let project = projects::find_by_name(&state.db_pool, &project_name)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to fetch project: {}", e),
-            )
-        })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                format!("Project '{}' not found", project_name),
-            )
-        })?;
+        .internal_err("Failed to fetch project")?
+        .ok_or_else(|| ServerError::not_found(format!("Project '{}' not found", project_name)))?;
 
     // Check permission
-    check_deploy_permission(&state, &project, &user)
-        .await
-        .map_err(|e| (StatusCode::FORBIDDEN, e))?;
+    check_deploy_permission(&state, &project, &user).await?;
 
     // Fetch deployment
     let deployment = db_deployments::find_by_project_and_deployment_id(
@@ -1941,27 +1587,18 @@ pub async fn stream_deployment_logs(
         &deployment_id,
     )
     .await
-    .map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to fetch deployment: {}", e),
-        )
-    })?
+    .internal_err("Failed to fetch deployment")?
     .ok_or_else(|| {
-        (
-            StatusCode::NOT_FOUND,
-            format!(
-                "Deployment '{}' not found for project '{}'",
-                deployment_id, project_name
-            ),
-        )
+        ServerError::not_found(format!(
+            "Deployment '{}' not found for project '{}'",
+            deployment_id, project_name
+        ))
     })?;
 
     // Check if deployment is in a state where logs make sense
     if state_machine::is_terminal(&deployment.status) {
-        return Err((
-            StatusCode::GONE,
-            "Deployment is no longer running - logs may not be available".to_string(),
+        return Err(ServerError::gone(
+            "Deployment is no longer running - logs may not be available",
         ));
     }
 
@@ -1973,10 +1610,8 @@ pub async fn stream_deployment_logs(
             | DbDeploymentStatus::Pushing
             | DbDeploymentStatus::Pushed
     ) {
-        return Err((
-            StatusCode::SERVICE_UNAVAILABLE,
-            "Deployment not ready yet - no logs available. Try again when deployment is running."
-                .to_string(),
+        return Err(ServerError::service_unavailable(
+            "Deployment not ready yet - no logs available. Try again when deployment is running.",
         ));
     }
 
@@ -2002,15 +1637,11 @@ pub async fn stream_deployment_logs(
                 || error_msg.contains("ContainerCreating")
                 || error_msg.contains("PodInitializing")
             {
-                (
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    "Deployment pod not ready yet. Please try again in a moment.".to_string(),
+                ServerError::service_unavailable(
+                    "Deployment pod not ready yet. Please try again in a moment.",
                 )
             } else {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to stream logs: {}", e),
-                )
+                ServerError::internal_anyhow(e, "Failed to stream logs")
             }
         })?;
 
@@ -2063,9 +1694,9 @@ mod tests {
         })
         .unwrap_err();
 
-        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert_eq!(err.status, StatusCode::BAD_REQUEST);
         assert_eq!(
-            err.1,
+            err.message,
             "PORT cannot be set via env overrides. Use http_port/--http-port instead."
         );
     }
@@ -2080,9 +1711,9 @@ mod tests {
         })
         .unwrap_err();
 
-        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert_eq!(err.status, StatusCode::BAD_REQUEST);
         assert_eq!(
-            err.1,
+            err.message,
             "Env override 'API_KEY' cannot be protected unless it is also secret."
         );
     }
@@ -2097,9 +1728,9 @@ mod tests {
         })
         .unwrap_err();
 
-        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert_eq!(err.status, StatusCode::BAD_REQUEST);
         assert_eq!(
-            err.1,
+            err.message,
             "Invalid env var key '' (must be alphanumeric with underscores)"
         );
     }

--- a/src/server/deployment/handlers.rs
+++ b/src/server/deployment/handlers.rs
@@ -1612,7 +1612,8 @@ pub async fn stream_deployment_logs(
     ) {
         return Err(ServerError::service_unavailable(
             "Deployment not ready yet - no logs available. Try again when deployment is running.",
-        ));
+        )
+        .expected());
     }
 
     // Get log stream from deployment backend
@@ -1640,6 +1641,7 @@ pub async fn stream_deployment_logs(
                 ServerError::service_unavailable(
                     "Deployment pod not ready yet. Please try again in a moment.",
                 )
+                .expected()
             } else {
                 ServerError::internal_anyhow(e, "Failed to stream logs")
             }

--- a/src/server/deployment/utils.rs
+++ b/src/server/deployment/utils.rs
@@ -116,12 +116,6 @@ pub async fn create_deployment_with_hooks(
         {
             Ok(vars) => vars,
             Err(e) => {
-                error!(
-                    "Extension type '{}' before_deployment hook failed: {:?}",
-                    extension.extension_type(),
-                    e
-                );
-
                 let error_msg = format!(
                     "Extension type '{}' failed: {}",
                     extension.extension_type(),
@@ -136,7 +130,13 @@ pub async fn create_deployment_with_hooks(
                     );
                 }
 
-                return Err(ServerError::internal(error_msg));
+                return Err(ServerError::internal_anyhow(
+                    e,
+                    format!(
+                        "Extension type '{}' before_deployment hook failed",
+                        extension.extension_type()
+                    ),
+                ));
             }
         };
 
@@ -158,12 +158,7 @@ pub async fn create_deployment_with_hooks(
             )
             .await
             {
-                error!(
-                    "Failed to write env var '{}' for deployment {}: {:?}",
-                    var.key, deployment.deployment_id, e
-                );
-
-                let error_msg = format!("Failed to write env var '{}': {}", var.key, e);
+                let error_msg = format!("Failed to write env var '{}'", var.key);
                 if let Err(mark_err) =
                     db_deployments::mark_failed(&state.db_pool, deployment.id, &error_msg).await
                 {
@@ -173,7 +168,7 @@ pub async fn create_deployment_with_hooks(
                     );
                 }
 
-                return Err(ServerError::internal(error_msg));
+                return Err(ServerError::internal_anyhow(e, error_msg));
             }
         }
     }

--- a/src/server/deployment/utils.rs
+++ b/src/server/deployment/utils.rs
@@ -1,10 +1,10 @@
-use axum::http::StatusCode;
 use chrono::Utc;
 use tracing::error;
 
 use crate::db::deployments as db_deployments;
 use crate::db::env_vars as db_env_vars;
 use crate::db::models::{Deployment, Project};
+use crate::server::error::{ServerError, ServerErrorExt};
 use crate::server::extensions::InjectedEnvVarValue;
 use crate::server::state::AppState;
 
@@ -94,24 +94,19 @@ pub async fn get_deployment_image_tag(
 /// * `project` - The project this deployment belongs to
 ///
 /// # Returns
-/// The created deployment on success, or an error tuple (StatusCode, String)
+/// The created deployment on success, or a ServerError
 pub async fn create_deployment_with_hooks(
     state: &AppState,
     params: db_deployments::CreateDeploymentParams<'_>,
     project: &Project,
-) -> Result<Deployment, (StatusCode, String)> {
+) -> Result<Deployment, ServerError> {
     // Extract deployment_group before moving params (needed for extension hooks)
     let deployment_group = params.deployment_group.to_string();
 
     // Create the deployment record
     let deployment = db_deployments::create(&state.db_pool, params)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to create deployment: {}", e),
-            )
-        })?;
+        .internal_err("Failed to create deployment")?;
 
     // Call before_deployment hooks for all registered extensions
     for (_, extension) in state.extension_registry.iter() {
@@ -141,7 +136,7 @@ pub async fn create_deployment_with_hooks(
                     );
                 }
 
-                return Err((StatusCode::INTERNAL_SERVER_ERROR, error_msg));
+                return Err(ServerError::internal(error_msg));
             }
         };
 
@@ -178,7 +173,7 @@ pub async fn create_deployment_with_hooks(
                     );
                 }
 
-                return Err((StatusCode::INTERNAL_SERVER_ERROR, error_msg));
+                return Err(ServerError::internal(error_msg));
             }
         }
     }

--- a/src/server/env_vars/handlers.rs
+++ b/src/server/env_vars/handlers.rs
@@ -2,6 +2,7 @@ use super::models::{EnvVarResponse, EnvVarValueResponse, EnvVarsResponse, SetEnv
 use crate::db::models::User;
 use crate::db::{env_vars as db_env_vars, projects};
 use crate::server::deployment::models as deployment_models;
+use crate::server::error::{ServerError, ServerErrorExt};
 use crate::server::extensions::InjectedEnvVarValue;
 use crate::server::state::AppState;
 use axum::{
@@ -11,54 +12,7 @@ use axum::{
 };
 use std::collections::HashMap;
 
-/// Format an error and its full chain of causes for logging/display
-fn format_error_chain(error: &anyhow::Error) -> String {
-    let mut chain = vec![error.to_string()];
-
-    // Collect all causes
-    let mut current_error = error.source();
-    while let Some(cause) = current_error {
-        chain.push(cause.to_string());
-        current_error = cause.source();
-    }
-
-    // Join them with " -> " to show the causal chain
-    chain.join(" -> ")
-}
-
-/// Check if user has access to a project (admin bypass)
-///
-/// Admins always have access. Non-admins must pass the project ownership/team membership check.
-async fn ensure_project_access_or_admin(
-    state: &AppState,
-    user: &User,
-    project: &crate::db::models::Project,
-) -> Result<(), (StatusCode, String)> {
-    // Admins bypass all access checks
-    if state.is_admin(&user.email) {
-        return Ok(());
-    }
-
-    // Check if user has access via ownership or team membership
-    let can_access = projects::user_can_access(&state.db_pool, project.id, user.id)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to check project access: {:#}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Database error".to_string(),
-            )
-        })?;
-
-    if !can_access {
-        return Err((
-            StatusCode::FORBIDDEN,
-            "You do not have access to this project".to_string(),
-        ));
-    }
-
-    Ok(())
-}
+use crate::server::project::handlers::ensure_project_access_or_admin;
 
 /// Set or update a project environment variable
 pub async fn set_project_env_var(
@@ -66,28 +20,18 @@ pub async fn set_project_env_var(
     Extension(user): Extension<User>,
     Path((project_id_or_name, key)): Path<(String, String)>,
     Json(payload): Json<SetEnvVarRequest>,
-) -> Result<Json<EnvVarResponse>, (StatusCode, String)> {
+) -> Result<Json<EnvVarResponse>, ServerError> {
     // Find project by ID or name
     let project = if let Ok(uuid) = project_id_or_name.parse() {
         projects::find_by_id(&state.db_pool, uuid)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get project: {}", e),
-                )
-            })?
+            .internal_err("Failed to get project")?
     } else {
         projects::find_by_name(&state.db_pool, &project_id_or_name)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get project: {}", e),
-                )
-            })?
+            .internal_err("Failed to get project")?
     }
-    .ok_or_else(|| (StatusCode::NOT_FOUND, "Project not found".to_string()))?;
+    .ok_or_else(|| ServerError::not_found("Project not found"))?;
 
     // Check permission (admin bypass)
     ensure_project_access_or_admin(&state, &user, &project).await?;
@@ -98,18 +42,15 @@ pub async fn set_project_env_var(
 
     // Validate: is_protected requires is_secret (non-secrets cannot be "protected")
     if is_protected && !payload.is_secret {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "Non-secret variables cannot be protected. Protection only applies to secrets."
-                .to_string(),
+        return Err(ServerError::bad_request(
+            "Non-secret variables cannot be protected. Protection only applies to secrets.",
         ));
     }
 
     // IMPORTANT: If this is a secret, we must have an encryption provider
     if payload.is_secret && state.encryption_provider.is_none() {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "Cannot store secret variables: no encryption provider configured".to_string(),
+        return Err(ServerError::bad_request(
+            "Cannot store secret variables: no encryption provider configured",
         ));
     }
 
@@ -120,17 +61,10 @@ pub async fn set_project_env_var(
             .as_ref()
             .expect("Encryption provider checked above");
 
-        provider.encrypt(&payload.value).await.map_err(|e| {
-            // Log the full error chain for debugging
-            tracing::error!("Encryption failed: {:?}", e);
-
-            // Format error chain for the response
-            let error_chain = format_error_chain(&e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to encrypt secret: {}", error_chain),
-            )
-        })?
+        provider
+            .encrypt(&payload.value)
+            .await
+            .internal_err("Failed to encrypt secret")?
     } else {
         payload.value.clone()
     };
@@ -145,12 +79,7 @@ pub async fn set_project_env_var(
         is_protected,
     )
     .await
-    .map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to store environment variable: {}", e),
-        )
-    })?;
+    .internal_err("Failed to store environment variable")?;
 
     tracing::info!(
         "Set environment variable '{}' for project '{}' (secret: {}, protected: {}). This will apply to new deployments only.",
@@ -179,28 +108,18 @@ pub async fn list_project_env_vars(
     Extension(user): Extension<User>,
     Path(project_id_or_name): Path<String>,
     Query(params): Query<HashMap<String, String>>,
-) -> Result<Json<EnvVarsResponse>, (StatusCode, String)> {
+) -> Result<Json<EnvVarsResponse>, ServerError> {
     // Find project by ID or name
     let project = if let Ok(uuid) = project_id_or_name.parse() {
         projects::find_by_id(&state.db_pool, uuid)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get project: {}", e),
-                )
-            })?
+            .internal_err("Failed to get project")?
     } else {
         projects::find_by_name(&state.db_pool, &project_id_or_name)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get project: {}", e),
-                )
-            })?
+            .internal_err("Failed to get project")?
     }
-    .ok_or_else(|| (StatusCode::NOT_FOUND, "Project not found".to_string()))?;
+    .ok_or_else(|| ServerError::not_found("Project not found"))?;
 
     // Check permission (admin bypass)
     ensure_project_access_or_admin(&state, &user, &project).await?;
@@ -214,12 +133,7 @@ pub async fn list_project_env_vars(
     // Get all environment variables
     let db_env_vars = db_env_vars::list_project_env_vars(&state.db_pool, project.id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to list environment variables: {}", e),
-            )
-        })?;
+        .internal_err("Failed to list environment variables")?;
 
     // Convert to API response
     let mut env_vars = Vec::new();
@@ -227,21 +141,13 @@ pub async fn list_project_env_vars(
         let value = if include_unprotected && var.is_secret && !var.is_protected {
             // Decrypt unprotected secret
             match &state.encryption_provider {
-                Some(provider) => provider.decrypt(&var.value).await.map_err(|e| {
-                    tracing::error!(
-                        "Failed to decrypt unprotected secret '{}': {:?}",
-                        var.key,
-                        e
-                    );
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Failed to decrypt secret '{}': {}", var.key, e),
-                    )
-                })?,
+                Some(provider) => provider
+                    .decrypt(&var.value)
+                    .await
+                    .internal_err("Failed to decrypt secret")?,
                 None => {
-                    return Err((
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        "Cannot decrypt secrets: no encryption provider configured".to_string(),
+                    return Err(ServerError::internal(
+                        "Cannot decrypt secrets: no encryption provider configured",
                     ))
                 }
             }
@@ -273,28 +179,18 @@ pub async fn delete_project_env_var(
     State(state): State<AppState>,
     Extension(user): Extension<User>,
     Path((project_id_or_name, key)): Path<(String, String)>,
-) -> Result<StatusCode, (StatusCode, String)> {
+) -> Result<StatusCode, ServerError> {
     // Find project by ID or name
     let project = if let Ok(uuid) = project_id_or_name.parse() {
         projects::find_by_id(&state.db_pool, uuid)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get project: {}", e),
-                )
-            })?
+            .internal_err("Failed to get project")?
     } else {
         projects::find_by_name(&state.db_pool, &project_id_or_name)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get project: {}", e),
-                )
-            })?
+            .internal_err("Failed to get project")?
     }
-    .ok_or_else(|| (StatusCode::NOT_FOUND, "Project not found".to_string()))?;
+    .ok_or_else(|| ServerError::not_found("Project not found"))?;
 
     // Check permission (admin bypass)
     ensure_project_access_or_admin(&state, &user, &project).await?;
@@ -302,18 +198,13 @@ pub async fn delete_project_env_var(
     // Delete environment variable
     let deleted = db_env_vars::delete_project_env_var(&state.db_pool, project.id, &key)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to delete environment variable: {}", e),
-            )
-        })?;
+        .internal_err("Failed to delete environment variable")?;
 
     if !deleted {
-        return Err((
-            StatusCode::NOT_FOUND,
-            format!("Environment variable '{}' not found", key),
-        ));
+        return Err(ServerError::not_found(format!(
+            "Environment variable '{}' not found",
+            key
+        )));
     }
 
     tracing::info!(
@@ -335,28 +226,18 @@ pub async fn list_deployment_env_vars(
     Extension(user): Extension<User>,
     Path((project_id_or_name, deployment_id)): Path<(String, String)>,
     Query(params): Query<HashMap<String, String>>,
-) -> Result<Json<EnvVarsResponse>, (StatusCode, String)> {
+) -> Result<Json<EnvVarsResponse>, ServerError> {
     // Find project by ID or name
     let project = if let Ok(uuid) = project_id_or_name.parse() {
         projects::find_by_id(&state.db_pool, uuid)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get project: {}", e),
-                )
-            })?
+            .internal_err("Failed to get project")?
     } else {
         projects::find_by_name(&state.db_pool, &project_id_or_name)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get project: {}", e),
-                )
-            })?
+            .internal_err("Failed to get project")?
     }
-    .ok_or_else(|| (StatusCode::NOT_FOUND, "Project not found".to_string()))?;
+    .ok_or_else(|| ServerError::not_found("Project not found"))?;
 
     // Check permission (admin bypass)
     ensure_project_access_or_admin(&state, &user, &project).await?;
@@ -365,13 +246,8 @@ pub async fn list_deployment_env_vars(
     let deployment =
         crate::db::deployments::find_by_deployment_id(&state.db_pool, &deployment_id, project.id)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get deployment: {}", e),
-                )
-            })?
-            .ok_or_else(|| (StatusCode::NOT_FOUND, "Deployment not found".to_string()))?;
+            .internal_err("Failed to get deployment")?
+            .ok_or_else(|| ServerError::not_found("Deployment not found"))?;
 
     // Check if we should include unprotected values
     let include_unprotected = params
@@ -382,12 +258,7 @@ pub async fn list_deployment_env_vars(
     // Get all deployment environment variables
     let db_env_vars = db_env_vars::list_deployment_env_vars(&state.db_pool, deployment.id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to list deployment environment variables: {}", e),
-            )
-        })?;
+        .internal_err("Failed to list deployment environment variables")?;
 
     // Convert to API response
     let mut env_vars = Vec::new();
@@ -395,21 +266,13 @@ pub async fn list_deployment_env_vars(
         let value = if include_unprotected && var.is_secret && !var.is_protected {
             // Decrypt unprotected secret
             match &state.encryption_provider {
-                Some(provider) => provider.decrypt(&var.value).await.map_err(|e| {
-                    tracing::error!(
-                        "Failed to decrypt unprotected secret '{}': {:?}",
-                        var.key,
-                        e
-                    );
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Failed to decrypt secret '{}': {}", var.key, e),
-                    )
-                })?,
+                Some(provider) => provider
+                    .decrypt(&var.value)
+                    .await
+                    .internal_err("Failed to decrypt secret")?,
                 None => {
-                    return Err((
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        "Cannot decrypt secrets: no encryption provider configured".to_string(),
+                    return Err(ServerError::internal(
+                        "Cannot decrypt secrets: no encryption provider configured",
                     ))
                 }
             }
@@ -441,28 +304,18 @@ pub async fn get_project_env_var_value(
     State(state): State<AppState>,
     Extension(user): Extension<User>,
     Path((project_id_or_name, key)): Path<(String, String)>,
-) -> Result<Json<EnvVarValueResponse>, (StatusCode, String)> {
+) -> Result<Json<EnvVarValueResponse>, ServerError> {
     // Find project by ID or name
     let project = if let Ok(uuid) = project_id_or_name.parse() {
         projects::find_by_id(&state.db_pool, uuid)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get project: {}", e),
-                )
-            })?
+            .internal_err("Failed to get project")?
     } else {
         projects::find_by_name(&state.db_pool, &project_id_or_name)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get project: {}", e),
-                )
-            })?
+            .internal_err("Failed to get project")?
     }
-    .ok_or_else(|| (StatusCode::NOT_FOUND, "Project not found".to_string()))?;
+    .ok_or_else(|| ServerError::not_found("Project not found"))?;
 
     // Check permission (admin bypass)
     ensure_project_access_or_admin(&state, &user, &project).await?;
@@ -470,44 +323,29 @@ pub async fn get_project_env_var_value(
     // Get the specific environment variable
     let env_var = db_env_vars::get_project_env_var(&state.db_pool, project.id, &key)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to get environment variable: {}", e),
-            )
-        })?
+        .internal_err("Failed to get environment variable")?
         .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                format!("Environment variable '{}' not found", key),
-            )
+            ServerError::not_found(format!("Environment variable '{}' not found", key))
         })?;
 
     // Validate: must be an unprotected secret
     if !env_var.is_secret || env_var.is_protected {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            format!(
-                "Environment variable '{}' is a protected secret and cannot be retrieved. \
-                 Update it with --protected=false to allow retrieval.",
-                key
-            ),
-        ));
+        return Err(ServerError::bad_request(format!(
+            "Environment variable '{}' is a protected secret and cannot be retrieved. \
+             Update it with --protected=false to allow retrieval.",
+            key
+        )));
     }
 
     // Decrypt the value
     let decrypted_value = match &state.encryption_provider {
-        Some(provider) => provider.decrypt(&env_var.value).await.map_err(|e| {
-            tracing::error!("Failed to decrypt unprotected secret '{}': {:?}", key, e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to decrypt secret '{}': {}", key, e),
-            )
-        })?,
+        Some(provider) => provider
+            .decrypt(&env_var.value)
+            .await
+            .internal_err("Failed to decrypt secret")?,
         None => {
-            return Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Cannot decrypt secrets: no encryption provider configured".to_string(),
+            return Err(ServerError::internal(
+                "Cannot decrypt secrets: no encryption provider configured",
             ))
         }
     };
@@ -529,28 +367,18 @@ pub async fn get_deployment_env_var_value(
     State(state): State<AppState>,
     Extension(user): Extension<User>,
     Path((project_id_or_name, deployment_id, key)): Path<(String, String, String)>,
-) -> Result<Json<EnvVarValueResponse>, (StatusCode, String)> {
+) -> Result<Json<EnvVarValueResponse>, ServerError> {
     // Find project by ID or name
     let project = if let Ok(uuid) = project_id_or_name.parse() {
         projects::find_by_id(&state.db_pool, uuid)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get project: {}", e),
-                )
-            })?
+            .internal_err("Failed to get project")?
     } else {
         projects::find_by_name(&state.db_pool, &project_id_or_name)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get project: {}", e),
-                )
-            })?
+            .internal_err("Failed to get project")?
     }
-    .ok_or_else(|| (StatusCode::NOT_FOUND, "Project not found".to_string()))?;
+    .ok_or_else(|| ServerError::not_found("Project not found"))?;
 
     // Check permission (admin bypass)
     ensure_project_access_or_admin(&state, &user, &project).await?;
@@ -559,59 +387,35 @@ pub async fn get_deployment_env_var_value(
     let deployment =
         crate::db::deployments::find_by_deployment_id(&state.db_pool, &deployment_id, project.id)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get deployment: {}", e),
-                )
-            })?
-            .ok_or_else(|| (StatusCode::NOT_FOUND, "Deployment not found".to_string()))?;
+            .internal_err("Failed to get deployment")?
+            .ok_or_else(|| ServerError::not_found("Deployment not found"))?;
 
     // Get the specific environment variable
     let env_var = db_env_vars::get_deployment_env_var(&state.db_pool, deployment.id, &key)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to get environment variable: {}", e),
-            )
-        })?
+        .internal_err("Failed to get environment variable")?
         .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                format!("Environment variable '{}' not found", key),
-            )
+            ServerError::not_found(format!("Environment variable '{}' not found", key))
         })?;
 
     // Validate: must be an unprotected secret
     if !env_var.is_secret || env_var.is_protected {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            format!(
-                "Environment variable '{}' is a protected secret and cannot be retrieved. \
-                 Update it with --protected=false to allow retrieval.",
-                key
-            ),
-        ));
+        return Err(ServerError::bad_request(format!(
+            "Environment variable '{}' is a protected secret and cannot be retrieved. \
+             Update it with --protected=false to allow retrieval.",
+            key
+        )));
     }
 
     // Decrypt the value
     let decrypted_value = match &state.encryption_provider {
-        Some(provider) => provider.decrypt(&env_var.value).await.map_err(|e| {
-            tracing::error!(
-                "Failed to decrypt unprotected deployment secret '{}': {:?}",
-                key,
-                e
-            );
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to decrypt secret '{}': {}", key, e),
-            )
-        })?,
+        Some(provider) => provider
+            .decrypt(&env_var.value)
+            .await
+            .internal_err("Failed to decrypt secret")?,
         None => {
-            return Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Cannot decrypt secrets: no encryption provider configured".to_string(),
+            return Err(ServerError::internal(
+                "Cannot decrypt secrets: no encryption provider configured",
             ))
         }
     };
@@ -641,28 +445,18 @@ pub async fn preview_deployment_env_vars(
     Extension(user): Extension<User>,
     Path(project_id_or_name): Path<String>,
     Query(params): Query<HashMap<String, String>>,
-) -> Result<Json<EnvVarsResponse>, (StatusCode, String)> {
+) -> Result<Json<EnvVarsResponse>, ServerError> {
     // Find project by ID or name
     let project = if let Ok(uuid) = project_id_or_name.parse() {
         projects::find_by_id(&state.db_pool, uuid)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get project: {}", e),
-                )
-            })?
+            .internal_err("Failed to get project")?
     } else {
         projects::find_by_name(&state.db_pool, &project_id_or_name)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get project: {}", e),
-                )
-            })?
+            .internal_err("Failed to get project")?
     }
-    .ok_or_else(|| (StatusCode::NOT_FOUND, "Project not found".to_string()))?;
+    .ok_or_else(|| ServerError::not_found("Project not found"))?;
 
     // Check permission (admin bypass)
     ensure_project_access_or_admin(&state, &user, &project).await?;
@@ -678,32 +472,19 @@ pub async fn preview_deployment_env_vars(
     // 1. Load user-set project vars
     let db_vars = db_env_vars::list_project_env_vars(&state.db_pool, project.id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to list environment variables: {}", e),
-            )
-        })?;
+        .internal_err("Failed to list environment variables")?;
 
     for var in db_vars {
         if var.is_secret && !var.is_protected {
             // Unprotected secret — decrypt for preview
             let decrypted = match &state.encryption_provider {
-                Some(provider) => provider.decrypt(&var.value).await.map_err(|e| {
-                    tracing::error!(
-                        "Failed to decrypt unprotected secret '{}': {:?}",
-                        var.key,
-                        e
-                    );
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Failed to decrypt secret '{}': {}", var.key, e),
-                    )
-                })?,
+                Some(provider) => provider
+                    .decrypt(&var.value)
+                    .await
+                    .internal_err("Failed to decrypt secret")?,
                 None => {
-                    return Err((
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        "Cannot decrypt secrets: no encryption provider configured".to_string(),
+                    return Err(ServerError::internal(
+                        "Cannot decrypt secrets: no encryption provider configured",
                     ))
                 }
             };

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -134,23 +134,47 @@ impl ServerError {
 impl IntoResponse for ServerError {
     fn into_response(self) -> Response {
         // Log server errors (5xx) with full context using structured fields
+        // 503 Service Unavailable is logged at WARN since it typically represents
+        // expected transient conditions (e.g. pod not ready yet), not actual failures.
         if self.status.is_server_error() {
-            // Log with structured fields to prevent log injection
-            if let Some(source) = &self.source {
-                tracing::error!(
-                    status = self.status.as_u16(),
-                    message = %self.message,
-                    context = ?self.context,
-                    error = ?source,
-                    "Server error"
-                );
+            let log_level = if self.status == StatusCode::SERVICE_UNAVAILABLE {
+                tracing::Level::WARN
             } else {
-                tracing::error!(
-                    status = self.status.as_u16(),
-                    message = %self.message,
-                    context = ?self.context,
-                    "Server error"
-                );
+                tracing::Level::ERROR
+            };
+
+            if let Some(source) = &self.source {
+                match log_level {
+                    tracing::Level::WARN => tracing::warn!(
+                        status = self.status.as_u16(),
+                        message = %self.message,
+                        context = ?self.context,
+                        error = ?source,
+                        "Server error"
+                    ),
+                    _ => tracing::error!(
+                        status = self.status.as_u16(),
+                        message = %self.message,
+                        context = ?self.context,
+                        error = ?source,
+                        "Server error"
+                    ),
+                }
+            } else {
+                match log_level {
+                    tracing::Level::WARN => tracing::warn!(
+                        status = self.status.as_u16(),
+                        message = %self.message,
+                        context = ?self.context,
+                        "Server error"
+                    ),
+                    _ => tracing::error!(
+                        status = self.status.as_u16(),
+                        message = %self.message,
+                        context = ?self.context,
+                        "Server error"
+                    ),
+                }
             }
         }
 

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -48,6 +48,8 @@ pub struct ServerError {
     pub context: Vec<(&'static str, String)>,
     /// Optional suggestions for the client (e.g. fuzzy-matched names)
     pub suggestions: Option<Vec<String>>,
+    /// If true, skip error-level logging (for expected transient conditions)
+    pub expected: bool,
 }
 
 impl ServerError {
@@ -59,6 +61,7 @@ impl ServerError {
             source: None,
             context: Vec::new(),
             suggestions: None,
+            expected: false,
         }
     }
 
@@ -74,6 +77,7 @@ impl ServerError {
             source: Some(source),
             context: Vec::new(),
             suggestions: None,
+            expected: false,
         }
     }
 
@@ -86,6 +90,15 @@ impl ServerError {
     /// Add suggestions to the error response (chainable)
     pub fn with_suggestions(mut self, suggestions: Option<Vec<String>>) -> Self {
         self.suggestions = suggestions;
+        self
+    }
+
+    /// Mark this error as expected, suppressing ERROR-level logging (chainable)
+    ///
+    /// Use for transient conditions that are normal (e.g. "pod not ready yet")
+    /// rather than actual failures. These are logged at WARN instead of ERROR.
+    pub fn expected(mut self) -> Self {
+        self.expected = true;
         self
     }
 
@@ -134,47 +147,41 @@ impl ServerError {
 impl IntoResponse for ServerError {
     fn into_response(self) -> Response {
         // Log server errors (5xx) with full context using structured fields
-        // 503 Service Unavailable is logged at WARN since it typically represents
-        // expected transient conditions (e.g. pod not ready yet), not actual failures.
+        // Errors marked as `expected` are logged at WARN (transient conditions
+        // like "pod not ready yet"), all others at ERROR.
         if self.status.is_server_error() {
-            let log_level = if self.status == StatusCode::SERVICE_UNAVAILABLE {
-                tracing::Level::WARN
-            } else {
-                tracing::Level::ERROR
-            };
-
-            if let Some(source) = &self.source {
-                match log_level {
-                    tracing::Level::WARN => tracing::warn!(
+            if self.expected {
+                if let Some(source) = &self.source {
+                    tracing::warn!(
                         status = self.status.as_u16(),
                         message = %self.message,
                         context = ?self.context,
                         error = ?source,
-                        "Server error"
-                    ),
-                    _ => tracing::error!(
+                        "Expected server error"
+                    );
+                } else {
+                    tracing::warn!(
                         status = self.status.as_u16(),
                         message = %self.message,
                         context = ?self.context,
-                        error = ?source,
-                        "Server error"
-                    ),
+                        "Expected server error"
+                    );
                 }
+            } else if let Some(source) = &self.source {
+                tracing::error!(
+                    status = self.status.as_u16(),
+                    message = %self.message,
+                    context = ?self.context,
+                    error = ?source,
+                    "Server error"
+                );
             } else {
-                match log_level {
-                    tracing::Level::WARN => tracing::warn!(
-                        status = self.status.as_u16(),
-                        message = %self.message,
-                        context = ?self.context,
-                        "Server error"
-                    ),
-                    _ => tracing::error!(
-                        status = self.status.as_u16(),
-                        message = %self.message,
-                        context = ?self.context,
-                        "Server error"
-                    ),
-                }
+                tracing::error!(
+                    status = self.status.as_u16(),
+                    message = %self.message,
+                    context = ?self.context,
+                    "Server error"
+                );
             }
         }
 

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -46,6 +46,8 @@ pub struct ServerError {
     pub source: Option<anyhow::Error>,
     /// Structured context for logging (key-value pairs)
     pub context: Vec<(&'static str, String)>,
+    /// Optional suggestions for the client (e.g. fuzzy-matched names)
+    pub suggestions: Option<Vec<String>>,
 }
 
 impl ServerError {
@@ -56,6 +58,7 @@ impl ServerError {
             message: message.into(),
             source: None,
             context: Vec::new(),
+            suggestions: None,
         }
     }
 
@@ -70,12 +73,19 @@ impl ServerError {
             message: message.into(),
             source: Some(source),
             context: Vec::new(),
+            suggestions: None,
         }
     }
 
     /// Add a context field for logging (chainable)
     pub fn with_context(mut self, key: &'static str, value: impl Into<String>) -> Self {
         self.context.push((key, value.into()));
+        self
+    }
+
+    /// Add suggestions to the error response (chainable)
+    pub fn with_suggestions(mut self, suggestions: Option<Vec<String>>) -> Self {
+        self.suggestions = suggestions;
         self
     }
 
@@ -104,6 +114,21 @@ impl ServerError {
     pub fn not_found(message: impl Into<String>) -> Self {
         Self::new(StatusCode::NOT_FOUND, message)
     }
+
+    /// Create a 409 Conflict error
+    pub fn conflict(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::CONFLICT, message)
+    }
+
+    /// Create a 410 Gone error
+    pub fn gone(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::GONE, message)
+    }
+
+    /// Create a 503 Service Unavailable error
+    pub fn service_unavailable(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::SERVICE_UNAVAILABLE, message)
+    }
 }
 
 impl IntoResponse for ServerError {
@@ -130,9 +155,16 @@ impl IntoResponse for ServerError {
         }
 
         // Return clean JSON error response to client
-        let body = Json(json!({
-            "error": self.message,
-        }));
+        let body = if let Some(suggestions) = &self.suggestions {
+            Json(json!({
+                "error": self.message,
+                "suggestions": suggestions,
+            }))
+        } else {
+            Json(json!({
+                "error": self.message,
+            }))
+        };
 
         (self.status, body).into_response()
     }
@@ -148,6 +180,18 @@ impl From<sqlx::Error> for ServerError {
 impl From<anyhow::Error> for ServerError {
     fn from(err: anyhow::Error) -> Self {
         Self::internal_anyhow(err, "Internal server error")
+    }
+}
+
+impl From<(StatusCode, String)> for ServerError {
+    fn from((status, message): (StatusCode, String)) -> Self {
+        Self::new(status, message)
+    }
+}
+
+impl From<ServerError> for (StatusCode, String) {
+    fn from(err: ServerError) -> Self {
+        (err.status, err.message)
     }
 }
 
@@ -258,6 +302,42 @@ mod tests {
 
         let internal = ServerError::internal("Server error");
         assert_eq!(internal.status, StatusCode::INTERNAL_SERVER_ERROR);
+
+        let conflict = ServerError::conflict("Already exists");
+        assert_eq!(conflict.status, StatusCode::CONFLICT);
+
+        let gone = ServerError::gone("No longer available");
+        assert_eq!(gone.status, StatusCode::GONE);
+
+        let unavailable = ServerError::service_unavailable("Try later");
+        assert_eq!(unavailable.status, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn test_server_error_with_suggestions() {
+        let error = ServerError::not_found("Team 'devopsy' not found")
+            .with_suggestions(Some(vec!["devops".to_string(), "dev-ops".to_string()]));
+
+        let response = error.into_response();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+        let body_bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+
+        assert_eq!(body_json["error"], "Team 'devopsy' not found");
+        assert_eq!(body_json["suggestions"][0], "devops");
+        assert_eq!(body_json["suggestions"][1], "dev-ops");
+    }
+
+    #[tokio::test]
+    async fn test_server_error_without_suggestions_has_no_suggestions_key() {
+        let error = ServerError::not_found("Not found");
+        let response = error.into_response();
+
+        let body_bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+
+        assert!(body_json.get("suggestions").is_none());
     }
 
     #[tokio::test]

--- a/src/server/extensions/handlers.rs
+++ b/src/server/extensions/handlers.rs
@@ -83,7 +83,7 @@ pub async fn create_extension(
         if error_msg.contains("duplicate key") || error_msg.contains("unique constraint") {
             ServerError::conflict(format!("Extension '{}' already exists", extension_name))
         } else {
-            ServerError::internal(error_msg)
+            ServerError::internal_anyhow(e, "Failed to create extension")
         }
     })?;
 

--- a/src/server/extensions/handlers.rs
+++ b/src/server/extensions/handlers.rs
@@ -1,6 +1,7 @@
 use super::models::*;
 use crate::db::models::User;
 use crate::db::{extensions as db_extensions, projects};
+use crate::server::error::{ServerError, ServerErrorExt};
 use crate::server::state::AppState;
 use axum::{
     extract::{Extension as AxumExtension, Path, State},
@@ -12,7 +13,7 @@ use axum::{
 pub async fn list_extension_types(
     State(state): State<AppState>,
     AxumExtension(_user): AxumExtension<User>,
-) -> Result<Json<ListExtensionTypesResponse>, (StatusCode, String)> {
+) -> Result<Json<ListExtensionTypesResponse>, ServerError> {
     // Note: This endpoint doesn't require project access - it lists all available
     // extension types that any authenticated user can see and potentially enable on their projects
 
@@ -37,33 +38,35 @@ pub async fn create_extension(
     AxumExtension(user): AxumExtension<User>,
     Path((project_name, extension_name)): Path<(String, String)>,
     Json(payload): Json<CreateExtensionRequest>,
-) -> Result<Json<CreateExtensionResponse>, (StatusCode, String)> {
+) -> Result<Json<CreateExtensionResponse>, ServerError> {
     // Get project and verify access
     let project = projects::find_by_name(&state.db_pool, &project_name)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .ok_or((StatusCode::NOT_FOUND, "Project not found".to_string()))?;
+        .internal_err("Failed to look up project")?
+        .ok_or_else(|| ServerError::not_found("Project not found"))?;
 
     // Check project ownership/access
     let has_access = check_project_access(&state, &user, project.id).await?;
     if !has_access {
-        return Err((StatusCode::FORBIDDEN, "Access denied".to_string()));
+        return Err(ServerError::forbidden("Access denied"));
     }
 
     // Get extension handler by type
     let extension = state
         .extension_registry
         .get(&payload.extension_type)
-        .ok_or((
-            StatusCode::BAD_REQUEST,
-            format!("Unknown extension type: {}", payload.extension_type),
-        ))?;
+        .ok_or_else(|| {
+            ServerError::bad_request(format!(
+                "Unknown extension type: {}",
+                payload.extension_type
+            ))
+        })?;
 
     // Validate spec
     extension
         .validate_spec(&payload.spec)
         .await
-        .map_err(|e| (StatusCode::BAD_REQUEST, format!("Invalid spec: {}", e)))?;
+        .map_err(|e| ServerError::bad_request(format!("Invalid spec: {}", e)))?;
 
     // Create extension (will fail if already exists)
     let _ext_record = db_extensions::create(
@@ -78,12 +81,9 @@ pub async fn create_extension(
         // Check if it's a unique constraint violation
         let error_msg = e.to_string();
         if error_msg.contains("duplicate key") || error_msg.contains("unique constraint") {
-            (
-                StatusCode::CONFLICT,
-                format!("Extension '{}' already exists", extension_name),
-            )
+            ServerError::conflict(format!("Extension '{}' already exists", extension_name))
         } else {
-            (StatusCode::INTERNAL_SERVER_ERROR, error_msg)
+            ServerError::internal(error_msg)
         }
     })?;
 
@@ -97,14 +97,14 @@ pub async fn create_extension(
             &state.db_pool,
         )
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .internal_err("Failed to run extension spec update hook")?;
 
     // Fetch updated extension to get the latest status (may have been initialized by on_spec_updated)
     let ext_record =
         db_extensions::find_by_project_and_name(&state.db_pool, project.id, &extension_name)
             .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-            .ok_or((StatusCode::NOT_FOUND, "Extension not found".to_string()))?;
+            .internal_err("Failed to fetch extension after creation")?
+            .ok_or_else(|| ServerError::not_found("Extension not found"))?;
 
     // Format status using the extension provider
     let status_summary = extension.format_status(&ext_record.status);
@@ -128,40 +128,42 @@ pub async fn update_extension(
     AxumExtension(user): AxumExtension<User>,
     Path((project_name, extension_name)): Path<(String, String)>,
     Json(payload): Json<UpdateExtensionRequest>,
-) -> Result<Json<UpdateExtensionResponse>, (StatusCode, String)> {
+) -> Result<Json<UpdateExtensionResponse>, ServerError> {
     // Get project and verify access
     let project = projects::find_by_name(&state.db_pool, &project_name)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .ok_or((StatusCode::NOT_FOUND, "Project not found".to_string()))?;
+        .internal_err("Failed to look up project")?
+        .ok_or_else(|| ServerError::not_found("Project not found"))?;
 
     // Check project ownership/access
     let has_access = check_project_access(&state, &user, project.id).await?;
     if !has_access {
-        return Err((StatusCode::FORBIDDEN, "Access denied".to_string()));
+        return Err(ServerError::forbidden("Access denied"));
     }
 
     // Get existing extension to determine its type
     let existing =
         db_extensions::find_by_project_and_name(&state.db_pool, project.id, &extension_name)
             .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-            .ok_or((StatusCode::NOT_FOUND, "Extension not found".to_string()))?;
+            .internal_err("Failed to look up extension")?
+            .ok_or_else(|| ServerError::not_found("Extension not found"))?;
 
     // Get extension handler by type
     let extension = state
         .extension_registry
         .get(&existing.extension_type)
-        .ok_or((
-            StatusCode::BAD_REQUEST,
-            format!("Unknown extension type: {}", existing.extension_type),
-        ))?;
+        .ok_or_else(|| {
+            ServerError::bad_request(format!(
+                "Unknown extension type: {}",
+                existing.extension_type
+            ))
+        })?;
 
     // Validate new spec
     extension
         .validate_spec(&payload.spec)
         .await
-        .map_err(|e| (StatusCode::BAD_REQUEST, format!("Invalid spec: {}", e)))?;
+        .map_err(|e| ServerError::bad_request(format!("Invalid spec: {}", e)))?;
 
     // Update extension (upsert will update existing, keeping the extension_type)
     let _ext_record = db_extensions::upsert(
@@ -172,7 +174,7 @@ pub async fn update_extension(
         &payload.spec,
     )
     .await
-    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    .internal_err("Failed to update extension")?;
 
     // Call extension's spec update hook
     extension
@@ -184,14 +186,14 @@ pub async fn update_extension(
             &state.db_pool,
         )
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .internal_err("Failed to run extension spec update hook")?;
 
     // Fetch updated extension to get the latest status (may have been modified by on_spec_updated)
     let ext_record =
         db_extensions::find_by_project_and_name(&state.db_pool, project.id, &extension_name)
             .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-            .ok_or((StatusCode::NOT_FOUND, "Extension not found".to_string()))?;
+            .internal_err("Failed to fetch extension after update")?
+            .ok_or_else(|| ServerError::not_found("Extension not found"))?;
 
     // Format status using the extension provider
     let status_summary = extension.format_status(&ext_record.status);
@@ -215,25 +217,25 @@ pub async fn patch_extension(
     AxumExtension(user): AxumExtension<User>,
     Path((project_name, extension_name)): Path<(String, String)>,
     Json(payload): Json<UpdateExtensionRequest>,
-) -> Result<Json<UpdateExtensionResponse>, (StatusCode, String)> {
+) -> Result<Json<UpdateExtensionResponse>, ServerError> {
     // Get project and verify access
     let project = projects::find_by_name(&state.db_pool, &project_name)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .ok_or((StatusCode::NOT_FOUND, "Project not found".to_string()))?;
+        .internal_err("Failed to look up project")?
+        .ok_or_else(|| ServerError::not_found("Project not found"))?;
 
     // Check project ownership/access
     let has_access = check_project_access(&state, &user, project.id).await?;
     if !has_access {
-        return Err((StatusCode::FORBIDDEN, "Access denied".to_string()));
+        return Err(ServerError::forbidden("Access denied"));
     }
 
     // Get existing extension
     let existing =
         db_extensions::find_by_project_and_name(&state.db_pool, project.id, &extension_name)
             .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-            .ok_or((StatusCode::NOT_FOUND, "Extension not found".to_string()))?;
+            .internal_err("Failed to look up extension")?
+            .ok_or_else(|| ServerError::not_found("Extension not found"))?;
 
     // Merge specs (null values in payload remove fields from existing)
     let merged_spec = merge_json_with_nulls(&existing.spec, &payload.spec);
@@ -242,18 +244,18 @@ pub async fn patch_extension(
     let extension = state
         .extension_registry
         .get(&existing.extension_type)
-        .ok_or((
-            StatusCode::BAD_REQUEST,
-            format!("Unknown extension type: {}", existing.extension_type),
-        ))?;
+        .ok_or_else(|| {
+            ServerError::bad_request(format!(
+                "Unknown extension type: {}",
+                existing.extension_type
+            ))
+        })?;
 
     // Validate merged spec
-    extension.validate_spec(&merged_spec).await.map_err(|e| {
-        (
-            StatusCode::BAD_REQUEST,
-            format!("Invalid spec after merge: {}", e),
-        )
-    })?;
+    extension
+        .validate_spec(&merged_spec)
+        .await
+        .map_err(|e| ServerError::bad_request(format!("Invalid spec after merge: {}", e)))?;
 
     // Update extension with merged spec
     let _ext_record = db_extensions::upsert(
@@ -264,7 +266,7 @@ pub async fn patch_extension(
         &merged_spec,
     )
     .await
-    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    .internal_err("Failed to update extension")?;
 
     // Call extension's spec update hook
     extension
@@ -276,14 +278,14 @@ pub async fn patch_extension(
             &state.db_pool,
         )
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .internal_err("Failed to run extension spec update hook")?;
 
     // Fetch updated extension to get the latest status (may have been modified by on_spec_updated)
     let ext_record =
         db_extensions::find_by_project_and_name(&state.db_pool, project.id, &extension_name)
             .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-            .ok_or((StatusCode::NOT_FOUND, "Extension not found".to_string()))?;
+            .internal_err("Failed to fetch extension after patch")?
+            .ok_or_else(|| ServerError::not_found("Extension not found"))?;
 
     // Format status using the extension provider
     let status_summary = extension.format_status(&ext_record.status);
@@ -306,20 +308,20 @@ pub async fn list_extensions(
     State(state): State<AppState>,
     AxumExtension(user): AxumExtension<User>,
     Path(project_name): Path<String>,
-) -> Result<Json<ListExtensionsResponse>, (StatusCode, String)> {
+) -> Result<Json<ListExtensionsResponse>, ServerError> {
     let project = projects::find_by_name(&state.db_pool, &project_name)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .ok_or((StatusCode::NOT_FOUND, "Project not found".to_string()))?;
+        .internal_err("Failed to look up project")?
+        .ok_or_else(|| ServerError::not_found("Project not found"))?;
 
     let has_access = check_project_access(&state, &user, project.id).await?;
     if !has_access {
-        return Err((StatusCode::FORBIDDEN, "Access denied".to_string()));
+        return Err(ServerError::forbidden("Access denied"));
     }
 
     let extensions = db_extensions::list_by_project(&state.db_pool, project.id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .internal_err("Failed to list extensions")?;
 
     let extensions: Vec<Extension> = extensions
         .into_iter()
@@ -351,21 +353,21 @@ pub async fn get_extension(
     State(state): State<AppState>,
     AxumExtension(user): AxumExtension<User>,
     Path((project_name, extension_name)): Path<(String, String)>,
-) -> Result<Json<Extension>, (StatusCode, String)> {
+) -> Result<Json<Extension>, ServerError> {
     let project = projects::find_by_name(&state.db_pool, &project_name)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .ok_or((StatusCode::NOT_FOUND, "Project not found".to_string()))?;
+        .internal_err("Failed to look up project")?
+        .ok_or_else(|| ServerError::not_found("Project not found"))?;
 
     let has_access = check_project_access(&state, &user, project.id).await?;
     if !has_access {
-        return Err((StatusCode::FORBIDDEN, "Access denied".to_string()));
+        return Err(ServerError::forbidden("Access denied"));
     }
 
     let ext = db_extensions::find_by_project_and_name(&state.db_pool, project.id, &extension_name)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .ok_or((StatusCode::NOT_FOUND, "Extension not found".to_string()))?;
+        .internal_err("Failed to look up extension")?
+        .ok_or_else(|| ServerError::not_found("Extension not found"))?;
 
     // Get extension provider by type to format status
     let status_summary = state
@@ -390,20 +392,20 @@ pub async fn delete_extension(
     State(state): State<AppState>,
     AxumExtension(user): AxumExtension<User>,
     Path((project_name, extension_name)): Path<(String, String)>,
-) -> Result<StatusCode, (StatusCode, String)> {
+) -> Result<StatusCode, ServerError> {
     let project = projects::find_by_name(&state.db_pool, &project_name)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .ok_or((StatusCode::NOT_FOUND, "Project not found".to_string()))?;
+        .internal_err("Failed to look up project")?
+        .ok_or_else(|| ServerError::not_found("Project not found"))?;
 
     let has_access = check_project_access(&state, &user, project.id).await?;
     if !has_access {
-        return Err((StatusCode::FORBIDDEN, "Access denied".to_string()));
+        return Err(ServerError::forbidden("Access denied"));
     }
 
     db_extensions::mark_deleted(&state.db_pool, project.id, &extension_name)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .internal_err("Failed to delete extension")?;
 
     Ok(StatusCode::NO_CONTENT)
 }
@@ -413,7 +415,7 @@ async fn check_project_access(
     state: &AppState,
     user: &User,
     project_id: uuid::Uuid,
-) -> Result<bool, (StatusCode, String)> {
+) -> Result<bool, ServerError> {
     // Check if user is admin
     if state.is_admin(&user.email) {
         return Ok(true);
@@ -422,7 +424,7 @@ async fn check_project_access(
     // Check if user has access to project (owner or team member)
     let accessible_projects = projects::list_accessible_by_user(&state.db_pool, user.id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .internal_err("Failed to check project access")?;
 
     Ok(accessible_projects.iter().any(|p| p.id == project_id))
 }

--- a/src/server/project/handlers.rs
+++ b/src/server/project/handlers.rs
@@ -1,8 +1,8 @@
 use super::fuzzy::find_similar_projects;
 use super::models::{
     AccessClassInfo, CreateProjectRequest, CreateProjectResponse, GetProjectParams,
-    ListAccessClassesResponse, OwnerInfo, Project as ApiProject, ProjectErrorResponse,
-    ProjectOwner, ProjectStatus, TeamInfo, UpdateProjectRequest, UpdateProjectResponse, UserInfo,
+    ListAccessClassesResponse, OwnerInfo, Project as ApiProject, ProjectOwner, ProjectStatus,
+    TeamInfo, UpdateProjectRequest, UpdateProjectResponse, UserInfo,
 };
 use crate::db::models::User;
 use crate::db::{projects, service_accounts, teams as db_teams, users as db_users};
@@ -331,32 +331,21 @@ pub async fn get_project(
     Extension(user): Extension<User>,
     Path(id_or_name): Path<String>,
     Query(params): Query<GetProjectParams>,
-) -> Result<Json<serde_json::Value>, (StatusCode, Json<ProjectErrorResponse>)> {
+) -> Result<Json<serde_json::Value>, ServerError> {
     // Resolve project by ID or name
     let project = resolve_project(&state, &id_or_name, params.by_id).await?;
 
     // Check read permission
     let can_read = check_read_permission(&state, &project, &user)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ProjectErrorResponse {
-                    error: format!("Failed to check permissions: {}", e),
-                    suggestions: None,
-                }),
-            )
-        })?;
+        .map_err(|e| ServerError::internal(format!("Failed to check permissions: {}", e)))?;
 
     if !can_read {
         // Use 404 to hide project existence from unauthorized users
-        return Err((
-            StatusCode::NOT_FOUND,
-            Json(ProjectErrorResponse {
-                error: format!("Project '{}' not found", id_or_name),
-                suggestions: None,
-            }),
-        ));
+        return Err(ServerError::not_found(format!(
+            "Project '{}' not found",
+            id_or_name
+        )));
     }
 
     // Calculate deployment URLs if there's an active deployment
@@ -381,12 +370,9 @@ pub async fn get_project(
                             urls.custom_domain_urls,
                         ),
                         Err(e) => {
-                            return Err((
-                                StatusCode::INTERNAL_SERVER_ERROR,
-                                Json(ProjectErrorResponse {
-                                    error: format!("Failed to calculate URLs: {}", e),
-                                    suggestions: None,
-                                }),
+                            return Err(ServerError::internal_anyhow(
+                                e,
+                                "Failed to calculate URLs",
                             ));
                         }
                     }
@@ -395,26 +381,17 @@ pub async fn get_project(
                 }
             }
             Err(e) => {
-                return Err((
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ProjectErrorResponse {
-                        error: format!("Failed to get active deployments: {}", e),
-                        suggestions: None,
-                    }),
+                return Err(ServerError::internal_anyhow(
+                    e,
+                    "Failed to get active deployments",
                 ));
             }
         };
 
     // Resolve owner info
-    let owner_info = resolve_owner_info(&state, &project).await.map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ProjectErrorResponse {
-                error: format!("Failed to resolve owner info: {}", e),
-                suggestions: None,
-            }),
-        )
-    })?;
+    let owner_info = resolve_owner_info(&state, &project)
+        .await
+        .map_err(|e| ServerError::internal(format!("Failed to resolve owner info: {}", e)))?;
 
     let mut api_project = convert_project(project.clone(), owner_info);
     api_project.default_url = default_url;
@@ -425,15 +402,7 @@ pub async fn get_project(
     let deployment_groups =
         crate::db::deployments::get_active_deployment_groups(&state.db_pool, project.id)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ProjectErrorResponse {
-                        error: format!("Failed to get deployment groups: {}", e),
-                        suggestions: None,
-                    }),
-                )
-            })?;
+            .internal_err("Failed to get deployment groups")?;
     api_project.deployment_groups = if deployment_groups.is_empty() {
         None
     } else {
@@ -443,15 +412,7 @@ pub async fn get_project(
     // Load app users and teams
     let (app_users, app_teams) = load_app_users_for_project(&state, project.id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ProjectErrorResponse {
-                    error: format!("Failed to load app users: {}", e),
-                    suggestions: None,
-                }),
-            )
-        })?;
+        .map_err(|e| ServerError::internal(format!("Failed to load app users: {}", e)))?;
     api_project.app_users = app_users;
     api_project.app_teams = app_teams;
 
@@ -464,53 +425,29 @@ pub async fn update_project(
     Path(id_or_name): Path<String>,
     Query(params): Query<GetProjectParams>,
     Json(payload): Json<UpdateProjectRequest>,
-) -> Result<Json<UpdateProjectResponse>, (StatusCode, Json<ProjectErrorResponse>)> {
+) -> Result<Json<UpdateProjectResponse>, ServerError> {
     // Resolve project by ID or name
     let project = resolve_project(&state, &id_or_name, params.by_id).await?;
 
     // Check write permission
     let can_write = check_write_permission(&state, &project, &user)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ProjectErrorResponse {
-                    error: format!("Failed to check permissions: {}", e),
-                    suggestions: None,
-                }),
-            )
-        })?;
+        .map_err(|e| ServerError::internal(format!("Failed to check permissions: {}", e)))?;
 
     if !can_write {
-        return Err((
-            StatusCode::FORBIDDEN,
-            Json(ProjectErrorResponse {
-                error: "You do not have permission to update this project".to_string(),
-                suggestions: None,
-            }),
+        return Err(ServerError::forbidden(
+            "You do not have permission to update this project",
         ));
     }
 
     // Service accounts cannot update projects
     let is_sa = service_accounts::is_service_account(&state.db_pool, user.id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ProjectErrorResponse {
-                    error: format!("Failed to check service account status: {}", e),
-                    suggestions: None,
-                }),
-            )
-        })?;
+        .internal_err("Failed to check service account status")?;
 
     if is_sa {
-        return Err((
-            StatusCode::FORBIDDEN,
-            Json(ProjectErrorResponse {
-                error: "Service accounts cannot modify projects".to_string(),
-                suggestions: None,
-            }),
+        return Err(ServerError::forbidden(
+            "Service accounts cannot modify projects",
         ));
     }
 
@@ -526,38 +463,16 @@ pub async fn update_project(
                     // Valid UUID - look up by ID
                     db_users::find_by_id(&state.db_pool, uuid)
                         .await
-                        .map_err(|e| {
-                            (
-                                StatusCode::INTERNAL_SERVER_ERROR,
-                                Json(ProjectErrorResponse {
-                                    error: format!("Failed to verify user: {}", e),
-                                    suggestions: None,
-                                }),
-                            )
-                        })?
+                        .internal_err("Failed to verify user")?
                 } else {
                     // Not a UUID - treat as email
                     db_users::find_by_email(&state.db_pool, &user_identifier)
                         .await
-                        .map_err(|e| {
-                            (
-                                StatusCode::INTERNAL_SERVER_ERROR,
-                                Json(ProjectErrorResponse {
-                                    error: format!("Failed to verify user: {}", e),
-                                    suggestions: None,
-                                }),
-                            )
-                        })?
+                        .internal_err("Failed to verify user")?
                 };
 
                 let user = user.ok_or_else(|| {
-                    (
-                        StatusCode::NOT_FOUND,
-                        Json(ProjectErrorResponse {
-                            error: format!("User '{}' not found", user_identifier),
-                            suggestions: None,
-                        }),
-                    )
+                    ServerError::not_found(format!("User '{}' not found", user_identifier))
                 })?;
 
                 (Some(user.id), None)
@@ -568,64 +483,28 @@ pub async fn update_project(
                     // Valid UUID - look up by ID
                     db_teams::find_by_id(&state.db_pool, uuid)
                         .await
-                        .map_err(|e| {
-                            (
-                                StatusCode::INTERNAL_SERVER_ERROR,
-                                Json(ProjectErrorResponse {
-                                    error: format!("Failed to verify team: {}", e),
-                                    suggestions: None,
-                                }),
-                            )
-                        })?
+                        .internal_err("Failed to verify team")?
                 } else {
                     // Not a UUID - treat as team name
                     db_teams::find_by_name(&state.db_pool, &team_identifier)
                         .await
-                        .map_err(|e| {
-                            (
-                                StatusCode::INTERNAL_SERVER_ERROR,
-                                Json(ProjectErrorResponse {
-                                    error: format!("Failed to verify team: {}", e),
-                                    suggestions: None,
-                                }),
-                            )
-                        })?
+                        .internal_err("Failed to verify team")?
                 };
 
                 let team = team.ok_or_else(|| {
-                    (
-                        StatusCode::NOT_FOUND,
-                        Json(ProjectErrorResponse {
-                            error: format!("Team '{}' not found", team_identifier),
-                            suggestions: None,
-                        }),
-                    )
+                    ServerError::not_found(format!("Team '{}' not found", team_identifier))
                 })?;
 
                 // Verify the requesting user is a member of the team they're transferring to
                 let is_member = db_teams::is_member(&state.db_pool, team.id, user.id)
                     .await
-                    .map_err(|e| {
-                        (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(ProjectErrorResponse {
-                                error: format!("Failed to check team membership: {}", e),
-                                suggestions: None,
-                            }),
-                        )
-                    })?;
+                    .internal_err("Failed to check team membership")?;
 
                 if !is_member {
-                    return Err((
-                        StatusCode::FORBIDDEN,
-                        Json(ProjectErrorResponse {
-                            error: format!(
-                                "You must be a member of team '{}' to transfer projects to it",
-                                team.name
-                            ),
-                            suggestions: None,
-                        }),
-                    ));
+                    return Err(ServerError::forbidden(format!(
+                        "You must be a member of team '{}' to transfer projects to it",
+                        team.name
+                    )));
                 }
 
                 (None, Some(team.id))
@@ -639,15 +518,7 @@ pub async fn update_project(
             owner_team_id,
         )
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ProjectErrorResponse {
-                    error: format!("Failed to update project owner: {}", e),
-                    suggestions: None,
-                }),
-            )
-        })?;
+        .internal_err("Failed to update project owner")?;
     }
 
     // Update access_class if provided
@@ -663,184 +534,82 @@ pub async fn update_project(
                 .collect::<Vec<_>>()
                 .join(", ");
 
-            return Err((
-                StatusCode::BAD_REQUEST,
-                Json(ProjectErrorResponse {
-                    error: format!(
-                        "Invalid access class '{}'. Available: {}",
-                        access_class, available
-                    ),
-                    suggestions: None,
-                }),
-            ));
+            return Err(ServerError::bad_request(format!(
+                "Invalid access class '{}'. Available: {}",
+                access_class, available
+            )));
         }
 
         updated_project =
             projects::update_access_class(&state.db_pool, updated_project.id, access_class)
                 .await
-                .map_err(|e| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(ProjectErrorResponse {
-                            error: format!("Failed to update project access class: {}", e),
-                            suggestions: None,
-                        }),
-                    )
-                })?;
+                .internal_err("Failed to update project access class")?;
     }
 
     // Update app users if provided
     if let Some(app_users) = payload.app_users {
-        let mut tx = state.db_pool.begin().await.map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ProjectErrorResponse {
-                    error: format!("Failed to start transaction: {}", e),
-                    suggestions: None,
-                }),
-            )
-        })?;
+        let mut tx = state
+            .db_pool
+            .begin()
+            .await
+            .internal_err("Failed to start transaction")?;
 
         // Remove all existing app users
         let existing_users = crate::db::project_app_users::list_users(&mut *tx, updated_project.id)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ProjectErrorResponse {
-                        error: format!("Failed to list existing app users: {}", e),
-                        suggestions: None,
-                    }),
-                )
-            })?;
+            .internal_err("Failed to list existing app users")?;
 
         for user_id in existing_users {
             crate::db::project_app_users::remove_user(&mut *tx, updated_project.id, user_id)
                 .await
-                .map_err(|e| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(ProjectErrorResponse {
-                            error: format!("Failed to remove app user: {}", e),
-                            suggestions: None,
-                        }),
-                    )
-                })?;
+                .internal_err("Failed to remove app user")?;
         }
 
         // Add new app users
         for user_identifier in &app_users {
-            let user_id = resolve_user_identifier(&state.db_pool, user_identifier)
-                .await
-                .map_err(|e| {
-                    (
-                        e.status,
-                        Json(ProjectErrorResponse {
-                            error: e.message,
-                            suggestions: None,
-                        }),
-                    )
-                })?;
+            let user_id = resolve_user_identifier(&state.db_pool, user_identifier).await?;
 
             crate::db::project_app_users::add_user(&mut *tx, updated_project.id, user_id)
                 .await
-                .map_err(|e| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(ProjectErrorResponse {
-                            error: format!("Failed to add app user: {}", e),
-                            suggestions: None,
-                        }),
-                    )
-                })?;
+                .internal_err("Failed to add app user")?;
         }
 
-        tx.commit().await.map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ProjectErrorResponse {
-                    error: format!("Failed to commit transaction: {}", e),
-                    suggestions: None,
-                }),
-            )
-        })?;
+        tx.commit()
+            .await
+            .internal_err("Failed to commit transaction")?;
     }
 
     // Update app teams if provided
     if let Some(app_teams) = payload.app_teams {
-        let mut tx = state.db_pool.begin().await.map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ProjectErrorResponse {
-                    error: format!("Failed to start transaction: {}", e),
-                    suggestions: None,
-                }),
-            )
-        })?;
+        let mut tx = state
+            .db_pool
+            .begin()
+            .await
+            .internal_err("Failed to start transaction")?;
 
         // Remove all existing app teams
         let existing_teams = crate::db::project_app_users::list_teams(&mut *tx, updated_project.id)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ProjectErrorResponse {
-                        error: format!("Failed to list existing app teams: {}", e),
-                        suggestions: None,
-                    }),
-                )
-            })?;
+            .internal_err("Failed to list existing app teams")?;
 
         for team_id in existing_teams {
             crate::db::project_app_users::remove_team(&mut *tx, updated_project.id, team_id)
                 .await
-                .map_err(|e| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(ProjectErrorResponse {
-                            error: format!("Failed to remove app team: {}", e),
-                            suggestions: None,
-                        }),
-                    )
-                })?;
+                .internal_err("Failed to remove app team")?;
         }
 
         // Add new app teams
         for team_identifier in &app_teams {
-            let team_id = resolve_team_identifier(&state.db_pool, team_identifier)
-                .await
-                .map_err(|e| {
-                    (
-                        e.status,
-                        Json(ProjectErrorResponse {
-                            error: e.message,
-                            suggestions: None,
-                        }),
-                    )
-                })?;
+            let team_id = resolve_team_identifier(&state.db_pool, team_identifier).await?;
 
             crate::db::project_app_users::add_team(&mut *tx, updated_project.id, team_id)
                 .await
-                .map_err(|e| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(ProjectErrorResponse {
-                            error: format!("Failed to add app team: {}", e),
-                            suggestions: None,
-                        }),
-                    )
-                })?;
+                .internal_err("Failed to add app team")?;
         }
 
-        tx.commit().await.map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ProjectErrorResponse {
-                    error: format!("Failed to commit transaction: {}", e),
-                    suggestions: None,
-                }),
-            )
-        })?;
+        tx.commit()
+            .await
+            .internal_err("Failed to commit transaction")?;
     }
 
     // Update status if provided
@@ -851,28 +620,12 @@ pub async fn update_project(
             crate::db::models::ProjectStatus::from(status),
         )
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ProjectErrorResponse {
-                    error: format!("Failed to update project status: {}", e),
-                    suggestions: None,
-                }),
-            )
-        })?;
+        .internal_err("Failed to update project status")?;
     }
 
     let owner_info = resolve_owner_info(&state, &updated_project)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ProjectErrorResponse {
-                    error: format!("Failed to resolve owner info: {}", e),
-                    suggestions: None,
-                }),
-            )
-        })?;
+        .map_err(|e| ServerError::internal(format!("Failed to resolve owner info: {}", e)))?;
 
     Ok(Json(UpdateProjectResponse {
         project: convert_project(updated_project, owner_info),
@@ -884,53 +637,29 @@ pub async fn delete_project(
     Extension(user): Extension<User>,
     Path(id_or_name): Path<String>,
     Query(params): Query<GetProjectParams>,
-) -> Result<StatusCode, (StatusCode, Json<ProjectErrorResponse>)> {
+) -> Result<StatusCode, ServerError> {
     // Resolve project by ID or name
     let project = resolve_project(&state, &id_or_name, params.by_id).await?;
 
     // Check write permission
     let can_write = check_write_permission(&state, &project, &user)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ProjectErrorResponse {
-                    error: format!("Failed to check permissions: {}", e),
-                    suggestions: None,
-                }),
-            )
-        })?;
+        .map_err(|e| ServerError::internal(format!("Failed to check permissions: {}", e)))?;
 
     if !can_write {
-        return Err((
-            StatusCode::FORBIDDEN,
-            Json(ProjectErrorResponse {
-                error: "You do not have permission to delete this project".to_string(),
-                suggestions: None,
-            }),
+        return Err(ServerError::forbidden(
+            "You do not have permission to delete this project",
         ));
     }
 
     // Service accounts cannot delete projects
     let is_sa = service_accounts::is_service_account(&state.db_pool, user.id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ProjectErrorResponse {
-                    error: format!("Failed to check service account status: {}", e),
-                    suggestions: None,
-                }),
-            )
-        })?;
+        .internal_err("Failed to check service account status")?;
 
     if is_sa {
-        return Err((
-            StatusCode::FORBIDDEN,
-            Json(ProjectErrorResponse {
-                error: "Service accounts cannot modify projects".to_string(),
-                suggestions: None,
-            }),
+        return Err(ServerError::forbidden(
+            "Service accounts cannot modify projects",
         ));
     }
 
@@ -942,15 +671,7 @@ pub async fn delete_project(
     // Mark project as deleting
     projects::mark_deleting(&state.db_pool, project.id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ProjectErrorResponse {
-                    error: format!("Failed to mark project for deletion: {}", e),
-                    suggestions: None,
-                }),
-            )
-        })?;
+        .internal_err("Failed to mark project for deletion")?;
 
     tracing::info!("Project {} marked for deletion", project.name);
 
@@ -1019,21 +740,15 @@ async fn resolve_project(
     state: &AppState,
     id_or_name: &str,
     by_id: bool,
-) -> Result<crate::db::models::Project, (StatusCode, Json<ProjectErrorResponse>)> {
+) -> Result<crate::db::models::Project, ServerError> {
     tracing::info!("Resolving project '{}', by_id={}", id_or_name, by_id);
 
     let project = if by_id {
         // Explicit ID lookup
         tracing::info!("Using explicit ID lookup");
-        query_project_by_id(state, id_or_name).await.map_err(|e| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ProjectErrorResponse {
-                    error: e,
-                    suggestions: None,
-                }),
-            )
-        })?
+        query_project_by_id(state, id_or_name)
+            .await
+            .map_err(ServerError::not_found)?
     } else {
         // Try name first, fallback to ID
         tracing::info!("Trying name lookup first, will fallback to ID");
@@ -1065,13 +780,8 @@ async fn resolve_project(
                         Err(_) => None,
                     };
 
-                    (
-                        StatusCode::NOT_FOUND,
-                        Json(ProjectErrorResponse {
-                            error: format!("Project '{}' not found", id_or_name),
-                            suggestions,
-                        }),
-                    )
+                    ServerError::not_found(format!("Project '{}' not found", id_or_name))
+                        .with_suggestions(suggestions)
                 })?
             }
         }
@@ -1155,6 +865,32 @@ fn convert_project(project: crate::db::models::Project, owner: Option<OwnerInfo>
         app_users: vec![], // Will be populated by caller if needed
         app_teams: vec![], // Will be populated by caller if needed
     }
+}
+
+/// Check if user has access to a project, returning an error if not (admin bypass)
+///
+/// Admins always have access. Non-admins must pass the project ownership/team membership check.
+/// Returns `Ok(())` if access is granted, or `Err(ServerError::forbidden(...))` if not.
+pub async fn ensure_project_access_or_admin(
+    state: &AppState,
+    user: &User,
+    project: &crate::db::models::Project,
+) -> Result<(), ServerError> {
+    if state.is_admin(&user.email) {
+        return Ok(());
+    }
+
+    let can_access = projects::user_can_access(&state.db_pool, project.id, user.id)
+        .await
+        .internal_err("Failed to check project access")?;
+
+    if !can_access {
+        return Err(ServerError::forbidden(
+            "You do not have access to this project",
+        ));
+    }
+
+    Ok(())
 }
 
 /// Check if user can read a project (owner, team member, or admin)

--- a/src/server/project/models.rs
+++ b/src/server/project/models.rs
@@ -146,14 +146,6 @@ pub enum OwnerInfo {
     Team(TeamInfo),
 }
 
-// Error response with optional fuzzy match suggestions
-#[derive(Debug, Serialize, Clone)]
-pub struct ProjectErrorResponse {
-    pub error: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub suggestions: Option<Vec<String>>,
-}
-
 // Query parameters for project lookup
 #[derive(Debug, Deserialize, Clone)]
 pub struct GetProjectParams {

--- a/src/server/team/handlers.rs
+++ b/src/server/team/handlers.rs
@@ -1,10 +1,11 @@
 use super::fuzzy::find_similar_teams;
 use super::models::{
-    CreateTeamRequest, CreateTeamResponse, GetTeamParams, Team as ApiTeam, TeamErrorResponse,
-    UpdateTeamRequest, UpdateTeamResponse, UserInfo,
+    CreateTeamRequest, CreateTeamResponse, GetTeamParams, Team as ApiTeam, UpdateTeamRequest,
+    UpdateTeamResponse, UserInfo,
 };
 use crate::db::models::{TeamRole, User};
 use crate::db::{service_accounts, teams as db_teams};
+use crate::server::error::{ServerError, ServerErrorExt};
 use crate::server::state::AppState;
 use axum::{
     extract::{Extension, Path, Query, State},
@@ -17,7 +18,7 @@ pub async fn create_team(
     State(state): State<AppState>,
     Extension(user): Extension<User>,
     Json(payload): Json<CreateTeamRequest>,
-) -> Result<Json<CreateTeamResponse>, (StatusCode, String)> {
+) -> Result<Json<CreateTeamResponse>, ServerError> {
     // Check if user is allowed to create teams
     let is_admin = state.is_admin(&user.email);
     if !state.auth_settings.allow_team_creation && !is_admin {
@@ -26,9 +27,8 @@ pub async fn create_team(
             user.email,
             payload.name
         );
-        return Err((
-            StatusCode::FORBIDDEN,
-            "Team creation is disabled. Please contact your administrator.".to_string(),
+        return Err(ServerError::forbidden(
+            "Team creation is disabled. Please contact your administrator.",
         ));
     }
 
@@ -36,9 +36,8 @@ pub async fn create_team(
 
     // Validate that at least one owner is specified
     if payload.owners.is_empty() {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "At least one owner must be specified".to_string(),
+        return Err(ServerError::bad_request(
+            "At least one owner must be specified",
         ));
     }
 
@@ -48,13 +47,12 @@ pub async fn create_team(
         .iter()
         .map(|id| Uuid::parse_str(id))
         .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| (StatusCode::BAD_REQUEST, format!("Invalid owner ID: {}", e)))?;
+        .server_err(StatusCode::BAD_REQUEST, "Invalid owner ID")?;
 
     // Verify the authenticated user is in the owners list
     if !owner_ids.contains(&user.id) {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "You must be an owner of the team you create".to_string(),
+        return Err(ServerError::bad_request(
+            "You must be an owner of the team you create",
         ));
     }
 
@@ -64,7 +62,7 @@ pub async fn create_team(
         .iter()
         .map(|id| Uuid::parse_str(id))
         .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| (StatusCode::BAD_REQUEST, format!("Invalid member ID: {}", e)))?;
+        .server_err(StatusCode::BAD_REQUEST, "Invalid member ID")?;
 
     // Create the team
     let team = db_teams::create(&state.db_pool, &payload.name)
@@ -73,15 +71,9 @@ pub async fn create_team(
             if e.to_string().contains("duplicate key")
                 || e.to_string().contains("unique constraint")
             {
-                (
-                    StatusCode::CONFLICT,
-                    format!("Team '{}' already exists", payload.name),
-                )
+                ServerError::conflict(format!("Team '{}' already exists", payload.name))
             } else {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to create team: {}", e),
-                )
+                ServerError::internal_anyhow(e, "Failed to create team")
             }
         })?;
 
@@ -89,12 +81,7 @@ pub async fn create_team(
     for owner_id in owner_ids {
         db_teams::add_member(&state.db_pool, team.id, owner_id, TeamRole::Owner)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to add owner: {}", e),
-                )
-            })?;
+            .internal_err("Failed to add owner")?;
     }
 
     // Add members.
@@ -102,31 +89,16 @@ pub async fn create_team(
     for member_id in member_ids {
         db_teams::add_member(&state.db_pool, team.id, member_id, TeamRole::Member)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to add member: {}", e),
-                )
-            })?;
+            .internal_err("Failed to add member")?;
     }
 
     // Fetch members/owners with email info for response
     let members = db_teams::get_members(&state.db_pool, team.id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to get team members: {}", e),
-            )
-        })?;
+        .internal_err("Failed to get team members")?;
     let owners = db_teams::get_owners(&state.db_pool, team.id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to get team owners: {}", e),
-            )
-        })?;
+        .internal_err("Failed to get team owners")?;
 
     let member_infos = users_to_infos(&members);
     let owner_infos = users_to_infos(&owners);
@@ -141,34 +113,18 @@ pub async fn get_team(
     Extension(_user): Extension<User>,
     Path(id_or_name): Path<String>,
     Query(params): Query<GetTeamParams>,
-) -> Result<Json<serde_json::Value>, (StatusCode, Json<TeamErrorResponse>)> {
+) -> Result<Json<serde_json::Value>, ServerError> {
     // Resolve team by ID or name
     let team = resolve_team(&state, &id_or_name, params.by_id).await?;
 
     // Always resolve member/owner emails
     let members = db_teams::get_members(&state.db_pool, team.id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(TeamErrorResponse {
-                    error: format!("Failed to get team members: {}", e),
-                    suggestions: None,
-                }),
-            )
-        })?;
+        .internal_err("Failed to get team members")?;
 
     let owners = db_teams::get_owners(&state.db_pool, team.id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(TeamErrorResponse {
-                    error: format!("Failed to get team owners: {}", e),
-                    suggestions: None,
-                }),
-            )
-        })?;
+        .internal_err("Failed to get team owners")?;
 
     let member_infos = users_to_infos(&members);
     let owner_infos = users_to_infos(&owners);
@@ -184,7 +140,7 @@ pub async fn update_team(
     Path(id_or_name): Path<String>,
     Query(params): Query<GetTeamParams>,
     Json(payload): Json<UpdateTeamRequest>,
-) -> Result<Json<UpdateTeamResponse>, (StatusCode, Json<TeamErrorResponse>)> {
+) -> Result<Json<UpdateTeamResponse>, ServerError> {
     // Resolve team by ID or name
     let team = resolve_team(&state, &id_or_name, params.by_id).await?;
 
@@ -193,37 +149,21 @@ pub async fn update_team(
     let is_owner = if !is_admin {
         db_teams::is_owner(&state.db_pool, team.id, user.id)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(TeamErrorResponse {
-                        error: format!("Failed to check team ownership: {}", e),
-                        suggestions: None,
-                    }),
-                )
-            })?
+            .internal_err("Failed to check team ownership")?
     } else {
         true // Admins bypass ownership check
     };
 
     if !is_owner {
-        return Err((
-            StatusCode::FORBIDDEN,
-            Json(TeamErrorResponse {
-                error: "You must be an owner of the team to update it".to_string(),
-                suggestions: None,
-            }),
+        return Err(ServerError::forbidden(
+            "You must be an owner of the team to update it",
         ));
     }
 
     // Check if team is IdP-managed (only admins can modify)
     if team.idp_managed && !is_admin {
-        return Err((
-            StatusCode::FORBIDDEN,
-            Json(TeamErrorResponse {
-                error: "This team is managed by your Identity Provider. Only administrators can modify IdP-managed teams.".to_string(),
-                suggestions: None,
-            }),
+        return Err(ServerError::forbidden(
+            "This team is managed by your Identity Provider. Only administrators can modify IdP-managed teams.",
         ));
     }
 
@@ -242,28 +182,12 @@ pub async fn update_team(
             .iter()
             .map(|id| Uuid::parse_str(id))
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| {
-                (
-                    StatusCode::BAD_REQUEST,
-                    Json(TeamErrorResponse {
-                        error: format!("Invalid member ID: {}", e),
-                        suggestions: None,
-                    }),
-                )
-            })?;
+            .server_err(StatusCode::BAD_REQUEST, "Invalid member ID")?;
 
         // Get current members
         let current_members = db_teams::get_members(&state.db_pool, team.id)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(TeamErrorResponse {
-                        error: format!("Failed to get current members: {}", e),
-                        suggestions: None,
-                    }),
-                )
-            })?;
+            .internal_err("Failed to get current members")?;
 
         let current_member_ids: Vec<Uuid> = current_members.iter().map(|m| m.id).collect();
 
@@ -277,15 +201,7 @@ pub async fn update_team(
                     TeamRole::Member,
                 )
                 .await
-                .map_err(|e| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(TeamErrorResponse {
-                            error: format!("Failed to remove member: {}", e),
-                            suggestions: None,
-                        }),
-                    )
-                })?;
+                .internal_err("Failed to remove member")?;
             }
         }
 
@@ -293,23 +209,11 @@ pub async fn update_team(
         for member_id in &member_ids {
             let is_sa = service_accounts::is_service_account(&state.db_pool, *member_id)
                 .await
-                .map_err(|e| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(TeamErrorResponse {
-                            error: format!("Failed to check service account status: {}", e),
-                            suggestions: None,
-                        }),
-                    )
-                })?;
+                .internal_err("Failed to check service account status")?;
 
             if is_sa {
-                return Err((
-                    StatusCode::BAD_REQUEST,
-                    Json(TeamErrorResponse {
-                        error: "Service accounts cannot be team members".to_string(),
-                        suggestions: None,
-                    }),
+                return Err(ServerError::bad_request(
+                    "Service accounts cannot be team members",
                 ));
             }
         }
@@ -319,15 +223,7 @@ pub async fn update_team(
             if !current_member_ids.contains(&member_id) {
                 db_teams::add_member(&state.db_pool, team.id, member_id, TeamRole::Member)
                     .await
-                    .map_err(|e| {
-                        (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(TeamErrorResponse {
-                                error: format!("Failed to add member: {}", e),
-                                suggestions: None,
-                            }),
-                        )
-                    })?;
+                    .internal_err("Failed to add member")?;
             }
         }
     }
@@ -338,28 +234,12 @@ pub async fn update_team(
             .iter()
             .map(|id| Uuid::parse_str(id))
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| {
-                (
-                    StatusCode::BAD_REQUEST,
-                    Json(TeamErrorResponse {
-                        error: format!("Invalid owner ID: {}", e),
-                        suggestions: None,
-                    }),
-                )
-            })?;
+            .server_err(StatusCode::BAD_REQUEST, "Invalid owner ID")?;
 
         // Get current owners
         let current_owners = db_teams::get_owners(&state.db_pool, team.id)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(TeamErrorResponse {
-                        error: format!("Failed to get current owners: {}", e),
-                        suggestions: None,
-                    }),
-                )
-            })?;
+            .internal_err("Failed to get current owners")?;
 
         let current_owner_ids: Vec<Uuid> = current_owners.iter().map(|o| o.id).collect();
 
@@ -373,15 +253,7 @@ pub async fn update_team(
                     TeamRole::Owner,
                 )
                 .await
-                .map_err(|e| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(TeamErrorResponse {
-                            error: format!("Failed to remove owner: {}", e),
-                            suggestions: None,
-                        }),
-                    )
-                })?;
+                .internal_err("Failed to remove owner")?;
             }
         }
 
@@ -389,23 +261,11 @@ pub async fn update_team(
         for owner_id in &owner_ids {
             let is_sa = service_accounts::is_service_account(&state.db_pool, *owner_id)
                 .await
-                .map_err(|e| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(TeamErrorResponse {
-                            error: format!("Failed to check service account status: {}", e),
-                            suggestions: None,
-                        }),
-                    )
-                })?;
+                .internal_err("Failed to check service account status")?;
 
             if is_sa {
-                return Err((
-                    StatusCode::BAD_REQUEST,
-                    Json(TeamErrorResponse {
-                        error: "Service accounts cannot be team members".to_string(),
-                        suggestions: None,
-                    }),
+                return Err(ServerError::bad_request(
+                    "Service accounts cannot be team members",
                 ));
             }
         }
@@ -415,28 +275,12 @@ pub async fn update_team(
             if !current_owner_ids.contains(&owner_id) {
                 db_teams::add_member(&state.db_pool, team.id, owner_id, TeamRole::Owner)
                     .await
-                    .map_err(|e| {
-                        (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(TeamErrorResponse {
-                                error: format!("Failed to add owner: {}", e),
-                                suggestions: None,
-                            }),
-                        )
-                    })?;
+                    .internal_err("Failed to add owner")?;
             } else {
                 // Update role if already a member but not an owner
                 db_teams::update_member_role(&state.db_pool, team.id, owner_id, TeamRole::Owner)
                     .await
-                    .map_err(|e| {
-                        (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(TeamErrorResponse {
-                                error: format!("Failed to update member role: {}", e),
-                                suggestions: None,
-                            }),
-                        )
-                    })?;
+                    .internal_err("Failed to update member role")?;
             }
         }
     }
@@ -444,27 +288,11 @@ pub async fn update_team(
     // Fetch updated members and owners
     let members = db_teams::get_members(&state.db_pool, updated_team.id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(TeamErrorResponse {
-                    error: format!("Failed to get team members: {}", e),
-                    suggestions: None,
-                }),
-            )
-        })?;
+        .internal_err("Failed to get team members")?;
 
     let owners = db_teams::get_owners(&state.db_pool, updated_team.id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(TeamErrorResponse {
-                    error: format!("Failed to get team owners: {}", e),
-                    suggestions: None,
-                }),
-            )
-        })?;
+        .internal_err("Failed to get team owners")?;
 
     let member_infos = users_to_infos(&members);
     let owner_infos = users_to_infos(&owners);
@@ -479,7 +307,7 @@ pub async fn delete_team(
     Extension(user): Extension<User>,
     Path(id_or_name): Path<String>,
     Query(params): Query<GetTeamParams>,
-) -> Result<StatusCode, (StatusCode, Json<TeamErrorResponse>)> {
+) -> Result<StatusCode, ServerError> {
     // Resolve team by ID or name
     let team = resolve_team(&state, &id_or_name, params.by_id).await?;
 
@@ -488,51 +316,27 @@ pub async fn delete_team(
     let is_owner = if !is_admin {
         db_teams::is_owner(&state.db_pool, team.id, user.id)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(TeamErrorResponse {
-                        error: format!("Failed to check team ownership: {}", e),
-                        suggestions: None,
-                    }),
-                )
-            })?
+            .internal_err("Failed to check team ownership")?
     } else {
         true // Admins bypass ownership check
     };
 
     if !is_owner {
-        return Err((
-            StatusCode::FORBIDDEN,
-            Json(TeamErrorResponse {
-                error: "You must be an owner of the team to delete it".to_string(),
-                suggestions: None,
-            }),
+        return Err(ServerError::forbidden(
+            "You must be an owner of the team to delete it",
         ));
     }
 
     // Check if team is IdP-managed (only admins can delete)
     if team.idp_managed && !is_admin {
-        return Err((
-            StatusCode::FORBIDDEN,
-            Json(TeamErrorResponse {
-                error: "This team is managed by your Identity Provider. Only administrators can delete IdP-managed teams.".to_string(),
-                suggestions: None,
-            }),
+        return Err(ServerError::forbidden(
+            "This team is managed by your Identity Provider. Only administrators can delete IdP-managed teams.",
         ));
     }
 
     db_teams::delete(&state.db_pool, team.id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(TeamErrorResponse {
-                    error: format!("Failed to delete team: {}", e),
-                    suggestions: None,
-                }),
-            )
-        })?;
+        .internal_err("Failed to delete team")?;
 
     Ok(StatusCode::NO_CONTENT)
 }
@@ -540,24 +344,16 @@ pub async fn delete_team(
 pub async fn list_teams(
     State(state): State<AppState>,
     Extension(user): Extension<User>,
-) -> Result<Json<Vec<ApiTeam>>, (StatusCode, String)> {
+) -> Result<Json<Vec<ApiTeam>>, ServerError> {
     // Admins can see all teams; other users see all teams if allow_list_all_teams is enabled
     let teams = if state.is_admin(&user.email) || state.auth_settings.allow_list_all_teams {
-        db_teams::list(&state.db_pool).await.map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to list teams: {}", e),
-            )
-        })?
+        db_teams::list(&state.db_pool)
+            .await
+            .internal_err("Failed to list teams")?
     } else {
         db_teams::list_for_user(&state.db_pool, user.id)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to list teams: {}", e),
-                )
-            })?
+            .internal_err("Failed to list teams")?
     };
 
     let mut api_teams = Vec::new();
@@ -565,21 +361,11 @@ pub async fn list_teams(
     for team in teams {
         let members = db_teams::get_members(&state.db_pool, team.id)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get team members: {}", e),
-                )
-            })?;
+            .internal_err("Failed to get team members")?;
 
         let owners = db_teams::get_owners(&state.db_pool, team.id)
             .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to get team owners: {}", e),
-                )
-            })?;
+            .internal_err("Failed to get team owners")?;
 
         let member_infos = users_to_infos(&members);
         let owner_infos = users_to_infos(&owners);
@@ -621,21 +407,15 @@ async fn resolve_team(
     state: &AppState,
     id_or_name: &str,
     by_id: bool,
-) -> Result<crate::db::models::Team, (StatusCode, Json<TeamErrorResponse>)> {
+) -> Result<crate::db::models::Team, ServerError> {
     tracing::info!("Resolving team '{}', by_id={}", id_or_name, by_id);
 
     let team = if by_id {
         // Explicit ID lookup
         tracing::info!("Using explicit ID lookup");
-        query_team_by_id(state, id_or_name).await.map_err(|e| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(TeamErrorResponse {
-                    error: e,
-                    suggestions: None,
-                }),
-            )
-        })?
+        query_team_by_id(state, id_or_name)
+            .await
+            .map_err(ServerError::not_found)?
     } else {
         // Try name first, fallback to ID
         tracing::info!("Trying name lookup first, will fallback to ID");
@@ -666,13 +446,8 @@ async fn resolve_team(
                         Err(_) => None,
                     };
 
-                    (
-                        StatusCode::NOT_FOUND,
-                        Json(TeamErrorResponse {
-                            error: format!("Team '{}' not found", id_or_name),
-                            suggestions,
-                        }),
-                    )
+                    ServerError::not_found(format!("Team '{}' not found", id_or_name))
+                        .with_suggestions(suggestions)
                 })?
             }
         }

--- a/src/server/team/models.rs
+++ b/src/server/team/models.rs
@@ -51,14 +51,6 @@ pub struct UserInfo {
     pub email: String,
 }
 
-// Error response with optional fuzzy match suggestions
-#[derive(Debug, Serialize, Clone)]
-pub struct TeamErrorResponse {
-    pub error: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub suggestions: Option<Vec<String>>,
-}
-
 // Query parameters for team lookup
 #[derive(Debug, Deserialize, Clone)]
 pub struct GetTeamParams {

--- a/src/server/workload_identity/handlers.rs
+++ b/src/server/workload_identity/handlers.rs
@@ -6,6 +6,7 @@ use axum::{
 use uuid::Uuid;
 
 use crate::db::{projects, service_accounts, users, User};
+use crate::server::error::{ServerError, ServerErrorExt};
 use crate::server::project::handlers::{check_read_permission, check_write_permission};
 use crate::server::state::AppState;
 use crate::server::workload_identity::models::{
@@ -13,10 +14,8 @@ use crate::server::workload_identity::models::{
     WorkloadIdentityResponse,
 };
 
-type Result<T> = std::result::Result<T, (StatusCode, String)>;
-
 /// Verify that an OIDC issuer is reachable and has valid configuration
-async fn verify_oidc_issuer(issuer_url: &str) -> Result<()> {
+async fn verify_oidc_issuer(issuer_url: &str) -> Result<(), ServerError> {
     // Construct the OIDC discovery URL
     let discovery_url = if issuer_url.ends_with('/') {
         format!("{}well-known/openid-configuration", issuer_url)
@@ -29,13 +28,10 @@ async fn verify_oidc_issuer(issuer_url: &str) -> Result<()> {
     // Attempt to fetch the OIDC configuration
     let response = reqwest::get(&discovery_url)
         .await
-        .map_err(|e| {
-            tracing::warn!("Failed to reach OIDC issuer {}: {:#}", issuer_url, e);
-            (
-                StatusCode::BAD_REQUEST,
-                format!("Failed to reach OIDC issuer: {}. Please verify the issuer URL is correct and accessible.", e),
-            )
-        })?;
+        .server_err(
+            StatusCode::BAD_REQUEST,
+            format!("Failed to reach OIDC issuer: please verify the issuer URL '{}' is correct and accessible", issuer_url),
+        )?;
 
     if !response.status().is_success() {
         tracing::warn!(
@@ -43,37 +39,29 @@ async fn verify_oidc_issuer(issuer_url: &str) -> Result<()> {
             issuer_url,
             response.status()
         );
-        return Err((
-            StatusCode::BAD_REQUEST,
-            format!(
-                "OIDC issuer returned status {}: {}. Please verify the issuer URL points to a valid OIDC provider.",
-                response.status(),
-                response.status().canonical_reason().unwrap_or("Unknown")
-            ),
-        ));
+        return Err(ServerError::bad_request(format!(
+            "OIDC issuer returned status {}: {}. Please verify the issuer URL points to a valid OIDC provider.",
+            response.status(),
+            response.status().canonical_reason().unwrap_or("Unknown")
+        )));
     }
 
     // Try to parse the response as JSON to verify it's valid OIDC configuration
-    let config: serde_json::Value = response.json().await.map_err(|e| {
-        tracing::warn!("Failed to parse OIDC configuration from {}: {:#}", issuer_url, e);
-        (
-            StatusCode::BAD_REQUEST,
-            format!("Invalid OIDC configuration: {}. The issuer URL does not return valid OIDC discovery metadata.", e),
-        )
-    })?;
+    let config: serde_json::Value = response.json().await.server_err(
+        StatusCode::BAD_REQUEST,
+        format!("Invalid OIDC configuration: the issuer URL '{}' does not return valid OIDC discovery metadata", issuer_url),
+    )?;
 
     // Verify required OIDC fields are present
     if config.get("issuer").is_none() {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "OIDC configuration missing required 'issuer' field".to_string(),
+        return Err(ServerError::bad_request(
+            "OIDC configuration missing required 'issuer' field",
         ));
     }
 
     if config.get("jwks_uri").is_none() {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "OIDC configuration missing required 'jwks_uri' field".to_string(),
+        return Err(ServerError::bad_request(
+            "OIDC configuration missing required 'jwks_uri' field",
         ));
     }
 
@@ -87,62 +75,52 @@ pub async fn create_workload_identity(
     Extension(user): Extension<User>,
     Path(project_name): Path<String>,
     Json(req): Json<CreateWorkloadIdentityRequest>,
-) -> Result<Json<WorkloadIdentityResponse>> {
+) -> Result<Json<WorkloadIdentityResponse>, ServerError> {
     // Get project
     let project = projects::find_by_name(&state.db_pool, &project_name)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .ok_or_else(|| (StatusCode::NOT_FOUND, "Project not found".to_string()))?;
+        .internal_err("Failed to find project")?
+        .ok_or_else(|| ServerError::not_found("Project not found"))?;
 
     // Check permission: user must be able to write to project
     if !check_write_permission(&state, &project, &user)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .map_err(ServerError::internal)?
     {
-        return Err((
-            StatusCode::FORBIDDEN,
-            "Cannot manage service accounts for this project".to_string(),
+        return Err(ServerError::forbidden(
+            "Cannot manage service accounts for this project",
         ));
     }
 
     // Validate issuer URL
     if req.issuer_url.is_empty() {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "Issuer URL cannot be empty".to_string(),
-        ));
+        return Err(ServerError::bad_request("Issuer URL cannot be empty"));
     }
 
     // In production, should validate HTTPS
     // For now, just check it's a valid URL format
     if !req.issuer_url.starts_with("http://") && !req.issuer_url.starts_with("https://") {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "Issuer URL must be a valid HTTP(S) URL".to_string(),
+        return Err(ServerError::bad_request(
+            "Issuer URL must be a valid HTTP(S) URL",
         ));
     }
 
     // Validate claims requirements
     if req.claims.is_empty() {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "At least one claim is required".to_string(),
-        ));
+        return Err(ServerError::bad_request("At least one claim is required"));
     }
 
     // Require 'aud' claim
     if !req.claims.contains_key("aud") {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "The 'aud' (audience) claim is required for service accounts".to_string(),
+        return Err(ServerError::bad_request(
+            "The 'aud' (audience) claim is required for service accounts",
         ));
     }
 
     // Require at least one additional claim besides 'aud'
     if req.claims.len() < 2 {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "At least one claim in addition to 'aud' is required (e.g., project_path, ref_protected)".to_string(),
+        return Err(ServerError::bad_request(
+            "At least one claim in addition to 'aud' is required (e.g., project_path, ref_protected)",
         ));
     }
 
@@ -152,34 +130,17 @@ pub async fn create_workload_identity(
     // Create service account
     let sa = service_accounts::create(&state.db_pool, project.id, &req.issuer_url, &req.claims)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to create service account: {:#}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to create service account: {}", e),
-            )
-        })?;
+        .internal_err("Failed to create service account")?;
 
     // Get user for response
     let sa_user = users::find_by_id(&state.db_pool, sa.user_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .ok_or_else(|| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Service account user not found".to_string(),
-            )
-        })?;
+        .internal_err("Failed to find service account user")?
+        .ok_or_else(|| ServerError::internal("Service account user not found"))?;
 
     // Convert JSONB claims to HashMap for response
-    let claims: std::collections::HashMap<String, String> = serde_json::from_value(sa.claims)
-        .map_err(|e| {
-            tracing::error!("Failed to deserialize claims: {:#}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Failed to deserialize claims".to_string(),
-            )
-        })?;
+    let claims: std::collections::HashMap<String, String> =
+        serde_json::from_value(sa.claims).internal_err("Failed to deserialize claims")?;
 
     Ok(Json(WorkloadIdentityResponse {
         id: sa.id.to_string(),
@@ -196,48 +157,38 @@ pub async fn list_workload_identities(
     State(state): State<AppState>,
     Extension(user): Extension<User>,
     Path(project_name): Path<String>,
-) -> Result<Json<ListWorkloadIdentitiesResponse>> {
+) -> Result<Json<ListWorkloadIdentitiesResponse>, ServerError> {
     // Get project
     let project = projects::find_by_name(&state.db_pool, &project_name)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .ok_or_else(|| (StatusCode::NOT_FOUND, "Project not found".to_string()))?;
+        .internal_err("Failed to find project")?
+        .ok_or_else(|| ServerError::not_found("Project not found"))?;
 
     // Check read permission
     if !check_read_permission(&state, &project, &user)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .map_err(ServerError::internal)?
     {
-        return Err((StatusCode::NOT_FOUND, "Project not found".to_string()));
+        return Err(ServerError::not_found("Project not found"));
     }
 
     // Get active service accounts
     let sas = service_accounts::list_by_project(&state.db_pool, project.id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .internal_err("Failed to list service accounts")?;
 
     // Convert to response
     let mut workload_identities = Vec::new();
     for sa in sas {
         let sa_user = users::find_by_id(&state.db_pool, sa.user_id)
             .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-            .ok_or_else(|| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "Service account user not found".to_string(),
-                )
-            })?;
+            .internal_err("Failed to find service account user")?
+            .ok_or_else(|| ServerError::internal("Service account user not found"))?;
 
         // Convert JSONB claims to HashMap
         let claims: std::collections::HashMap<String, String> =
-            serde_json::from_value(sa.claims.clone()).map_err(|e| {
-                tracing::error!("Failed to deserialize claims: {:#}", e);
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "Failed to deserialize claims".to_string(),
-                )
-            })?;
+            serde_json::from_value(sa.claims.clone())
+                .internal_err("Failed to deserialize claims")?;
 
         workload_identities.push(WorkloadIdentityResponse {
             id: sa.id.to_string(),
@@ -259,68 +210,46 @@ pub async fn get_workload_identity(
     State(state): State<AppState>,
     Extension(user): Extension<User>,
     Path((project_name, sa_id)): Path<(String, Uuid)>,
-) -> Result<Json<WorkloadIdentityResponse>> {
+) -> Result<Json<WorkloadIdentityResponse>, ServerError> {
     // Get project
     let project = projects::find_by_name(&state.db_pool, &project_name)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .ok_or_else(|| (StatusCode::NOT_FOUND, "Project not found".to_string()))?;
+        .internal_err("Failed to find project")?
+        .ok_or_else(|| ServerError::not_found("Project not found"))?;
 
     // Check read permission
     if !check_read_permission(&state, &project, &user)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .map_err(ServerError::internal)?
     {
-        return Err((StatusCode::NOT_FOUND, "Project not found".to_string()));
+        return Err(ServerError::not_found("Project not found"));
     }
 
     // Get service account
     let sa = service_accounts::get_by_id(&state.db_pool, sa_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                "Service account not found".to_string(),
-            )
-        })?;
+        .internal_err("Failed to find service account")?
+        .ok_or_else(|| ServerError::not_found("Service account not found"))?;
 
     // Verify SA belongs to this project
     if sa.project_id != project.id {
-        return Err((
-            StatusCode::NOT_FOUND,
-            "Service account not found".to_string(),
-        ));
+        return Err(ServerError::not_found("Service account not found"));
     }
 
     // Check if deleted
     if sa.deleted_at.is_some() {
-        return Err((
-            StatusCode::NOT_FOUND,
-            "Service account not found".to_string(),
-        ));
+        return Err(ServerError::not_found("Service account not found"));
     }
 
     // Get user
     let sa_user = users::find_by_id(&state.db_pool, sa.user_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .ok_or_else(|| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Service account user not found".to_string(),
-            )
-        })?;
+        .internal_err("Failed to find service account user")?
+        .ok_or_else(|| ServerError::internal("Service account user not found"))?;
 
     // Convert JSONB claims to HashMap
-    let claims: std::collections::HashMap<String, String> = serde_json::from_value(sa.claims)
-        .map_err(|e| {
-            tracing::error!("Failed to deserialize claims: {:#}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Failed to deserialize claims".to_string(),
-            )
-        })?;
+    let claims: std::collections::HashMap<String, String> =
+        serde_json::from_value(sa.claims).internal_err("Failed to deserialize claims")?;
 
     Ok(Json(WorkloadIdentityResponse {
         id: sa.id.to_string(),
@@ -338,72 +267,55 @@ pub async fn update_workload_identity(
     Extension(user): Extension<User>,
     Path((project_name, sa_id)): Path<(String, Uuid)>,
     Json(req): Json<UpdateWorkloadIdentityRequest>,
-) -> Result<Json<WorkloadIdentityResponse>> {
+) -> Result<Json<WorkloadIdentityResponse>, ServerError> {
     // Get project
     let project = projects::find_by_name(&state.db_pool, &project_name)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .ok_or_else(|| (StatusCode::NOT_FOUND, "Project not found".to_string()))?;
+        .internal_err("Failed to find project")?
+        .ok_or_else(|| ServerError::not_found("Project not found"))?;
 
     // Check write permission
     if !check_write_permission(&state, &project, &user)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .map_err(ServerError::internal)?
     {
-        return Err((
-            StatusCode::FORBIDDEN,
-            "Cannot manage service accounts for this project".to_string(),
+        return Err(ServerError::forbidden(
+            "Cannot manage service accounts for this project",
         ));
     }
 
     // Get service account
     let sa = service_accounts::get_by_id(&state.db_pool, sa_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                "Service account not found".to_string(),
-            )
-        })?;
+        .internal_err("Failed to find service account")?
+        .ok_or_else(|| ServerError::not_found("Service account not found"))?;
 
     // Verify SA belongs to this project
     if sa.project_id != project.id {
-        return Err((
-            StatusCode::NOT_FOUND,
-            "Service account not found".to_string(),
-        ));
+        return Err(ServerError::not_found("Service account not found"));
     }
 
     // Check if deleted
     if sa.deleted_at.is_some() {
-        return Err((
-            StatusCode::NOT_FOUND,
-            "Service account not found".to_string(),
-        ));
+        return Err(ServerError::not_found("Service account not found"));
     }
 
     // Validate that at least one field is provided
     if req.issuer_url.is_none() && req.claims.is_none() {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "At least one field (issuer_url or claims) must be provided for update".to_string(),
+        return Err(ServerError::bad_request(
+            "At least one field (issuer_url or claims) must be provided for update",
         ));
     }
 
     // Validate issuer URL if provided
     if let Some(ref issuer_url) = req.issuer_url {
         if issuer_url.is_empty() {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                "Issuer URL cannot be empty".to_string(),
-            ));
+            return Err(ServerError::bad_request("Issuer URL cannot be empty"));
         }
 
         if !issuer_url.starts_with("http://") && !issuer_url.starts_with("https://") {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                "Issuer URL must be a valid HTTP(S) URL".to_string(),
+            return Err(ServerError::bad_request(
+                "Issuer URL must be a valid HTTP(S) URL",
             ));
         }
     }
@@ -411,25 +323,20 @@ pub async fn update_workload_identity(
     // Validate claims if provided
     if let Some(ref claims) = req.claims {
         if claims.is_empty() {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                "Claims cannot be empty".to_string(),
-            ));
+            return Err(ServerError::bad_request("Claims cannot be empty"));
         }
 
         // Require 'aud' claim
         if !claims.contains_key("aud") {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                "The 'aud' (audience) claim is required for service accounts".to_string(),
+            return Err(ServerError::bad_request(
+                "The 'aud' (audience) claim is required for service accounts",
             ));
         }
 
         // Require at least one additional claim besides 'aud'
         if claims.len() < 2 {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                "At least one claim in addition to 'aud' is required (e.g., project_path, ref_protected)".to_string(),
+            return Err(ServerError::bad_request(
+                "At least one claim in addition to 'aud' is required (e.g., project_path, ref_protected)",
             ));
         }
     }
@@ -442,28 +349,17 @@ pub async fn update_workload_identity(
         req.claims.as_ref(),
     )
     .await
-    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    .internal_err("Failed to update service account")?;
 
     // Get user for response
     let sa_user = users::find_by_id(&state.db_pool, updated_sa.user_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .ok_or_else(|| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Service account user not found".to_string(),
-            )
-        })?;
+        .internal_err("Failed to find service account user")?
+        .ok_or_else(|| ServerError::internal("Service account user not found"))?;
 
     // Convert JSONB claims to HashMap for response
     let claims: std::collections::HashMap<String, String> =
-        serde_json::from_value(updated_sa.claims).map_err(|e| {
-            tracing::error!("Failed to deserialize claims: {:#}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Failed to deserialize claims".to_string(),
-            )
-        })?;
+        serde_json::from_value(updated_sa.claims).internal_err("Failed to deserialize claims")?;
 
     Ok(Json(WorkloadIdentityResponse {
         id: updated_sa.id.to_string(),
@@ -480,55 +376,43 @@ pub async fn delete_workload_identity(
     State(state): State<AppState>,
     Extension(user): Extension<User>,
     Path((project_name, sa_id)): Path<(String, Uuid)>,
-) -> Result<StatusCode> {
+) -> Result<StatusCode, ServerError> {
     // Get project
     let project = projects::find_by_name(&state.db_pool, &project_name)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .ok_or_else(|| (StatusCode::NOT_FOUND, "Project not found".to_string()))?;
+        .internal_err("Failed to find project")?
+        .ok_or_else(|| ServerError::not_found("Project not found"))?;
 
     // Check write permission
     if !check_write_permission(&state, &project, &user)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .map_err(ServerError::internal)?
     {
-        return Err((
-            StatusCode::FORBIDDEN,
-            "Cannot manage service accounts for this project".to_string(),
+        return Err(ServerError::forbidden(
+            "Cannot manage service accounts for this project",
         ));
     }
 
     // Get service account
     let sa = service_accounts::get_by_id(&state.db_pool, sa_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                "Service account not found".to_string(),
-            )
-        })?;
+        .internal_err("Failed to find service account")?
+        .ok_or_else(|| ServerError::not_found("Service account not found"))?;
 
     // Verify SA belongs to this project
     if sa.project_id != project.id {
-        return Err((
-            StatusCode::NOT_FOUND,
-            "Service account not found".to_string(),
-        ));
+        return Err(ServerError::not_found("Service account not found"));
     }
 
     // Check if already deleted
     if sa.deleted_at.is_some() {
-        return Err((
-            StatusCode::NOT_FOUND,
-            "Service account not found".to_string(),
-        ));
+        return Err(ServerError::not_found("Service account not found"));
     }
 
     // Soft delete
     service_accounts::soft_delete(&state.db_pool, sa_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .internal_err("Failed to delete service account")?;
 
     Ok(StatusCode::NO_CONTENT)
 }


### PR DESCRIPTION
## Summary
- Migrate all ~40 server handlers across 8 files from `(StatusCode, String)` error tuples to the existing `ServerError` type, which automatically logs 5xx errors with full error chains and structured context
- Extend `ServerError` with `suggestions` field (for fuzzy-match 404s on project/team lookups), new constructors (`conflict`, `gone`, `service_unavailable`), `From<(StatusCode, String)>` impl, and an `expected()` flag to downgrade specific 5xx responses to WARN-level logging
- Mark "pod not ready" 503 responses as `.expected()` so they log at WARN instead of ERROR (these are normal transient conditions during deployment rollout)
- Clean up: remove unused `ProjectErrorResponse`/`TeamErrorResponse` server-side types, remove duplicated `format_error_chain()`, deduplicate `ensure_project_access_or_admin` into `project::handlers`

Net result: -1225 lines, and all 5xx errors now produce detailed server logs instead of generic "request completed with server error status=500" messages.

## Test plan
- [x] `cargo fmt --all` — clean
- [x] `mise run lint` — clippy, fmt check, sqlx check, helm lint all pass
- [x] `cargo test --all-features` — all 236 tests pass
- [ ] Manual: verify 500 errors now show full error details in server logs
- [ ] Manual: verify 400/404/403 responses still return correct JSON to client
- [ ] Manual: verify project/team 404 responses still include `suggestions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)