### PR TITLE
feat: add ssrf_trusted_hosts for allowing internal OIDC providers

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -12,7 +12,9 @@ server:
   jwt_claims: ["sub", "email", "name"]
   static_dir: "${RISE_STATIC_DIR:-static}" # In-container: /var/lib/rise/static; local dev: static/
   docs_dir: "${RISE_DOCS_DIR:-docs}" # In-container: /var/rise/docs; local dev: docs/
-  allow_private_networks: true # Allow HTTP and private IPs for local OIDC (Dex at localhost)
+  ssrf:
+    allow_private_networks: true # Allow private IPs for local OIDC (Dex at localhost)
+    allow_http: true # Allow HTTP for local development
 
 database:
   url: "${DATABASE_URL}"

--- a/docs/schemas/backend-settings.schema.json
+++ b/docs/schemas/backend-settings.schema.json
@@ -1068,6 +1068,14 @@
             "null"
           ]
         },
+        "ssrf_trusted_hosts": {
+          "default": [],
+          "description": "Hostnames that are allowed to resolve to private/internal IP addresses.\nUse this to permit SSRF-validated requests to trusted internal services\n(e.g., an internal Keycloak or OIDC provider) without enabling `allow_private_networks`.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "static_dir": {
           "default": null,
           "description": "Directory containing static assets (Tera templates, SVGs, Vite build output).\nDefaults to the RISE_STATIC_DIR environment variable.",

--- a/docs/schemas/backend-settings.schema.json
+++ b/docs/schemas/backend-settings.schema.json
@@ -986,11 +986,6 @@
     },
     "ServerSettings": {
       "properties": {
-        "allow_private_networks": {
-          "default": false,
-          "description": "Allow HTTP and private/loopback IPs in SSRF-validated URLs.\nWARNING: Only enable for local development. Never enable in production.",
-          "type": "boolean"
-        },
         "cookie_domain": {
           "default": "",
           "description": "Cookie domain for session cookies (e.g., \".rise.dev\" for all subdomains, \"\" for current host only)",
@@ -1068,13 +1063,9 @@
             "null"
           ]
         },
-        "ssrf_trusted_hosts": {
-          "default": [],
-          "description": "Hostnames that are allowed to resolve to private/internal IP addresses.\nUse this to permit SSRF-validated requests to trusted internal services\n(e.g., an internal Keycloak or OIDC provider) without enabling `allow_private_networks`.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
+        "ssrf": {
+          "$ref": "#/$defs/SsrfConfig",
+          "description": "SSRF validation configuration."
         },
         "static_dir": {
           "default": null,
@@ -1091,6 +1082,30 @@
         "public_url",
         "jwt_signing_secret"
       ],
+      "type": "object"
+    },
+    "SsrfConfig": {
+      "description": "SSRF validation configuration.\n\nControls how Rise validates URLs before making server-side requests.\nAll fields default to the most restrictive settings (HTTPS required,\nprivate networks blocked, no trusted hosts).",
+      "properties": {
+        "allow_http": {
+          "default": false,
+          "description": "Allow HTTP (non-TLS) URLs in SSRF-validated requests.\nWARNING: Only enable for local development. Never enable in production.",
+          "type": "boolean"
+        },
+        "allow_private_networks": {
+          "default": false,
+          "description": "Allow private/loopback IPs in SSRF-validated URLs.\nWARNING: Only enable for local development. Never enable in production.",
+          "type": "boolean"
+        },
+        "trusted_hosts": {
+          "default": [],
+          "description": "Hostnames that are allowed to resolve to private/internal IP addresses.\nUse this to permit SSRF-validated requests to trusted internal services\n(e.g., an internal Keycloak or OIDC provider) without enabling\n`allow_private_networks`.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
       "type": "object"
     },
     "io.k8s.api.networking.v1.IPBlock": {

--- a/src/server/auth/jwt.rs
+++ b/src/server/auth/jwt.rs
@@ -79,16 +79,17 @@ impl JwksCache {
 pub struct JwtValidator {
     jwks_cache: Arc<RwLock<HashMap<String, JwksCache>>>,
     http_client: reqwest::Client,
-    allow_private_networks: bool,
+    ssrf_config: crate::server::ssrf::SsrfConfig,
 }
 
 impl JwtValidator {
     /// Create a new JWT validator
-    pub fn new(allow_private_networks: bool) -> Self {
+    pub fn new(ssrf_config: crate::server::ssrf::SsrfConfig) -> Self {
+        let http_client = crate::server::ssrf::safe_client(&ssrf_config);
         Self {
             jwks_cache: Arc::new(RwLock::new(HashMap::new())),
-            http_client: crate::server::ssrf::safe_client(allow_private_networks),
-            allow_private_networks,
+            http_client,
+            ssrf_config,
         }
     }
 
@@ -100,7 +101,7 @@ impl JwtValidator {
         );
 
         // SSRF-validate the discovery URL before fetching
-        crate::server::ssrf::validate_url(&discovery_url, self.allow_private_networks)
+        crate::server::ssrf::validate_url(&discovery_url, &self.ssrf_config)
             .await
             .map_err(|e| anyhow!("OIDC discovery URL failed SSRF validation: {}", e))?;
 
@@ -121,7 +122,7 @@ impl JwtValidator {
         // SSRF-validate the JWKS URI before returning it.
         // An attacker-controlled OIDC provider could return a jwks_uri pointing
         // to an internal IP (e.g., metadata endpoint, internal service).
-        crate::server::ssrf::validate_url(&discovery.jwks_uri, self.allow_private_networks)
+        crate::server::ssrf::validate_url(&discovery.jwks_uri, &self.ssrf_config)
             .await
             .map_err(|e| anyhow!("JWKS URI failed SSRF validation: {}", e))?;
 
@@ -403,7 +404,10 @@ impl JwtValidator {
 
 impl Default for JwtValidator {
     fn default() -> Self {
-        Self::new(false)
+        Self::new(crate::server::ssrf::SsrfConfig {
+            allow_private_networks: false,
+            trusted_hosts: vec![],
+        })
     }
 }
 
@@ -413,7 +417,7 @@ mod tests {
 
     #[test]
     fn test_jwt_validator_creation() {
-        let validator = JwtValidator::new(false);
+        let validator = JwtValidator::default();
         // Validator should be created with empty cache
         assert!(validator.jwks_cache.try_read().is_ok());
     }

--- a/src/server/auth/jwt.rs
+++ b/src/server/auth/jwt.rs
@@ -404,10 +404,7 @@ impl JwtValidator {
 
 impl Default for JwtValidator {
     fn default() -> Self {
-        Self::new(crate::server::ssrf::SsrfConfig {
-            allow_private_networks: false,
-            trusted_hosts: vec![],
-        })
+        Self::new(crate::server::ssrf::SsrfConfig::default())
     }
 }
 

--- a/src/server/extensions/providers/oauth/handlers.rs
+++ b/src/server/extensions/providers/oauth/handlers.rs
@@ -685,7 +685,7 @@ pub async fn callback(
     };
 
     // Resolve OAuth endpoints (from spec or OIDC discovery)
-    let endpoints = resolve_oauth_endpoints(&spec, &ssrf_config)
+    let endpoints = resolve_oauth_endpoints(&spec, ssrf_config)
         .await
         .map_err(|e| {
             (
@@ -695,7 +695,7 @@ pub async fn callback(
         })?;
 
     // SSRF-validate the token endpoint before exchanging credentials
-    crate::server::ssrf::validate_url(&endpoints.token_endpoint, &ssrf_config)
+    crate::server::ssrf::validate_url(&endpoints.token_endpoint, ssrf_config)
         .await
         .map_err(|e| {
             error!("Token endpoint failed SSRF validation: {}", e);
@@ -706,7 +706,7 @@ pub async fn callback(
         })?;
 
     // Exchange authorization code for tokens (with PKCE code verifier)
-    let http_client = crate::server::ssrf::safe_client(&ssrf_config);
+    let http_client = crate::server::ssrf::safe_client(ssrf_config);
     let response = http_client
         .post(&endpoints.token_endpoint)
         .header("Accept", "application/json")
@@ -1832,7 +1832,7 @@ pub async fn oidc_jwks(
             ))?;
 
             // SSRF-validate the JWKS URI before fetching
-            crate::server::ssrf::validate_url(&jwks_uri, &ssrf_config)
+            crate::server::ssrf::validate_url(&jwks_uri, ssrf_config)
                 .await
                 .map_err(|e| {
                     error!("JWKS URI failed SSRF validation: {}", e);
@@ -1842,7 +1842,7 @@ pub async fn oidc_jwks(
                     )
                 })?;
 
-            let http_client = crate::server::ssrf::safe_client(&ssrf_config);
+            let http_client = crate::server::ssrf::safe_client(ssrf_config);
 
             // Fetch JWKS
             let jwks_response = http_client.get(&jwks_uri).send().await.map_err(|e| {

--- a/src/server/extensions/providers/oauth/handlers.rs
+++ b/src/server/extensions/providers/oauth/handlers.rs
@@ -34,7 +34,7 @@ struct ResolvedEndpoints {
 /// Fetch OIDC discovery document from issuer URL
 async fn fetch_oidc_discovery(
     issuer_url: &str,
-    allow_private_networks: bool,
+    ssrf_config: &crate::server::ssrf::SsrfConfig,
 ) -> Result<OidcDiscoveryDocument, String> {
     let discovery_url = format!(
         "{}/.well-known/openid-configuration",
@@ -42,14 +42,14 @@ async fn fetch_oidc_discovery(
     );
 
     // SSRF-validate the discovery URL before fetching
-    crate::server::ssrf::validate_url(&discovery_url, allow_private_networks)
+    crate::server::ssrf::validate_url(&discovery_url, ssrf_config)
         .await
         .map_err(|e| {
             error!("OIDC discovery URL failed SSRF validation: {}", e);
             format!("OIDC discovery URL failed SSRF validation: {}", e)
         })?;
 
-    let http_client = crate::server::ssrf::safe_client(allow_private_networks);
+    let http_client = crate::server::ssrf::safe_client(ssrf_config);
     let response = http_client.get(&discovery_url).send().await.map_err(|e| {
         error!(
             "Failed to fetch OIDC discovery from {}: {:?}",
@@ -80,7 +80,7 @@ async fn fetch_oidc_discovery(
 /// Resolve OAuth endpoints from spec, falling back to OIDC discovery
 async fn resolve_oauth_endpoints(
     spec: &OAuthExtensionSpec,
-    allow_private_networks: bool,
+    ssrf_config: &crate::server::ssrf::SsrfConfig,
 ) -> Result<ResolvedEndpoints, String> {
     // If both endpoints are provided in spec, use them directly
     if let (Some(auth), Some(token)) = (&spec.authorization_endpoint, &spec.token_endpoint) {
@@ -91,7 +91,7 @@ async fn resolve_oauth_endpoints(
     }
 
     // Fetch OIDC discovery document
-    let discovery = fetch_oidc_discovery(&spec.issuer_url, allow_private_networks).await?;
+    let discovery = fetch_oidc_discovery(&spec.issuer_url, ssrf_config).await?;
 
     // Use spec override if provided, otherwise use discovery
     let authorization_endpoint = spec
@@ -524,8 +524,8 @@ pub async fn authorize(
     };
 
     // Resolve OAuth endpoints (from spec or OIDC discovery)
-    let allow_private_networks = state.server_settings.allow_private_networks;
-    let endpoints = resolve_oauth_endpoints(&spec, allow_private_networks)
+    let ssrf_config = state.server_settings.ssrf_config();
+    let endpoints = resolve_oauth_endpoints(&spec, &ssrf_config)
         .await
         .map_err(|e| {
             (
@@ -631,13 +631,13 @@ pub async fn callback(
         "Encryption provider not configured".to_string(),
     ))?;
 
-    let allow_private_networks = state.server_settings.allow_private_networks;
+    let ssrf_config = state.server_settings.ssrf_config();
 
     use super::provider::{OAuthProvider, OAuthProviderConfig};
     let oauth_provider = OAuthProvider::new(OAuthProviderConfig {
         db_pool: state.db_pool.clone(),
         encryption_provider: encryption_provider.clone(),
-        http_client: crate::server::ssrf::safe_client(allow_private_networks),
+        http_client: crate::server::ssrf::safe_client(&ssrf_config),
         api_domain: state.public_url.clone(),
     });
 
@@ -685,7 +685,7 @@ pub async fn callback(
     };
 
     // Resolve OAuth endpoints (from spec or OIDC discovery)
-    let endpoints = resolve_oauth_endpoints(&spec, allow_private_networks)
+    let endpoints = resolve_oauth_endpoints(&spec, &ssrf_config)
         .await
         .map_err(|e| {
             (
@@ -695,7 +695,7 @@ pub async fn callback(
         })?;
 
     // SSRF-validate the token endpoint before exchanging credentials
-    crate::server::ssrf::validate_url(&endpoints.token_endpoint, allow_private_networks)
+    crate::server::ssrf::validate_url(&endpoints.token_endpoint, &ssrf_config)
         .await
         .map_err(|e| {
             error!("Token endpoint failed SSRF validation: {}", e);
@@ -706,7 +706,7 @@ pub async fn callback(
         })?;
 
     // Exchange authorization code for tokens (with PKCE code verifier)
-    let http_client = crate::server::ssrf::safe_client(allow_private_networks);
+    let http_client = crate::server::ssrf::safe_client(&ssrf_config);
     let response = http_client
         .post(&endpoints.token_endpoint)
         .header("Accept", "application/json")
@@ -1464,7 +1464,7 @@ async fn handle_refresh_token_grant(
             error!("Encryption provider not configured");
             oauth2_error("server_error", Some("Internal server error".to_string()))
         })?,
-        http_client: crate::server::ssrf::safe_client(state.server_settings.allow_private_networks),
+        http_client: crate::server::ssrf::safe_client(&state.server_settings.ssrf_config()),
         api_domain: state.public_url.clone(),
     });
 
@@ -1668,9 +1668,9 @@ pub async fn oidc_discovery(
     }
 
     // Try to fetch upstream OIDC discovery
-    let allow_private_networks = state.server_settings.allow_private_networks;
+    let ssrf_config = state.server_settings.ssrf_config();
     let upstream_issuer = &spec.issuer_url;
-    let discovery_result = fetch_oidc_discovery(upstream_issuer, allow_private_networks).await;
+    let discovery_result = fetch_oidc_discovery(upstream_issuer, &ssrf_config).await;
 
     match discovery_result {
         Ok(upstream_discovery) => {
@@ -1820,8 +1820,8 @@ pub async fn oidc_jwks(
     })?;
 
     // Try to fetch OIDC discovery to get jwks_uri
-    let allow_private_networks = state.server_settings.allow_private_networks;
-    let discovery_result = fetch_oidc_discovery(&spec.issuer_url, allow_private_networks).await;
+    let ssrf_config = state.server_settings.ssrf_config();
+    let discovery_result = fetch_oidc_discovery(&spec.issuer_url, &ssrf_config).await;
 
     match discovery_result {
         Ok(discovery) => {
@@ -1832,7 +1832,7 @@ pub async fn oidc_jwks(
             ))?;
 
             // SSRF-validate the JWKS URI before fetching
-            crate::server::ssrf::validate_url(&jwks_uri, allow_private_networks)
+            crate::server::ssrf::validate_url(&jwks_uri, &ssrf_config)
                 .await
                 .map_err(|e| {
                     error!("JWKS URI failed SSRF validation: {}", e);
@@ -1842,7 +1842,7 @@ pub async fn oidc_jwks(
                     )
                 })?;
 
-            let http_client = crate::server::ssrf::safe_client(allow_private_networks);
+            let http_client = crate::server::ssrf::safe_client(&ssrf_config);
 
             // Fetch JWKS
             let jwks_response = http_client.get(&jwks_uri).send().await.map_err(|e| {

--- a/src/server/extensions/providers/oauth/handlers.rs
+++ b/src/server/extensions/providers/oauth/handlers.rs
@@ -631,13 +631,13 @@ pub async fn callback(
         "Encryption provider not configured".to_string(),
     ))?;
 
-    let ssrf_config = state.server_settings.ssrf.clone();
+    let ssrf_config = &state.server_settings.ssrf;
 
     use super::provider::{OAuthProvider, OAuthProviderConfig};
     let oauth_provider = OAuthProvider::new(OAuthProviderConfig {
         db_pool: state.db_pool.clone(),
         encryption_provider: encryption_provider.clone(),
-        http_client: crate::server::ssrf::safe_client(&ssrf_config),
+        http_client: crate::server::ssrf::safe_client(ssrf_config),
         api_domain: state.public_url.clone(),
     });
 
@@ -1668,9 +1668,9 @@ pub async fn oidc_discovery(
     }
 
     // Try to fetch upstream OIDC discovery
-    let ssrf_config = state.server_settings.ssrf.clone();
+    let ssrf_config = &state.server_settings.ssrf;
     let upstream_issuer = &spec.issuer_url;
-    let discovery_result = fetch_oidc_discovery(upstream_issuer, &ssrf_config).await;
+    let discovery_result = fetch_oidc_discovery(upstream_issuer, ssrf_config).await;
 
     match discovery_result {
         Ok(upstream_discovery) => {
@@ -1820,8 +1820,8 @@ pub async fn oidc_jwks(
     })?;
 
     // Try to fetch OIDC discovery to get jwks_uri
-    let ssrf_config = state.server_settings.ssrf.clone();
-    let discovery_result = fetch_oidc_discovery(&spec.issuer_url, &ssrf_config).await;
+    let ssrf_config = &state.server_settings.ssrf;
+    let discovery_result = fetch_oidc_discovery(&spec.issuer_url, ssrf_config).await;
 
     match discovery_result {
         Ok(discovery) => {

--- a/src/server/extensions/providers/oauth/handlers.rs
+++ b/src/server/extensions/providers/oauth/handlers.rs
@@ -524,7 +524,7 @@ pub async fn authorize(
     };
 
     // Resolve OAuth endpoints (from spec or OIDC discovery)
-    let ssrf_config = state.server_settings.ssrf_config();
+    let ssrf_config = state.server_settings.ssrf.clone();
     let endpoints = resolve_oauth_endpoints(&spec, &ssrf_config)
         .await
         .map_err(|e| {
@@ -631,7 +631,7 @@ pub async fn callback(
         "Encryption provider not configured".to_string(),
     ))?;
 
-    let ssrf_config = state.server_settings.ssrf_config();
+    let ssrf_config = state.server_settings.ssrf.clone();
 
     use super::provider::{OAuthProvider, OAuthProviderConfig};
     let oauth_provider = OAuthProvider::new(OAuthProviderConfig {
@@ -1464,7 +1464,7 @@ async fn handle_refresh_token_grant(
             error!("Encryption provider not configured");
             oauth2_error("server_error", Some("Internal server error".to_string()))
         })?,
-        http_client: crate::server::ssrf::safe_client(&state.server_settings.ssrf_config()),
+        http_client: crate::server::ssrf::safe_client(&state.server_settings.ssrf),
         api_domain: state.public_url.clone(),
     });
 
@@ -1668,7 +1668,7 @@ pub async fn oidc_discovery(
     }
 
     // Try to fetch upstream OIDC discovery
-    let ssrf_config = state.server_settings.ssrf_config();
+    let ssrf_config = state.server_settings.ssrf.clone();
     let upstream_issuer = &spec.issuer_url;
     let discovery_result = fetch_oidc_discovery(upstream_issuer, &ssrf_config).await;
 
@@ -1820,7 +1820,7 @@ pub async fn oidc_jwks(
     })?;
 
     // Try to fetch OIDC discovery to get jwks_uri
-    let ssrf_config = state.server_settings.ssrf_config();
+    let ssrf_config = state.server_settings.ssrf.clone();
     let discovery_result = fetch_oidc_discovery(&spec.issuer_url, &ssrf_config).await;
 
     match discovery_result {

--- a/src/server/extensions/providers/oauth/handlers.rs
+++ b/src/server/extensions/providers/oauth/handlers.rs
@@ -524,8 +524,8 @@ pub async fn authorize(
     };
 
     // Resolve OAuth endpoints (from spec or OIDC discovery)
-    let ssrf_config = state.server_settings.ssrf.clone();
-    let endpoints = resolve_oauth_endpoints(&spec, &ssrf_config)
+    let ssrf_config = &state.server_settings.ssrf;
+    let endpoints = resolve_oauth_endpoints(&spec, ssrf_config)
         .await
         .map_err(|e| {
             (

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -79,6 +79,22 @@ pub struct ServerSettings {
     /// WARNING: Only enable for local development. Never enable in production.
     #[serde(default)]
     pub allow_private_networks: bool,
+
+    /// Hostnames that are allowed to resolve to private/internal IP addresses.
+    /// Use this to permit SSRF-validated requests to trusted internal services
+    /// (e.g., an internal Keycloak or OIDC provider) without enabling `allow_private_networks`.
+    #[serde(default)]
+    pub ssrf_trusted_hosts: Vec<String>,
+}
+
+impl ServerSettings {
+    /// Build an [`SsrfConfig`](super::ssrf::SsrfConfig) from the server settings.
+    pub fn ssrf_config(&self) -> super::ssrf::SsrfConfig {
+        super::ssrf::SsrfConfig {
+            allow_private_networks: self.allow_private_networks,
+            trusted_hosts: self.ssrf_trusted_hosts.clone(),
+        }
+    }
 }
 
 fn default_cookie_secure() -> bool {

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -75,26 +75,9 @@ pub struct ServerSettings {
     #[serde(default = "default_docs_dir")]
     pub docs_dir: Option<String>,
 
-    /// Allow HTTP and private/loopback IPs in SSRF-validated URLs.
-    /// WARNING: Only enable for local development. Never enable in production.
+    /// SSRF validation configuration.
     #[serde(default)]
-    pub allow_private_networks: bool,
-
-    /// Hostnames that are allowed to resolve to private/internal IP addresses.
-    /// Use this to permit SSRF-validated requests to trusted internal services
-    /// (e.g., an internal Keycloak or OIDC provider) without enabling `allow_private_networks`.
-    #[serde(default)]
-    pub ssrf_trusted_hosts: Vec<String>,
-}
-
-impl ServerSettings {
-    /// Build an [`SsrfConfig`](super::ssrf::SsrfConfig) from the server settings.
-    pub fn ssrf_config(&self) -> super::ssrf::SsrfConfig {
-        super::ssrf::SsrfConfig {
-            allow_private_networks: self.allow_private_networks,
-            trusted_hosts: self.ssrf_trusted_hosts.clone(),
-        }
-    }
+    pub ssrf: super::ssrf::SsrfConfig,
 }
 
 fn default_cookie_secure() -> bool {

--- a/src/server/ssrf.rs
+++ b/src/server/ssrf.rs
@@ -1,6 +1,24 @@
 use std::net::IpAddr;
 use std::time::Duration;
 
+/// SSRF validation configuration.
+#[derive(Debug, Clone)]
+pub struct SsrfConfig {
+    /// Allow HTTP and private/loopback IPs (development only).
+    pub allow_private_networks: bool,
+    /// Hostnames exempt from private IP blocking (e.g., internal OIDC providers).
+    pub trusted_hosts: Vec<String>,
+}
+
+impl SsrfConfig {
+    /// Check whether a hostname is in the trusted hosts list.
+    fn is_trusted_host(&self, host: &str) -> bool {
+        self.trusted_hosts
+            .iter()
+            .any(|h| h.eq_ignore_ascii_case(host))
+    }
+}
+
 /// Errors that can occur during SSRF-safe URL validation.
 #[derive(Debug)]
 pub enum SsrfError {
@@ -61,16 +79,21 @@ fn is_blocked_ip(ip: &IpAddr) -> bool {
 /// Checks:
 /// 1. Scheme must be HTTPS (unless `allow_private_networks` is true)
 /// 2. Hostname must be present
-/// 3. All resolved IP addresses must not be in blocked ranges (unless `allow_private_networks` is true)
+/// 3. All resolved IP addresses must not be in blocked ranges (unless the hostname
+///    is in `trusted_hosts` or `allow_private_networks` is true)
+///
+/// Trusted hosts are allowed to resolve to private IPs while keeping SSRF
+/// protection for all other hostnames. Use this for internal services like
+/// Keycloak or other OIDC providers that resolve to cluster-internal addresses.
 ///
 /// When `allow_private_networks` is true, HTTP and private/loopback IPs are permitted.
-/// **WARNING**: Only enable for local development. Never enable in production.
-pub async fn validate_url(url: &str, allow_private_networks: bool) -> Result<(), SsrfError> {
+/// **WARNING**: Only enable `allow_private_networks` for local development. Never enable in production.
+pub async fn validate_url(url: &str, config: &SsrfConfig) -> Result<(), SsrfError> {
     // Parse the URL
     let parsed = url::Url::parse(url).map_err(|e| SsrfError::InvalidUrl(e.to_string()))?;
 
     // Require HTTPS (unless relaxed for development)
-    if !allow_private_networks && parsed.scheme() != "https" {
+    if !config.allow_private_networks && parsed.scheme() != "https" {
         return Err(SsrfError::HttpsRequired);
     }
 
@@ -79,16 +102,19 @@ pub async fn validate_url(url: &str, allow_private_networks: bool) -> Result<(),
         .host_str()
         .ok_or_else(|| SsrfError::InvalidUrl("URL has no host".to_string()))?;
 
+    // Check if the hostname is trusted (allowed to resolve to private IPs)
+    let is_trusted = config.is_trusted_host(host);
+
     // If host is already an IP address, check it directly
     if let Ok(ip) = host.parse::<IpAddr>() {
-        if !allow_private_networks && is_blocked_ip(&ip) {
+        if !config.allow_private_networks && !is_trusted && is_blocked_ip(&ip) {
             return Err(SsrfError::BlockedIpRange(ip));
         }
         return Ok(());
     }
 
-    // Skip DNS resolution checks when private networks are allowed
-    if allow_private_networks {
+    // Skip DNS resolution checks when private networks are allowed or host is trusted
+    if config.allow_private_networks || is_trusted {
         return Ok(());
     }
 
@@ -124,18 +150,19 @@ pub async fn validate_url(url: &str, allow_private_networks: bool) -> Result<(),
 /// - Custom redirect policy (max 3 hops, HTTPS-only, blocks private/internal IPs)
 ///
 /// When `allow_private_networks` is true, redirect checks for HTTPS and blocked IPs are skipped.
-/// **WARNING**: Only enable for local development. Never enable in production.
-pub fn safe_client(allow_private_networks: bool) -> reqwest::Client {
+/// **WARNING**: Only enable `allow_private_networks` for local development. Never enable in production.
+pub fn safe_client(config: &SsrfConfig) -> reqwest::Client {
+    let config = config.clone();
     reqwest::Client::builder()
         .timeout(Duration::from_secs(10))
         .connect_timeout(Duration::from_secs(5))
         .redirect(reqwest::redirect::Policy::custom(move |attempt| {
             if attempt.previous().len() >= 3 {
                 attempt.error("too many redirects")
-            } else if !allow_private_networks && attempt.url().scheme() != "https" {
+            } else if !config.allow_private_networks && attempt.url().scheme() != "https" {
                 attempt.error("redirect target must use HTTPS")
             } else if let Some(host) = attempt.url().host_str() {
-                if !allow_private_networks {
+                if !config.allow_private_networks && !config.is_trusted_host(host) {
                     if let Ok(ip) = host.parse::<IpAddr>() {
                         if is_blocked_ip(&ip) {
                             return attempt
@@ -155,6 +182,27 @@ pub fn safe_client(allow_private_networks: bool) -> reqwest::Client {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn strict() -> SsrfConfig {
+        SsrfConfig {
+            allow_private_networks: false,
+            trusted_hosts: vec![],
+        }
+    }
+
+    fn permissive() -> SsrfConfig {
+        SsrfConfig {
+            allow_private_networks: true,
+            trusted_hosts: vec![],
+        }
+    }
+
+    fn with_trusted(hosts: &[&str]) -> SsrfConfig {
+        SsrfConfig {
+            allow_private_networks: false,
+            trusted_hosts: hosts.iter().map(|s| s.to_string()).collect(),
+        }
+    }
 
     #[test]
     fn test_blocked_ipv4_loopback() {
@@ -234,41 +282,41 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_url_rejects_http() {
-        let result = validate_url("http://example.com", false).await;
+        let result = validate_url("http://example.com", &strict()).await;
         assert!(matches!(result, Err(SsrfError::HttpsRequired)));
     }
 
     #[tokio::test]
     async fn test_validate_url_rejects_invalid_url() {
-        let result = validate_url("not-a-url", false).await;
+        let result = validate_url("not-a-url", &strict()).await;
         assert!(matches!(result, Err(SsrfError::InvalidUrl(_))));
     }
 
     #[tokio::test]
     async fn test_validate_url_rejects_ip_loopback() {
-        let result = validate_url("https://127.0.0.1/path", false).await;
+        let result = validate_url("https://127.0.0.1/path", &strict()).await;
         assert!(matches!(result, Err(SsrfError::BlockedIpRange(_))));
     }
 
     #[tokio::test]
     async fn test_validate_url_rejects_ip_metadata() {
-        let result = validate_url("https://169.254.169.254/latest/meta-data/", false).await;
+        let result = validate_url("https://169.254.169.254/latest/meta-data/", &strict()).await;
         assert!(matches!(result, Err(SsrfError::BlockedIpRange(_))));
     }
 
     #[tokio::test]
     async fn test_validate_url_rejects_private_ip() {
-        let result = validate_url("https://10.0.0.1/internal", false).await;
+        let result = validate_url("https://10.0.0.1/internal", &strict()).await;
         assert!(matches!(result, Err(SsrfError::BlockedIpRange(_))));
 
-        let result = validate_url("https://192.168.1.1/admin", false).await;
+        let result = validate_url("https://192.168.1.1/admin", &strict()).await;
         assert!(matches!(result, Err(SsrfError::BlockedIpRange(_))));
     }
 
     #[tokio::test]
     async fn test_validate_url_accepts_public_https() {
         // Use a known public IP to avoid DNS dependency and make the test deterministic.
-        let result = validate_url("https://8.8.8.8/", false).await;
+        let result = validate_url("https://8.8.8.8/", &strict()).await;
         assert!(
             result.is_ok(),
             "expected public HTTPS URL to be accepted, got: {:?}",
@@ -278,14 +326,14 @@ mod tests {
 
     #[test]
     fn test_safe_client_builds_successfully() {
-        let _client = safe_client(false);
+        let _client = safe_client(&strict());
     }
 
     // Tests for allow_private_networks = true
 
     #[tokio::test]
     async fn test_validate_url_allows_http_when_private_networks_enabled() {
-        let result = validate_url("http://localhost:5556", true).await;
+        let result = validate_url("http://localhost:5556", &permissive()).await;
         assert!(
             result.is_ok(),
             "expected HTTP URL to be accepted with allow_private_networks, got: {:?}",
@@ -295,7 +343,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_url_allows_loopback_when_private_networks_enabled() {
-        let result = validate_url("https://127.0.0.1/path", true).await;
+        let result = validate_url("https://127.0.0.1/path", &permissive()).await;
         assert!(
             result.is_ok(),
             "expected loopback IP to be accepted with allow_private_networks, got: {:?}",
@@ -305,7 +353,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_url_allows_private_ip_when_private_networks_enabled() {
-        let result = validate_url("https://192.168.1.1/admin", true).await;
+        let result = validate_url("https://192.168.1.1/admin", &permissive()).await;
         assert!(
             result.is_ok(),
             "expected private IP to be accepted with allow_private_networks, got: {:?}",
@@ -315,6 +363,50 @@ mod tests {
 
     #[test]
     fn test_safe_client_builds_with_private_networks() {
-        let _client = safe_client(true);
+        let _client = safe_client(&permissive());
+    }
+
+    // Tests for trusted_hosts
+
+    #[tokio::test]
+    async fn test_validate_url_allows_trusted_host_with_private_ip() {
+        // A trusted host should be allowed even if it would resolve to a private IP.
+        // We use an IP-literal URL here to test the is_trusted check on the host string.
+        let config = with_trusted(&["10.0.0.1"]);
+        let result = validate_url("https://10.0.0.1/internal", &config).await;
+        assert!(
+            result.is_ok(),
+            "expected trusted IP-literal host to be accepted, got: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_validate_url_rejects_untrusted_host_with_private_ip() {
+        let config = with_trusted(&["other.internal"]);
+        let result = validate_url("https://10.0.0.1/internal", &config).await;
+        assert!(
+            matches!(result, Err(SsrfError::BlockedIpRange(_))),
+            "expected untrusted IP-literal to be blocked, got: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_validate_url_trusted_host_still_requires_https() {
+        let config = with_trusted(&["internal.example.com"]);
+        let result = validate_url("http://internal.example.com/api", &config).await;
+        assert!(
+            matches!(result, Err(SsrfError::HttpsRequired)),
+            "expected HTTPS requirement even for trusted hosts, got: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_trusted_host_case_insensitive() {
+        let config = with_trusted(&["Keycloak.Example.COM"]);
+        assert!(config.is_trusted_host("keycloak.example.com"));
+        assert!(config.is_trusted_host("KEYCLOAK.EXAMPLE.COM"));
     }
 }

--- a/src/server/ssrf.rs
+++ b/src/server/ssrf.rs
@@ -1,12 +1,30 @@
+use schemars::JsonSchema;
+use serde::Deserialize;
 use std::net::IpAddr;
 use std::time::Duration;
 
 /// SSRF validation configuration.
-#[derive(Debug, Clone)]
+///
+/// Controls how Rise validates URLs before making server-side requests.
+/// All fields default to the most restrictive settings (HTTPS required,
+/// private networks blocked, no trusted hosts).
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
 pub struct SsrfConfig {
-    /// Allow HTTP and private/loopback IPs (development only).
+    /// Allow private/loopback IPs in SSRF-validated URLs.
+    /// WARNING: Only enable for local development. Never enable in production.
+    #[serde(default)]
     pub allow_private_networks: bool,
-    /// Hostnames exempt from private IP blocking (e.g., internal OIDC providers).
+
+    /// Allow HTTP (non-TLS) URLs in SSRF-validated requests.
+    /// WARNING: Only enable for local development. Never enable in production.
+    #[serde(default)]
+    pub allow_http: bool,
+
+    /// Hostnames that are allowed to resolve to private/internal IP addresses.
+    /// Use this to permit SSRF-validated requests to trusted internal services
+    /// (e.g., an internal Keycloak or OIDC provider) without enabling
+    /// `allow_private_networks`.
+    #[serde(default)]
     pub trusted_hosts: Vec<String>,
 }
 
@@ -16,6 +34,11 @@ impl SsrfConfig {
         self.trusted_hosts
             .iter()
             .any(|h| h.eq_ignore_ascii_case(host))
+    }
+
+    /// Whether HTTP is allowed (either via `allow_http` or `allow_private_networks`).
+    fn http_allowed(&self) -> bool {
+        self.allow_http || self.allow_private_networks
     }
 }
 
@@ -77,7 +100,7 @@ fn is_blocked_ip(ip: &IpAddr) -> bool {
 /// Validate that a URL is safe to fetch (SSRF protection).
 ///
 /// Checks:
-/// 1. Scheme must be HTTPS (unless `allow_private_networks` is true)
+/// 1. Scheme must be HTTPS (unless `allow_http` or `allow_private_networks` is true)
 /// 2. Hostname must be present
 /// 3. All resolved IP addresses must not be in blocked ranges (unless the hostname
 ///    is in `trusted_hosts` or `allow_private_networks` is true)
@@ -85,15 +108,12 @@ fn is_blocked_ip(ip: &IpAddr) -> bool {
 /// Trusted hosts are allowed to resolve to private IPs while keeping SSRF
 /// protection for all other hostnames. Use this for internal services like
 /// Keycloak or other OIDC providers that resolve to cluster-internal addresses.
-///
-/// When `allow_private_networks` is true, HTTP and private/loopback IPs are permitted.
-/// **WARNING**: Only enable `allow_private_networks` for local development. Never enable in production.
 pub async fn validate_url(url: &str, config: &SsrfConfig) -> Result<(), SsrfError> {
     // Parse the URL
     let parsed = url::Url::parse(url).map_err(|e| SsrfError::InvalidUrl(e.to_string()))?;
 
-    // Require HTTPS (unless relaxed for development)
-    if !config.allow_private_networks && parsed.scheme() != "https" {
+    // Require HTTPS (unless relaxed)
+    if !config.http_allowed() && parsed.scheme() != "https" {
         return Err(SsrfError::HttpsRequired);
     }
 
@@ -146,11 +166,11 @@ pub async fn validate_url(url: &str, config: &SsrfConfig) -> Result<(), SsrfErro
 /// Create an HTTP client configured with SSRF mitigations.
 ///
 /// The client has:
-/// - 10-second connect and total request timeout
+/// - 5-second connect timeout and 10-second total request timeout
 /// - Custom redirect policy (max 3 hops, HTTPS-only, blocks private/internal IPs)
 ///
 /// When `allow_private_networks` is true, redirect checks for HTTPS and blocked IPs are skipped.
-/// **WARNING**: Only enable `allow_private_networks` for local development. Never enable in production.
+/// When `allow_http` is true, only the HTTPS requirement on redirects is relaxed.
 pub fn safe_client(config: &SsrfConfig) -> reqwest::Client {
     let config = config.clone();
     reqwest::Client::builder()
@@ -159,7 +179,7 @@ pub fn safe_client(config: &SsrfConfig) -> reqwest::Client {
         .redirect(reqwest::redirect::Policy::custom(move |attempt| {
             if attempt.previous().len() >= 3 {
                 attempt.error("too many redirects")
-            } else if !config.allow_private_networks && attempt.url().scheme() != "https" {
+            } else if !config.http_allowed() && attempt.url().scheme() != "https" {
                 attempt.error("redirect target must use HTTPS")
             } else if let Some(host) = attempt.url().host_str() {
                 if !config.allow_private_networks && !config.is_trusted_host(host) {
@@ -184,23 +204,28 @@ mod tests {
     use super::*;
 
     fn strict() -> SsrfConfig {
-        SsrfConfig {
-            allow_private_networks: false,
-            trusted_hosts: vec![],
-        }
+        SsrfConfig::default()
     }
 
     fn permissive() -> SsrfConfig {
         SsrfConfig {
             allow_private_networks: true,
+            allow_http: true,
             trusted_hosts: vec![],
+        }
+    }
+
+    fn with_allow_http() -> SsrfConfig {
+        SsrfConfig {
+            allow_http: true,
+            ..SsrfConfig::default()
         }
     }
 
     fn with_trusted(hosts: &[&str]) -> SsrfConfig {
         SsrfConfig {
-            allow_private_networks: false,
             trusted_hosts: hosts.iter().map(|s| s.to_string()).collect(),
+            ..SsrfConfig::default()
         }
     }
 
@@ -408,5 +433,27 @@ mod tests {
         let config = with_trusted(&["Keycloak.Example.COM"]);
         assert!(config.is_trusted_host("keycloak.example.com"));
         assert!(config.is_trusted_host("KEYCLOAK.EXAMPLE.COM"));
+    }
+
+    // Tests for allow_http
+
+    #[tokio::test]
+    async fn test_validate_url_allows_http_when_allow_http_enabled() {
+        let result = validate_url("http://example.com", &with_allow_http()).await;
+        assert!(
+            result.is_ok(),
+            "expected HTTP URL to be accepted with allow_http, got: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_validate_url_allow_http_still_blocks_private_ips() {
+        let result = validate_url("https://10.0.0.1/internal", &with_allow_http()).await;
+        assert!(
+            matches!(result, Err(SsrfError::BlockedIpRange(_))),
+            "expected private IP to be blocked even with allow_http, got: {:?}",
+            result
+        );
     }
 }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -294,7 +294,7 @@ impl AppState {
         Self::run_migrations(&db_pool).await?;
 
         // Initialize JWT validator (JWKS is fetched on-demand)
-        let jwt_validator = Arc::new(JwtValidator::new(settings.server.ssrf_config()));
+        let jwt_validator = Arc::new(JwtValidator::new(settings.server.ssrf.clone()));
 
         // Initialize JWT signer for ingress authentication (required)
         let jwt_signer = Arc::new(

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -294,7 +294,7 @@ impl AppState {
         Self::run_migrations(&db_pool).await?;
 
         // Initialize JWT validator (JWKS is fetched on-demand)
-        let jwt_validator = Arc::new(JwtValidator::new(settings.server.allow_private_networks));
+        let jwt_validator = Arc::new(JwtValidator::new(settings.server.ssrf_config()));
 
         // Initialize JWT signer for ingress authentication (required)
         let jwt_signer = Arc::new(

--- a/src/server/workload_identity/handlers.rs
+++ b/src/server/workload_identity/handlers.rs
@@ -156,7 +156,7 @@ pub async fn create_workload_identity(
 
     // Verify OIDC issuer is reachable and has valid configuration
     // (also validates HTTPS requirement and SSRF protections)
-    verify_oidc_issuer(&req.issuer_url, &state.server_settings.ssrf_config()).await?;
+    verify_oidc_issuer(&req.issuer_url, &state.server_settings.ssrf).await?;
 
     // Create service account
     let sa = service_accounts::create(&state.db_pool, project.id, &req.issuer_url, &req.claims)
@@ -351,7 +351,7 @@ pub async fn update_workload_identity(
         }
 
         // Validate SSRF protections (HTTPS requirement + blocks private/internal IPs)
-        ssrf::validate_url(issuer_url, &state.server_settings.ssrf_config())
+        ssrf::validate_url(issuer_url, &state.server_settings.ssrf)
             .await
             .map_err(|e| {
                 tracing::warn!(

--- a/src/server/workload_identity/handlers.rs
+++ b/src/server/workload_identity/handlers.rs
@@ -22,10 +22,10 @@ use crate::server::workload_identity::models::{
 /// enforces request timeout and redirect limits.
 async fn verify_oidc_issuer(
     issuer_url: &str,
-    allow_private_networks: bool,
+    ssrf_config: &ssrf::SsrfConfig,
 ) -> Result<(), ServerError> {
     // Validate the issuer URL against SSRF (requires HTTPS, blocks private IPs)
-    ssrf::validate_url(issuer_url, allow_private_networks)
+    ssrf::validate_url(issuer_url, ssrf_config)
         .await
         .map_err(|e| {
             tracing::warn!(
@@ -46,7 +46,7 @@ async fn verify_oidc_issuer(
     tracing::debug!("Verifying OIDC issuer at: {}", discovery_url);
 
     // Use SSRF-safe client (timeout + redirect limits)
-    let client = ssrf::safe_client(allow_private_networks);
+    let client = ssrf::safe_client(ssrf_config);
 
     // Attempt to fetch the OIDC configuration
     let response = client.get(&discovery_url)
@@ -156,11 +156,7 @@ pub async fn create_workload_identity(
 
     // Verify OIDC issuer is reachable and has valid configuration
     // (also validates HTTPS requirement and SSRF protections)
-    verify_oidc_issuer(
-        &req.issuer_url,
-        state.server_settings.allow_private_networks,
-    )
-    .await?;
+    verify_oidc_issuer(&req.issuer_url, &state.server_settings.ssrf_config()).await?;
 
     // Create service account
     let sa = service_accounts::create(&state.db_pool, project.id, &req.issuer_url, &req.claims)
@@ -355,7 +351,7 @@ pub async fn update_workload_identity(
         }
 
         // Validate SSRF protections (HTTPS requirement + blocks private/internal IPs)
-        ssrf::validate_url(issuer_url, state.server_settings.allow_private_networks)
+        ssrf::validate_url(issuer_url, &state.server_settings.ssrf_config())
             .await
             .map_err(|e| {
                 tracing::warn!(


### PR DESCRIPTION
## Summary

- Adds a new nested `server.ssrf` config block with three independent knobs for SSRF validation:
  - `allow_private_networks` — permit private/loopback IPs (dev only)
  - `allow_http` — permit HTTP URLs without also allowing private networks
  - `trusted_hosts` — allowlist specific hostnames to resolve to private IPs
- Introduces `SsrfConfig` struct replacing the previous bare `allow_private_networks: bool` threaded through all callsites
- Regenerates config schema

```yaml
server:
  ssrf:
    allow_private_networks: false
    allow_http: false
    trusted_hosts:
      - example.domain.com
```

## Motivation

SSRF protection prevents accessing local IPs. Previously the only workaround was `allow_private_networks: true`, which is unsafe for production. `trusted_hosts` allows exempting specific hostnames while keeping SSRF protection for everything else.
