### PR TITLE
fix: env var source display and environment-scoped var propagation

### DIFF
--- a/example/hello-world/rise.toml
+++ b/example/hello-world/rise.toml
@@ -7,7 +7,13 @@ access_class = "private"
 custom_domains = []
 
 [project.env]
+APP_ENV = "production"
 
+[environments.production]
+env = { LOG_LEVEL = "warn" }
+
+[environments.staging]
+env = { LOG_LEVEL = "debug" }
 # Build-time arguments (optional)
 # These are passed to the build process and can configure build behavior
 # Uncomment to use:

--- a/frontend/src/features/resources.tsx
+++ b/frontend/src/features/resources.tsx
@@ -949,6 +949,21 @@ export function DomainsList({ projectName, defaultUrl = null }) {
     );
 }
 
+function EnvVarSourceTag({ source }) {
+    if (!source) return null;
+    if (source.startsWith('env:')) {
+        return <MonoTag color="blue">{source.slice(4)}</MonoTag>;
+    }
+    const colorMap = {
+        system: 'gray',
+        global: 'green',
+        extension: 'purple',
+        toml: 'yellow',
+        cli: 'blue',
+    };
+    return <MonoTag color={colorMap[source] || 'gray'}>{source}</MonoTag>;
+}
+
 // Environment Variables Component
 export function EnvVarsList({ projectName, deploymentId }) {
     const [envVars, setEnvVars] = useState([]);
@@ -1109,6 +1124,9 @@ export function EnvVarsList({ projectName, deploymentId }) {
                             <MonoTh className="px-6 py-3 text-left">Key</MonoTh>
                             <MonoTh className="px-6 py-3 text-left">Value</MonoTh>
                             <MonoTh className="px-6 py-3 text-left">Type</MonoTh>
+                            {deploymentId && (
+                                <MonoTh className="px-6 py-3 text-left">Source</MonoTh>
+                            )}
                             {showEnvColumn && (
                                 <MonoTh className="px-6 py-3 text-left">Environment</MonoTh>
                             )}
@@ -1119,7 +1137,7 @@ export function EnvVarsList({ projectName, deploymentId }) {
                     </MonoTableHead>
                     <MonoTableBody>
                         {envVars.length === 0 ? (
-                            <MonoTableEmptyRow colSpan={deploymentId ? 3 : (showEnvColumn ? 5 : 4)}>No environment variables configured.</MonoTableEmptyRow>
+                            <MonoTableEmptyRow colSpan={deploymentId ? 4 : (showEnvColumn ? 5 : 4)}>No environment variables configured.</MonoTableEmptyRow>
                         ) : (
                             envVars.map(env => (
                             <MonoTableRow key={`${env.key}-${env.environment || ''}`} interactive className="transition-colors">
@@ -1176,6 +1194,11 @@ export function EnvVarsList({ projectName, deploymentId }) {
                                         <MonoTag color="gray">plain</MonoTag>
                                     )}
                                 </MonoTd>
+                                {deploymentId && (
+                                    <MonoTd className="px-6 py-4 text-sm">
+                                        <EnvVarSourceTag source={env.source} />
+                                    </MonoTd>
+                                )}
                                 {showEnvColumn && (
                                     <MonoTd className="px-6 py-4 text-sm text-gray-700 dark:text-gray-300">
                                         {env.environment ? (

--- a/frontend/src/features/resources.tsx
+++ b/frontend/src/features/resources.tsx
@@ -560,7 +560,13 @@ export function ServiceAccountsList({ projectName }) {
                                         .join(', ')}
                                 </MonoTd>
                                 <MonoTd className="px-6 py-4 text-sm text-gray-700 dark:text-gray-300">
-                                    {sa.allowed_environments ? sa.allowed_environments.join(', ') : 'All'}
+                                    {sa.allowed_environments ? sa.allowed_environments.map((envName, i) => (
+                                        <span key={envName} className="inline-flex items-center gap-1.5">
+                                            {i > 0 && ', '}
+                                            <EnvironmentColorDot color={environments.find(e => e.name === envName)?.color} />
+                                            {envName}
+                                        </span>
+                                    )) : 'All'}
                                 </MonoTd>
                                 <MonoTd className="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">{formatDate(sa.created_at)}</MonoTd>
                                 <MonoTd className="px-6 py-4 text-sm">
@@ -949,19 +955,28 @@ export function DomainsList({ projectName, defaultUrl = null }) {
     );
 }
 
-function EnvVarSourceTag({ source }) {
+const ENV_VAR_SOURCE_COLORS = {
+    system: 'gray',
+    global: 'green',
+    extension: 'purple',
+    toml: 'yellow',
+    cli: 'blue',
+};
+
+function EnvVarSourceTag({ source, environments = [] }) {
     if (!source) return null;
-    if (source.startsWith('env:')) {
-        return <MonoTag color="blue">{source.slice(4)}</MonoTag>;
+    const envPrefix = 'env:';
+    if (source.startsWith(envPrefix)) {
+        const envName = source.slice(envPrefix.length);
+        const envColor = environments.find(e => e.name === envName)?.color;
+        return (
+            <span className="inline-flex items-center gap-1.5">
+                <EnvironmentColorDot color={envColor} />
+                <MonoTag color="blue">{envName}</MonoTag>
+            </span>
+        );
     }
-    const colorMap = {
-        system: 'gray',
-        global: 'green',
-        extension: 'purple',
-        toml: 'yellow',
-        cli: 'blue',
-    };
-    return <MonoTag color={colorMap[source] || 'gray'}>{source}</MonoTag>;
+    return <MonoTag color={ENV_VAR_SOURCE_COLORS[source] || 'gray'}>{source}</MonoTag>;
 }
 
 // Environment Variables Component
@@ -992,13 +1007,12 @@ export function EnvVarsList({ projectName, deploymentId }) {
         is_protected: type === 'protected',
     });
 
-    // Load environments for filter dropdown (project-level only)
+    // Load environments for filter dropdown and source color dots
     useEffect(() => {
-        if (deploymentId) return;
         api.getProjectEnvironments(projectName)
             .then(data => setEnvironments(data || []))
             .catch(() => {});
-    }, [projectName, deploymentId]);
+    }, [projectName]);
 
     const loadEnvVars = useCallback(async () => {
         try {
@@ -1196,7 +1210,7 @@ export function EnvVarsList({ projectName, deploymentId }) {
                                 </MonoTd>
                                 {deploymentId && (
                                     <MonoTd className="px-6 py-4 text-sm">
-                                        <EnvVarSourceTag source={env.source} />
+                                        <EnvVarSourceTag source={env.source} environments={environments} />
                                     </MonoTd>
                                 )}
                                 {showEnvColumn && (

--- a/src/build/method.rs
+++ b/src/build/method.rs
@@ -112,7 +112,7 @@ pub(crate) struct BuildOptions {
 }
 
 impl BuildOptions {
-    /// Create BuildOptions from BuildArgs and Config
+    /// Create BuildOptions from BuildArgs and Config.
     ///
     /// Configuration precedence (highest to lowest):
     /// 1. CLI flags (BuildArgs)
@@ -120,23 +120,31 @@ impl BuildOptions {
     /// 3. Project config file (rise.toml / .rise.toml)
     /// 4. Global config file (via Config getters)
     /// 5. Auto-detection/defaults (via Config getters)
+    ///
+    /// When `preloaded_config` is provided, its `.build` section is used instead
+    /// of loading rise.toml from disk, avoiding duplicate file reads/warnings.
     pub(crate) fn from_build_args(
         config: &Config,
         image_tag: String,
         app_path: String,
         build_args: &BuildArgs,
+        preloaded_config: Option<crate::build::config::ProjectBuildConfig>,
     ) -> Self {
         use tracing::warn;
 
-        // Load project-level build config from app_path with error handling
-        let project_config = match crate::build::config::load_full_project_config(&app_path) {
-            Ok(cfg) => cfg.and_then(|c| c.build),
-            Err(e) => {
-                warn!(
-                    "Failed to load project config: {:#}. Continuing without it.",
-                    e
-                );
-                None
+        // Use preloaded config if available, otherwise load from disk
+        let project_config = if let Some(cfg) = preloaded_config {
+            cfg.build
+        } else {
+            match crate::build::config::load_full_project_config(&app_path) {
+                Ok(cfg) => cfg.and_then(|c| c.build),
+                Err(e) => {
+                    warn!(
+                        "Failed to load project config: {:#}. Continuing without it.",
+                        e
+                    );
+                    None
+                }
             }
         };
 

--- a/src/cli/deployment/core.rs
+++ b/src/cli/deployment/core.rs
@@ -429,6 +429,9 @@ pub struct EnvOverride {
     pub is_secret: bool,
     pub is_protected: bool,
     pub source: Option<String>,
+    /// Target environment name. When set, the server only applies this override
+    /// if the resolved deployment environment matches. `None` means global.
+    pub for_environment: Option<String>,
 }
 
 /// Options for creating a deployment
@@ -455,6 +458,8 @@ pub struct DeploymentOptions<'a> {
     /// URL to the pull request/merge request associated with this deployment.
     /// If None, auto-detection from CI environment variables is attempted.
     pub pull_request_url: Option<String>,
+    /// Pre-loaded project config from rise.toml to avoid re-loading during build.
+    pub toml_config: Option<build::config::ProjectBuildConfig>,
 }
 
 pub async fn create_deployment(
@@ -680,6 +685,7 @@ pub async fn create_deployment(
             deployment_info.image_tag.clone(),
             deploy_opts.path.to_string(),
             deploy_opts.build_args,
+            deploy_opts.toml_config,
         );
 
         // Step 2: Login to registry if credentials provided
@@ -960,6 +966,9 @@ async fn call_create_deployment_api(
                 });
                 if let Some(ref source) = o.source {
                     v["source"] = serde_json::json!(source);
+                }
+                if let Some(ref env) = o.for_environment {
+                    v["for_environment"] = serde_json::json!(env);
                 }
                 v
             })

--- a/src/cli/environment.rs
+++ b/src/cli/environment.rs
@@ -56,7 +56,7 @@ pub async fn handle_environment_command(
             production,
             color,
         } => {
-            let project_name = crate::resolve_project_name(project.clone(), path, None)?;
+            let project_name = crate::resolve_project_name(project.clone(), path)?;
             create_environment(
                 http_client,
                 backend_url,
@@ -70,7 +70,7 @@ pub async fn handle_environment_command(
             .await
         }
         crate::EnvironmentCommands::List { project, path } => {
-            let project_name = crate::resolve_project_name(project.clone(), path, None)?;
+            let project_name = crate::resolve_project_name(project.clone(), path)?;
             list_environments(http_client, backend_url, &token, &project_name).await
         }
         crate::EnvironmentCommands::Show {
@@ -78,7 +78,7 @@ pub async fn handle_environment_command(
             project,
             path,
         } => {
-            let project_name = crate::resolve_project_name(project.clone(), path, None)?;
+            let project_name = crate::resolve_project_name(project.clone(), path)?;
             show_environment(http_client, backend_url, &token, &project_name, name).await
         }
         crate::EnvironmentCommands::Update {
@@ -90,7 +90,7 @@ pub async fn handle_environment_command(
             production,
             color,
         } => {
-            let project_name = crate::resolve_project_name(project.clone(), path, None)?;
+            let project_name = crate::resolve_project_name(project.clone(), path)?;
             update_environment(
                 http_client,
                 backend_url,
@@ -109,7 +109,7 @@ pub async fn handle_environment_command(
             project,
             path,
         } => {
-            let project_name = crate::resolve_project_name(project.clone(), path, None)?;
+            let project_name = crate::resolve_project_name(project.clone(), path)?;
             delete_environment(http_client, backend_url, &token, &project_name, name).await
         }
     }

--- a/src/cli/environment.rs
+++ b/src/cli/environment.rs
@@ -56,7 +56,7 @@ pub async fn handle_environment_command(
             production,
             color,
         } => {
-            let project_name = crate::resolve_project_name(project.clone(), path)?;
+            let project_name = crate::resolve_project_name(project.clone(), path, None)?;
             create_environment(
                 http_client,
                 backend_url,
@@ -70,7 +70,7 @@ pub async fn handle_environment_command(
             .await
         }
         crate::EnvironmentCommands::List { project, path } => {
-            let project_name = crate::resolve_project_name(project.clone(), path)?;
+            let project_name = crate::resolve_project_name(project.clone(), path, None)?;
             list_environments(http_client, backend_url, &token, &project_name).await
         }
         crate::EnvironmentCommands::Show {
@@ -78,7 +78,7 @@ pub async fn handle_environment_command(
             project,
             path,
         } => {
-            let project_name = crate::resolve_project_name(project.clone(), path)?;
+            let project_name = crate::resolve_project_name(project.clone(), path, None)?;
             show_environment(http_client, backend_url, &token, &project_name, name).await
         }
         crate::EnvironmentCommands::Update {
@@ -90,7 +90,7 @@ pub async fn handle_environment_command(
             production,
             color,
         } => {
-            let project_name = crate::resolve_project_name(project.clone(), path)?;
+            let project_name = crate::resolve_project_name(project.clone(), path, None)?;
             update_environment(
                 http_client,
                 backend_url,
@@ -109,7 +109,7 @@ pub async fn handle_environment_command(
             project,
             path,
         } => {
-            let project_name = crate::resolve_project_name(project.clone(), path)?;
+            let project_name = crate::resolve_project_name(project.clone(), path, None)?;
             delete_environment(http_client, backend_url, &token, &project_name, name).await
         }
     }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -45,6 +45,7 @@ pub async fn run_locally(
         image_tag.clone(),
         options.path.to_string(),
         options.build_args,
+        None,
     )
     .with_push(false); // Never push local dev images
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,12 +24,16 @@ mod server;
 use cli::*;
 
 /// Resolve project name from explicit argument or rise.toml fallback.
-///
-/// When `preloaded_config` is provided, it is used instead of loading from disk.
-/// This avoids duplicate loads (and duplicate log/warning output) when the caller
+#[cfg(feature = "cli")]
+fn resolve_project_name(explicit_project: Option<String>, path: &str) -> Result<String> {
+    resolve_project_name_with_config(explicit_project, path, None)
+}
+
+/// Like [`resolve_project_name`] but accepts a preloaded config to avoid
+/// duplicate disk loads (and duplicate log/warning output) when the caller
 /// has already loaded the config for other purposes.
 #[cfg(feature = "cli")]
-fn resolve_project_name(
+fn resolve_project_name_with_config(
     explicit_project: Option<String>,
     path: &str,
     preloaded_config: Option<&build::config::ProjectBuildConfig>,
@@ -994,7 +998,7 @@ async fn main() -> Result<()> {
                         identifier,
                         path,
                     } => {
-                        let project_name = resolve_project_name(project.clone(), path, None)?;
+                        let project_name = resolve_project_name(project.clone(), path)?;
                         cli::project::add_app_user(
                             &http_client,
                             &backend_url,
@@ -1009,7 +1013,7 @@ async fn main() -> Result<()> {
                         identifier,
                         path,
                     } => {
-                        let project_name = resolve_project_name(project.clone(), path, None)?;
+                        let project_name = resolve_project_name(project.clone(), path)?;
                         cli::project::remove_app_user(
                             &http_client,
                             &backend_url,
@@ -1020,7 +1024,7 @@ async fn main() -> Result<()> {
                         .await?;
                     }
                     AppUserCommands::List { project, path } => {
-                        let project_name = resolve_project_name(project.clone(), path, None)?;
+                        let project_name = resolve_project_name(project.clone(), path)?;
                         cli::project::list_app_users(
                             &http_client,
                             &backend_url,
@@ -1135,8 +1139,11 @@ async fn main() -> Result<()> {
                 let toml_config = build::config::load_full_project_config(&args.path)
                     .context("Failed to load rise.toml")?;
 
-                let project_name =
-                    resolve_project_name(args.project.clone(), &args.path, toml_config.as_ref())?;
+                let project_name = resolve_project_name_with_config(
+                    args.project.clone(),
+                    &args.path,
+                    toml_config.as_ref(),
+                )?;
 
                 // Both --image and --from cannot be specified together
                 if args.image.is_some() && args.from.is_some() {
@@ -1313,7 +1320,7 @@ async fn main() -> Result<()> {
                 group,
                 limit,
             } => {
-                let project_name = resolve_project_name(project.clone(), path, None)?;
+                let project_name = resolve_project_name(project.clone(), path)?;
                 deployment::list_deployments(
                     &http_client,
                     &backend_url,
@@ -1331,7 +1338,7 @@ async fn main() -> Result<()> {
                 follow,
                 timeout,
             } => {
-                let project_name = resolve_project_name(project.clone(), path, None)?;
+                let project_name = resolve_project_name(project.clone(), path)?;
                 deployment::show_deployment(
                     &http_client,
                     &backend_url,
@@ -1348,7 +1355,7 @@ async fn main() -> Result<()> {
                 path,
                 group,
             } => {
-                let project_name = resolve_project_name(project.clone(), path, None)?;
+                let project_name = resolve_project_name(project.clone(), path)?;
                 deployment::stop_deployments_by_group(
                     &http_client,
                     &backend_url,
@@ -1367,7 +1374,7 @@ async fn main() -> Result<()> {
                 timestamps,
                 since,
             } => {
-                let project_name = resolve_project_name(project.clone(), path, None)?;
+                let project_name = resolve_project_name(project.clone(), path)?;
                 let token = config.get_token().ok_or_else(|| {
                     anyhow::anyhow!("Not logged in. Please run 'rise login' first.")
                 })?;
@@ -1394,7 +1401,7 @@ async fn main() -> Result<()> {
                 issuer,
                 claims,
             } => {
-                let project_name = resolve_project_name(project.clone(), path, None)?;
+                let project_name = resolve_project_name(project.clone(), path)?;
                 let claims_map: std::collections::HashMap<String, String> =
                     claims.iter().cloned().collect();
 
@@ -1426,7 +1433,7 @@ async fn main() -> Result<()> {
                 .await?;
             }
             ServiceAccountCommands::List { project, path } => {
-                let project_name = resolve_project_name(project.clone(), path, None)?;
+                let project_name = resolve_project_name(project.clone(), path)?;
                 service_account::list_service_accounts(
                     &http_client,
                     &backend_url,
@@ -1436,7 +1443,7 @@ async fn main() -> Result<()> {
                 .await?;
             }
             ServiceAccountCommands::Show { project, path, id } => {
-                let project_name = resolve_project_name(project.clone(), path, None)?;
+                let project_name = resolve_project_name(project.clone(), path)?;
                 service_account::show_service_account(
                     &http_client,
                     &backend_url,
@@ -1447,7 +1454,7 @@ async fn main() -> Result<()> {
                 .await?;
             }
             ServiceAccountCommands::Delete { project, path, id } => {
-                let project_name = resolve_project_name(project.clone(), path, None)?;
+                let project_name = resolve_project_name(project.clone(), path)?;
                 service_account::delete_service_account(
                     &http_client,
                     &backend_url,
@@ -1476,7 +1483,7 @@ async fn main() -> Result<()> {
                     protected,
                     environment,
                 } => {
-                    let project_name = resolve_project_name(project.clone(), path, None)?;
+                    let project_name = resolve_project_name(project.clone(), path)?;
                     // Protected defaults to true for secrets, false for non-secrets
                     // Can be explicitly overridden with --protected flag
                     let is_protected = protected.unwrap_or(*secret);
@@ -1498,7 +1505,7 @@ async fn main() -> Result<()> {
                     path,
                     environment,
                 } => {
-                    let project_name = resolve_project_name(project.clone(), path, None)?;
+                    let project_name = resolve_project_name(project.clone(), path)?;
                     env::list_env(
                         &http_client,
                         &backend_url,
@@ -1514,7 +1521,7 @@ async fn main() -> Result<()> {
                     key,
                     environment,
                 } => {
-                    let project_name = resolve_project_name(project.clone(), path, None)?;
+                    let project_name = resolve_project_name(project.clone(), path)?;
                     env::get_env(
                         &http_client,
                         &backend_url,
@@ -1531,7 +1538,7 @@ async fn main() -> Result<()> {
                     key,
                     environment,
                 } => {
-                    let project_name = resolve_project_name(project.clone(), path, None)?;
+                    let project_name = resolve_project_name(project.clone(), path)?;
                     env::unset_env(
                         &http_client,
                         &backend_url,
@@ -1548,7 +1555,7 @@ async fn main() -> Result<()> {
                     file,
                     environment,
                 } => {
-                    let project_name = resolve_project_name(project.clone(), path, None)?;
+                    let project_name = resolve_project_name(project.clone(), path)?;
                     env::import_env(
                         &http_client,
                         &backend_url,
@@ -1564,7 +1571,7 @@ async fn main() -> Result<()> {
                     path,
                     deployment_id,
                 } => {
-                    let project_name = resolve_project_name(project.clone(), path, None)?;
+                    let project_name = resolve_project_name(project.clone(), path)?;
                     env::list_deployment_env(
                         &http_client,
                         &backend_url,
@@ -1586,12 +1593,12 @@ async fn main() -> Result<()> {
                     path,
                     domain,
                 } => {
-                    let project_name = resolve_project_name(project.clone(), path, None)?;
+                    let project_name = resolve_project_name(project.clone(), path)?;
                     domain::add_domain(&http_client, &backend_url, &token, &project_name, domain)
                         .await?;
                 }
                 DomainCommands::List { project, path } => {
-                    let project_name = resolve_project_name(project.clone(), path, None)?;
+                    let project_name = resolve_project_name(project.clone(), path)?;
                     domain::list_domains(&http_client, &backend_url, &token, &project_name).await?;
                 }
                 DomainCommands::Remove {
@@ -1599,7 +1606,7 @@ async fn main() -> Result<()> {
                     path,
                     domain,
                 } => {
-                    let project_name = resolve_project_name(project.clone(), path, None)?;
+                    let project_name = resolve_project_name(project.clone(), path)?;
                     domain::remove_domain(
                         &http_client,
                         &backend_url,
@@ -1619,7 +1626,7 @@ async fn main() -> Result<()> {
                 r#type,
                 spec,
             } => {
-                let project_name = resolve_project_name(project.clone(), path, None)?;
+                let project_name = resolve_project_name(project.clone(), path)?;
                 let spec: serde_json::Value =
                     serde_json::from_str(spec).context("Failed to parse spec as JSON")?;
                 extension::create_extension(&project_name, extension, r#type, spec).await?;
@@ -1630,7 +1637,7 @@ async fn main() -> Result<()> {
                 extension,
                 spec,
             } => {
-                let project_name = resolve_project_name(project.clone(), path, None)?;
+                let project_name = resolve_project_name(project.clone(), path)?;
                 let spec: serde_json::Value =
                     serde_json::from_str(spec).context("Failed to parse spec as JSON")?;
                 extension::update_extension(&project_name, extension, spec).await?;
@@ -1641,13 +1648,13 @@ async fn main() -> Result<()> {
                 extension,
                 spec,
             } => {
-                let project_name = resolve_project_name(project.clone(), path, None)?;
+                let project_name = resolve_project_name(project.clone(), path)?;
                 let spec: serde_json::Value =
                     serde_json::from_str(spec).context("Failed to parse spec as JSON")?;
                 extension::patch_extension(&project_name, extension, spec).await?;
             }
             ExtensionCommands::List { project, path } => {
-                let project_name = resolve_project_name(project.clone(), path, None)?;
+                let project_name = resolve_project_name(project.clone(), path)?;
                 extension::list_extensions(&project_name).await?;
             }
             ExtensionCommands::Show {
@@ -1655,7 +1662,7 @@ async fn main() -> Result<()> {
                 path,
                 extension,
             } => {
-                let project_name = resolve_project_name(project.clone(), path, None)?;
+                let project_name = resolve_project_name(project.clone(), path)?;
                 extension::show_extension(&project_name, extension).await?;
             }
             ExtensionCommands::Delete {
@@ -1663,7 +1670,7 @@ async fn main() -> Result<()> {
                 path,
                 extension,
             } => {
-                let project_name = resolve_project_name(project.clone(), path, None)?;
+                let project_name = resolve_project_name(project.clone(), path)?;
                 extension::delete_extension(&project_name, extension).await?;
             }
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,14 +23,33 @@ mod server;
 #[cfg(feature = "cli")]
 use cli::*;
 
-/// Resolve project name from explicit argument or rise.toml fallback
+/// Resolve project name from explicit argument or rise.toml fallback.
+///
+/// When `preloaded_config` is provided, it is used instead of loading from disk.
+/// This avoids duplicate loads (and duplicate log/warning output) when the caller
+/// has already loaded the config for other purposes.
 #[cfg(feature = "cli")]
-fn resolve_project_name(explicit_project: Option<String>, path: &str) -> Result<String> {
+fn resolve_project_name(
+    explicit_project: Option<String>,
+    path: &str,
+    preloaded_config: Option<&build::config::ProjectBuildConfig>,
+) -> Result<String> {
     if let Some(project) = explicit_project {
-        Ok(project)
-    } else if let Some(config) = build::config::load_full_project_config(path)? {
-        if let Some(project_config) = config.project {
-            Ok(project_config.name)
+        return Ok(project);
+    }
+
+    // Use preloaded config if available, otherwise load from disk
+    let owned_config;
+    let config = if let Some(cfg) = preloaded_config {
+        Some(cfg)
+    } else {
+        owned_config = build::config::load_full_project_config(path)?;
+        owned_config.as_ref()
+    };
+
+    if let Some(cfg) = config {
+        if let Some(ref project_config) = cfg.project {
+            Ok(project_config.name.clone())
         } else {
             anyhow::bail!("No project name specified and rise.toml has no [project] section")
         }
@@ -975,7 +994,7 @@ async fn main() -> Result<()> {
                         identifier,
                         path,
                     } => {
-                        let project_name = resolve_project_name(project.clone(), path)?;
+                        let project_name = resolve_project_name(project.clone(), path, None)?;
                         cli::project::add_app_user(
                             &http_client,
                             &backend_url,
@@ -990,7 +1009,7 @@ async fn main() -> Result<()> {
                         identifier,
                         path,
                     } => {
-                        let project_name = resolve_project_name(project.clone(), path)?;
+                        let project_name = resolve_project_name(project.clone(), path, None)?;
                         cli::project::remove_app_user(
                             &http_client,
                             &backend_url,
@@ -1001,7 +1020,7 @@ async fn main() -> Result<()> {
                         .await?;
                     }
                     AppUserCommands::List { project, path } => {
-                        let project_name = resolve_project_name(project.clone(), path)?;
+                        let project_name = resolve_project_name(project.clone(), path, None)?;
                         cli::project::list_app_users(
                             &http_client,
                             &backend_url,
@@ -1111,7 +1130,13 @@ async fn main() -> Result<()> {
         },
         Commands::Deployment(deployment_cmd) => match deployment_cmd {
             DeploymentCommands::Create { args } => {
-                let project_name = resolve_project_name(args.project.clone(), &args.path)?;
+                // Load rise.toml once — reused for project name resolution,
+                // environment resolution, env var collection, and build config.
+                let toml_config = build::config::load_full_project_config(&args.path)
+                    .context("Failed to load rise.toml")?;
+
+                let project_name =
+                    resolve_project_name(args.project.clone(), &args.path, toml_config.as_ref())?;
 
                 // Both --image and --from cannot be specified together
                 if args.image.is_some() && args.from.is_some() {
@@ -1143,10 +1168,6 @@ async fn main() -> Result<()> {
                     }
                 }
 
-                // Load rise.toml config for env resolution and env var overrides
-                let toml_config = build::config::load_full_project_config(&args.path)
-                    .context("Failed to load rise.toml")?;
-
                 // Resolve environment: explicit --environment flag takes precedence,
                 // otherwise fall back to the `default = true` environment from rise.toml.
                 let resolved_environment = args.environment.clone().or_else(|| {
@@ -1158,11 +1179,14 @@ async fn main() -> Result<()> {
                     })
                 });
 
-                // Collect runtime env overrides with source tracking
-                // Priority: toml < cli (later overrides earlier for same key)
+                // Collect runtime env overrides with source tracking.
+                // All toml vars are sent tagged with for_environment; the server
+                // filters them after resolving the deployment's target environment.
+                // Priority: toml < cli (later overrides earlier for same key within
+                // the same for_environment scope).
                 let mut env_overrides: Vec<deployment::EnvOverride> = Vec::new();
 
-                // 1. Collect [project.env] vars from rise.toml
+                // 1. Collect [project.env] vars from rise.toml (global, no for_environment)
                 if let Some(ref cfg) = toml_config {
                     if let Some(ref project_config) = cfg.project {
                         for (key, value) in &project_config.env {
@@ -1172,31 +1196,28 @@ async fn main() -> Result<()> {
                                 is_secret: false,
                                 is_protected: false,
                                 source: Some("toml".to_string()),
+                                for_environment: None,
                             });
                         }
                     }
 
-                    // 2. Collect [environments.TARGET.env] vars (override global)
-                    // Apply per-environment toml overrides when the target environment is
-                    // known client-side (explicit --environment or toml default = true).
-                    if let Some(env_name) = resolved_environment.as_ref() {
-                        if let Some(env_config) = cfg.environments.get(env_name) {
-                            for (key, value) in &env_config.env {
-                                // Remove any existing override for this key (from project.env)
-                                env_overrides.retain(|o| o.key != *key);
-                                env_overrides.push(deployment::EnvOverride {
-                                    key: key.clone(),
-                                    value: value.clone(),
-                                    is_secret: false,
-                                    is_protected: false,
-                                    source: Some("toml".to_string()),
-                                });
-                            }
+                    // 2. Collect [environments.*.env] vars from rise.toml, tagged with
+                    //    for_environment so the server can filter after resolution.
+                    for (env_name, env_config) in &cfg.environments {
+                        for (key, value) in &env_config.env {
+                            env_overrides.push(deployment::EnvOverride {
+                                key: key.clone(),
+                                value: value.clone(),
+                                is_secret: false,
+                                is_protected: false,
+                                source: Some("toml".to_string()),
+                                for_environment: Some(env_name.clone()),
+                            });
                         }
                     }
                 }
 
-                // 3. CLI overrides (override toml for same key)
+                // 3. CLI overrides (global, override toml for same key)
 
                 // --env KEY=VALUE → plain text
                 for (key, value) in &args.env {
@@ -1207,6 +1228,7 @@ async fn main() -> Result<()> {
                         is_secret: false,
                         is_protected: false,
                         source: Some("cli".to_string()),
+                        for_environment: None,
                     });
                 }
 
@@ -1219,6 +1241,7 @@ async fn main() -> Result<()> {
                         is_secret: true,
                         is_protected: false,
                         source: Some("cli".to_string()),
+                        for_environment: None,
                     });
                 }
 
@@ -1231,6 +1254,7 @@ async fn main() -> Result<()> {
                         is_secret: true,
                         is_protected: true,
                         source: Some("cli".to_string()),
+                        for_environment: None,
                     });
                 }
 
@@ -1249,6 +1273,7 @@ async fn main() -> Result<()> {
                             is_secret: var.is_secret,
                             is_protected: var.is_secret, // secrets from file are protected by default
                             source: Some("cli".to_string()),
+                            for_environment: None,
                         });
                     }
                 }
@@ -1277,6 +1302,7 @@ async fn main() -> Result<()> {
                         env_overrides,
                         job_url: args.job_url.clone(),
                         pull_request_url: args.pull_request_url.clone(),
+                        toml_config,
                     },
                 )
                 .await?;
@@ -1287,7 +1313,7 @@ async fn main() -> Result<()> {
                 group,
                 limit,
             } => {
-                let project_name = resolve_project_name(project.clone(), path)?;
+                let project_name = resolve_project_name(project.clone(), path, None)?;
                 deployment::list_deployments(
                     &http_client,
                     &backend_url,
@@ -1305,7 +1331,7 @@ async fn main() -> Result<()> {
                 follow,
                 timeout,
             } => {
-                let project_name = resolve_project_name(project.clone(), path)?;
+                let project_name = resolve_project_name(project.clone(), path, None)?;
                 deployment::show_deployment(
                     &http_client,
                     &backend_url,
@@ -1322,7 +1348,7 @@ async fn main() -> Result<()> {
                 path,
                 group,
             } => {
-                let project_name = resolve_project_name(project.clone(), path)?;
+                let project_name = resolve_project_name(project.clone(), path, None)?;
                 deployment::stop_deployments_by_group(
                     &http_client,
                     &backend_url,
@@ -1341,7 +1367,7 @@ async fn main() -> Result<()> {
                 timestamps,
                 since,
             } => {
-                let project_name = resolve_project_name(project.clone(), path)?;
+                let project_name = resolve_project_name(project.clone(), path, None)?;
                 let token = config.get_token().ok_or_else(|| {
                     anyhow::anyhow!("Not logged in. Please run 'rise login' first.")
                 })?;
@@ -1368,7 +1394,7 @@ async fn main() -> Result<()> {
                 issuer,
                 claims,
             } => {
-                let project_name = resolve_project_name(project.clone(), path)?;
+                let project_name = resolve_project_name(project.clone(), path, None)?;
                 let claims_map: std::collections::HashMap<String, String> =
                     claims.iter().cloned().collect();
 
@@ -1400,7 +1426,7 @@ async fn main() -> Result<()> {
                 .await?;
             }
             ServiceAccountCommands::List { project, path } => {
-                let project_name = resolve_project_name(project.clone(), path)?;
+                let project_name = resolve_project_name(project.clone(), path, None)?;
                 service_account::list_service_accounts(
                     &http_client,
                     &backend_url,
@@ -1410,7 +1436,7 @@ async fn main() -> Result<()> {
                 .await?;
             }
             ServiceAccountCommands::Show { project, path, id } => {
-                let project_name = resolve_project_name(project.clone(), path)?;
+                let project_name = resolve_project_name(project.clone(), path, None)?;
                 service_account::show_service_account(
                     &http_client,
                     &backend_url,
@@ -1421,7 +1447,7 @@ async fn main() -> Result<()> {
                 .await?;
             }
             ServiceAccountCommands::Delete { project, path, id } => {
-                let project_name = resolve_project_name(project.clone(), path)?;
+                let project_name = resolve_project_name(project.clone(), path, None)?;
                 service_account::delete_service_account(
                     &http_client,
                     &backend_url,
@@ -1450,7 +1476,7 @@ async fn main() -> Result<()> {
                     protected,
                     environment,
                 } => {
-                    let project_name = resolve_project_name(project.clone(), path)?;
+                    let project_name = resolve_project_name(project.clone(), path, None)?;
                     // Protected defaults to true for secrets, false for non-secrets
                     // Can be explicitly overridden with --protected flag
                     let is_protected = protected.unwrap_or(*secret);
@@ -1472,7 +1498,7 @@ async fn main() -> Result<()> {
                     path,
                     environment,
                 } => {
-                    let project_name = resolve_project_name(project.clone(), path)?;
+                    let project_name = resolve_project_name(project.clone(), path, None)?;
                     env::list_env(
                         &http_client,
                         &backend_url,
@@ -1488,7 +1514,7 @@ async fn main() -> Result<()> {
                     key,
                     environment,
                 } => {
-                    let project_name = resolve_project_name(project.clone(), path)?;
+                    let project_name = resolve_project_name(project.clone(), path, None)?;
                     env::get_env(
                         &http_client,
                         &backend_url,
@@ -1505,7 +1531,7 @@ async fn main() -> Result<()> {
                     key,
                     environment,
                 } => {
-                    let project_name = resolve_project_name(project.clone(), path)?;
+                    let project_name = resolve_project_name(project.clone(), path, None)?;
                     env::unset_env(
                         &http_client,
                         &backend_url,
@@ -1522,7 +1548,7 @@ async fn main() -> Result<()> {
                     file,
                     environment,
                 } => {
-                    let project_name = resolve_project_name(project.clone(), path)?;
+                    let project_name = resolve_project_name(project.clone(), path, None)?;
                     env::import_env(
                         &http_client,
                         &backend_url,
@@ -1538,7 +1564,7 @@ async fn main() -> Result<()> {
                     path,
                     deployment_id,
                 } => {
-                    let project_name = resolve_project_name(project.clone(), path)?;
+                    let project_name = resolve_project_name(project.clone(), path, None)?;
                     env::list_deployment_env(
                         &http_client,
                         &backend_url,
@@ -1560,12 +1586,12 @@ async fn main() -> Result<()> {
                     path,
                     domain,
                 } => {
-                    let project_name = resolve_project_name(project.clone(), path)?;
+                    let project_name = resolve_project_name(project.clone(), path, None)?;
                     domain::add_domain(&http_client, &backend_url, &token, &project_name, domain)
                         .await?;
                 }
                 DomainCommands::List { project, path } => {
-                    let project_name = resolve_project_name(project.clone(), path)?;
+                    let project_name = resolve_project_name(project.clone(), path, None)?;
                     domain::list_domains(&http_client, &backend_url, &token, &project_name).await?;
                 }
                 DomainCommands::Remove {
@@ -1573,7 +1599,7 @@ async fn main() -> Result<()> {
                     path,
                     domain,
                 } => {
-                    let project_name = resolve_project_name(project.clone(), path)?;
+                    let project_name = resolve_project_name(project.clone(), path, None)?;
                     domain::remove_domain(
                         &http_client,
                         &backend_url,
@@ -1593,7 +1619,7 @@ async fn main() -> Result<()> {
                 r#type,
                 spec,
             } => {
-                let project_name = resolve_project_name(project.clone(), path)?;
+                let project_name = resolve_project_name(project.clone(), path, None)?;
                 let spec: serde_json::Value =
                     serde_json::from_str(spec).context("Failed to parse spec as JSON")?;
                 extension::create_extension(&project_name, extension, r#type, spec).await?;
@@ -1604,7 +1630,7 @@ async fn main() -> Result<()> {
                 extension,
                 spec,
             } => {
-                let project_name = resolve_project_name(project.clone(), path)?;
+                let project_name = resolve_project_name(project.clone(), path, None)?;
                 let spec: serde_json::Value =
                     serde_json::from_str(spec).context("Failed to parse spec as JSON")?;
                 extension::update_extension(&project_name, extension, spec).await?;
@@ -1615,13 +1641,13 @@ async fn main() -> Result<()> {
                 extension,
                 spec,
             } => {
-                let project_name = resolve_project_name(project.clone(), path)?;
+                let project_name = resolve_project_name(project.clone(), path, None)?;
                 let spec: serde_json::Value =
                     serde_json::from_str(spec).context("Failed to parse spec as JSON")?;
                 extension::patch_extension(&project_name, extension, spec).await?;
             }
             ExtensionCommands::List { project, path } => {
-                let project_name = resolve_project_name(project.clone(), path)?;
+                let project_name = resolve_project_name(project.clone(), path, None)?;
                 extension::list_extensions(&project_name).await?;
             }
             ExtensionCommands::Show {
@@ -1629,7 +1655,7 @@ async fn main() -> Result<()> {
                 path,
                 extension,
             } => {
-                let project_name = resolve_project_name(project.clone(), path)?;
+                let project_name = resolve_project_name(project.clone(), path, None)?;
                 extension::show_extension(&project_name, extension).await?;
             }
             ExtensionCommands::Delete {
@@ -1637,7 +1663,7 @@ async fn main() -> Result<()> {
                 path,
                 extension,
             } => {
-                let project_name = resolve_project_name(project.clone(), path)?;
+                let project_name = resolve_project_name(project.clone(), path, None)?;
                 extension::delete_extension(&project_name, extension).await?;
             }
         },
@@ -1652,6 +1678,7 @@ async fn main() -> Result<()> {
                 tag.clone(),
                 path.clone(),
                 build_args,
+                None,
             )
             .with_push(*push);
 

--- a/src/server/deployment/handlers.rs
+++ b/src/server/deployment/handlers.rs
@@ -248,6 +248,36 @@ async fn insert_rise_env_vars(
     Ok(())
 }
 
+/// Filter env overrides by target environment.
+///
+/// - `for_environment: None` → always included (global override)
+/// - `for_environment: Some(name)` → included only if name matches `resolved_environment`
+///
+/// Logs a warning for each override that was dropped because its `for_environment`
+/// didn't match the resolved environment.
+fn filter_env_overrides_by_environment<'a>(
+    overrides: &'a [models::EnvOverride],
+    resolved_environment: Option<&str>,
+) -> Vec<&'a models::EnvOverride> {
+    let mut result = Vec::new();
+    for o in overrides {
+        match &o.for_environment {
+            None => result.push(o),
+            Some(env_name) => {
+                if resolved_environment == Some(env_name.as_str()) {
+                    result.push(o);
+                } else {
+                    warn!(
+                        "Env override '{}' skipped: for_environment '{}' does not match resolved environment {:?}",
+                        o.key, env_name, resolved_environment
+                    );
+                }
+            }
+        }
+    }
+    result
+}
+
 /// Apply env var overrides from the deployment request.
 ///
 /// Encrypts secret values and upserts each override into the deployment's env vars.
@@ -267,23 +297,14 @@ async fn apply_env_overrides(
         return Ok(());
     }
 
-    // Filter overrides by target environment:
-    // - for_environment: None → always included (global override)
-    // - for_environment: Some(name) → included only if name matches resolved environment
-    let filtered: Vec<&models::EnvOverride> = overrides
-        .iter()
-        .filter(|o| match &o.for_environment {
-            None => true,
-            Some(env_name) => resolved_environment == Some(env_name.as_str()),
-        })
-        .collect();
+    let filtered = filter_env_overrides_by_environment(overrides, resolved_environment);
 
     if filtered.is_empty() {
         return Ok(());
     }
 
     info!(
-        "Applying {} env override(s) to deployment {} (filtered from {}, environment: {:?})",
+        "Applying {} env override(s) to deployment {} ({} total, environment: {:?})",
         filtered.len(),
         deployment_id,
         overrides.len(),
@@ -2129,6 +2150,74 @@ mod tests {
         });
 
         assert!(!is_protected);
+    }
+
+    fn make_override(key: &str, for_environment: Option<&str>) -> EnvOverride {
+        EnvOverride {
+            key: key.to_string(),
+            value: "v".to_string(),
+            is_secret: false,
+            is_protected: None,
+            source: None,
+            for_environment: for_environment.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    fn filter_env_overrides_global_always_included() {
+        let overrides = vec![make_override("A", None), make_override("B", None)];
+        let result = super::filter_env_overrides_by_environment(&overrides, Some("production"));
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn filter_env_overrides_scoped_included_when_env_matches() {
+        let overrides = vec![make_override("A", Some("production"))];
+        let result = super::filter_env_overrides_by_environment(&overrides, Some("production"));
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].key, "A");
+    }
+
+    #[test]
+    fn filter_env_overrides_scoped_excluded_when_env_differs() {
+        let overrides = vec![make_override("A", Some("staging"))];
+        let result = super::filter_env_overrides_by_environment(&overrides, Some("production"));
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn filter_env_overrides_mixed_global_and_scoped() {
+        let overrides = vec![
+            make_override("GLOBAL", None),
+            make_override("PROD_ONLY", Some("production")),
+            make_override("STG_ONLY", Some("staging")),
+        ];
+        let result = super::filter_env_overrides_by_environment(&overrides, Some("production"));
+        assert_eq!(result.len(), 2);
+        let keys: Vec<&str> = result.iter().map(|o| o.key.as_str()).collect();
+        assert!(keys.contains(&"GLOBAL"));
+        assert!(keys.contains(&"PROD_ONLY"));
+    }
+
+    #[test]
+    fn filter_env_overrides_all_scoped_none_matching() {
+        let overrides = vec![
+            make_override("A", Some("staging")),
+            make_override("B", Some("dev")),
+        ];
+        let result = super::filter_env_overrides_by_environment(&overrides, Some("production"));
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn filter_env_overrides_no_resolved_env_only_globals_pass() {
+        let overrides = vec![
+            make_override("GLOBAL", None),
+            make_override("SCOPED", Some("production")),
+        ];
+        let result = super::filter_env_overrides_by_environment(&overrides, None);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].key, "GLOBAL");
     }
 
     #[sqlx::test]

--- a/src/server/deployment/handlers.rs
+++ b/src/server/deployment/handlers.rs
@@ -259,6 +259,7 @@ async fn apply_env_overrides(
     state: &AppState,
     deployment_id: uuid::Uuid,
     overrides: &[models::EnvOverride],
+    resolved_environment: Option<&str>,
 ) -> Result<(), ServerError> {
     use crate::db::models::EnvVarSource;
 
@@ -266,13 +267,30 @@ async fn apply_env_overrides(
         return Ok(());
     }
 
+    // Filter overrides by target environment:
+    // - for_environment: None → always included (global override)
+    // - for_environment: Some(name) → included only if name matches resolved environment
+    let filtered: Vec<&models::EnvOverride> = overrides
+        .iter()
+        .filter(|o| match &o.for_environment {
+            None => true,
+            Some(env_name) => resolved_environment == Some(env_name.as_str()),
+        })
+        .collect();
+
+    if filtered.is_empty() {
+        return Ok(());
+    }
+
     info!(
-        "Applying {} env override(s) to deployment {}",
+        "Applying {} env override(s) to deployment {} (filtered from {}, environment: {:?})",
+        filtered.len(),
+        deployment_id,
         overrides.len(),
-        deployment_id
+        resolved_environment,
     );
 
-    for env_override in overrides {
+    for env_override in filtered {
         let is_protected = validate_env_override(env_override)?;
 
         // Validate source: only client-allowed values (toml, cli) are accepted.
@@ -852,7 +870,13 @@ pub async fn create_deployment(
         }
 
         // Apply env overrides from the request
-        apply_env_overrides(&state, new_deployment.id, &payload.env_overrides).await?;
+        apply_env_overrides(
+            &state,
+            new_deployment.id,
+            &payload.env_overrides,
+            resolved_environment.as_ref().map(|e| e.name.as_str()),
+        )
+        .await?;
 
         // Upsert PORT env var with the final http_port value
         crate::db::env_vars::upsert_deployment_env_var(
@@ -962,7 +986,13 @@ pub async fn create_deployment(
             .internal_err("Failed to copy environment variables")?;
 
             // Apply env overrides from the request
-            apply_env_overrides(&state, deployment.id, &payload.env_overrides).await?;
+            apply_env_overrides(
+                &state,
+                deployment.id,
+                &payload.env_overrides,
+                resolved_environment.as_ref().map(|e| e.name.as_str()),
+            )
+            .await?;
 
             crate::db::env_vars::upsert_deployment_env_var(
                 &state.db_pool,
@@ -1049,7 +1079,13 @@ pub async fn create_deployment(
         .internal_err("Failed to copy environment variables")?;
 
         // Apply env overrides from the request
-        apply_env_overrides(&state, deployment.id, &payload.env_overrides).await?;
+        apply_env_overrides(
+            &state,
+            deployment.id,
+            &payload.env_overrides,
+            resolved_environment.as_ref().map(|e| e.name.as_str()),
+        )
+        .await?;
 
         // Upsert PORT env var with the resolved effective value
         // This overwrites any user-set PORT with the resolved value (which may be the same)
@@ -1138,7 +1174,13 @@ pub async fn create_deployment(
         .internal_err("Failed to copy environment variables")?;
 
         // Apply env overrides from the request
-        apply_env_overrides(&state, deployment.id, &payload.env_overrides).await?;
+        apply_env_overrides(
+            &state,
+            deployment.id,
+            &payload.env_overrides,
+            resolved_environment.as_ref().map(|e| e.name.as_str()),
+        )
+        .await?;
 
         // Upsert PORT env var with the resolved effective value
         // This overwrites any user-set PORT with the resolved value (which may be the same)
@@ -2011,6 +2053,7 @@ mod tests {
             is_secret: false,
             is_protected: Some(false),
             source: None,
+            for_environment: None,
         })
         .unwrap_err();
 
@@ -2029,6 +2072,7 @@ mod tests {
             is_secret: false,
             is_protected: Some(true),
             source: None,
+            for_environment: None,
         })
         .unwrap_err();
 
@@ -2047,6 +2091,7 @@ mod tests {
             is_secret: false,
             is_protected: Some(false),
             source: None,
+            for_environment: None,
         })
         .unwrap_err();
 
@@ -2065,6 +2110,7 @@ mod tests {
             is_secret: true,
             is_protected: None,
             source: None,
+            for_environment: None,
         })
         .unwrap();
 
@@ -2079,6 +2125,7 @@ mod tests {
             is_secret: true,
             is_protected: Some(false),
             source: None,
+            for_environment: None,
         });
 
         assert!(!is_protected);

--- a/src/server/deployment/models.rs
+++ b/src/server/deployment/models.rs
@@ -194,6 +194,10 @@ pub struct EnvOverride {
     pub is_protected: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
+    /// Target environment name. When set, this override is only applied if the
+    /// resolved deployment environment matches. `None` means the override is global.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub for_environment: Option<String>,
 }
 
 // Request to create a deployment


### PR DESCRIPTION
## Summary
- Add a "Source" column to the deployment env vars table showing where each variable originated (system, global, extension, toml, cli, or environment name)
- Uses color-coded `MonoTag` badges with `EnvironmentColorDot` for environment-scoped sources
- Add environment color dots to the Service Accounts table's Environments column
- Fix environment-scoped env vars from `rise.toml` (`[environments.*.env]`) being silently dropped when the CLI couldn't resolve the target environment locally
- Send all env overrides tagged with `for_environment` to the server, which filters them after resolving the deployment target (single source of truth)
- Fix triple-loading of `rise.toml` during `rise deploy` by loading once and passing the config through

## Test plan
- [x] View a deployment's environment variables in the UI and verify the Source column appears with color-coded tags
- [x] Confirm env-scoped sources show the environment color dot next to the name
- [x] Verify the Source column does NOT appear on the project-level env vars view
- [x] Check that the Service Accounts table shows color dots next to environment names
- [x] Deploy with `[environments.production.env]` vars in rise.toml (without `--environment` flag) and verify they propagate to the deployment
- [x] Verify only ONE "Loading project config" log line appears during `rise deploy`
- [x] Verify backwards compatibility: old CLI (without `for_environment`) still works with new server

## Screenshots

<img width="1205" height="514" alt="image" src="https://github.com/user-attachments/assets/28391587-8a66-4454-894c-0ecd8159e2a7" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)