### PR TITLE
chore(deps): update rust dependencies and toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ env:
   IMAGE_NAME: niklasrosenstein/rise
   BUILDER_IMAGE_NAME: niklasrosenstein/rise-builder
   CHART_REGISTRY: ghcr.io/niklasrosenstein/rise
-  RUST_VERSION: "1.91.1"
+  RUST_VERSION: "1.94.1"
 
 jobs:
   prepare:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -285,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -920,9 +920,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -942,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3491,9 +3491,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -5310,9 +5310,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -5507,9 +5507,9 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe985f41e291eecef5e5c0770a18d28390addb03331c043964d9e916453d6f16"
+checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
 dependencies = [
  "core-foundation 0.10.1",
  "jni",

--- a/mise.toml
+++ b/mise.toml
@@ -3,7 +3,7 @@ railpack = "github:railwayapp/railpack"
 buildkit = "github:moby/buildkit"
 
 [tools]
-minikube = "1.37.0"
+minikube = "1.38.1"
 pack = "0.39.0"
 railpack = "0.15.1"
 buildkit = "0.28.0"
@@ -11,7 +11,7 @@ buildkit = "0.28.0"
 "cargo:cargo-all-features" = "latest"
 mdbook = "latest"
 helm = "latest"
-rust = { version = "1.91.1", profile = "default" }
+rust = { version = "1.94.1", profile = "default" }
 kubectl = "latest"
 k9s = "latest"
 

--- a/src/cli/deployment/core.rs
+++ b/src/cli/deployment/core.rs
@@ -533,120 +533,121 @@ pub async fn create_deployment(
         }
     });
 
-    if deploy_opts.image.is_some() && deploy_opts.push_image {
-        // Push-image path: pull image locally, tag it, and push to Rise registry
-        let source_image = deploy_opts.image.unwrap();
-        info!(
-            "Pulling and pushing image '{}' to Rise registry",
-            source_image
-        );
-
-        // Determine container CLI from config/build args
-        let container_cli = match &deploy_opts.build_args.container_cli {
-            Some(cli) => cli.clone(),
-            None => config.get_container_cli().command().to_string(),
-        };
-
-        login_to_registry(
-            http_client,
-            backend_url,
-            &token,
-            &container_cli,
-            &deployment_info.credentials,
-            deploy_opts.project_name,
-            &deployment_info.deployment_id,
-        )
-        .await?;
-
-        // Pull the source image for linux/amd64
-        if let Err(e) = build::docker_pull(&container_cli, source_image, "linux/amd64") {
-            update_deployment_status(
-                http_client,
-                backend_url,
-                &token,
-                deploy_opts.project_name,
-                &deployment_info.deployment_id,
-                "Failed",
-                Some(&e.to_string()),
-            )
-            .await?;
-            return Err(e);
-        }
-
-        // Tag it with the Rise registry image tag
-        if let Err(e) = build::docker_tag(&container_cli, source_image, &deployment_info.image_tag)
-        {
-            update_deployment_status(
-                http_client,
-                backend_url,
-                &token,
-                deploy_opts.project_name,
-                &deployment_info.deployment_id,
-                "Failed",
-                Some(&e.to_string()),
-            )
-            .await?;
-            return Err(e);
-        }
-
-        // Update status to Building (reusing existing state for push phase)
-        update_deployment_status(
-            http_client,
-            backend_url,
-            &token,
-            deploy_opts.project_name,
-            &deployment_info.deployment_id,
-            "Building",
-            None,
-        )
-        .await?;
-
-        // Push to Rise registry
-        if let Err(e) = build::docker_push(&container_cli, &deployment_info.image_tag) {
-            update_deployment_status(
-                http_client,
-                backend_url,
-                &token,
-                deploy_opts.project_name,
-                &deployment_info.deployment_id,
-                "Failed",
-                Some(&e.to_string()),
-            )
-            .await?;
-            return Err(e);
-        }
-
-        // Mark as pushed (controller will take over deployment)
-        update_deployment_status(
-            http_client,
-            backend_url,
-            &token,
-            deploy_opts.project_name,
-            &deployment_info.deployment_id,
-            "Pushed",
-            None,
-        )
-        .await?;
-
-        info!(
-            "✓ Successfully pushed {} to {}",
-            source_image, deployment_info.image_tag
-        );
-    } else if deploy_opts.image.is_some() || deploy_opts.from_deployment.is_some() {
-        // Pre-built image path or redeploy from existing deployment: Skip build/push, backend already marked as Pushed
-        if let Some(from_deployment) = &deploy_opts.from_deployment {
+    if let Some(source_image) = &deploy_opts.image {
+        if deploy_opts.push_image {
+            // Push-image path: pull image locally, tag it, and push to Rise registry
             info!(
-                "✓ Deployment created from existing deployment '{}' with {} environment variables",
-                from_deployment,
-                if deploy_opts.use_source_env_vars {
-                    "source"
-                } else {
-                    "current project"
-                }
+                "Pulling and pushing image '{}' to Rise registry",
+                source_image
+            );
+
+            // Determine container CLI from config/build args
+            let container_cli = match &deploy_opts.build_args.container_cli {
+                Some(cli) => cli.clone(),
+                None => config.get_container_cli().command().to_string(),
+            };
+
+            login_to_registry(
+                http_client,
+                backend_url,
+                &token,
+                &container_cli,
+                &deployment_info.credentials,
+                deploy_opts.project_name,
+                &deployment_info.deployment_id,
+            )
+            .await?;
+
+            // Pull the source image for linux/amd64
+            if let Err(e) = build::docker_pull(&container_cli, source_image, "linux/amd64") {
+                update_deployment_status(
+                    http_client,
+                    backend_url,
+                    &token,
+                    deploy_opts.project_name,
+                    &deployment_info.deployment_id,
+                    "Failed",
+                    Some(&e.to_string()),
+                )
+                .await?;
+                return Err(e);
+            }
+
+            // Tag it with the Rise registry image tag
+            if let Err(e) =
+                build::docker_tag(&container_cli, source_image, &deployment_info.image_tag)
+            {
+                update_deployment_status(
+                    http_client,
+                    backend_url,
+                    &token,
+                    deploy_opts.project_name,
+                    &deployment_info.deployment_id,
+                    "Failed",
+                    Some(&e.to_string()),
+                )
+                .await?;
+                return Err(e);
+            }
+
+            // Update status to Building (reusing existing state for push phase)
+            update_deployment_status(
+                http_client,
+                backend_url,
+                &token,
+                deploy_opts.project_name,
+                &deployment_info.deployment_id,
+                "Building",
+                None,
+            )
+            .await?;
+
+            // Push to Rise registry
+            if let Err(e) = build::docker_push(&container_cli, &deployment_info.image_tag) {
+                update_deployment_status(
+                    http_client,
+                    backend_url,
+                    &token,
+                    deploy_opts.project_name,
+                    &deployment_info.deployment_id,
+                    "Failed",
+                    Some(&e.to_string()),
+                )
+                .await?;
+                return Err(e);
+            }
+
+            // Mark as pushed (controller will take over deployment)
+            update_deployment_status(
+                http_client,
+                backend_url,
+                &token,
+                deploy_opts.project_name,
+                &deployment_info.deployment_id,
+                "Pushed",
+                None,
+            )
+            .await?;
+
+            info!(
+                "✓ Successfully pushed {} to {}",
+                source_image, deployment_info.image_tag
             );
         } else {
+            // Pre-built image path: Skip build/push, backend already marked as Pushed
             info!("✓ Pre-built image deployment created");
         }
+    } else if let Some(from_deployment) = &deploy_opts.from_deployment {
+        // Redeploy from existing deployment: Skip build/push, backend already marked as Pushed
+        info!(
+            "✓ Deployment created from existing deployment '{}' with {} environment variables",
+            from_deployment,
+            if deploy_opts.use_source_env_vars {
+                "source"
+            } else {
+                "current project"
+            }
+        );
     } else {
         // Build from source path: Execute build and push
         let options = BuildOptions::from_build_args(


### PR DESCRIPTION
## Summary
- Rust toolchain: 1.91.1 → 1.94.1 (mise.toml, ci.yml)
- Minikube: 1.37.0 → 1.38.1 (mise.toml)
- `cargo update`: aws-lc-rs 1.16.2→1.16.3, clap 4.6.0→4.6.1, uuid 1.23.0→1.23.1, webbrowser 1.2.0→1.2.1, and transitive deps

## Test plan
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-features --all-targets -- -D warnings` passes
- [ ] CI unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)