### PR TITLE
fix: use hostPort for ingress-nginx in k3s dev setup

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -213,7 +213,13 @@ sudo cat /etc/rancher/k3s/k3s.yaml > ~/.kube/config
 kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.31.4/manifests/operator-crds.yaml --server-side --force-conflicts
 kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.31.4/manifests/tigera-operator.yaml --server-side --force-conflicts
 kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.31.4/manifests/custom-resources.yaml --server-side --force-conflicts
-helm upgrade --install --repo https://kubernetes.github.io/ingress-nginx ingress-nginx --namespace ingress-nginx ingress-nginx --create-namespace
+helm upgrade --install ingress-nginx ingress-nginx \
+  --repo https://kubernetes.github.io/ingress-nginx \
+  --namespace ingress-nginx --create-namespace \
+  --set controller.hostPort.enabled=true \
+  --set controller.hostPort.ports.http=8080 \
+  --set controller.hostPort.ports.https=8443 \
+  --set controller.service.type=ClusterIP
 
 # Install Metacontroller + Rise CRDs for development
 HOST_IP=$(kubectl get node $(hostname) -o jsonpath='{.metadata.annotations.k3s\\.io/internal-ip}')


### PR DESCRIPTION
## Summary
- Configure ingress-nginx in the `k3s:up` task to use `hostPort` mode, binding directly to ports 8080 (HTTP) and 8443 (HTTPS) on the host
- Set the service type to `ClusterIP` to avoid a dangling LoadBalancer/NodePort service
- Provides deterministic port access without requiring a background `kubectl port-forward` process

## Test plan
- [ ] Run `mise run k3s:up` and verify ingress-nginx pods bind to host ports 8080/8443
- [ ] Verify apps are accessible at `http://rise.local:8080`

🤖 Generated with [Claude Code](https://claude.com/claude-code)