### PR TITLE
fix: use envelope encryption for KMS to support large secrets

### DIFF
--- a/src/server/encryption/providers/aws_kms.rs
+++ b/src/server/encryption/providers/aws_kms.rs
@@ -1,13 +1,29 @@
-use anyhow::{Context, Result};
+use aes_gcm::{
+    aead::{Aead, AeadCore, KeyInit, OsRng},
+    Aes256Gcm, Nonce,
+};
+use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 use aws_sdk_kms::primitives::Blob;
+use aws_sdk_kms::types::DataKeySpec;
 use aws_sdk_kms::Client as KmsClient;
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 
 use crate::server::encryption::EncryptionProvider;
 
+/// Magic prefix to identify envelope-encrypted data (vs legacy direct KMS encryption).
+/// "ENVL" in ASCII bytes.
+const ENVELOPE_PREFIX: &[u8] = b"ENVL";
+
 /// AWS KMS encryption provider
-/// Uses AWS KMS for encryption/decryption operations
+///
+/// Uses envelope encryption: a data encryption key (DEK) is generated via KMS,
+/// the plaintext is encrypted locally with AES-256-GCM using the DEK, and the
+/// KMS-encrypted DEK is stored alongside the ciphertext. This avoids the KMS
+/// 4096-byte plaintext limit.
+///
+/// Legacy ciphertexts (direct KMS encryption) are detected on decrypt by the
+/// absence of the envelope prefix and handled transparently.
 pub struct AwsKmsEncryptionProvider {
     client: KmsClient,
     key_id: String,
@@ -49,41 +65,124 @@ impl AwsKmsEncryptionProvider {
 #[async_trait]
 impl EncryptionProvider for AwsKmsEncryptionProvider {
     async fn encrypt(&self, plaintext: &str) -> Result<String> {
+        // Generate a data encryption key via KMS
         let response = self
             .client
-            .encrypt()
+            .generate_data_key()
             .key_id(&self.key_id)
-            .plaintext(Blob::new(plaintext.as_bytes()))
+            .key_spec(DataKeySpec::Aes256)
             .send()
             .await
             .with_context(|| {
                 format!(
-                    "KMS encryption failed for key '{}'. Common causes: \
+                    "KMS GenerateDataKey failed for key '{}'. Common causes: \
                      1) Invalid key ARN/ID, 2) No AWS credentials available, \
-                     3) Insufficient IAM permissions (kms:Encrypt), \
+                     3) Insufficient IAM permissions (kms:GenerateDataKey), \
                      4) Key is disabled or pending deletion",
                     self.key_id
                 )
             })?;
 
-        let ciphertext_blob = response
+        let plaintext_key = response
+            .plaintext()
+            .context("No plaintext key in GenerateDataKey response")?;
+        let encrypted_key = response
             .ciphertext_blob()
-            .context("No ciphertext blob in KMS response")?;
+            .context("No ciphertext blob in GenerateDataKey response")?;
+        let encrypted_key_bytes = encrypted_key.as_ref();
 
-        // Encode to base64 for storage in database
-        Ok(BASE64.encode(ciphertext_blob.as_ref()))
+        // Encrypt the data locally with AES-256-GCM
+        let cipher = Aes256Gcm::new_from_slice(plaintext_key.as_ref())
+            .context("Failed to create AES-256-GCM cipher from data key")?;
+        let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+        let ciphertext = cipher
+            .encrypt(&nonce, plaintext.as_bytes())
+            .map_err(|e| anyhow::anyhow!("AES-GCM encryption failed: {}", e))?;
+
+        // Pack: prefix(4) + encrypted_key_len(2 BE) + encrypted_key + nonce(12) + ciphertext
+        let ek_len = encrypted_key_bytes.len() as u16;
+        let mut combined = Vec::with_capacity(
+            ENVELOPE_PREFIX.len() + 2 + encrypted_key_bytes.len() + 12 + ciphertext.len(),
+        );
+        combined.extend_from_slice(ENVELOPE_PREFIX);
+        combined.extend_from_slice(&ek_len.to_be_bytes());
+        combined.extend_from_slice(encrypted_key_bytes);
+        combined.extend_from_slice(&nonce);
+        combined.extend_from_slice(&ciphertext);
+
+        Ok(BASE64.encode(&combined))
     }
 
     async fn decrypt(&self, ciphertext_base64: &str) -> Result<String> {
-        // Decode from base64
-        let ciphertext_bytes = BASE64
+        let combined = BASE64
             .decode(ciphertext_base64)
             .context("Failed to decode ciphertext from base64")?;
 
+        // Detect format: envelope (prefixed) vs legacy (direct KMS)
+        if combined.starts_with(ENVELOPE_PREFIX) {
+            self.decrypt_envelope(&combined[ENVELOPE_PREFIX.len()..])
+                .await
+        } else {
+            self.decrypt_legacy(&combined).await
+        }
+    }
+}
+
+impl AwsKmsEncryptionProvider {
+    /// Decrypt envelope-encrypted data (new format).
+    async fn decrypt_envelope(&self, data: &[u8]) -> Result<String> {
+        if data.len() < 2 {
+            bail!("Invalid envelope ciphertext: too short for key length");
+        }
+
+        // Read encrypted key length
+        let ek_len = u16::from_be_bytes([data[0], data[1]]) as usize;
+        let data = &data[2..];
+
+        if data.len() < ek_len + 12 {
+            bail!("Invalid envelope ciphertext: too short for key + nonce");
+        }
+
+        let (encrypted_key, rest) = data.split_at(ek_len);
+        let (nonce_bytes, ciphertext) = rest.split_at(12);
+
+        // Decrypt the DEK via KMS
         let response = self
             .client
             .decrypt()
-            .ciphertext_blob(Blob::new(ciphertext_bytes))
+            .ciphertext_blob(Blob::new(encrypted_key.to_vec()))
+            .send()
+            .await
+            .with_context(|| {
+                format!(
+                    "KMS decryption of data key failed for key '{}'. Common causes: \
+                     1) No AWS credentials available, 2) Insufficient IAM permissions (kms:Decrypt), \
+                     3) Key is disabled or pending deletion",
+                    self.key_id
+                )
+            })?;
+
+        let plaintext_key = response
+            .plaintext()
+            .context("No plaintext in KMS decrypt response")?;
+
+        // Decrypt the data locally with AES-256-GCM
+        let cipher = Aes256Gcm::new_from_slice(plaintext_key.as_ref())
+            .context("Failed to create AES-256-GCM cipher from decrypted data key")?;
+        let nonce = Nonce::from_slice(nonce_bytes);
+        let plaintext_bytes = cipher
+            .decrypt(nonce, ciphertext)
+            .map_err(|e| anyhow::anyhow!("AES-GCM decryption failed: {}", e))?;
+
+        String::from_utf8(plaintext_bytes).context("Decrypted data is not valid UTF-8")
+    }
+
+    /// Decrypt legacy direct-KMS-encrypted data (backward compatibility).
+    async fn decrypt_legacy(&self, ciphertext_bytes: &[u8]) -> Result<String> {
+        let response = self
+            .client
+            .decrypt()
+            .ciphertext_blob(Blob::new(ciphertext_bytes.to_vec()))
             .send()
             .await
             .with_context(|| {
@@ -99,10 +198,7 @@ impl EncryptionProvider for AwsKmsEncryptionProvider {
             .plaintext()
             .context("No plaintext in KMS response")?;
 
-        // Convert to UTF-8 string
-        let plaintext = String::from_utf8(plaintext_blob.clone().into_inner())
-            .context("Decrypted data is not valid UTF-8")?;
-
-        Ok(plaintext)
+        String::from_utf8(plaintext_blob.clone().into_inner())
+            .context("Decrypted data is not valid UTF-8")
     }
 }


### PR DESCRIPTION
Direct KMS encryption has a 4096-byte plaintext limit, which causes failures when storing large secret env vars (e.g. SPINE_CONFIG_STR).

Switch to envelope encryption: generate a data encryption key (DEK) via KMS GenerateDataKey, encrypt data locally with AES-256-GCM, and store the KMS-encrypted DEK alongside the ciphertext.

Existing secrets encrypted with direct KMS are detected by the absence of the "ENVL" prefix and decrypted using the legacy path.