### PR TITLE
fix: allow PKCE and client_secret together for confidential OAuth clients

### DIFF
--- a/docs/user-guide/oauth.md
+++ b/docs/user-guide/oauth.md
@@ -413,7 +413,7 @@ Content-Type: application/x-www-form-urlencoded
 ```
 
 **Error Codes:**
-- `invalid_request` (400): Missing or invalid parameters, or both `client_secret` and `code_verifier` provided
+- `invalid_request` (400): Missing or invalid parameters (e.g., neither `client_secret` nor `code_verifier` provided)
 - `invalid_client` (401): Invalid client_id or client_secret
 - `invalid_grant` (400): Invalid/expired code, or PKCE validation failed
 - `unsupported_grant_type` (400): Unknown grant_type

--- a/docs/user-guide/oauth.md
+++ b/docs/user-guide/oauth.md
@@ -381,12 +381,10 @@ Content-Type: application/x-www-form-urlencoded
 - `grant_type` (required): Must be `"authorization_code"`
 - `code` (required): Authorization code from callback
 - `client_id` (required): Rise client ID from environment variable `{EXTENSION}_CLIENT_ID`
-- **Client authentication (choose ONE method - mutually exclusive):**
-  - **Confidential clients (backend apps):**
-    - `client_secret` (required): Rise client secret from environment variable `{EXTENSION}_CLIENT_SECRET`
-  - **Public clients (SPAs with PKCE):**
-    - `code_verifier` (required): PKCE code verifier (proves client initiated the flow)
-  - **Note:** Providing both `client_secret` and `code_verifier` will result in an `invalid_request` error
+- **Client authentication (at least one required):**
+  - `client_secret`: Rise client secret (confidential clients)
+  - `code_verifier`: PKCE code verifier (proves client initiated the flow)
+  - Both may be provided together for defense-in-depth (recommended by OAuth 2.1)
 
 **For refresh_token grant (refresh access token):**
 - `grant_type` (required): Must be `"refresh_token"`

--- a/src/server/extensions/providers/oauth/handlers.rs
+++ b/src/server/extensions/providers/oauth/handlers.rs
@@ -1267,18 +1267,12 @@ async fn token_endpoint_inner(
 
     match req.grant_type.as_str() {
         "authorization_code" => {
-            // authorization_code grant: REQUIRE client_secret OR code_verifier (PKCE)
+            // authorization_code grant: REQUIRE client_secret OR code_verifier (PKCE), or both.
+            // Confidential clients may use PKCE as additional protection (recommended by OAuth 2.1).
             if !has_client_secret && !has_code_verifier {
                 return Err(oauth2_error(
                     "invalid_request",
-                    Some("Missing client authentication: provide either client_secret (confidential clients) or code_verifier (public clients with PKCE)".to_string()),
-                ));
-            }
-            // For authorization_code grant, client_secret and code_verifier are mutually exclusive
-            if has_client_secret && has_code_verifier {
-                return Err(oauth2_error(
-                    "invalid_request",
-                    Some("Client authentication methods are mutually exclusive: provide either client_secret (confidential clients) or code_verifier (public clients), not both".to_string()),
+                    Some("Missing client authentication: provide client_secret, code_verifier (PKCE), or both".to_string()),
                 ));
             }
         }
@@ -1362,15 +1356,6 @@ async fn handle_authorization_code_grant(
     extension_name: String,
     req: TokenRequest,
 ) -> Result<Response, (StatusCode, Json<OAuth2ErrorResponse>)> {
-    // SECURITY: Ensure mutual exclusivity of authentication methods
-    // This is defensive programming - the check should already have happened in token_endpoint_inner
-    if req.client_secret.is_some() && req.code_verifier.is_some() {
-        return Err(oauth2_error(
-            "invalid_request",
-            Some("Authentication methods must be mutually exclusive".to_string()),
-        ));
-    }
-
     // Validate required parameters
     let code = req.code.ok_or_else(|| {
         oauth2_error(

--- a/src/server/extensions/providers/oauth/handlers.rs
+++ b/src/server/extensions/providers/oauth/handlers.rs
@@ -1266,15 +1266,16 @@ async fn token_endpoint_inner(
     let has_code_verifier = req.code_verifier.is_some();
 
     match req.grant_type.as_str() {
+        // authorization_code grant: REQUIRE client_secret OR code_verifier (PKCE), or both.
+        // Confidential clients may use PKCE as additional protection (recommended by OAuth 2.1).
+        "authorization_code" if !has_client_secret && !has_code_verifier => {
+            return Err(oauth2_error(
+                "invalid_request",
+                Some("Missing client authentication: provide client_secret, code_verifier (PKCE), or both".to_string()),
+            ));
+        }
         "authorization_code" => {
-            // authorization_code grant: REQUIRE client_secret OR code_verifier (PKCE), or both.
-            // Confidential clients may use PKCE as additional protection (recommended by OAuth 2.1).
-            if !has_client_secret && !has_code_verifier {
-                return Err(oauth2_error(
-                    "invalid_request",
-                    Some("Missing client authentication: provide client_secret, code_verifier (PKCE), or both".to_string()),
-                ));
-            }
+            // Valid: has client_secret, code_verifier, or both
         }
         "refresh_token" if has_code_verifier => {
             // refresh_token grant: REJECT code_verifier (PKCE is only for authorization_code grant)


### PR DESCRIPTION
## Summary

- Remove the mutual-exclusion check that rejected OAuth token requests providing both `client_secret` and `code_verifier` (PKCE)
- Confidential clients can now use PKCE as an additional layer of defense, as recommended by OAuth 2.1
- Update token endpoint documentation to reflect the new behavior

## Test plan

- [x] Verify confidential client can exchange auth code with both `client_secret` and `code_verifier`
- [x] Verify public client (PKCE only, no `client_secret`) still works
- [x] Verify confidential client (`client_secret` only, no PKCE) still works
- [x] Verify request with neither `client_secret` nor `code_verifier` is still rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)