### PR TITLE
security: SSRF protection for OIDC/OAuth URLs with dev bypass flag

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -12,6 +12,7 @@ server:
   jwt_claims: ["sub", "email", "name"]
   static_dir: "${RISE_STATIC_DIR:-static}" # In-container: /var/lib/rise/static; local dev: static/
   docs_dir: "${RISE_DOCS_DIR:-docs}" # In-container: /var/rise/docs; local dev: docs/
+  allow_private_networks: true # Allow HTTP and private IPs for local OIDC (Dex at localhost)
 
 database:
   url: "${DATABASE_URL}"

--- a/docs/schemas/backend-settings.schema.json
+++ b/docs/schemas/backend-settings.schema.json
@@ -1038,6 +1038,11 @@
     },
     "ServerSettings": {
       "properties": {
+        "allow_private_networks": {
+          "default": false,
+          "description": "Allow HTTP and private/loopback IPs in SSRF-validated URLs. WARNING: Only enable for local development. Never enable in production.",
+          "type": "boolean"
+        },
         "cookie_domain": {
           "default": "",
           "description": "Cookie domain for session cookies (e.g., \".rise.dev\" for all subdomains, \"\" for current host only)",

--- a/src/server/auth/jwt.rs
+++ b/src/server/auth/jwt.rs
@@ -93,6 +93,11 @@ impl JwtValidator {
     async fn discover_jwks_uri(&self, issuer_url: &str) -> Result<String> {
         let discovery_url = format!("{}/.well-known/openid-configuration", issuer_url);
 
+        // SSRF-validate the discovery URL before fetching
+        crate::server::ssrf::validate_url(&discovery_url)
+            .await
+            .map_err(|e| anyhow!("OIDC discovery URL failed SSRF validation: {}", e))?;
+
         tracing::debug!("Discovering OIDC configuration from {}", discovery_url);
 
         let response = self

--- a/src/server/auth/jwt.rs
+++ b/src/server/auth/jwt.rs
@@ -78,14 +78,16 @@ impl JwksCache {
 pub struct JwtValidator {
     jwks_cache: Arc<RwLock<HashMap<String, JwksCache>>>,
     http_client: reqwest::Client,
+    allow_private_networks: bool,
 }
 
 impl JwtValidator {
     /// Create a new JWT validator
-    pub fn new() -> Self {
+    pub fn new(allow_private_networks: bool) -> Self {
         Self {
             jwks_cache: Arc::new(RwLock::new(HashMap::new())),
-            http_client: crate::server::ssrf::safe_client(),
+            http_client: crate::server::ssrf::safe_client(allow_private_networks),
+            allow_private_networks,
         }
     }
 
@@ -94,7 +96,7 @@ impl JwtValidator {
         let discovery_url = format!("{}/.well-known/openid-configuration", issuer_url);
 
         // SSRF-validate the discovery URL before fetching
-        crate::server::ssrf::validate_url(&discovery_url)
+        crate::server::ssrf::validate_url(&discovery_url, self.allow_private_networks)
             .await
             .map_err(|e| anyhow!("OIDC discovery URL failed SSRF validation: {}", e))?;
 
@@ -115,7 +117,7 @@ impl JwtValidator {
         // SSRF-validate the JWKS URI before returning it.
         // An attacker-controlled OIDC provider could return a jwks_uri pointing
         // to an internal IP (e.g., metadata endpoint, internal service).
-        crate::server::ssrf::validate_url(&discovery.jwks_uri)
+        crate::server::ssrf::validate_url(&discovery.jwks_uri, self.allow_private_networks)
             .await
             .map_err(|e| anyhow!("JWKS URI failed SSRF validation: {}", e))?;
 
@@ -380,7 +382,7 @@ impl JwtValidator {
 
 impl Default for JwtValidator {
     fn default() -> Self {
-        Self::new()
+        Self::new(false)
     }
 }
 
@@ -390,7 +392,7 @@ mod tests {
 
     #[test]
     fn test_jwt_validator_creation() {
-        let validator = JwtValidator::new();
+        let validator = JwtValidator::new(false);
         // Validator should be created with empty cache
         assert!(validator.jwks_cache.try_read().is_ok());
     }

--- a/src/server/auth/jwt.rs
+++ b/src/server/auth/jwt.rs
@@ -107,6 +107,13 @@ impl JwtValidator {
             .await
             .context("Failed to parse OIDC discovery document")?;
 
+        // SSRF-validate the JWKS URI before returning it.
+        // An attacker-controlled OIDC provider could return a jwks_uri pointing
+        // to an internal IP (e.g., metadata endpoint, internal service).
+        crate::server::ssrf::validate_url(&discovery.jwks_uri)
+            .await
+            .map_err(|e| anyhow!("JWKS URI failed SSRF validation: {}", e))?;
+
         Ok(discovery.jwks_uri)
     }
 

--- a/src/server/extensions/providers/oauth/handlers.rs
+++ b/src/server/extensions/providers/oauth/handlers.rs
@@ -32,21 +32,24 @@ struct ResolvedEndpoints {
 }
 
 /// Fetch OIDC discovery document from issuer URL
-async fn fetch_oidc_discovery(issuer_url: &str) -> Result<OidcDiscoveryDocument, String> {
+async fn fetch_oidc_discovery(
+    issuer_url: &str,
+    allow_private_networks: bool,
+) -> Result<OidcDiscoveryDocument, String> {
     let discovery_url = format!(
         "{}/.well-known/openid-configuration",
         issuer_url.trim_end_matches('/')
     );
 
     // SSRF-validate the discovery URL before fetching
-    crate::server::ssrf::validate_url(&discovery_url)
+    crate::server::ssrf::validate_url(&discovery_url, allow_private_networks)
         .await
         .map_err(|e| {
             error!("OIDC discovery URL failed SSRF validation: {}", e);
             format!("OIDC discovery URL failed SSRF validation: {}", e)
         })?;
 
-    let http_client = crate::server::ssrf::safe_client();
+    let http_client = crate::server::ssrf::safe_client(allow_private_networks);
     let response = http_client.get(&discovery_url).send().await.map_err(|e| {
         error!(
             "Failed to fetch OIDC discovery from {}: {:?}",
@@ -75,7 +78,10 @@ async fn fetch_oidc_discovery(issuer_url: &str) -> Result<OidcDiscoveryDocument,
 }
 
 /// Resolve OAuth endpoints from spec, falling back to OIDC discovery
-async fn resolve_oauth_endpoints(spec: &OAuthExtensionSpec) -> Result<ResolvedEndpoints, String> {
+async fn resolve_oauth_endpoints(
+    spec: &OAuthExtensionSpec,
+    allow_private_networks: bool,
+) -> Result<ResolvedEndpoints, String> {
     // If both endpoints are provided in spec, use them directly
     if let (Some(auth), Some(token)) = (&spec.authorization_endpoint, &spec.token_endpoint) {
         return Ok(ResolvedEndpoints {
@@ -85,7 +91,7 @@ async fn resolve_oauth_endpoints(spec: &OAuthExtensionSpec) -> Result<ResolvedEn
     }
 
     // Fetch OIDC discovery document
-    let discovery = fetch_oidc_discovery(&spec.issuer_url).await?;
+    let discovery = fetch_oidc_discovery(&spec.issuer_url, allow_private_networks).await?;
 
     // Use spec override if provided, otherwise use discovery
     let authorization_endpoint = spec
@@ -518,12 +524,15 @@ pub async fn authorize(
     };
 
     // Resolve OAuth endpoints (from spec or OIDC discovery)
-    let endpoints = resolve_oauth_endpoints(&spec).await.map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to resolve OAuth endpoints: {}", e),
-        )
-    })?;
+    let allow_private_networks = state.server_settings.allow_private_networks;
+    let endpoints = resolve_oauth_endpoints(&spec, allow_private_networks)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to resolve OAuth endpoints: {}", e),
+            )
+        })?;
 
     // Build authorization URL
     let mut auth_url = Url::parse(&endpoints.authorization_endpoint).map_err(|e| {
@@ -622,11 +631,13 @@ pub async fn callback(
         "Encryption provider not configured".to_string(),
     ))?;
 
+    let allow_private_networks = state.server_settings.allow_private_networks;
+
     use super::provider::{OAuthProvider, OAuthProviderConfig};
     let oauth_provider = OAuthProvider::new(OAuthProviderConfig {
         db_pool: state.db_pool.clone(),
         encryption_provider: encryption_provider.clone(),
-        http_client: crate::server::ssrf::safe_client(),
+        http_client: crate::server::ssrf::safe_client(allow_private_networks),
         api_domain: state.public_url.clone(),
     });
 
@@ -674,15 +685,17 @@ pub async fn callback(
     };
 
     // Resolve OAuth endpoints (from spec or OIDC discovery)
-    let endpoints = resolve_oauth_endpoints(&spec).await.map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to resolve OAuth endpoints: {}", e),
-        )
-    })?;
+    let endpoints = resolve_oauth_endpoints(&spec, allow_private_networks)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to resolve OAuth endpoints: {}", e),
+            )
+        })?;
 
     // SSRF-validate the token endpoint before exchanging credentials
-    crate::server::ssrf::validate_url(&endpoints.token_endpoint)
+    crate::server::ssrf::validate_url(&endpoints.token_endpoint, allow_private_networks)
         .await
         .map_err(|e| {
             error!("Token endpoint failed SSRF validation: {}", e);
@@ -693,7 +706,7 @@ pub async fn callback(
         })?;
 
     // Exchange authorization code for tokens (with PKCE code verifier)
-    let http_client = crate::server::ssrf::safe_client();
+    let http_client = crate::server::ssrf::safe_client(allow_private_networks);
     let response = http_client
         .post(&endpoints.token_endpoint)
         .header("Accept", "application/json")
@@ -1452,7 +1465,7 @@ async fn handle_refresh_token_grant(
             error!("Encryption provider not configured");
             oauth2_error("server_error", Some("Internal server error".to_string()))
         })?,
-        http_client: crate::server::ssrf::safe_client(),
+        http_client: crate::server::ssrf::safe_client(state.server_settings.allow_private_networks),
         api_domain: state.public_url.clone(),
     });
 
@@ -1656,8 +1669,9 @@ pub async fn oidc_discovery(
     }
 
     // Try to fetch upstream OIDC discovery
+    let allow_private_networks = state.server_settings.allow_private_networks;
     let upstream_issuer = &spec.issuer_url;
-    let discovery_result = fetch_oidc_discovery(upstream_issuer).await;
+    let discovery_result = fetch_oidc_discovery(upstream_issuer, allow_private_networks).await;
 
     match discovery_result {
         Ok(upstream_discovery) => {
@@ -1807,7 +1821,8 @@ pub async fn oidc_jwks(
     })?;
 
     // Try to fetch OIDC discovery to get jwks_uri
-    let discovery_result = fetch_oidc_discovery(&spec.issuer_url).await;
+    let allow_private_networks = state.server_settings.allow_private_networks;
+    let discovery_result = fetch_oidc_discovery(&spec.issuer_url, allow_private_networks).await;
 
     match discovery_result {
         Ok(discovery) => {
@@ -1818,7 +1833,7 @@ pub async fn oidc_jwks(
             ))?;
 
             // SSRF-validate the JWKS URI before fetching
-            crate::server::ssrf::validate_url(&jwks_uri)
+            crate::server::ssrf::validate_url(&jwks_uri, allow_private_networks)
                 .await
                 .map_err(|e| {
                     error!("JWKS URI failed SSRF validation: {}", e);
@@ -1828,7 +1843,7 @@ pub async fn oidc_jwks(
                     )
                 })?;
 
-            let http_client = crate::server::ssrf::safe_client();
+            let http_client = crate::server::ssrf::safe_client(allow_private_networks);
 
             // Fetch JWKS
             let jwks_response = http_client.get(&jwks_uri).send().await.map_err(|e| {

--- a/src/server/extensions/providers/oauth/handlers.rs
+++ b/src/server/extensions/providers/oauth/handlers.rs
@@ -38,7 +38,7 @@ async fn fetch_oidc_discovery(issuer_url: &str) -> Result<OidcDiscoveryDocument,
         issuer_url.trim_end_matches('/')
     );
 
-    let http_client = reqwest::Client::new();
+    let http_client = crate::server::ssrf::safe_client();
     let response = http_client.get(&discovery_url).send().await.map_err(|e| {
         error!(
             "Failed to fetch OIDC discovery from {}: {:?}",
@@ -618,7 +618,7 @@ pub async fn callback(
     let oauth_provider = OAuthProvider::new(OAuthProviderConfig {
         db_pool: state.db_pool.clone(),
         encryption_provider: encryption_provider.clone(),
-        http_client: reqwest::Client::new(),
+        http_client: crate::server::ssrf::safe_client(),
         api_domain: state.public_url.clone(),
     });
 
@@ -674,7 +674,7 @@ pub async fn callback(
     })?;
 
     // Exchange authorization code for tokens (with PKCE code verifier)
-    let http_client = reqwest::Client::new();
+    let http_client = crate::server::ssrf::safe_client();
     let response = http_client
         .post(&endpoints.token_endpoint)
         .header("Accept", "application/json")
@@ -1433,7 +1433,7 @@ async fn handle_refresh_token_grant(
             error!("Encryption provider not configured");
             oauth2_error("server_error", Some("Internal server error".to_string()))
         })?,
-        http_client: reqwest::Client::new(),
+        http_client: crate::server::ssrf::safe_client(),
         api_domain: state.public_url.clone(),
     });
 
@@ -1798,7 +1798,18 @@ pub async fn oidc_jwks(
                 "No jwks_uri in OIDC discovery".to_string(),
             ))?;
 
-            let http_client = reqwest::Client::new();
+            // SSRF-validate the JWKS URI before fetching
+            crate::server::ssrf::validate_url(&jwks_uri)
+                .await
+                .map_err(|e| {
+                    error!("JWKS URI failed SSRF validation: {}", e);
+                    (
+                        StatusCode::BAD_REQUEST,
+                        format!("JWKS URI failed SSRF validation: {}", e),
+                    )
+                })?;
+
+            let http_client = crate::server::ssrf::safe_client();
 
             // Fetch JWKS
             let jwks_response = http_client.get(&jwks_uri).send().await.map_err(|e| {

--- a/src/server/extensions/providers/oauth/handlers.rs
+++ b/src/server/extensions/providers/oauth/handlers.rs
@@ -38,6 +38,14 @@ async fn fetch_oidc_discovery(issuer_url: &str) -> Result<OidcDiscoveryDocument,
         issuer_url.trim_end_matches('/')
     );
 
+    // SSRF-validate the discovery URL before fetching
+    crate::server::ssrf::validate_url(&discovery_url)
+        .await
+        .map_err(|e| {
+            error!("OIDC discovery URL failed SSRF validation: {}", e);
+            format!("OIDC discovery URL failed SSRF validation: {}", e)
+        })?;
+
     let http_client = crate::server::ssrf::safe_client();
     let response = http_client.get(&discovery_url).send().await.map_err(|e| {
         error!(
@@ -672,6 +680,17 @@ pub async fn callback(
             format!("Failed to resolve OAuth endpoints: {}", e),
         )
     })?;
+
+    // SSRF-validate the token endpoint before exchanging credentials
+    crate::server::ssrf::validate_url(&endpoints.token_endpoint)
+        .await
+        .map_err(|e| {
+            error!("Token endpoint failed SSRF validation: {}", e);
+            (
+                StatusCode::BAD_REQUEST,
+                format!("Token endpoint failed SSRF validation: {}", e),
+            )
+        })?;
 
     // Exchange authorization code for tokens (with PKCE code verifier)
     let http_client = crate::server::ssrf::safe_client();

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -74,6 +74,11 @@ pub struct ServerSettings {
     /// Defaults to the RISE_DOCS_DIR environment variable.
     #[serde(default = "default_docs_dir")]
     pub docs_dir: Option<String>,
+
+    /// Allow HTTP and private/loopback IPs in SSRF-validated URLs.
+    /// WARNING: Only enable for local development. Never enable in production.
+    #[serde(default)]
+    pub allow_private_networks: bool,
 }
 
 fn default_cookie_secure() -> bool {

--- a/src/server/ssrf.rs
+++ b/src/server/ssrf.rs
@@ -59,15 +59,18 @@ fn is_blocked_ip(ip: &IpAddr) -> bool {
 /// Validate that a URL is safe to fetch (SSRF protection).
 ///
 /// Checks:
-/// 1. Scheme must be HTTPS
+/// 1. Scheme must be HTTPS (unless `allow_private_networks` is true)
 /// 2. Hostname must be present
-/// 3. All resolved IP addresses must not be in blocked ranges
-pub async fn validate_url(url: &str) -> Result<(), SsrfError> {
+/// 3. All resolved IP addresses must not be in blocked ranges (unless `allow_private_networks` is true)
+///
+/// When `allow_private_networks` is true, HTTP and private/loopback IPs are permitted.
+/// **WARNING**: Only enable for local development. Never enable in production.
+pub async fn validate_url(url: &str, allow_private_networks: bool) -> Result<(), SsrfError> {
     // Parse the URL
     let parsed = url::Url::parse(url).map_err(|e| SsrfError::InvalidUrl(e.to_string()))?;
 
-    // Require HTTPS
-    if parsed.scheme() != "https" {
+    // Require HTTPS (unless relaxed for development)
+    if !allow_private_networks && parsed.scheme() != "https" {
         return Err(SsrfError::HttpsRequired);
     }
 
@@ -78,9 +81,14 @@ pub async fn validate_url(url: &str) -> Result<(), SsrfError> {
 
     // If host is already an IP address, check it directly
     if let Ok(ip) = host.parse::<IpAddr>() {
-        if is_blocked_ip(&ip) {
+        if !allow_private_networks && is_blocked_ip(&ip) {
             return Err(SsrfError::BlockedIpRange(ip));
         }
+        return Ok(());
+    }
+
+    // Skip DNS resolution checks when private networks are allowed
+    if allow_private_networks {
         return Ok(());
     }
 
@@ -114,20 +122,25 @@ pub async fn validate_url(url: &str) -> Result<(), SsrfError> {
 /// The client has:
 /// - 10-second connect and total request timeout
 /// - Custom redirect policy (max 3 hops, HTTPS-only, blocks private/internal IPs)
-pub fn safe_client() -> reqwest::Client {
+///
+/// When `allow_private_networks` is true, redirect checks for HTTPS and blocked IPs are skipped.
+/// **WARNING**: Only enable for local development. Never enable in production.
+pub fn safe_client(allow_private_networks: bool) -> reqwest::Client {
     reqwest::Client::builder()
         .timeout(Duration::from_secs(10))
         .connect_timeout(Duration::from_secs(5))
-        .redirect(reqwest::redirect::Policy::custom(|attempt| {
+        .redirect(reqwest::redirect::Policy::custom(move |attempt| {
             if attempt.previous().len() >= 3 {
                 attempt.error("too many redirects")
-            } else if attempt.url().scheme() != "https" {
+            } else if !allow_private_networks && attempt.url().scheme() != "https" {
                 attempt.error("redirect target must use HTTPS")
             } else if let Some(host) = attempt.url().host_str() {
-                if let Ok(ip) = host.parse::<IpAddr>() {
-                    if is_blocked_ip(&ip) {
-                        return attempt
-                            .error(format!("redirect target resolves to blocked IP: {}", ip));
+                if !allow_private_networks {
+                    if let Ok(ip) = host.parse::<IpAddr>() {
+                        if is_blocked_ip(&ip) {
+                            return attempt
+                                .error(format!("redirect target resolves to blocked IP: {}", ip));
+                        }
                     }
                 }
                 attempt.follow()
@@ -221,41 +234,41 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_url_rejects_http() {
-        let result = validate_url("http://example.com").await;
+        let result = validate_url("http://example.com", false).await;
         assert!(matches!(result, Err(SsrfError::HttpsRequired)));
     }
 
     #[tokio::test]
     async fn test_validate_url_rejects_invalid_url() {
-        let result = validate_url("not-a-url").await;
+        let result = validate_url("not-a-url", false).await;
         assert!(matches!(result, Err(SsrfError::InvalidUrl(_))));
     }
 
     #[tokio::test]
     async fn test_validate_url_rejects_ip_loopback() {
-        let result = validate_url("https://127.0.0.1/path").await;
+        let result = validate_url("https://127.0.0.1/path", false).await;
         assert!(matches!(result, Err(SsrfError::BlockedIpRange(_))));
     }
 
     #[tokio::test]
     async fn test_validate_url_rejects_ip_metadata() {
-        let result = validate_url("https://169.254.169.254/latest/meta-data/").await;
+        let result = validate_url("https://169.254.169.254/latest/meta-data/", false).await;
         assert!(matches!(result, Err(SsrfError::BlockedIpRange(_))));
     }
 
     #[tokio::test]
     async fn test_validate_url_rejects_private_ip() {
-        let result = validate_url("https://10.0.0.1/internal").await;
+        let result = validate_url("https://10.0.0.1/internal", false).await;
         assert!(matches!(result, Err(SsrfError::BlockedIpRange(_))));
 
-        let result = validate_url("https://192.168.1.1/admin").await;
+        let result = validate_url("https://192.168.1.1/admin", false).await;
         assert!(matches!(result, Err(SsrfError::BlockedIpRange(_))));
     }
 
     #[tokio::test]
     async fn test_validate_url_accepts_public_https() {
         // Use a known public IP to avoid DNS dependency and make the test deterministic.
-        let result = validate_url("https://8.8.8.8/").await;
+        let result = validate_url("https://8.8.8.8/", false).await;
         assert!(
             result.is_ok(),
             "expected public HTTPS URL to be accepted, got: {:?}",
@@ -265,6 +278,43 @@ mod tests {
 
     #[test]
     fn test_safe_client_builds_successfully() {
-        let _client = safe_client();
+        let _client = safe_client(false);
+    }
+
+    // Tests for allow_private_networks = true
+
+    #[tokio::test]
+    async fn test_validate_url_allows_http_when_private_networks_enabled() {
+        let result = validate_url("http://localhost:5556", true).await;
+        assert!(
+            result.is_ok(),
+            "expected HTTP URL to be accepted with allow_private_networks, got: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_validate_url_allows_loopback_when_private_networks_enabled() {
+        let result = validate_url("https://127.0.0.1/path", true).await;
+        assert!(
+            result.is_ok(),
+            "expected loopback IP to be accepted with allow_private_networks, got: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_validate_url_allows_private_ip_when_private_networks_enabled() {
+        let result = validate_url("https://192.168.1.1/admin", true).await;
+        assert!(
+            result.is_ok(),
+            "expected private IP to be accepted with allow_private_networks, got: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_safe_client_builds_with_private_networks() {
+        let _client = safe_client(true);
     }
 }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -294,7 +294,7 @@ impl AppState {
         Self::run_migrations(&db_pool).await?;
 
         // Initialize JWT validator (JWKS is fetched on-demand)
-        let jwt_validator = Arc::new(JwtValidator::new());
+        let jwt_validator = Arc::new(JwtValidator::new(settings.server.allow_private_networks));
 
         // Initialize JWT signer for ingress authentication (required)
         let jwt_signer = Arc::new(

--- a/src/server/workload_identity/handlers.rs
+++ b/src/server/workload_identity/handlers.rs
@@ -20,16 +20,21 @@ use crate::server::workload_identity::models::{
 ///
 /// Includes SSRF protections: requires HTTPS, blocks private/internal IPs,
 /// enforces request timeout and redirect limits.
-async fn verify_oidc_issuer(issuer_url: &str) -> Result<(), ServerError> {
+async fn verify_oidc_issuer(
+    issuer_url: &str,
+    allow_private_networks: bool,
+) -> Result<(), ServerError> {
     // Validate the issuer URL against SSRF (requires HTTPS, blocks private IPs)
-    ssrf::validate_url(issuer_url).await.map_err(|e| {
-        tracing::warn!(
-            "SSRF validation failed for issuer URL '{}': {}",
-            issuer_url,
-            e
-        );
-        ServerError::bad_request(format!("Invalid OIDC issuer URL: {}", e))
-    })?;
+    ssrf::validate_url(issuer_url, allow_private_networks)
+        .await
+        .map_err(|e| {
+            tracing::warn!(
+                "SSRF validation failed for issuer URL '{}': {}",
+                issuer_url,
+                e
+            );
+            ServerError::bad_request(format!("Invalid OIDC issuer URL: {}", e))
+        })?;
 
     // Construct the OIDC discovery URL
     let discovery_url = if issuer_url.ends_with('/') {
@@ -41,7 +46,7 @@ async fn verify_oidc_issuer(issuer_url: &str) -> Result<(), ServerError> {
     tracing::debug!("Verifying OIDC issuer at: {}", discovery_url);
 
     // Use SSRF-safe client (timeout + redirect limits)
-    let client = ssrf::safe_client();
+    let client = ssrf::safe_client(allow_private_networks);
 
     // Attempt to fetch the OIDC configuration
     let response = client.get(&discovery_url)
@@ -118,13 +123,6 @@ pub async fn create_workload_identity(
         return Err(ServerError::bad_request("Issuer URL cannot be empty"));
     }
 
-    // OIDC issuers must use HTTPS per the OpenID Connect Discovery spec
-    if !req.issuer_url.starts_with("https://") {
-        return Err(ServerError::bad_request(
-            "Issuer URL must use HTTPS (required by the OpenID Connect specification)",
-        ));
-    }
-
     // Validate claims requirements
     if req.claims.is_empty() {
         return Err(ServerError::bad_request("At least one claim is required"));
@@ -145,7 +143,12 @@ pub async fn create_workload_identity(
     }
 
     // Verify OIDC issuer is reachable and has valid configuration
-    verify_oidc_issuer(&req.issuer_url).await?;
+    // (also validates HTTPS requirement and SSRF protections)
+    verify_oidc_issuer(
+        &req.issuer_url,
+        state.server_settings.allow_private_networks,
+    )
+    .await?;
 
     // Create service account
     let sa = service_accounts::create(&state.db_pool, project.id, &req.issuer_url, &req.claims)
@@ -339,21 +342,17 @@ pub async fn update_workload_identity(
             return Err(ServerError::bad_request("Issuer URL cannot be empty"));
         }
 
-        if !issuer_url.starts_with("https://") {
-            return Err(ServerError::bad_request(
-                "Issuer URL must use HTTPS (required by the OpenID Connect specification)",
-            ));
-        }
-
-        // Validate SSRF protections (blocks private/internal IPs)
-        ssrf::validate_url(issuer_url).await.map_err(|e| {
-            tracing::warn!(
-                "SSRF validation failed for issuer URL '{}': {}",
-                issuer_url,
-                e
-            );
-            ServerError::bad_request(format!("Invalid OIDC issuer URL: {}", e))
-        })?;
+        // Validate SSRF protections (HTTPS requirement + blocks private/internal IPs)
+        ssrf::validate_url(issuer_url, state.server_settings.allow_private_networks)
+            .await
+            .map_err(|e| {
+                tracing::warn!(
+                    "SSRF validation failed for issuer URL '{}': {}",
+                    issuer_url,
+                    e
+                );
+                ServerError::bad_request(format!("Invalid OIDC issuer URL: {}", e))
+            })?;
     }
 
     // Validate claims if provided


### PR DESCRIPTION
## Summary
- Add `ssrf.rs` module with `validate_url()` and `safe_client()` for SSRF protection (HTTPS-only, blocks private/loopback IPs, timeout + redirect limits)
- SSRF-validate all outgoing OIDC/OAuth URLs: discovery endpoints, JWKS URIs, and token endpoints
- Replace unconstrained `reqwest::Client::new()` with `ssrf::safe_client()` in OAuth extension handlers and JWT validator
- Add `server.allow_private_networks` config flag (default: `false`) to relax SSRF checks for local development (e.g., Dex at `http://localhost:5556`)
- Thread the flag through `validate_url()`, `safe_client()`, `JwtValidator`, and all handler call sites
- Remove redundant manual HTTPS checks in workload identity handlers (now handled by `validate_url` conditionally)

## Test plan
- [x] `cargo fmt`, `cargo clippy --all-features`, `cargo test --all-features` pass
- [x] Config schema regenerated with new `allow_private_networks` field
- [x] Test OAuth login flow end-to-end with a valid OIDC provider
- [x] Verify local dev works with `allow_private_networks: true` against Dex at localhost

🤖 Generated with [Claude Code](https://claude.com/claude-code)