### PR TITLE
feat: add public JSON Schema endpoint for rise.toml

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -6,6 +6,8 @@ Rise projects are configured through a `rise.toml` file in your project director
 
 The `rise.toml` file defines your project metadata and build settings. Both `rise.toml` and `.rise.toml` are supported — if both exist, `rise.toml` takes precedence (with a warning).
 
+A [JSON Schema](https://rise.example.com/api/v1/schema/rise-toml/v1) is available for editor auto-completion and validation.
+
 ### `[project]` Section
 
 ```toml

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -6,7 +6,11 @@ Rise projects are configured through a `rise.toml` file in your project director
 
 The `rise.toml` file defines your project metadata and build settings. Both `rise.toml` and `.rise.toml` are supported — if both exist, `rise.toml` takes precedence (with a warning).
 
-A [JSON Schema](https://rise.example.com/api/v1/schema/rise-toml/v1) is available for editor auto-completion and validation.
+A [JSON Schema](https://rise.example.com/api/v1/schema/rise-toml/v1) is available for editor auto-completion and validation. To enable it in editors that support the [Taplo](https://taplo.tamasfe.dev/) TOML language server, add this comment as the first line of your `rise.toml`:
+
+```toml
+#:schema https://rise.example.com/api/v1/schema/rise-toml/v1
+```
 
 ### `[project]` Section
 

--- a/example/hello-world-js/rise.toml
+++ b/example/hello-world-js/rise.toml
@@ -1,3 +1,4 @@
+#:schema http://rise.local:3000/api/v1/schema/rise-toml/v1
 version = 1
 
 [project]

--- a/example/hello-world-py/rise.toml
+++ b/example/hello-world-py/rise.toml
@@ -1,3 +1,4 @@
+#:schema http://rise.local:3000/api/v1/schema/rise-toml/v1
 version = 1
 
 [project]

--- a/example/hello-world/rise.toml
+++ b/example/hello-world/rise.toml
@@ -1,3 +1,4 @@
+#:schema http://rise.local:3000/api/v1/schema/rise-toml/v1
 version = 1
 
 [project]

--- a/example/oauth-exchange-flow/rise.toml
+++ b/example/oauth-exchange-flow/rise.toml
@@ -1,3 +1,4 @@
+#:schema http://rise.local:3000/api/v1/schema/rise-toml/v1
 version = 1
 
 [project]

--- a/example/oauth-pkce-flow/rise.toml
+++ b/example/oauth-pkce-flow/rise.toml
@@ -1,3 +1,4 @@
+#:schema http://rise.local:3000/api/v1/schema/rise-toml/v1
 version = 1
 
 [project]

--- a/src/build/config.rs
+++ b/src/build/config.rs
@@ -1,104 +1,11 @@
 // Project-level build configuration (rise.toml / .rise.toml)
 
 use anyhow::Result;
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::path::Path;
 use tracing::{debug, info, warn};
 
-/// Root structure for rise.toml / .rise.toml configuration file
-#[derive(Debug, Deserialize, Serialize, Default)]
-pub struct ProjectBuildConfig {
-    /// Optional version (must be 1 if present)
-    pub version: Option<u32>,
-
-    /// Project metadata (optional)
-    #[serde(default)]
-    pub project: Option<ProjectConfig>,
-
-    /// Build configuration (optional)
-    #[serde(default)]
-    pub build: Option<BuildConfig>,
-
-    /// Per-environment configuration (optional)
-    #[serde(default)]
-    pub environments: HashMap<String, EnvironmentConfig>,
-}
-
-/// Per-environment configuration
-#[derive(Debug, Deserialize, Serialize, Clone, Default)]
-pub struct EnvironmentConfig {
-    /// Plain-text environment variables scoped to this environment
-    #[serde(default)]
-    pub env: HashMap<String, String>,
-}
-
-/// Project metadata configuration
-#[derive(Debug, Deserialize, Serialize, Clone)]
-pub struct ProjectConfig {
-    /// Project name
-    pub name: String,
-
-    /// Access class (e.g., public, private)
-    #[serde(default = "default_access_class", alias = "visibility")]
-    pub access_class: String,
-
-    /// Custom domains
-    #[serde(default)]
-    pub custom_domains: Vec<String>,
-
-    /// Plain-text environment variables (non-secret)
-    #[serde(default)]
-    pub env: HashMap<String, String>,
-
-    /// URL to where the project code lives (e.g. a GitHub/GitLab repository)
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub source_url: Option<String>,
-}
-
-fn default_access_class() -> String {
-    "public".to_string()
-}
-
-/// Build configuration options for a project
-#[derive(Debug, Deserialize, Serialize, Default)]
-pub struct BuildConfig {
-    /// Build backend (docker, docker:build, docker:buildx, buildctl, pack, railpack[:buildx], railpack:buildctl)
-    pub backend: Option<String>,
-
-    /// Buildpack builder to use (only for pack backend)
-    pub builder: Option<String>,
-
-    /// Buildpack(s) to use (only for pack backend)
-    pub buildpacks: Option<Vec<String>>,
-
-    /// Build arguments to pass to the build
-    /// Format: KEY=VALUE or KEY (to pass from environment)
-    #[serde(alias = "env")]
-    pub args: Option<Vec<String>>,
-
-    /// Container CLI to use (docker or podman)
-    pub container_cli: Option<String>,
-
-    /// Enable managed BuildKit daemon with SSL certificate support
-    pub managed_buildkit: Option<bool>,
-
-    /// Path to Dockerfile (relative to rise.toml location). Defaults to "Dockerfile" or "Containerfile"
-    pub dockerfile: Option<String>,
-
-    /// Default build context (docker/podman only) - the context directory for the build
-    /// This is the path argument to `docker build <path>`. Defaults to rise.toml location.
-    /// Path is relative to the rise.toml file location.
-    pub build_context: Option<String>,
-
-    /// Build contexts (docker/podman only) - additional named contexts for multi-stage builds
-    /// Format: { "name" = "path" } where path is relative to the rise.toml file location
-    #[serde(default)]
-    pub build_contexts: Option<HashMap<String, String>>,
-
-    /// Disable build cache
-    pub no_cache: Option<bool>,
-}
+// Re-export shared config types from rise_toml module
+pub use crate::rise_toml::*;
 
 /// Load full project configuration from rise.toml or .rise.toml
 ///
@@ -177,6 +84,7 @@ pub fn write_project_config(app_path: &str, config: &ProjectBuildConfig) -> Resu
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
     #[test]
     fn test_load_config_with_unused_fields() {

--- a/src/build/config.rs
+++ b/src/build/config.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use tracing::{debug, info, warn};
 
 // Re-export shared config types from rise_toml module
-pub use crate::rise_toml::*;
+pub use crate::rise_toml::{ProjectBuildConfig, ProjectConfig};
 
 /// Load full project configuration from rise.toml or .rise.toml
 ///
@@ -84,6 +84,7 @@ pub fn write_project_config(app_path: &str, config: &ProjectBuildConfig) -> Resu
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::rise_toml::EnvironmentConfig;
     use std::collections::HashMap;
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,9 @@ mod build;
 #[cfg(feature = "cli")]
 mod cli;
 
+#[cfg(any(feature = "cli", feature = "backend"))]
+mod rise_toml;
+
 #[cfg(feature = "backend")]
 mod db;
 #[cfg(feature = "backend")]

--- a/src/rise_toml.rs
+++ b/src/rise_toml.rs
@@ -1,0 +1,105 @@
+//! Shared type definitions for the `rise.toml` / `.rise.toml` project configuration file.
+//!
+//! These types are used by both the CLI (for reading/writing config) and the backend
+//! (for generating a JSON Schema endpoint).
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Root structure for rise.toml / .rise.toml configuration file
+#[derive(Debug, Deserialize, Serialize, Default)]
+#[cfg_attr(feature = "backend", derive(schemars::JsonSchema))]
+pub struct ProjectBuildConfig {
+    /// Optional version (must be 1 if present)
+    pub version: Option<u32>,
+
+    /// Project metadata (optional)
+    #[serde(default)]
+    pub project: Option<ProjectConfig>,
+
+    /// Build configuration (optional)
+    #[serde(default)]
+    pub build: Option<BuildConfig>,
+
+    /// Per-environment configuration (optional)
+    #[serde(default)]
+    pub environments: HashMap<String, EnvironmentConfig>,
+}
+
+/// Per-environment configuration
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+#[cfg_attr(feature = "backend", derive(schemars::JsonSchema))]
+pub struct EnvironmentConfig {
+    /// Plain-text environment variables scoped to this environment
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+}
+
+/// Project metadata configuration
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[cfg_attr(feature = "backend", derive(schemars::JsonSchema))]
+pub struct ProjectConfig {
+    /// Project name
+    pub name: String,
+
+    /// Access class (e.g., public, private)
+    #[serde(default = "default_access_class", alias = "visibility")]
+    pub access_class: String,
+
+    /// Custom domains
+    #[serde(default)]
+    pub custom_domains: Vec<String>,
+
+    /// Plain-text environment variables (non-secret)
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+
+    /// URL to where the project code lives (e.g. a GitHub/GitLab repository)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_url: Option<String>,
+}
+
+pub fn default_access_class() -> String {
+    "public".to_string()
+}
+
+/// Build configuration options for a project
+#[derive(Debug, Deserialize, Serialize, Default)]
+#[cfg_attr(feature = "backend", derive(schemars::JsonSchema))]
+pub struct BuildConfig {
+    /// Build backend (docker, docker:build, docker:buildx, buildctl, pack, railpack[:buildx], railpack:buildctl)
+    pub backend: Option<String>,
+
+    /// Buildpack builder to use (only for pack backend)
+    pub builder: Option<String>,
+
+    /// Buildpack(s) to use (only for pack backend)
+    pub buildpacks: Option<Vec<String>>,
+
+    /// Build arguments to pass to the build
+    /// Format: KEY=VALUE or KEY (to pass from environment)
+    #[serde(alias = "env")]
+    pub args: Option<Vec<String>>,
+
+    /// Container CLI to use (docker or podman)
+    pub container_cli: Option<String>,
+
+    /// Enable managed BuildKit daemon with SSL certificate support
+    pub managed_buildkit: Option<bool>,
+
+    /// Path to Dockerfile (relative to rise.toml location). Defaults to "Dockerfile" or "Containerfile"
+    pub dockerfile: Option<String>,
+
+    /// Default build context (docker/podman only) - the context directory for the build
+    /// This is the path argument to `docker build <path>`. Defaults to rise.toml location.
+    /// Path is relative to the rise.toml file location.
+    pub build_context: Option<String>,
+
+    /// Build contexts (docker/podman only) - additional named contexts for multi-stage builds
+    /// Format: { "name" = "path" } where path is relative to the rise.toml file location
+    #[serde(default)]
+    pub build_contexts: Option<HashMap<String, String>>,
+
+    /// Disable build cache
+    pub no_cache: Option<bool>,
+}

--- a/src/rise_toml.rs
+++ b/src/rise_toml.rs
@@ -59,7 +59,7 @@ pub struct ProjectConfig {
     pub source_url: Option<String>,
 }
 
-pub fn default_access_class() -> String {
+pub(crate) fn default_access_class() -> String {
     "public".to_string()
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -112,6 +112,10 @@ pub async fn run_server(settings: settings::Settings) -> Result<()> {
     let public_routes = Router::new()
         .route("/health", axum::routing::get(health_check))
         .route("/version", axum::routing::get(version_info))
+        .route(
+            "/schema/rise-toml/v1",
+            axum::routing::get(rise_toml_schema_v1),
+        )
         .merge(auth::routes::public_routes());
 
     // Auth-only routes (require authentication but NOT platform access)
@@ -512,6 +516,11 @@ async fn version_info() -> axum::Json<serde_json::Value> {
         "version": env!("CARGO_PKG_VERSION"),
         "repository": env!("CARGO_PKG_REPOSITORY"),
     }))
+}
+
+async fn rise_toml_schema_v1() -> axum::Json<serde_json::Value> {
+    let schema = schemars::schema_for!(crate::rise_toml::ProjectBuildConfig);
+    axum::Json(schema.to_value())
 }
 
 /// Wait for a shutdown signal (SIGTERM or SIGINT)


### PR DESCRIPTION
## Summary
- Extract `rise.toml` config types (`ProjectBuildConfig`, `ProjectConfig`, `BuildConfig`, `EnvironmentConfig`) into a shared `src/rise_toml.rs` module, compiled under both `cli` and `backend` features
- Add conditional `schemars::JsonSchema` derives (backend feature only) and serve the generated schema at `GET /api/v1/schema/rise-toml/v1` as a public (no auth) endpoint
- Add JSON Schema reference link in `docs/user-guide/configuration.md`

## Test plan
- [x] `cargo build --features cli` compiles
- [x] `cargo build --features backend` compiles
- [x] `cargo clippy --all-features --all-targets -- -D warnings` passes
- [x] `cargo test --all-features build::config` — all 5 config tests pass
- [x] Manual: start server and `curl /api/v1/schema/rise-toml/v1` returns valid JSON Schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)