### PR TITLE
security: add configurable CPU limit for user-deployed containers

### DIFF
--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -765,8 +765,7 @@ Rise enforces secure-by-default Pod Security Standards for all deployed applicat
 - Writable root filesystem (for compatibility)
 
 **Resource limits (configurable):**
-- CPU request: 10m, Memory request: 64Mi, Memory limit: 512Mi
-- No CPU limit to avoid throttling
+- CPU request: 500m, CPU limit: 2, Memory request: 256Mi, Memory limit: 2Gi
 
 **Health probes (configurable):**
 - HTTP GET on application port at `/` path
@@ -782,6 +781,7 @@ type = "kubernetes"
 
 [deployment_controller.pod_resources]
 cpu_request = "50m"
+cpu_limit = "1"
 memory_request = "128Mi"
 memory_limit = "1Gi"
 ```

--- a/docs/schemas/backend-settings.schema.json
+++ b/docs/schemas/backend-settings.schema.json
@@ -874,19 +874,24 @@
     "PodResourceLimits": {
       "description": "Resource limits for pods",
       "properties": {
+        "cpu_limit": {
+          "default": "2",
+          "description": "CPU limit (e.g., \"1\", \"2\", \"4\")",
+          "type": "string"
+        },
         "cpu_request": {
-          "default": "10m",
-          "description": "CPU request (e.g., \"10m\", \"100m\", \"1\")",
+          "default": "500m",
+          "description": "CPU request (e.g., \"100m\", \"500m\", \"1\")",
           "type": "string"
         },
         "memory_limit": {
-          "default": "512Mi",
-          "description": "Memory limit (e.g., \"512Mi\", \"1Gi\", \"2Gi\") CPU limit intentionally omitted to avoid throttling",
+          "default": "2Gi",
+          "description": "Memory limit (e.g., \"512Mi\", \"1Gi\", \"2Gi\")",
           "type": "string"
         },
         "memory_request": {
-          "default": "64Mi",
-          "description": "Memory request (e.g., \"64Mi\", \"128Mi\", \"1Gi\")",
+          "default": "256Mi",
+          "description": "Memory request (e.g., \"128Mi\", \"256Mi\", \"1Gi\")",
           "type": "string"
         }
       },

--- a/docs/schemas/backend-settings.schema.json
+++ b/docs/schemas/backend-settings.schema.json
@@ -405,7 +405,7 @@
                   "type": "null"
                 }
               ],
-              "description": "Resource limits for deployed containers If not set, uses default conservative limits (10m CPU request, 64Mi memory request, 512Mi memory limit)"
+              "description": "Resource limits for deployed containers If not set, uses defaults: 500m CPU request, 256Mi memory request, 2 CPU limit, 2Gi memory limit"
             },
             "pod_security_enabled": {
               "default": true,

--- a/src/server/deployment/controller/kubernetes.rs
+++ b/src/server/deployment/controller/kubernetes.rs
@@ -2462,24 +2462,12 @@ impl KubernetesController {
     fn create_resource_requirements(&self) -> Option<ResourceRequirements> {
         use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 
-        // Use configured values or defaults
-        let (cpu_request, memory_request, cpu_limit, memory_limit) =
-            if let Some(ref config) = self.pod_resources {
-                (
-                    config.cpu_request.clone(),
-                    config.memory_request.clone(),
-                    config.cpu_limit.clone(),
-                    config.memory_limit.clone(),
-                )
-            } else {
-                // Use default values
-                (
-                    String::from("500m"),
-                    String::from("256Mi"),
-                    String::from("2"),
-                    String::from("2Gi"),
-                )
-            };
+        // Use configured values or defaults from PodResourceLimits::default()
+        let config = self.pod_resources.clone().unwrap_or_default();
+        let cpu_request = config.cpu_request;
+        let memory_request = config.memory_request;
+        let cpu_limit = config.cpu_limit;
+        let memory_limit = config.memory_limit;
 
         Some(ResourceRequirements {
             requests: Some({
@@ -5239,6 +5227,45 @@ mod tests {
         assert_eq!(volume_mounts[0].name, EXTRA_SERVICE_TOKENS_VOLUME_NAME);
         assert_eq!(volume_mounts[0].mount_path, EXTRA_SERVICE_TOKENS_MOUNT_PATH);
         assert_eq!(volume_mounts[0].read_only, Some(true));
+    }
+
+    #[tokio::test]
+    async fn test_resource_requirements_defaults() {
+        let controller = create_mock_controller();
+        let resources = controller
+            .create_resource_requirements()
+            .expect("should return resource requirements");
+
+        let requests = resources.requests.expect("should have requests");
+        assert_eq!(requests["cpu"].0, "500m");
+        assert_eq!(requests["memory"].0, "256Mi");
+
+        let limits = resources.limits.expect("should have limits");
+        assert_eq!(limits["cpu"].0, "2");
+        assert_eq!(limits["memory"].0, "2Gi");
+    }
+
+    #[tokio::test]
+    async fn test_resource_requirements_custom_values() {
+        let mut controller = create_mock_controller();
+        controller.pod_resources = Some(crate::server::settings::PodResourceLimits {
+            cpu_request: "100m".to_string(),
+            memory_request: "128Mi".to_string(),
+            cpu_limit: "4".to_string(),
+            memory_limit: "1Gi".to_string(),
+        });
+
+        let resources = controller
+            .create_resource_requirements()
+            .expect("should return resource requirements");
+
+        let requests = resources.requests.expect("should have requests");
+        assert_eq!(requests["cpu"].0, "100m");
+        assert_eq!(requests["memory"].0, "128Mi");
+
+        let limits = resources.limits.expect("should have limits");
+        assert_eq!(limits["cpu"].0, "4");
+        assert_eq!(limits["memory"].0, "1Gi");
     }
 
     #[test]

--- a/src/server/deployment/controller/kubernetes.rs
+++ b/src/server/deployment/controller/kubernetes.rs
@@ -2463,19 +2463,21 @@ impl KubernetesController {
         use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 
         // Use configured values or defaults
-        let (cpu_request, memory_request, memory_limit) =
+        let (cpu_request, memory_request, cpu_limit, memory_limit) =
             if let Some(ref config) = self.pod_resources {
                 (
                     config.cpu_request.clone(),
                     config.memory_request.clone(),
+                    config.cpu_limit.clone(),
                     config.memory_limit.clone(),
                 )
             } else {
                 // Use default values
                 (
-                    String::from("10m"),
-                    String::from("64Mi"),
-                    String::from("512Mi"),
+                    String::from("500m"),
+                    String::from("256Mi"),
+                    String::from("2"),
+                    String::from("2Gi"),
                 )
             };
 
@@ -2488,8 +2490,8 @@ impl KubernetesController {
             }),
             limits: Some({
                 let mut map = BTreeMap::new();
+                map.insert("cpu".to_string(), Quantity(cpu_limit));
                 map.insert("memory".to_string(), Quantity(memory_limit));
-                // No CPU limit - avoid throttling
                 map
             }),
             ..Default::default()

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -341,16 +341,19 @@ pub struct AccessClass {
 /// Resource limits for pods
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct PodResourceLimits {
-    /// CPU request (e.g., "10m", "100m", "1")
+    /// CPU request (e.g., "100m", "500m", "1")
     #[serde(default = "default_cpu_request")]
     pub cpu_request: String,
 
-    /// Memory request (e.g., "64Mi", "128Mi", "1Gi")
+    /// Memory request (e.g., "128Mi", "256Mi", "1Gi")
     #[serde(default = "default_memory_request")]
     pub memory_request: String,
 
+    /// CPU limit (e.g., "1", "2", "4")
+    #[serde(default = "default_cpu_limit")]
+    pub cpu_limit: String,
+
     /// Memory limit (e.g., "512Mi", "1Gi", "2Gi")
-    /// CPU limit intentionally omitted to avoid throttling
     #[serde(default = "default_memory_limit")]
     pub memory_limit: String,
 }
@@ -411,15 +414,19 @@ fn default_true() -> bool {
 }
 
 fn default_cpu_request() -> String {
-    "10m".to_string()
+    "500m".to_string()
 }
 
 fn default_memory_request() -> String {
-    "64Mi".to_string()
+    "256Mi".to_string()
+}
+
+fn default_cpu_limit() -> String {
+    "2".to_string()
 }
 
 fn default_memory_limit() -> String {
-    "512Mi".to_string()
+    "2Gi".to_string()
 }
 
 fn default_probe_path() -> String {

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -358,6 +358,17 @@ pub struct PodResourceLimits {
     pub memory_limit: String,
 }
 
+impl Default for PodResourceLimits {
+    fn default() -> Self {
+        Self {
+            cpu_request: default_cpu_request(),
+            memory_request: default_memory_request(),
+            cpu_limit: default_cpu_limit(),
+            memory_limit: default_memory_limit(),
+        }
+    }
+}
+
 /// Health probe configuration
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct HealthProbeConfig {
@@ -597,7 +608,7 @@ pub enum DeploymentControllerSettings {
         pod_security_enabled: bool,
 
         /// Resource limits for deployed containers
-        /// If not set, uses default conservative limits (10m CPU request, 64Mi memory request, 512Mi memory limit)
+        /// If not set, uses defaults: 500m CPU request, 256Mi memory request, 2 CPU limit, 2Gi memory limit
         #[serde(default)]
         pod_resources: Option<PodResourceLimits>,
 


### PR DESCRIPTION
## Summary
- Add `cpu_limit` field to `PodResourceLimits` (default: `"2"`)
- Update resource defaults: cpu_request `500m`, memory_request `256Mi`, memory_limit `2Gi`
- Apply CPU limit in Kubernetes controller's `create_resource_requirements()`

User-deployed containers previously had no CPU limit, allowing a misbehaving deployment to starve the cluster.

## Test plan
- [ ] Verify `cargo check --all-features` passes
- [ ] Verify `cargo clippy --all-features -- -D warnings` passes
- [ ] Deploy a test project and confirm pod spec includes CPU limit
- [ ] Test with custom `pod_resources.cpu_limit` in server config

🤖 Generated with [Claude Code](https://claude.com/claude-code)