### PR TITLE
fix(deps): update major Rust dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -207,7 +207,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -544,11 +544,11 @@ dependencies = [
  "pin-project-lite",
  "rustls 0.21.12",
  "rustls 0.23.38",
- "rustls-native-certs 0.8.3",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
- "tower 0.5.3",
+ "tower",
  "tracing",
 ]
 
@@ -698,7 +698,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -724,14 +724,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
+name = "backon"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
- "getrandom 0.2.17",
- "instant",
- "rand 0.8.5",
+ "fastrand",
+ "gloo-timers",
+ "tokio",
 ]
 
 [[package]]
@@ -949,7 +949,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1035,8 +1035,8 @@ dependencies = [
  "serde-untagged",
  "serde_core",
  "serde_json",
- "toml 1.1.2+spec-1.1.0",
- "winnow 1.0.1",
+ "toml",
+ "winnow",
  "yaml-rust2",
 ]
 
@@ -1213,7 +1213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -1262,14 +1262,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1277,27 +1277,26 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1321,14 +1320,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
+name = "derive_more"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "rustc_version",
+ "syn",
 ]
 
 [[package]]
@@ -1351,23 +1360,23 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "5.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1378,7 +1387,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1456,6 +1465,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1479,7 +1500,7 @@ dependencies = [
  "hkdf",
  "pem-rfc7468",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -1492,6 +1513,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1565,7 +1606,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1592,15 +1633,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fluent-uri"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1622,6 +1654,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -1720,7 +1758,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1836,13 +1874,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1889,10 +1939,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1902,7 +1948,18 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1918,30 +1975,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "headers"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "headers-core",
- "http 1.4.0",
- "httpdate",
- "mime",
- "sha1",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
-dependencies = [
- "http 1.4.0",
 ]
 
 [[package]]
@@ -1981,6 +2014,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
 ]
 
 [[package]]
@@ -2115,26 +2159,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-http-proxy"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ad4b0a1e37510028bc4ba81d0e38d239c39671b0f0ce9e02dfa93a8133f7c08"
-dependencies = [
- "bytes",
- "futures-util",
- "headers",
- "http 1.4.0",
- "hyper 1.9.0",
- "hyper-rustls 0.27.9",
- "hyper-util",
- "pin-project-lite",
- "rustls-native-certs 0.7.3",
- "tokio",
- "tokio-rustls 0.26.4",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2160,7 +2184,7 @@ dependencies = [
  "hyper-util",
  "log",
  "rustls 0.23.38",
- "rustls-native-certs 0.8.3",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
@@ -2411,15 +2435,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2448,6 +2463,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2474,7 +2513,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2493,7 +2532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2520,9 +2559,9 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "2.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1fb8864823fad91877e6caea0baca82e49e8db50f8e5c9f9a453e27d3330fc"
+checksum = "f300e415e2134745ef75f04562dd0145405c2f7fd92065db029ac4b16b57fe90"
 dependencies = [
  "jsonptr",
  "serde",
@@ -2543,26 +2582,23 @@ dependencies = [
 
 [[package]]
 name = "jsonpath-rust"
-version = "0.5.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d8fe85bd70ff715f31ce8c739194b423d79811a19602115d611a3ec85d6200"
+checksum = "633a7320c4bb672863a3782e89b9094ad70285e097ff6832cddd0ec615beadfa"
 dependencies = [
- "lazy_static",
- "once_cell",
  "pest",
  "pest_derive",
  "regex",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "jsonptr"
-version = "0.4.7"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c6e529149475ca0b2820835d3dce8fcc41c6b943ca608d32f35b449255e4627"
+checksum = "a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe"
 dependencies = [
- "fluent-uri",
  "serde",
  "serde_json",
 ]
@@ -2596,7 +2632,7 @@ dependencies = [
  "p256",
  "p384",
  "pem",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "serde",
  "serde_json",
@@ -2622,23 +2658,22 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.23.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8847402328d8301354c94d605481f25a6bdc1ed65471fd96af8eca71141b13"
+checksum = "51b326f5219dd55872a72c1b6ddd1b830b8334996c667449c29391d657d78d5e"
 dependencies = [
  "base64 0.22.1",
- "chrono",
+ "jiff",
  "schemars",
  "serde",
- "serde-value",
  "serde_json",
 ]
 
 [[package]]
 name = "kube"
-version = "0.95.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa21063c854820a77c5d7f8deeb7ffa55246d8304e4bcd8cce2956752c6604f8"
+checksum = "acc5a6a69da2975ed9925d56b5dcfc9cc739b66f37add06785b7c9f6d1e88741"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -2649,96 +2684,94 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.95.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c2355f5c9d8a11900e71a6fe1e47abd5ec45bf971eb4b162ffe97b46db9bb7"
+checksum = "0fcaf2d1f1a91e1805d4cd82e8333c022767ae8ffd65909bbef6802733a7dd40"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "chrono",
  "either",
  "futures",
- "home",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
- "hyper-http-proxy",
  "hyper-rustls 0.27.9",
  "hyper-timeout",
  "hyper-util",
+ "jiff",
  "jsonpath-rust",
  "k8s-openapi",
  "kube-core",
  "pem",
  "rustls 0.23.38",
- "rustls-pemfile 2.2.0",
  "secrecy",
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "tower 0.4.13",
- "tower-http 0.5.2",
+ "tower",
+ "tower-http",
  "tracing",
 ]
 
 [[package]]
 name = "kube-core"
-version = "0.95.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3030bd91c9db544a50247e7d48d7db9cf633c172732dce13351854526b1e666"
+checksum = "f126d2db7a8b532ec1d839ece2a71e2485dc3bbca6cc3c3f929becaa810e719e"
 dependencies = [
- "chrono",
+ "derive_more",
  "form_urlencoded",
  "http 1.4.0",
+ "jiff",
  "json-patch",
  "k8s-openapi",
  "schemars",
  "serde",
  "serde-value",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "kube-derive"
-version = "0.95.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa98be978eddd70a773aa8e86346075365bfb7eb48783410852dbf7cb57f0c27"
+checksum = "d6b9b97e121fce957f9cafc6da534abc4276983ab03190b76c09361e2df849fa"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
+ "serde",
  "serde_json",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "kube-runtime"
-version = "0.95.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5895cb8aa641ac922408f128b935652b34c2995f16ad7db0984f6caa50217914"
+checksum = "c072737075826ee74d3e615e80334e41e617ca3d14fb46ef7cdfda822d6f15f2"
 dependencies = [
  "ahash",
  "async-broadcast",
  "async-stream",
- "async-trait",
- "backoff",
- "derivative",
+ "backon",
+ "educe",
  "futures",
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
+ "hostname",
  "json-patch",
- "jsonptr",
  "k8s-openapi",
  "kube-client",
  "parking_lot",
  "pin-project",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -2923,10 +2956,10 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "tempfile",
 ]
@@ -3006,26 +3039,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
-]
-
-[[package]]
-name = "oauth2"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38841cdd844847e3e7c8d29cef9dcfed8877f8f56f9071f77843ecf3baf937f"
-dependencies = [
- "base64 0.13.1",
- "chrono",
- "getrandom 0.2.17",
- "http 0.2.12",
- "rand 0.8.5",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "sha2",
- "thiserror 1.0.69",
- "url",
 ]
 
 [[package]]
@@ -3130,14 +3143,8 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-probe"
@@ -3331,7 +3338,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3399,7 +3406,7 @@ checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3483,6 +3490,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3513,7 +3529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3634,13 +3650,33 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.6"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3694,7 +3730,6 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-rustls 0.24.2",
  "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
@@ -3704,8 +3739,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3713,14 +3747,12 @@ dependencies = [
  "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
  "winreg",
 ]
 
@@ -3757,8 +3789,8 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-util",
- "tower 0.5.3",
- "tower-http 0.6.8",
+ "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3820,7 +3852,6 @@ dependencies = [
  "lazy_static",
  "mime_guess",
  "moka",
- "oauth2",
  "oci-distribution",
  "openssl",
  "rand 0.9.4",
@@ -3842,9 +3873,9 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "toml 0.8.23",
- "tower 0.5.3",
- "tower-http 0.6.8",
+ "toml",
+ "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -3949,27 +3980,14 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
-dependencies = [
- "openssl-probe 0.1.6",
- "rustls-pemfile 2.2.0",
- "rustls-pki-types",
- "schannel",
- "security-framework 2.11.1",
-]
-
-[[package]]
-name = "rustls-native-certs"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -3979,15 +3997,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -4062,11 +4071,12 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
+ "ref-cast",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -4074,14 +4084,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.22"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4127,25 +4137,11 @@ dependencies = [
 
 [[package]]
 name = "secrecy"
-version = "0.8.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
- "serde",
  "zeroize",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
 ]
 
 [[package]]
@@ -4226,7 +4222,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4237,7 +4233,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4272,15 +4268,6 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -4560,7 +4547,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4583,7 +4570,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.117",
+ "syn",
  "tokio",
  "url",
 ]
@@ -4728,17 +4715,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -4771,7 +4747,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4883,7 +4859,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4894,7 +4870,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4996,7 +4972,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5056,36 +5032,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit",
-]
-
-[[package]]
-name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
+ "indexmap",
  "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "serde_spanned",
+ "toml_datetime",
  "toml_parser",
- "winnow 1.0.1",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -5098,50 +5055,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
-]
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -5154,25 +5080,7 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper 1.0.2",
  "tokio",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
-dependencies = [
- "base64 0.21.7",
- "bitflags 2.11.1",
- "bytes",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "mime",
- "pin-project-lite",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5184,14 +5092,16 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "base64 0.22.1",
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "iri-string",
+ "mime",
  "pin-project-lite",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5229,7 +5139,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5378,7 +5288,6 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -5526,7 +5435,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -5613,12 +5522,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-
-[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5680,7 +5583,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5691,7 +5594,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5879,15 +5782,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
@@ -5935,7 +5829,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -5951,7 +5845,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -6035,7 +5929,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -6056,7 +5950,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6076,7 +5970,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -6116,7 +6010,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ cli = [
 backend = [
     # Server core (former "server" feature)
     "dep:config",
-    "dep:oauth2",
     "dep:openssl",
     "dep:rsa",
     "dep:sqlx",
@@ -101,17 +100,16 @@ urlencoding = "2.1"
 # CLI-only dependencies
 clap = { version = "4.5.53", features = ["derive"], optional = true }
 comfy-table = { version = "7.1", optional = true }
-dirs = { version = "5.0", optional = true }
+dirs = { version = "6.0", optional = true }
 rsa = { version = "0.9", optional = true }
 tempfile = { version = "3.0", optional = true }
-toml = { version = "0.8", optional = true }
+toml = { version = "1", optional = true }
 url = { version = "2.5", optional = true }
 webbrowser = { version = "1.0.2", optional = true }
 serde_ignored = { version = "0.1", optional = true }
 
 # Server core dependencies
 config = { version = "0.15.19", optional = true }
-oauth2 = { version = "4.4", optional = true }
 openssl = { version = "0.10.75", features = ["vendored"], optional = true }
 sqlx = { version = "0.8", features = ["runtime-tokio-native-tls", "postgres", "uuid", "chrono", "migrate"], optional = true }
 tower = { version = "0.5.2", optional = true }
@@ -143,8 +141,8 @@ aws-sdk-rds = { version = "1.80", optional = true }
 aws-sdk-sts = { version = "1.80", optional = true }
 
 # Kubernetes feature dependencies
-kube = { version = "0.95", features = ["client", "runtime", "derive"], optional = true }
-k8s-openapi = { version = "0.23", features = ["v1_30", "schemars"], optional = true }
+kube = { version = "3", features = ["client", "runtime", "derive"], optional = true }
+k8s-openapi = { version = "0.27", features = ["v1_31", "schemars"], optional = true }
 rustls = { version = "0.23", features = ["ring"], optional = true }
 
 # Snowflake feature dependencies
@@ -153,7 +151,7 @@ snowflake-connector-rs = { version = "0.4", optional = true }
 # Server: OAuth2 token endpoint
 subtle = { version = "2.6.1", optional = true }
 serde_urlencoded = { version = "0.7.1", optional = true }
-schemars = { version = "0.8.22", optional = true }
+schemars = { version = "1", optional = true }
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/docs/schemas/backend-settings.schema.json
+++ b/docs/schemas/backend-settings.schema.json
@@ -96,7 +96,7 @@
         },
         "allow_list_all_teams": {
           "default": false,
-          "description": "Allow all users to list all teams (default: true).\nWhen false, non-admin users only see teams they are members of.",
+          "description": "Allow all users to list all teams (default: false).\nWhen false, non-admin users only see teams they are members of.",
           "type": "boolean"
         },
         "allow_team_creation": {

--- a/docs/schemas/backend-settings.schema.json
+++ b/docs/schemas/backend-settings.schema.json
@@ -1,15 +1,10 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "definitions": {
+  "$defs": {
     "AccessClass": {
       "description": "Access class configuration for ingress authentication",
       "properties": {
         "access_requirement": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/AccessRequirement"
-            }
-          ],
+          "$ref": "#/$defs/AccessRequirement",
           "description": "Access requirement level"
         },
         "custom_annotations": {
@@ -34,10 +29,10 @@
         }
       },
       "required": [
-        "access_requirement",
-        "description",
         "display_name",
-        "ingress_class"
+        "description",
+        "ingress_class",
+        "access_requirement"
       ],
       "type": "object"
     },
@@ -45,24 +40,18 @@
       "description": "Access requirement level for project ingress",
       "oneOf": [
         {
+          "const": "None",
           "description": "No authentication required - fully public access",
-          "enum": [
-            "None"
-          ],
           "type": "string"
         },
         {
+          "const": "Authenticated",
           "description": "Must be authenticated, but no project membership required",
-          "enum": [
-            "Authenticated"
-          ],
           "type": "string"
         },
         {
+          "const": "Member",
           "description": "Must be authenticated AND have project membership (owner or team member)",
-          "enum": [
-            "Member"
-          ],
           "type": "string"
         }
       ]
@@ -71,10 +60,8 @@
       "description": "Supported active sync sources for pulling users and groups",
       "oneOf": [
         {
-          "description": "Microsoft Entra ID (Azure AD) - uses Microsoft Graph API to pull users and groups assigned to the configured app registration.",
-          "enum": [
-            "Entra"
-          ],
+          "const": "Entra",
+          "description": "Microsoft Entra ID (Azure AD) - uses Microsoft Graph API to pull\nusers and groups assigned to the configured app registration.",
           "type": "string"
         }
       ]
@@ -85,19 +72,19 @@
           "default": 300,
           "description": "Interval in seconds for active sync polling (default: 300 = 5 minutes)",
           "format": "uint64",
-          "minimum": 0.0,
+          "minimum": 0,
           "type": "integer"
         },
         "active_sync_source": {
           "anyOf": [
             {
-              "$ref": "#/definitions/ActiveSyncSource"
+              "$ref": "#/$defs/ActiveSyncSource"
             },
             {
               "type": "null"
             }
           ],
-          "description": "Optional active sync source for pulling users and groups from an external IdP. When configured, Rise will periodically query the IdP for users and groups assigned to the app and sync them as Rise teams."
+          "description": "Optional active sync source for pulling users and groups from an external IdP.\nWhen configured, Rise will periodically query the IdP for users and groups\nassigned to the app and sync them as Rise teams."
         },
         "admin_users": {
           "default": [],
@@ -109,17 +96,17 @@
         },
         "allow_list_all_teams": {
           "default": false,
-          "description": "Allow all users to list all teams (default: true). When false, non-admin users only see teams they are members of.",
+          "description": "Allow all users to list all teams (default: true).\nWhen false, non-admin users only see teams they are members of.",
           "type": "boolean"
         },
         "allow_team_creation": {
           "default": true,
-          "description": "Allow regular users to create teams (default: true). When false, only admin users can create teams.",
+          "description": "Allow regular users to create teams (default: true).\nWhen false, only admin users can create teams.",
           "type": "boolean"
         },
         "authorize_url": {
           "default": null,
-          "description": "Optional custom authorize endpoint URL If not set, will be discovered from issuer's .well-known/openid-configuration or default to {issuer}/authorize",
+          "description": "Optional custom authorize endpoint URL\nIf not set, will be discovered from issuer's .well-known/openid-configuration\nor default to {issuer}/authorize",
           "type": [
             "string",
             "null"
@@ -133,23 +120,19 @@
         },
         "idp_group_sync_enabled": {
           "default": true,
-          "description": "Enable IdP group synchronization (default: true) When enabled, user team memberships are automatically synced from IdP groups claim on login",
+          "description": "Enable IdP group synchronization (default: true)\nWhen enabled, user team memberships are automatically synced from IdP groups claim on login",
           "type": "boolean"
         },
         "issuer": {
           "type": "string"
         },
         "platform_access": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/PlatformAccessConfig"
-            }
-          ],
+          "$ref": "#/$defs/PlatformAccessConfig",
           "description": "Platform access control configuration"
         },
         "token_url": {
           "default": null,
-          "description": "Optional custom token endpoint URL If not set, will be discovered from issuer's .well-known/openid-configuration or default to {issuer}/token",
+          "description": "Optional custom token endpoint URL\nIf not set, will be discovered from issuer's .well-known/openid-configuration\nor default to {issuer}/token",
           "type": [
             "string",
             "null"
@@ -157,9 +140,9 @@
         }
       },
       "required": [
+        "issuer",
         "client_id",
-        "client_secret",
-        "issuer"
+        "client_secret"
       ],
       "type": "object"
     },
@@ -169,42 +152,42 @@
           "default": 5,
           "description": "Interval in seconds for processing cancelling deployments (default: 5)",
           "format": "uint64",
-          "minimum": 0.0,
+          "minimum": 0,
           "type": "integer"
         },
         "expiration_interval_secs": {
           "default": 60,
           "description": "Interval in seconds for checking expired deployments (default: 60)",
           "format": "uint64",
-          "minimum": 0.0,
+          "minimum": 0,
           "type": "integer"
         },
         "health_check_interval_secs": {
           "default": 5,
           "description": "Interval in seconds for health checks on active deployments (default: 5)",
           "format": "uint64",
-          "minimum": 0.0,
+          "minimum": 0,
           "type": "integer"
         },
         "reconcile_interval_secs": {
           "default": 5,
           "description": "Interval in seconds for checking deployments to reconcile (default: 5)",
           "format": "uint64",
-          "minimum": 0.0,
+          "minimum": 0,
           "type": "integer"
         },
         "secret_refresh_interval_secs": {
           "default": 3600,
           "description": "Interval in seconds for refreshing Kubernetes image pull secrets (default: 3600)",
           "format": "uint64",
-          "minimum": 0.0,
+          "minimum": 0,
           "type": "integer"
         },
         "termination_interval_secs": {
           "default": 5,
           "description": "Interval in seconds for processing terminating deployments (default: 5)",
           "format": "uint64",
-          "minimum": 0.0,
+          "minimum": 0,
           "type": "integer"
         }
       },
@@ -214,17 +197,13 @@
       "description": "TLS mode for custom domains",
       "oneOf": [
         {
+          "const": "shared",
           "description": "All hosts (primary + custom domains) share the same TLS secret",
-          "enum": [
-            "shared"
-          ],
           "type": "string"
         },
         {
+          "const": "per-domain",
           "description": "Each custom domain gets its own tls-{domain} secret (cert-manager integration)",
-          "enum": [
-            "per-domain"
-          ],
           "type": "string"
         }
       ]
@@ -248,22 +227,22 @@
               "additionalProperties": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/AccessClass"
+                    "$ref": "#/$defs/AccessClass"
                   },
                   {
                     "type": "null"
                   }
                 ]
               },
-              "description": "Access classes defining ingress authentication levels Key: access class identifier (e.g., \"public\", \"private\") Value: access class configuration (display info, ingress settings) Use `null` in YAML to remove an inherited access class from parent configs",
+              "description": "Access classes defining ingress authentication levels\nKey: access class identifier (e.g., \"public\", \"private\")\nValue: access class configuration (display info, ingress settings)\nUse `null` in YAML to remove an inherited access class from parent configs",
               "type": "object"
             },
             "auth_backend_url": {
-              "description": "Backend URL for Nginx auth subrequests (internal cluster URL) Example: \"http://rise-backend.default.svc.cluster.local:3000\" This is the URL Nginx will use internally within the cluster to validate authentication. For Minikube development, use the Docker bridge IP to reach host (e.g., \"http://host.minikube.internal:3000\").",
+              "description": "Backend URL for Nginx auth subrequests (internal cluster URL)\nExample: \"http://rise-backend.default.svc.cluster.local:3000\"\nThis is the URL Nginx will use internally within the cluster to validate authentication.\nFor Minikube development, use the Docker bridge IP to reach host (e.g., \"http://host.minikube.internal:3000\").",
               "type": "string"
             },
             "auth_signin_url": {
-              "description": "Public backend URL for browser redirects during authentication Example: \"https://rise.dev\" This must be the public URL where the backend is accessible via Ingress. The domain should share a parent with app domains for cookie sharing (see struct docs).",
+              "description": "Public backend URL for browser redirects during authentication\nExample: \"https://rise.dev\"\nThis must be the public URL where the backend is accessible via Ingress.\nThe domain should share a parent with app domains for cookie sharing (see struct docs).",
               "type": "string"
             },
             "custom_domain_ingress_annotations": {
@@ -271,48 +250,44 @@
                 "type": "string"
               },
               "default": {},
-              "description": "Annotations to apply ONLY to custom domain ingresses (not primary ingresses) Use this for cert-manager integration or other custom domain-specific configuration Example: {\"cert-manager.io/cluster-issuer\": \"letsencrypt-prod\"}",
+              "description": "Annotations to apply ONLY to custom domain ingresses (not primary ingresses)\nUse this for cert-manager integration or other custom domain-specific configuration\nExample: {\"cert-manager.io/cluster-issuer\": \"letsencrypt-prod\"}",
               "type": "object"
             },
             "custom_domain_tls_mode": {
-              "allOf": [
-                {
-                  "$ref": "#/definitions/CustomDomainTlsMode"
-                }
-              ],
+              "$ref": "#/$defs/CustomDomainTlsMode",
               "default": "per-domain",
-              "description": "TLS mode for custom domains - \"shared\": All custom domains share ingress_tls_secret_name (requires it to be set) - \"per-domain\": Each custom domain gets its own tls-{domain} secret (works with cert-manager when custom_domain_ingress_annotations are configured)\n\nDefaults to \"per-domain\""
+              "description": "TLS mode for custom domains\n- \"shared\": All custom domains share ingress_tls_secret_name (requires it to be set)\n- \"per-domain\": Each custom domain gets its own tls-{domain} secret\n  (works with cert-manager when custom_domain_ingress_annotations are configured)\n\nDefaults to \"per-domain\""
             },
             "extra_service_token_audiences": {
               "additionalProperties": {
                 "type": "string"
               },
               "default": {},
-              "description": "Extra projected service account tokens to mount into every deployed app pod. Key becomes the in-pod filename under /var/run/secrets/rise/tokens/, value is the audience. Example: {\"vault\": \"https://vault.example.com\"}",
+              "description": "Extra projected service account tokens to mount into every deployed app pod.\nKey becomes the in-pod filename under /var/run/secrets/rise/tokens/, value is the audience.\nExample: {\"vault\": \"https://vault.example.com\"}",
               "type": "object"
             },
             "health_probes": {
               "anyOf": [
                 {
-                  "$ref": "#/definitions/HealthProbeConfig"
+                  "$ref": "#/$defs/HealthProbeConfig"
                 },
                 {
                   "type": "null"
                 }
               ],
-              "description": "Health probe configuration If not set, uses defaults (HTTP probes on app port at \"/\" path)"
+              "description": "Health probe configuration\nIf not set, uses defaults (HTTP probes on app port at \"/\" path)"
             },
             "host_aliases": {
               "additionalProperties": {
                 "type": "string"
               },
               "default": {},
-              "description": "Host aliases to inject into pod specs (hostname -> IP address) Maps hostnames to IP addresses, injected as Kubernetes hostAliases. Useful for local development where pods need to resolve custom hostnames. Example: {\"rise.local\": \"192.168.49.1\"}",
+              "description": "Host aliases to inject into pod specs (hostname -> IP address)\nMaps hostnames to IP addresses, injected as Kubernetes hostAliases.\nUseful for local development where pods need to resolve custom hostnames.\nExample: {\"rise.local\": \"192.168.49.1\"}",
               "type": "object"
             },
             "image_pull_secret_name": {
               "default": null,
-              "description": "Optional name of an existing imagePullSecret to use for deployments\n\nIf not specified: - With a registry provider (e.g., ECR): The controller creates and manages the secret - Without a registry provider: No image pull secret is used\n\nIf specified: - The named secret must exist in each project namespace - The controller will NOT create or manage the secret - Useful for static registries where credentials are managed externally\n\nExample: \"my-registry-secret\"",
+              "description": "Optional name of an existing imagePullSecret to use for deployments\n\nIf not specified:\n  - With a registry provider (e.g., ECR): The controller creates and manages the secret\n  - Without a registry provider: No image pull secret is used\n\nIf specified:\n  - The named secret must exist in each project namespace\n  - The controller will NOT create or manage the secret\n  - Useful for static registries where credentials are managed externally\n\nExample: \"my-registry-secret\"",
               "type": [
                 "string",
                 "null"
@@ -323,14 +298,15 @@
                 "type": "string"
               },
               "default": {},
-              "description": "Ingress annotations to apply to all deployed application ingresses These apply to both primary ingresses and custom domain ingresses For annotations specific to custom domains only, use custom_domain_ingress_annotations Example: {\"nginx.ingress.kubernetes.io/proxy-body-size\": \"10m\"}",
+              "description": "Ingress annotations to apply to all deployed application ingresses\nThese apply to both primary ingresses and custom domain ingresses\nFor annotations specific to custom domains only, use custom_domain_ingress_annotations\nExample: {\"nginx.ingress.kubernetes.io/proxy-body-size\": \"10m\"}",
               "type": "object"
             },
             "ingress_port": {
               "default": null,
-              "description": "Optional port number to append to all generated ingress URLs Used for development environments with port-forwarding (e.g., kubectl port-forward) Example: 8080 → \"https://myapp.apps.rise.local:8080\" If not set, URLs use standard ports (80 for HTTP, 443 for HTTPS)",
+              "description": "Optional port number to append to all generated ingress URLs\nUsed for development environments with port-forwarding (e.g., kubectl port-forward)\nExample: 8080 → \"https://myapp.apps.rise.local:8080\"\nIf not set, URLs use standard ports (80 for HTTP, 443 for HTTPS)",
               "format": "uint16",
-              "minimum": 0.0,
+              "maximum": 65535,
+              "minimum": 0,
               "type": [
                 "integer",
                 "null"
@@ -338,12 +314,12 @@
             },
             "ingress_schema": {
               "default": "https",
-              "description": "URL scheme for generated ingress URLs Used to specify whether URLs should use \"http\" or \"https\" Example: \"http\" → \"http://myapp.apps.rise.local\" Defaults to \"https\"",
+              "description": "URL scheme for generated ingress URLs\nUsed to specify whether URLs should use \"http\" or \"https\"\nExample: \"http\" → \"http://myapp.apps.rise.local\"\nDefaults to \"https\"",
               "type": "string"
             },
             "ingress_tls_secret_name": {
               "default": null,
-              "description": "TLS secret name for primary ingress certificates If set, enables TLS on primary ingresses with this secret For custom domain TLS, see custom_domain_tls_mode and custom_domain_ingress_annotations Example: \"rise-apps-tls\" (secret must exist in each namespace)",
+              "description": "TLS secret name for primary ingress certificates\nIf set, enables TLS on primary ingresses with this secret\nFor custom domain TLS, see custom_domain_tls_mode and custom_domain_ingress_annotations\nExample: \"rise-apps-tls\" (secret must exist in each namespace)",
               "type": [
                 "string",
                 "null"
@@ -362,12 +338,12 @@
                 "type": "string"
               },
               "default": {},
-              "description": "Annotations to apply to all managed namespaces Example: {\"company.com/team\": \"platform\", \"cost-center\": \"engineering\"}",
+              "description": "Annotations to apply to all managed namespaces\nExample: {\"company.com/team\": \"platform\", \"cost-center\": \"engineering\"}",
               "type": "object"
             },
             "namespace_format": {
               "default": "rise-{project_name}",
-              "description": "Namespace format template for deployed applications Template variables: {project_name} Example: \"rise-{project_name}\" → namespace \"rise-myapp\" for project \"myapp\" Defaults to \"rise-{project_name}\"",
+              "description": "Namespace format template for deployed applications\nTemplate variables: {project_name}\nExample: \"rise-{project_name}\" → namespace \"rise-myapp\" for project \"myapp\"\nDefaults to \"rise-{project_name}\"",
               "type": "string"
             },
             "namespace_labels": {
@@ -375,15 +351,11 @@
                 "type": "string"
               },
               "default": {},
-              "description": "Labels to apply to all managed namespaces Example: {\"environment\": \"production\", \"team\": \"platform\"}",
+              "description": "Labels to apply to all managed namespaces\nExample: {\"environment\": \"production\", \"team\": \"platform\"}",
               "type": "object"
             },
             "network_policy": {
-              "allOf": [
-                {
-                  "$ref": "#/definitions/NetworkPolicyConfig"
-                }
-              ],
+              "$ref": "#/$defs/NetworkPolicyConfig",
               "description": "NetworkPolicy configuration for deployed apps"
             },
             "node_selector": {
@@ -393,51 +365,49 @@
               "default": {
                 "kubernetes.io/arch": "amd64"
               },
-              "description": "Node selector for pod placement (controls which nodes pods can run on) Default: {\"kubernetes.io/arch\": \"amd64\"} Example: {\"kubernetes.io/arch\": \"amd64\", \"node-type\": \"compute\"}",
+              "description": "Node selector for pod placement (controls which nodes pods can run on)\nDefault: {\"kubernetes.io/arch\": \"amd64\"}\nExample: {\"kubernetes.io/arch\": \"amd64\", \"node-type\": \"compute\"}",
               "type": "object"
             },
             "pod_resources": {
               "anyOf": [
                 {
-                  "$ref": "#/definitions/PodResourceLimits"
+                  "$ref": "#/$defs/PodResourceLimits"
                 },
                 {
                   "type": "null"
                 }
               ],
-              "description": "Resource limits for deployed containers If not set, uses defaults: 500m CPU request, 256Mi memory request, 2 CPU limit, 2Gi memory limit"
+              "description": "Resource limits for deployed containers\nIf not set, uses defaults: 500m CPU request, 256Mi memory request, 2 CPU limit, 2Gi memory limit"
             },
             "pod_security_enabled": {
               "default": true,
-              "description": "Pod security settings (enabled by default) Set to false to disable security context enforcement",
+              "description": "Pod security settings (enabled by default)\nSet to false to disable security context enforcement",
               "type": "boolean"
             },
             "production_ingress_url_template": {
-              "description": "Ingress URL template for production (default) deployment group Supports both subdomain and sub-path routing: Subdomain: \"{project_name}.apps.rise.dev\" Sub-path: \"rise.dev/{project_name}\" Must contain {project_name} placeholder",
+              "description": "Ingress URL template for production (default) deployment group\nSupports both subdomain and sub-path routing:\n  Subdomain: \"{project_name}.apps.rise.dev\"\n  Sub-path: \"rise.dev/{project_name}\"\nMust contain {project_name} placeholder",
               "type": "string"
             },
             "staging_ingress_url_template": {
               "default": null,
-              "description": "Ingress URL template for staging (non-default) deployment groups Supports both subdomain and sub-path routing: Subdomain: \"{project_name}-{deployment_group}.preview.rise.dev\" Sub-path: \"rise.dev/{project_name}/{deployment_group}\" Must contain both {project_name} and {deployment_group} placeholders If not set, falls back to inserting \"-{deployment_group}\" before first dot",
+              "description": "Ingress URL template for staging (non-default) deployment groups\nSupports both subdomain and sub-path routing:\n  Subdomain: \"{project_name}-{deployment_group}.preview.rise.dev\"\n  Sub-path: \"rise.dev/{project_name}/{deployment_group}\"\nMust contain both {project_name} and {deployment_group} placeholders\nIf not set, falls back to inserting \"-{deployment_group}\" before first dot",
               "type": [
                 "string",
                 "null"
               ]
             },
             "type": {
-              "enum": [
-                "kubernetes"
-              ],
+              "const": "kubernetes",
               "type": "string"
             }
           },
           "required": [
-            "access_classes",
+            "type",
+            "production_ingress_url_template",
             "auth_backend_url",
             "auth_signin_url",
-            "network_policy",
-            "production_ingress_url_template",
-            "type"
+            "access_classes",
+            "network_policy"
           ],
           "type": "object"
         }
@@ -450,19 +420,17 @@
           "description": "Local AES-256-GCM encryption using a symmetric key",
           "properties": {
             "key": {
-              "description": "Base64-encoded 32-byte encryption key Generate with: openssl rand -base64 32",
+              "description": "Base64-encoded 32-byte encryption key\nGenerate with: openssl rand -base64 32",
               "type": "string"
             },
             "type": {
-              "enum": [
-                "aes-gcm-256"
-              ],
+              "const": "aes-gcm-256",
               "type": "string"
             }
           },
           "required": [
-            "key",
-            "type"
+            "type",
+            "key"
           ],
           "type": "object"
         },
@@ -493,16 +461,14 @@
               ]
             },
             "type": {
-              "enum": [
-                "aws-kms"
-              ],
+              "const": "aws-kms",
               "type": "string"
             }
           },
           "required": [
-            "key_id",
+            "type",
             "region",
-            "type"
+            "key_id"
           ],
           "type": "object"
         }
@@ -544,7 +510,7 @@
             },
             "default_engine_version": {
               "default": "18.2",
-              "description": "Default engine version to use if not specified in project extension spec Use AWS CLI to find versions: aws rds describe-db-engine-versions --engine postgres --query \"DBEngineVersions[*].EngineVersion\"",
+              "description": "Default engine version to use if not specified in project extension spec\nUse AWS CLI to find versions: aws rds describe-db-engine-versions --engine postgres --query \"DBEngineVersions[*].EngineVersion\"",
               "type": "string"
             },
             "disk_size": {
@@ -553,12 +519,12 @@
             },
             "instance_id_prefix": {
               "default": "rise",
-              "description": "Prefix for RDS instance identifiers Must match the IAM policy prefix configured in your Terraform infrastructure Default: \"rise\"",
+              "description": "Prefix for RDS instance identifiers\nMust match the IAM policy prefix configured in your Terraform infrastructure\nDefault: \"rise\"",
               "type": "string"
             },
             "instance_id_template": {
               "default": "{prefix}-{project_name}-{extension_name}",
-              "description": "Template for RDS instance identifiers Available placeholders: {prefix}, {project_name}, {extension_name} Default: \"{prefix}-{project_name}-{extension_name}\"",
+              "description": "Template for RDS instance identifiers\nAvailable placeholders: {prefix}, {project_name}, {extension_name}\nDefault: \"{prefix}-{project_name}-{extension_name}\"",
               "type": "string"
             },
             "instance_size": {
@@ -583,9 +549,7 @@
               ]
             },
             "type": {
-              "enum": [
-                "aws-rds-provisioner"
-              ],
+              "const": "aws-rds-provisioner",
               "type": "string"
             },
             "vpc_security_group_ids": {
@@ -601,10 +565,10 @@
             }
           },
           "required": [
-            "disk_size",
-            "instance_size",
+            "type",
             "region",
-            "type"
+            "instance_size",
+            "disk_size"
           ],
           "type": "object"
         },
@@ -614,9 +578,7 @@
             {
               "properties": {
                 "auth_type": {
-                  "enum": [
-                    "password"
-                  ],
+                  "const": "password",
                   "type": "string"
                 },
                 "password": {
@@ -657,9 +619,7 @@
               "description": "Private key source (path or inline PEM)",
               "properties": {
                 "auth_type": {
-                  "enum": [
-                    "private_key"
-                  ],
+                  "const": "private_key",
                   "type": "string"
                 },
                 "private_key_password": {
@@ -716,16 +676,14 @@
             },
             "role": {
               "default": null,
-              "description": "Snowflake role to use (must have CREATE INTEGRATION ON ACCOUNT privilege) Typically ACCOUNTADMIN or a custom role with appropriate grants",
+              "description": "Snowflake role to use (must have CREATE INTEGRATION ON ACCOUNT privilege)\nTypically ACCOUNTADMIN or a custom role with appropriate grants",
               "type": [
                 "string",
                 "null"
               ]
             },
             "type": {
-              "enum": [
-                "snowflake-oauth-provisioner"
-              ],
+              "const": "snowflake-oauth-provisioner",
               "type": "string"
             },
             "user": {
@@ -734,7 +692,7 @@
             },
             "warehouse": {
               "default": null,
-              "description": "Snowflake warehouse to use for queries Required for executing SQL statements",
+              "description": "Snowflake warehouse to use for queries\nRequired for executing SQL statements",
               "type": [
                 "string",
                 "null"
@@ -742,8 +700,8 @@
             }
           },
           "required": [
-            "account",
             "type",
+            "account",
             "user"
           ],
           "type": "object"
@@ -755,7 +713,7 @@
       "properties": {
         "providers": {
           "items": {
-            "$ref": "#/definitions/ExtensionProviderConfig"
+            "$ref": "#/$defs/ExtensionProviderConfig"
           },
           "type": "array"
         }
@@ -808,12 +766,12 @@
       "type": "object"
     },
     "NetworkPolicyConfig": {
-      "description": "NetworkPolicy configuration for deployed apps\n\nUses Kubernetes NetworkPolicy types directly. Egress semantics: - null: policyTypes is [\"Ingress\"] only, Kubernetes does not restrict egress - Empty list: policyTypes includes \"Egress\" with no rules = deny all egress - Non-empty list: explicit egress rules enforced",
+      "description": "NetworkPolicy configuration for deployed apps\n\nUses Kubernetes NetworkPolicy types directly. Egress semantics:\n- null: policyTypes is [\"Ingress\"] only, Kubernetes does not restrict egress\n- Empty list: policyTypes includes \"Egress\" with no rules = deny all egress\n- Non-empty list: explicit egress rules enforced",
       "properties": {
         "egress": {
           "description": "Egress rules (null = unrestricted egress)",
           "items": {
-            "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicyEgressRule"
+            "$ref": "#/$defs/io.k8s.api.networking.v1.NetworkPolicyEgressRule"
           },
           "type": [
             "array",
@@ -823,7 +781,7 @@
         "ingress": {
           "description": "Ingress rules",
           "items": {
-            "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicyIngressRule"
+            "$ref": "#/$defs/io.k8s.api.networking.v1.NetworkPolicyIngressRule"
           },
           "type": "array"
         }
@@ -853,11 +811,7 @@
           "type": "array"
         },
         "policy": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/PlatformAccessPolicy"
-            }
-          ],
+          "$ref": "#/$defs/PlatformAccessPolicy",
           "description": "Policy: \"allow_all\" (default) or \"restrictive\""
         }
       },
@@ -937,17 +891,15 @@
               ]
             },
             "type": {
-              "enum": [
-                "ecr"
-              ],
+              "const": "ecr",
               "type": "string"
             }
           },
           "required": [
-            "account_id",
-            "push_role_arn",
+            "type",
             "region",
-            "type"
+            "account_id",
+            "push_role_arn"
           ],
           "type": "object"
         },
@@ -955,7 +907,7 @@
           "properties": {
             "client_registry_url": {
               "default": null,
-              "description": "Optional client-facing registry URL for CLI push operations If not specified, defaults to registry_url",
+              "description": "Optional client-facing registry URL for CLI push operations\nIf not specified, defaults to registry_url",
               "type": [
                 "string",
                 "null"
@@ -969,15 +921,13 @@
               "type": "string"
             },
             "type": {
-              "enum": [
-                "oci-client-auth"
-              ],
+              "const": "oci-client-auth",
               "type": "string"
             }
           },
           "required": [
-            "registry_url",
-            "type"
+            "type",
+            "registry_url"
           ],
           "type": "object"
         },
@@ -998,11 +948,11 @@
             },
             "mint_pull_secrets": {
               "default": false,
-              "description": "When true, the Kubernetes controller creates and manages image pull secrets in each project namespace. Set to false if the cluster has its own pull mechanism.",
+              "description": "When true, the Kubernetes controller creates and manages image pull secrets\nin each project namespace. Set to false if the cluster has its own pull mechanism.",
               "type": "boolean"
             },
             "namespace": {
-              "description": "Full image path prefix within the registry (e.g., \"my-org/my-project\" or \"my-org/my-project/rise-apps\")",
+              "description": "Full image path prefix within the registry\n(e.g., \"my-org/my-project\" or \"my-org/my-project/rise-apps\")",
               "type": "string"
             },
             "registry_url": {
@@ -1014,9 +964,7 @@
               "type": "string"
             },
             "type": {
-              "enum": [
-                "gitlab"
-              ],
+              "const": "gitlab",
               "type": "string"
             },
             "username": {
@@ -1025,12 +973,12 @@
             }
           },
           "required": [
-            "gitlab_url",
-            "namespace",
-            "registry_url",
-            "token",
             "type",
-            "username"
+            "gitlab_url",
+            "registry_url",
+            "namespace",
+            "username",
+            "token"
           ],
           "type": "object"
         }
@@ -1040,7 +988,7 @@
       "properties": {
         "allow_private_networks": {
           "default": false,
-          "description": "Allow HTTP and private/loopback IPs in SSRF-validated URLs. WARNING: Only enable for local development. Never enable in production.",
+          "description": "Allow HTTP and private/loopback IPs in SSRF-validated URLs.\nWARNING: Only enable for local development. Never enable in production.",
           "type": "boolean"
         },
         "cookie_domain": {
@@ -1055,7 +1003,7 @@
         },
         "docs_dir": {
           "default": null,
-          "description": "Directory to serve documentation files from (e.g., \"/var/rise/docs\" or \"docs\") Defaults to the RISE_DOCS_DIR environment variable.",
+          "description": "Directory to serve documentation files from (e.g., \"/var/rise/docs\" or \"docs\")\nDefaults to the RISE_DOCS_DIR environment variable.",
           "type": [
             "string",
             "null"
@@ -1063,7 +1011,7 @@
         },
         "frontend_dev_proxy_url": {
           "default": null,
-          "description": "Development-only frontend proxy target (for Vite), e.g. \"http://localhost:5173\" When set, non-API frontend routes are proxied to this URL instead of serving embedded assets.",
+          "description": "Development-only frontend proxy target (for Vite), e.g. \"http://localhost:5173\"\nWhen set, non-API frontend routes are proxied to this URL instead of serving embedded assets.",
           "type": [
             "string",
             "null"
@@ -1078,7 +1026,7 @@
             "email",
             "name"
           ],
-          "description": "JWT claims to include from IdP token when issuing Rise JWTs Default: [\"sub\", \"email\", \"name\"]",
+          "description": "JWT claims to include from IdP token when issuing Rise JWTs\nDefault: [\"sub\", \"email\", \"name\"]",
           "items": {
             "type": "string"
           },
@@ -1086,18 +1034,19 @@
         },
         "jwt_expiry_seconds": {
           "default": 86400,
-          "description": "JWT token expiry duration in seconds Default: 86400 (24 hours)",
+          "description": "JWT token expiry duration in seconds\nDefault: 86400 (24 hours)",
           "format": "uint64",
-          "minimum": 0.0,
+          "minimum": 0,
           "type": "integer"
         },
         "jwt_signing_secret": {
-          "description": "JWT signing secret for ingress authentication (base64-encoded, minimum 32 bytes) Generate with: openssl rand -base64 32 Required for ingress authentication",
+          "description": "JWT signing secret for ingress authentication (base64-encoded, minimum 32 bytes)\nGenerate with: openssl rand -base64 32\nRequired for ingress authentication",
           "type": "string"
         },
         "port": {
           "format": "uint16",
-          "minimum": 0.0,
+          "maximum": 65535,
+          "minimum": 0,
           "type": "integer"
         },
         "public_url": {
@@ -1105,7 +1054,7 @@
         },
         "rs256_private_key_pem": {
           "default": null,
-          "description": "Optional RS256 private key in PEM format for JWT signing If not provided, a new key pair will be generated on startup (tokens will be invalidated on restart) To persist keys across restarts, generate with: openssl genrsa -out rs256.key 2048",
+          "description": "Optional RS256 private key in PEM format for JWT signing\nIf not provided, a new key pair will be generated on startup (tokens will be invalidated on restart)\nTo persist keys across restarts, generate with: openssl genrsa -out rs256.key 2048",
           "type": [
             "string",
             "null"
@@ -1113,7 +1062,7 @@
         },
         "rs256_public_key_pem": {
           "default": null,
-          "description": "Optional RS256 public key in PEM format for JWT verification If not provided, will be derived from rs256_private_key_pem or generated Generate from private key with: openssl rsa -in rs256.key -pubout -out rs256.pub",
+          "description": "Optional RS256 public key in PEM format for JWT verification\nIf not provided, will be derived from rs256_private_key_pem or generated\nGenerate from private key with: openssl rsa -in rs256.key -pubout -out rs256.pub",
           "type": [
             "string",
             "null"
@@ -1121,7 +1070,7 @@
         },
         "static_dir": {
           "default": null,
-          "description": "Directory containing static assets (Tera templates, SVGs, Vite build output). Defaults to the RISE_STATIC_DIR environment variable.",
+          "description": "Directory containing static assets (Tera templates, SVGs, Vite build output).\nDefaults to the RISE_STATIC_DIR environment variable.",
           "type": [
             "string",
             "null"
@@ -1130,9 +1079,9 @@
       },
       "required": [
         "host",
-        "jwt_signing_secret",
         "port",
-        "public_url"
+        "public_url",
+        "jwt_signing_secret"
       ],
       "type": "object"
     },
@@ -1162,14 +1111,14 @@
         "ports": {
           "description": "ports is a list of destination ports for outgoing traffic. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.",
           "items": {
-            "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicyPort"
+            "$ref": "#/$defs/io.k8s.api.networking.v1.NetworkPolicyPort"
           },
           "type": "array"
         },
         "to": {
           "description": "to is a list of destinations for outgoing traffic of pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all destinations (traffic not restricted by destination). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the to list.",
           "items": {
-            "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicyPeer"
+            "$ref": "#/$defs/io.k8s.api.networking.v1.NetworkPolicyPeer"
           },
           "type": "array"
         }
@@ -1182,14 +1131,14 @@
         "from": {
           "description": "from is a list of sources which should be able to access the pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all sources (traffic not restricted by source). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the from list.",
           "items": {
-            "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicyPeer"
+            "$ref": "#/$defs/io.k8s.api.networking.v1.NetworkPolicyPeer"
           },
           "type": "array"
         },
         "ports": {
           "description": "ports is a list of ports which should be made accessible on the pods selected for this rule. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.",
           "items": {
-            "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicyPort"
+            "$ref": "#/$defs/io.k8s.api.networking.v1.NetworkPolicyPort"
           },
           "type": "array"
         }
@@ -1200,27 +1149,15 @@
       "description": "NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of fields are allowed",
       "properties": {
         "ipBlock": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/io.k8s.api.networking.v1.IPBlock"
-            }
-          ],
+          "$ref": "#/$defs/io.k8s.api.networking.v1.IPBlock",
           "description": "ipBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be."
         },
         "namespaceSelector": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
-            }
-          ],
+          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "namespaceSelector selects namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.\n\nIf podSelector is also set, then the NetworkPolicyPeer as a whole selects the pods matching podSelector in the namespaces selected by namespaceSelector. Otherwise it selects all pods in the namespaces selected by namespaceSelector."
         },
         "podSelector": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
-            }
-          ],
+          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "podSelector is a label selector which selects pods. This field follows standard label selector semantics; if present but empty, it selects all pods.\n\nIf namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the pods matching podSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the pods matching podSelector in the policy's own namespace."
         }
       },
@@ -1235,11 +1172,7 @@
           "type": "integer"
         },
         "port": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString"
-            }
-          ],
+          "$ref": "#/$defs/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
           "description": "port represents the port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched."
         },
         "protocol": {
@@ -1255,7 +1188,7 @@
         "matchExpressions": {
           "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
           "items": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
+            "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
           },
           "type": "array"
         },
@@ -1299,20 +1232,21 @@
       "x-kubernetes-int-or-string": true
     }
   },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "properties": {
     "auth": {
-      "$ref": "#/definitions/AuthSettings"
+      "$ref": "#/$defs/AuthSettings"
     },
     "controller": {
-      "$ref": "#/definitions/ControllerSettings"
+      "$ref": "#/$defs/ControllerSettings"
     },
     "database": {
-      "$ref": "#/definitions/DatabaseSettings"
+      "$ref": "#/$defs/DatabaseSettings"
     },
     "deployment_controller": {
       "anyOf": [
         {
-          "$ref": "#/definitions/DeploymentControllerSettings"
+          "$ref": "#/$defs/DeploymentControllerSettings"
         },
         {
           "type": "null"
@@ -1322,7 +1256,7 @@
     "encryption": {
       "anyOf": [
         {
-          "$ref": "#/definitions/EncryptionSettings"
+          "$ref": "#/$defs/EncryptionSettings"
         },
         {
           "type": "null"
@@ -1332,7 +1266,7 @@
     "extensions": {
       "anyOf": [
         {
-          "$ref": "#/definitions/ExtensionsSettings"
+          "$ref": "#/$defs/ExtensionsSettings"
         },
         {
           "type": "null"
@@ -1342,7 +1276,7 @@
     "registry": {
       "anyOf": [
         {
-          "$ref": "#/definitions/RegistrySettings"
+          "$ref": "#/$defs/RegistrySettings"
         },
         {
           "type": "null"
@@ -1350,13 +1284,13 @@
       ]
     },
     "server": {
-      "$ref": "#/definitions/ServerSettings"
+      "$ref": "#/$defs/ServerSettings"
     }
   },
   "required": [
+    "server",
     "auth",
-    "database",
-    "server"
+    "database"
   ],
   "title": "Settings",
   "type": "object"

--- a/src/build/config.rs
+++ b/src/build/config.rs
@@ -114,7 +114,8 @@ pub fn load_full_project_config(app_path: &str) -> Result<Option<ProjectBuildCon
 
         // Deserialize and collect any unused fields
         let mut unused_fields = Vec::new();
-        let deserializer = toml::Deserializer::new(&content);
+        let deserializer = toml::Deserializer::parse(&content)
+            .map_err(|e| anyhow::anyhow!("Failed to parse TOML: {e}"))?;
         let config: ProjectBuildConfig = serde_ignored::deserialize(deserializer, |path| {
             unused_fields.push(path.to_string());
         })?;

--- a/src/build/config.rs
+++ b/src/build/config.rs
@@ -115,7 +115,7 @@ pub fn load_full_project_config(app_path: &str) -> Result<Option<ProjectBuildCon
         // Deserialize and collect any unused fields
         let mut unused_fields = Vec::new();
         let deserializer = toml::Deserializer::parse(&content)
-            .map_err(|e| anyhow::anyhow!("Failed to parse TOML: {e}"))?;
+            .map_err(|e| anyhow::Error::new(e).context("Failed to parse TOML"))?;
         let config: ProjectBuildConfig = serde_ignored::deserialize(deserializer, |path| {
             unused_fields.push(path.to_string());
         })?;

--- a/src/cli/backend.rs
+++ b/src/cli/backend.rs
@@ -37,7 +37,7 @@ pub async fn handle_backend_command(cmd: BackendCommands) -> Result<()> {
         }
         #[cfg(feature = "backend")]
         BackendCommands::ConfigSchema => {
-            let schema = crate::server::settings::Settings::json_schema_value()?;
+            let schema = crate::server::settings::Settings::json_schema_value();
             println!("{}", serde_json::to_string_pretty(&schema)?);
             Ok(())
         }

--- a/src/server/deployment/controller/kubernetes.rs
+++ b/src/server/deployment/controller/kubernetes.rs
@@ -1332,7 +1332,12 @@ impl KubernetesController {
                                 last_timestamp: event
                                     .last_timestamp
                                     .as_ref()
-                                    .map(|ts| ts.0)
+                                    .and_then(|ts| {
+                                        chrono::DateTime::from_timestamp(
+                                            ts.0.as_second(),
+                                            ts.0.subsec_nanosecond() as u32,
+                                        )
+                                    })
                                     .unwrap_or_else(Utc::now),
                             };
                             events_by_pod
@@ -2379,10 +2384,10 @@ impl KubernetesController {
                 ..Default::default()
             },
             spec: Some(NetworkPolicySpec {
-                pod_selector: LabelSelector {
+                pod_selector: Some(LabelSelector {
                     match_labels: Some(Self::group_labels(project, deployment)),
                     ..Default::default()
-                },
+                }),
                 policy_types: Some(policy_types),
                 egress: egress_rules,
                 ingress: Some(self.network_policy.ingress.clone()),

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -714,9 +714,9 @@ pub enum EncryptionSettings {
 }
 
 impl Settings {
-    pub fn json_schema_value() -> Result<serde_json::Value, anyhow::Error> {
+    pub fn json_schema_value() -> serde_json::Value {
         let schema = schemars::schema_for!(Settings);
-        Ok(serde_json::to_value(schema)?)
+        schema.to_value()
     }
 
     fn substitute_env_vars_in_string_with(

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -205,7 +205,7 @@ pub struct AuthSettings {
     /// When false, only admin users can create teams.
     #[serde(default = "default_allow_team_creation")]
     pub allow_team_creation: bool,
-    /// Allow all users to list all teams (default: true).
+    /// Allow all users to list all teams (default: false).
     /// When false, non-admin users only see teams they are members of.
     #[serde(default = "default_allow_list_all_teams")]
     pub allow_list_all_teams: bool,


### PR DESCRIPTION
## Summary
- Update `dirs` v5→v6, `kube` v0.95→v3, `schemars` v0.8→v1, `toml` v0.8→v1, `k8s-openapi` v0.23→v0.27
- Remove unused `oauth2` dependency (was declared but never imported anywhere)
- Adapt code for breaking changes: toml Deserializer API rename, schemars Schema type rework, k8s-openapi jiff timestamp migration, and NetworkPolicySpec field optionality change

## Test plan
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-features --all-targets -- -D warnings` passes
- [x] `cargo test --all-features` passes (274 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)