### PR TITLE
fix(chart): Fix pgautoupgrade init container for non-root pods

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ volumes:
 
 services:
   postgres:
-    image: postgres:18-alpine
+    image: postgres:18-trixie
     container_name: rise-postgres
     restart: unless-stopped
     ports:

--- a/docs/upgrading-postgresql.md
+++ b/docs/upgrading-postgresql.md
@@ -26,7 +26,7 @@ Ensure `postgresql.image.tag` is set to the target major version and that `postg
 ```bash
 helm upgrade <release> <chart> \
   --set postgresql.upgrade.enabled=true \
-  --set postgresql.image.tag="18-alpine" \
+  --set postgresql.image.tag="18-trixie" \
   --set postgresql.upgrade.image.tag="18-trixie"
 ```
 

--- a/docs/upgrading-postgresql.md
+++ b/docs/upgrading-postgresql.md
@@ -27,7 +27,7 @@ Ensure `postgresql.image.tag` is set to the target major version and that `postg
 helm upgrade <release> <chart> \
   --set postgresql.upgrade.enabled=true \
   --set postgresql.image.tag="18-alpine" \
-  --set postgresql.upgrade.image.tag="18-alpine3.21"
+  --set postgresql.upgrade.image.tag="18-trixie"
 ```
 
 With `postgresql.upgrade.enabled=true`, the pod runs a single **pg-upgrade** init container (using the pgautoupgrade image) before starting PostgreSQL. This container detects the version mismatch and migrates the data directory automatically.

--- a/helm/rise/README.md
+++ b/helm/rise/README.md
@@ -172,7 +172,7 @@ The chart can deploy a PostgreSQL database using a simple StatefulSet.
 |-----------|-------------|---------|
 | `postgresql.enabled` | Enable PostgreSQL deployment | `false` |
 | `postgresql.image.repository` | PostgreSQL image repository | `postgres` |
-| `postgresql.image.tag` | PostgreSQL image tag | `16-alpine` |
+| `postgresql.image.tag` | PostgreSQL image tag | `18-trixie` |
 | `postgresql.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `postgresql.auth.username` | PostgreSQL username | `rise` |
 | `postgresql.auth.password` | PostgreSQL password | `rise123` |

--- a/helm/rise/templates/postgresql-statefulset.yaml
+++ b/helm/rise/templates/postgresql-statefulset.yaml
@@ -33,6 +33,8 @@ spec:
         image: "{{ .Values.postgresql.upgrade.image.repository }}:{{ .Values.postgresql.upgrade.image.tag }}"
         imagePullPolicy: {{ .Values.postgresql.upgrade.image.pullPolicy }}
         env:
+        - name: PGAUTO_ONESHOT
+          value: "yes"
         - name: PGDATA
           value: /var/lib/postgresql/data/pgdata
         - name: POSTGRES_USER

--- a/helm/rise/values.yaml
+++ b/helm/rise/values.yaml
@@ -165,7 +165,7 @@ postgresql:
 
   image:
     repository: postgres
-    tag: "18-alpine"
+    tag: "18-trixie"
     pullPolicy: IfNotPresent
 
   auth:
@@ -191,11 +191,9 @@ postgresql:
   # See docs/upgrading-postgresql.md for the full procedure.
   # IMPORTANT: The pgautoupgrade image tag must match the TARGET PostgreSQL major version
   # (i.e., the same major version as postgresql.image.tag above).
-   # NOTE: This Debian-based tag requirement applies specifically to the pgautoupgrade image
-   # below, not necessarily to the main postgresql.image.tag above. Avoid pgautoupgrade
-   # Alpine tags (e.g., use "18-trixie" instead), because their postgres user has UID 70,
-   # which doesn't match our pod's runAsUser (999). pgautoupgrade then tries gosu when
-   # UIDs don't match, which fails without root.
+  # NOTE: Use Debian-based tags (e.g., "18-trixie") for both the main and upgrade images.
+  # Alpine postgres images use UID 70, which doesn't match our pod's runAsUser (999).
+  # pgautoupgrade tries gosu when UIDs don't match, which fails without root.
   upgrade:
     enabled: false
     image:

--- a/helm/rise/values.yaml
+++ b/helm/rise/values.yaml
@@ -191,9 +191,11 @@ postgresql:
   # See docs/upgrading-postgresql.md for the full procedure.
   # IMPORTANT: The pgautoupgrade image tag must match the TARGET PostgreSQL major version
   # (i.e., the same major version as postgresql.image.tag above).
-  # NOTE: Must use a Debian-based tag (e.g., "18-trixie") rather than Alpine, because
-  # the Alpine postgres user has UID 70 which doesn't match our pod's runAsUser (999).
-  # pgautoupgrade tries gosu when UIDs don't match, which fails without root.
+   # NOTE: This Debian-based tag requirement applies specifically to the pgautoupgrade image
+   # below, not necessarily to the main postgresql.image.tag above. Avoid pgautoupgrade
+   # Alpine tags (e.g., use "18-trixie" instead), because their postgres user has UID 70,
+   # which doesn't match our pod's runAsUser (999). pgautoupgrade then tries gosu when
+   # UIDs don't match, which fails without root.
   upgrade:
     enabled: false
     image:

--- a/helm/rise/values.yaml
+++ b/helm/rise/values.yaml
@@ -191,11 +191,14 @@ postgresql:
   # See docs/upgrading-postgresql.md for the full procedure.
   # IMPORTANT: The pgautoupgrade image tag must match the TARGET PostgreSQL major version
   # (i.e., the same major version as postgresql.image.tag above).
+  # NOTE: Must use a Debian-based tag (e.g., "18-trixie") rather than Alpine, because
+  # the Alpine postgres user has UID 70 which doesn't match our pod's runAsUser (999).
+  # pgautoupgrade tries gosu when UIDs don't match, which fails without root.
   upgrade:
     enabled: false
     image:
       repository: pgautoupgrade/pgautoupgrade
-      tag: "18-alpine"
+      tag: "18-trixie"
       pullPolicy: IfNotPresent
 
 # Dex OIDC provider (optional)


### PR DESCRIPTION
## Summary
- Switch all PostgreSQL images from Alpine to Debian (`18-trixie`) for consistent UID 999 across containers — Alpine uses UID 70 which causes pgautoupgrade's `gosu` to fail without root
- Add `PGAUTO_ONESHOT=yes` env var so the upgrade init container exits after upgrading instead of starting the PostgreSQL server
- Update docker-compose, Helm values, and docs to use `18-trixie` consistently

## Test plan
- [x] Deploy with `postgresql.upgrade.enabled=true` against a PG 16 data directory and verify the upgrade completes and the init container exits cleanly
- [x] Verify the main PostgreSQL container starts normally after the init container finishes
- [x] Verify `docker compose up` works with the updated image

🤖 Generated with [Claude Code](https://claude.com/claude-code)