### PR TITLE
fix: make OAuth rate limiting per-project, per-IP, configurable

### DIFF
--- a/docs/schemas/backend-settings.schema.json
+++ b/docs/schemas/backend-settings.schema.json
@@ -808,29 +808,29 @@
       "description": "Rate limiting configuration for OAuth endpoints (authorize, callback, token).\n\nThree independent limits are enforced:\n- **Per-project**: keyed by `{project_name}:{client_ip}` — limits traffic to each\n  project independently so one busy project cannot starve others.\n- **Per-session**: keyed by a hash of the `rise_jwt` cookie — limits per-user traffic.\n- **Global**: shared across all requests — caps total throughput.",
       "properties": {
         "global_max": {
-          "default": 3000,
-          "description": "Maximum total OAuth requests per window across all clients (default: 3000)",
+          "default": 1000,
+          "description": "Maximum total OAuth requests per window across all clients (default: 1000)",
           "format": "uint32",
           "minimum": 0,
           "type": "integer"
         },
         "global_window_secs": {
-          "default": 60,
-          "description": "Window in seconds for the global limit (default: 60)",
+          "default": 10,
+          "description": "Window in seconds for the global limit (default: 10)",
           "format": "uint64",
           "minimum": 0,
           "type": "integer"
         },
         "per_project_max": {
-          "default": 100,
-          "description": "Maximum requests per project+IP per window (default: 100)",
+          "default": 500,
+          "description": "Maximum requests per project+IP per window (default: 500)",
           "format": "uint32",
           "minimum": 0,
           "type": "integer"
         },
         "per_project_window_secs": {
-          "default": 60,
-          "description": "Window in seconds for per-project+IP limit (default: 60)",
+          "default": 10,
+          "description": "Window in seconds for per-project+IP limit (default: 10)",
           "format": "uint64",
           "minimum": 0,
           "type": "integer"
@@ -843,8 +843,8 @@
           "type": "integer"
         },
         "per_session_window_secs": {
-          "default": 60,
-          "description": "Window in seconds for per-session limit (default: 60)",
+          "default": 10,
+          "description": "Window in seconds for per-session limit (default: 10)",
           "format": "uint64",
           "minimum": 0,
           "type": "integer"

--- a/docs/schemas/backend-settings.schema.json
+++ b/docs/schemas/backend-settings.schema.json
@@ -805,7 +805,7 @@
       "type": "object"
     },
     "OAuthRateLimitSettings": {
-      "description": "Rate limiting configuration for OAuth endpoints (authorize, callback, token).\n\nThree independent limits are enforced:\n- **Per-project**: keyed by `{project_name}:{client_ip}` — limits traffic to each\n  project independently so one busy project cannot starve others.\n- **Per-session**: keyed by a hash of the `rise_jwt` cookie — limits per-user traffic.\n- **Global**: shared across all requests — caps total throughput.",
+      "description": "Rate limiting configuration for OAuth endpoints (authorize, callback, token).\n\nFour independent limits are enforced:\n- **Per-project**: keyed by project name — limits traffic to each project independently\n  so one busy project cannot starve others.\n- **Per-IP**: keyed by client IP — limits traffic from a single source address.\n- **Per-session**: keyed by a hash of the `rise_jwt` cookie — limits per-user traffic.\n- **Global**: shared across all requests — caps total throughput.",
       "properties": {
         "global_max": {
           "default": 1000,
@@ -821,16 +821,30 @@
           "minimum": 0,
           "type": "integer"
         },
+        "per_ip_max": {
+          "default": 500,
+          "description": "Maximum requests per client IP per window (default: 500)",
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "per_ip_window_secs": {
+          "default": 10,
+          "description": "Window in seconds for per-IP limit (default: 10)",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
         "per_project_max": {
           "default": 500,
-          "description": "Maximum requests per project+IP per window (default: 500)",
+          "description": "Maximum requests per project per window (default: 500)",
           "format": "uint32",
           "minimum": 0,
           "type": "integer"
         },
         "per_project_window_secs": {
           "default": 10,
-          "description": "Window in seconds for per-project+IP limit (default: 10)",
+          "description": "Window in seconds for per-project limit (default: 10)",
           "format": "uint64",
           "minimum": 0,
           "type": "integer"

--- a/docs/schemas/backend-settings.schema.json
+++ b/docs/schemas/backend-settings.schema.json
@@ -805,32 +805,32 @@
       "type": "object"
     },
     "OAuthRateLimitSettings": {
-      "description": "Rate limiting configuration for OAuth endpoints (authorize, callback, token).\n\nFour independent limits are enforced:\n- **Per-project**: keyed by project name — limits traffic to each project independently\n  so one busy project cannot starve others.\n- **Per-IP**: keyed by client IP — limits traffic from a single source address.\n- **Per-session**: keyed by a hash of the `rise_jwt` cookie — limits per-user traffic.\n- **Global**: shared across all requests — caps total throughput.",
+      "description": "Rate limiting configuration for OAuth endpoints (authorize, callback, token).\n\nFour independent limits are enforced:\n- **Per-project**: keyed by project name — limits traffic to each project independently\n  so one busy project cannot starve others.\n- **Per-IP**: keyed by client IP — limits traffic from a single source address.\n- **Per-session**: keyed by a hash of the `rise_jwt` cookie — limits per-user traffic.\n- **Global**: shared across all requests — caps total throughput.\n\nSetting any `*_max` value to `0` effectively blocks all OAuth traffic for that tier\n(every request will exceed the limit immediately).",
       "properties": {
         "global_max": {
-          "default": 1000,
-          "description": "Maximum total OAuth requests per window across all clients (default: 1000)",
+          "default": 2000,
+          "description": "Maximum total OAuth requests per window across all clients (default: 2000)",
           "format": "uint32",
           "minimum": 0,
           "type": "integer"
         },
         "global_window_secs": {
-          "default": 10,
-          "description": "Window in seconds for the global limit (default: 10)",
+          "default": 60,
+          "description": "Window in seconds for the global limit (default: 60)",
           "format": "uint64",
           "minimum": 0,
           "type": "integer"
         },
         "per_ip_max": {
-          "default": 500,
-          "description": "Maximum requests per client IP per window (default: 500)",
+          "default": 50,
+          "description": "Maximum requests per client IP per window (default: 50)",
           "format": "uint32",
           "minimum": 0,
           "type": "integer"
         },
         "per_ip_window_secs": {
-          "default": 10,
-          "description": "Window in seconds for per-IP limit (default: 10)",
+          "default": 60,
+          "description": "Window in seconds for per-IP limit (default: 60)",
           "format": "uint64",
           "minimum": 0,
           "type": "integer"
@@ -843,22 +843,22 @@
           "type": "integer"
         },
         "per_project_window_secs": {
-          "default": 10,
-          "description": "Window in seconds for per-project limit (default: 10)",
+          "default": 60,
+          "description": "Window in seconds for per-project limit (default: 60)",
           "format": "uint64",
           "minimum": 0,
           "type": "integer"
         },
         "per_session_max": {
-          "default": 30,
-          "description": "Maximum requests per session (rise_jwt cookie) per window (default: 30)",
+          "default": 20,
+          "description": "Maximum requests per session (rise_jwt cookie) per window (default: 20)",
           "format": "uint32",
           "minimum": 0,
           "type": "integer"
         },
         "per_session_window_secs": {
-          "default": 10,
-          "description": "Window in seconds for per-session limit (default: 10)",
+          "default": 60,
+          "description": "Window in seconds for per-session limit (default: 60)",
           "format": "uint64",
           "minimum": 0,
           "type": "integer"

--- a/docs/schemas/backend-settings.schema.json
+++ b/docs/schemas/backend-settings.schema.json
@@ -804,6 +804,54 @@
       ],
       "type": "object"
     },
+    "OAuthRateLimitSettings": {
+      "description": "Rate limiting configuration for OAuth endpoints (authorize, callback, token).\n\nThree independent limits are enforced:\n- **Per-project**: keyed by `{project_name}:{client_ip}` — limits traffic to each\n  project independently so one busy project cannot starve others.\n- **Per-session**: keyed by a hash of the `rise_jwt` cookie — limits per-user traffic.\n- **Global**: shared across all requests — caps total throughput.",
+      "properties": {
+        "global_max": {
+          "default": 3000,
+          "description": "Maximum total OAuth requests per window across all clients (default: 3000)",
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "global_window_secs": {
+          "default": 60,
+          "description": "Window in seconds for the global limit (default: 60)",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "per_project_max": {
+          "default": 100,
+          "description": "Maximum requests per project+IP per window (default: 100)",
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "per_project_window_secs": {
+          "default": 60,
+          "description": "Window in seconds for per-project+IP limit (default: 60)",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "per_session_max": {
+          "default": 30,
+          "description": "Maximum requests per session (rise_jwt cookie) per window (default: 30)",
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "per_session_window_secs": {
+          "default": 60,
+          "description": "Window in seconds for per-session limit (default: 60)",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
     "PlatformAccessConfig": {
       "description": "Platform access control configuration",
       "properties": {
@@ -1050,6 +1098,10 @@
         "jwt_signing_secret": {
           "description": "JWT signing secret for ingress authentication (base64-encoded, minimum 32 bytes)\nGenerate with: openssl rand -base64 32\nRequired for ingress authentication",
           "type": "string"
+        },
+        "oauth_rate_limit": {
+          "$ref": "#/$defs/OAuthRateLimitSettings",
+          "description": "OAuth endpoint rate limiting configuration."
         },
         "port": {
           "format": "uint16",

--- a/src/server/extensions/providers/oauth/handlers.rs
+++ b/src/server/extensions/providers/oauth/handlers.rs
@@ -353,7 +353,7 @@ pub async fn authorize(
     let session_key = crate::server::rate_limit::extract_session_key(&headers);
     if let Err(retry_after) = state
         .oauth_rate_limiter
-        .increment_and_check(&client_ip, session_key.as_deref(), Some(&project_name))
+        .increment_and_check(&client_ip, session_key.as_deref(), &project_name)
         .await
     {
         tracing::warn!(
@@ -599,7 +599,7 @@ pub async fn callback(
     let session_key = crate::server::rate_limit::extract_session_key(&headers);
     if let Err(retry_after) = state
         .oauth_rate_limiter
-        .increment_and_check(&client_ip, session_key.as_deref(), Some(&project_name))
+        .increment_and_check(&client_ip, session_key.as_deref(), &project_name)
         .await
     {
         tracing::warn!(
@@ -1087,7 +1087,7 @@ pub async fn token_endpoint(
     let session_key = crate::server::rate_limit::extract_session_key(&headers);
     if let Err(retry_after) = state
         .oauth_rate_limiter
-        .increment_and_check(&client_ip, session_key.as_deref(), Some(&project_name))
+        .increment_and_check(&client_ip, session_key.as_deref(), &project_name)
         .await
     {
         tracing::warn!(

--- a/src/server/extensions/providers/oauth/handlers.rs
+++ b/src/server/extensions/providers/oauth/handlers.rs
@@ -348,12 +348,12 @@ pub async fn authorize(
         project_name, extension_name
     );
 
-    // Rate limiting
+    // Rate limiting (keyed per project+IP so different projects have independent budgets)
     let client_ip = crate::server::rate_limit::extract_client_ip(&headers);
     let session_key = crate::server::rate_limit::extract_session_key(&headers);
     if let Err(retry_after) = state
         .oauth_rate_limiter
-        .increment_and_check(&client_ip, session_key.as_deref())
+        .increment_and_check(&client_ip, session_key.as_deref(), Some(&project_name))
         .await
     {
         tracing::warn!(
@@ -594,12 +594,12 @@ pub async fn callback(
         project_name, extension_name
     );
 
-    // Rate limiting
+    // Rate limiting (keyed per project+IP so different projects have independent budgets)
     let client_ip = crate::server::rate_limit::extract_client_ip(&headers);
     let session_key = crate::server::rate_limit::extract_session_key(&headers);
     if let Err(retry_after) = state
         .oauth_rate_limiter
-        .increment_and_check(&client_ip, session_key.as_deref())
+        .increment_and_check(&client_ip, session_key.as_deref(), Some(&project_name))
         .await
     {
         tracing::warn!(
@@ -1082,11 +1082,12 @@ pub async fn token_endpoint(
         .map(|s| s.to_string());
 
     // Rate limiting: count all attempts (including invalid ones) to thwart brute-force
+    // Keyed per project+IP so different projects have independent budgets.
     let client_ip = crate::server::rate_limit::extract_client_ip(&headers);
     let session_key = crate::server::rate_limit::extract_session_key(&headers);
     if let Err(retry_after) = state
         .oauth_rate_limiter
-        .increment_and_check(&client_ip, session_key.as_deref())
+        .increment_and_check(&client_ip, session_key.as_deref(), Some(&project_name))
         .await
     {
         tracing::warn!(

--- a/src/server/rate_limit.rs
+++ b/src/server/rate_limit.rs
@@ -11,9 +11,9 @@ use std::time::Duration;
 use super::settings::OAuthRateLimitSettings;
 
 /// Rate limiter for OAuth endpoints with three independent limits:
-/// - Per-project: keyed by `{project}:{ip}` (configurable, default 100 req/60s)
-/// - Per-session: keyed by `rise_jwt` cookie hash (configurable, default 30 req/60s)
-/// - Global: shared across all requests (configurable, default 3000 req/60s)
+/// - Per-project: keyed by `{project}:{ip}` (configurable, default 500 req/10s)
+/// - Per-session: keyed by `rise_jwt` cookie hash (configurable, default 30 req/10s)
+/// - Global: shared across all requests (configurable, default 1000 req/10s)
 pub struct OAuthRateLimiter {
     project_limiter: Arc<Cache<String, Arc<AtomicU32>>>,
     session_limiter: Arc<Cache<String, Arc<AtomicU32>>>,

--- a/src/server/rate_limit.rs
+++ b/src/server/rate_limit.rs
@@ -11,10 +11,10 @@ use std::time::Duration;
 use super::settings::OAuthRateLimitSettings;
 
 /// Rate limiter for OAuth endpoints with four independent limits:
-/// - Per-project: keyed by project name (configurable, default 500 req/10s)
-/// - Per-IP: keyed by client IP (configurable, default 500 req/10s)
-/// - Per-session: keyed by `rise_jwt` cookie hash (configurable, default 30 req/10s)
-/// - Global: shared across all requests (configurable, default 1000 req/10s)
+/// - Per-project: keyed by project name (configurable, default 500 req/60s)
+/// - Per-IP: keyed by client IP (configurable, default 50 req/60s)
+/// - Per-session: keyed by `rise_jwt` cookie hash (configurable, default 20 req/60s)
+/// - Global: shared across all requests (configurable, default 2000 req/60s)
 pub struct OAuthRateLimiter {
     project_limiter: Arc<Cache<String, Arc<AtomicU32>>>,
     ip_limiter: Arc<Cache<String, Arc<AtomicU32>>>,
@@ -79,12 +79,17 @@ impl OAuthRateLimiter {
 
     /// Atomically increment counters and check limits.
     ///
+    /// Uses `AtomicU32` counters stored in the cache so concurrent increments are never lost.
+    /// The cache's `time_to_live` acts as a fixed window: a counter entry is created (with TTL)
+    /// on first access and expires naturally, resetting the count. Subsequent increments within
+    /// the window use the existing entry without refreshing its TTL.
+    ///
     /// Returns `Ok(())` if within limits after incrementing, `Err(retry_after_secs)` if exceeded.
     pub async fn increment_and_check(
         &self,
         ip: &str,
         session_key: Option<&str>,
-        project: Option<&str>,
+        project: &str,
     ) -> Result<(), u64> {
         // Global
         let global_counter = self
@@ -99,17 +104,15 @@ impl OAuthRateLimiter {
         }
 
         // Per-project
-        if let Some(p) = project {
-            let project_counter = self
-                .project_limiter
-                .entry_by_ref(p)
-                .or_insert_with(std::future::ready(Arc::new(AtomicU32::new(0))))
-                .await
-                .into_value();
-            let project_count = project_counter.fetch_add(1, Ordering::Relaxed) + 1;
-            if project_count > self.per_project_max {
-                return Err(self.per_project_window_secs);
-            }
+        let project_counter = self
+            .project_limiter
+            .entry_by_ref(project)
+            .or_insert_with(std::future::ready(Arc::new(AtomicU32::new(0))))
+            .await
+            .into_value();
+        let project_count = project_counter.fetch_add(1, Ordering::Relaxed) + 1;
+        if project_count > self.per_project_max {
+            return Err(self.per_project_window_secs);
         }
 
         // Per-IP
@@ -301,7 +304,7 @@ mod tests {
     async fn test_rate_limiter_allows_within_limit() {
         let limiter = OAuthRateLimiter::new(&test_settings());
         assert!(limiter
-            .increment_and_check("1.2.3.4", None, Some("my-project"))
+            .increment_and_check("1.2.3.4", None, "my-project")
             .await
             .is_ok());
     }
@@ -314,12 +317,10 @@ mod tests {
         // Use different IPs so we only hit the project limit, not the IP limit
         for i in 0..settings.per_project_max {
             let ip = format!("10.0.0.{i}");
-            let _ = limiter.increment_and_check(&ip, None, Some(project)).await;
+            let _ = limiter.increment_and_check(&ip, None, project).await;
         }
         // Next request should be blocked by project limit
-        let result = limiter
-            .increment_and_check("10.0.1.0", None, Some(project))
-            .await;
+        let result = limiter.increment_and_check("10.0.1.0", None, project).await;
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), settings.per_project_window_secs);
     }
@@ -332,11 +333,11 @@ mod tests {
         // Use different projects so we only hit the IP limit, not the project limit
         for i in 0..settings.per_ip_max {
             let project = format!("project-{i}");
-            let _ = limiter.increment_and_check(ip, None, Some(&project)).await;
+            let _ = limiter.increment_and_check(ip, None, &project).await;
         }
         // Next request should be blocked by IP limit
         let result = limiter
-            .increment_and_check(ip, None, Some("another-project"))
+            .increment_and_check(ip, None, "another-project")
             .await;
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), settings.per_ip_window_secs);
@@ -350,18 +351,16 @@ mod tests {
         // Exhaust project-a's limit
         for i in 0..settings.per_project_max {
             let ip = format!("10.0.0.{i}");
-            let _ = limiter
-                .increment_and_check(&ip, None, Some("project-a"))
-                .await;
+            let _ = limiter.increment_and_check(&ip, None, "project-a").await;
         }
         // project-a should be blocked
         assert!(limiter
-            .increment_and_check("10.0.1.0", None, Some("project-a"))
+            .increment_and_check("10.0.1.0", None, "project-a")
             .await
             .is_err());
         // project-b should still be allowed
         assert!(limiter
-            .increment_and_check("10.0.1.1", None, Some("project-b"))
+            .increment_and_check("10.0.1.1", None, "project-b")
             .await
             .is_ok());
     }
@@ -376,12 +375,12 @@ mod tests {
             let ip = format!("10.0.0.{i}");
             let project = format!("proj-{i}");
             let _ = limiter
-                .increment_and_check(&ip, Some(session), Some(&project))
+                .increment_and_check(&ip, Some(session), &project)
                 .await;
         }
         // Next request should be blocked by session limit
         let result = limiter
-            .increment_and_check("10.0.1.0", Some(session), Some("proj-new"))
+            .increment_and_check("10.0.1.0", Some(session), "proj-new")
             .await;
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), settings.per_session_window_secs);

--- a/src/server/rate_limit.rs
+++ b/src/server/rate_limit.rs
@@ -10,16 +10,20 @@ use std::time::Duration;
 
 use super::settings::OAuthRateLimitSettings;
 
-/// Rate limiter for OAuth endpoints with three independent limits:
-/// - Per-project: keyed by `{project}:{ip}` (configurable, default 500 req/10s)
+/// Rate limiter for OAuth endpoints with four independent limits:
+/// - Per-project: keyed by project name (configurable, default 500 req/10s)
+/// - Per-IP: keyed by client IP (configurable, default 500 req/10s)
 /// - Per-session: keyed by `rise_jwt` cookie hash (configurable, default 30 req/10s)
 /// - Global: shared across all requests (configurable, default 1000 req/10s)
 pub struct OAuthRateLimiter {
     project_limiter: Arc<Cache<String, Arc<AtomicU32>>>,
+    ip_limiter: Arc<Cache<String, Arc<AtomicU32>>>,
     session_limiter: Arc<Cache<String, Arc<AtomicU32>>>,
     global_limiter: Arc<Cache<String, Arc<AtomicU32>>>,
     per_project_max: u32,
     per_project_window_secs: u64,
+    per_ip_max: u32,
+    per_ip_window_secs: u64,
     per_session_max: u32,
     per_session_window_secs: u64,
     global_max: u32,
@@ -27,7 +31,8 @@ pub struct OAuthRateLimiter {
 }
 
 impl OAuthRateLimiter {
-    const PROJECT_MAX_CAPACITY: u64 = 50_000;
+    const PROJECT_MAX_CAPACITY: u64 = 10_000;
+    const IP_MAX_CAPACITY: u64 = 50_000;
     const SESSION_MAX_CAPACITY: u64 = 10_000;
     const GLOBAL_MAX_CAPACITY: u64 = 1;
 
@@ -36,6 +41,12 @@ impl OAuthRateLimiter {
             Cache::builder()
                 .time_to_live(Duration::from_secs(settings.per_project_window_secs))
                 .max_capacity(Self::PROJECT_MAX_CAPACITY)
+                .build(),
+        );
+        let ip_limiter = Arc::new(
+            Cache::builder()
+                .time_to_live(Duration::from_secs(settings.per_ip_window_secs))
+                .max_capacity(Self::IP_MAX_CAPACITY)
                 .build(),
         );
         let session_limiter = Arc::new(
@@ -52,10 +63,13 @@ impl OAuthRateLimiter {
         );
         Self {
             project_limiter,
+            ip_limiter,
             session_limiter,
             global_limiter,
             per_project_max: settings.per_project_max,
             per_project_window_secs: settings.per_project_window_secs,
+            per_ip_max: settings.per_ip_max,
+            per_ip_window_secs: settings.per_ip_window_secs,
             per_session_max: settings.per_session_max,
             per_session_window_secs: settings.per_session_window_secs,
             global_max: settings.global_max,
@@ -64,9 +78,6 @@ impl OAuthRateLimiter {
     }
 
     /// Atomically increment counters and check limits.
-    ///
-    /// The `project` parameter scopes the per-IP limit so that each project gets its own
-    /// budget (key: `"{project}:{ip}"`). When `project` is `None`, the key is just the IP.
     ///
     /// Returns `Ok(())` if within limits after incrementing, `Err(retry_after_secs)` if exceeded.
     pub async fn increment_and_check(
@@ -87,20 +98,30 @@ impl OAuthRateLimiter {
             return Err(self.global_window_secs);
         }
 
-        // Per-project+IP
-        let project_key = match project {
-            Some(p) => format!("{p}:{ip}"),
-            None => ip.to_string(),
-        };
-        let project_counter = self
-            .project_limiter
-            .entry_by_ref(&project_key)
+        // Per-project
+        if let Some(p) = project {
+            let project_counter = self
+                .project_limiter
+                .entry_by_ref(p)
+                .or_insert_with(std::future::ready(Arc::new(AtomicU32::new(0))))
+                .await
+                .into_value();
+            let project_count = project_counter.fetch_add(1, Ordering::Relaxed) + 1;
+            if project_count > self.per_project_max {
+                return Err(self.per_project_window_secs);
+            }
+        }
+
+        // Per-IP
+        let ip_counter = self
+            .ip_limiter
+            .entry_by_ref(ip)
             .or_insert_with(std::future::ready(Arc::new(AtomicU32::new(0))))
             .await
             .into_value();
-        let project_count = project_counter.fetch_add(1, Ordering::Relaxed) + 1;
-        if project_count > self.per_project_max {
-            return Err(self.per_project_window_secs);
+        let ip_count = ip_counter.fetch_add(1, Ordering::Relaxed) + 1;
+        if ip_count > self.per_ip_max {
+            return Err(self.per_ip_window_secs);
         }
 
         // Per-session
@@ -207,6 +228,8 @@ mod tests {
         OAuthRateLimitSettings {
             per_project_max: 10,
             per_project_window_secs: 300,
+            per_ip_max: 10,
+            per_ip_window_secs: 300,
             per_session_max: 5,
             per_session_window_secs: 300,
             global_max: 1000,
@@ -287,37 +310,58 @@ mod tests {
     async fn test_rate_limiter_blocks_at_project_limit() {
         let settings = test_settings();
         let limiter = OAuthRateLimiter::new(&settings);
-        let ip = "10.0.0.1";
         let project = "my-project";
-        // Exhaust the per-project+IP limit
-        for _ in 0..settings.per_project_max {
-            let _ = limiter.increment_and_check(ip, None, Some(project)).await;
+        // Use different IPs so we only hit the project limit, not the IP limit
+        for i in 0..settings.per_project_max {
+            let ip = format!("10.0.0.{i}");
+            let _ = limiter.increment_and_check(&ip, None, Some(project)).await;
         }
-        // Next request should be blocked
-        let result = limiter.increment_and_check(ip, None, Some(project)).await;
+        // Next request should be blocked by project limit
+        let result = limiter
+            .increment_and_check("10.0.1.0", None, Some(project))
+            .await;
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), settings.per_project_window_secs);
+    }
+
+    #[tokio::test]
+    async fn test_rate_limiter_blocks_at_ip_limit() {
+        let settings = test_settings();
+        let limiter = OAuthRateLimiter::new(&settings);
+        let ip = "10.0.0.1";
+        // Use different projects so we only hit the IP limit, not the project limit
+        for i in 0..settings.per_ip_max {
+            let project = format!("project-{i}");
+            let _ = limiter.increment_and_check(ip, None, Some(&project)).await;
+        }
+        // Next request should be blocked by IP limit
+        let result = limiter
+            .increment_and_check(ip, None, Some("another-project"))
+            .await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), settings.per_ip_window_secs);
     }
 
     #[tokio::test]
     async fn test_rate_limiter_different_projects_independent() {
         let settings = test_settings();
         let limiter = OAuthRateLimiter::new(&settings);
-        let ip = "10.0.0.1";
+        // Use different IPs per request so we don't hit the IP limit
         // Exhaust project-a's limit
-        for _ in 0..settings.per_project_max {
+        for i in 0..settings.per_project_max {
+            let ip = format!("10.0.0.{i}");
             let _ = limiter
-                .increment_and_check(ip, None, Some("project-a"))
+                .increment_and_check(&ip, None, Some("project-a"))
                 .await;
         }
         // project-a should be blocked
         assert!(limiter
-            .increment_and_check(ip, None, Some("project-a"))
+            .increment_and_check("10.0.1.0", None, Some("project-a"))
             .await
             .is_err());
         // project-b should still be allowed
         assert!(limiter
-            .increment_and_check(ip, None, Some("project-b"))
+            .increment_and_check("10.0.1.1", None, Some("project-b"))
             .await
             .is_ok());
     }
@@ -326,17 +370,18 @@ mod tests {
     async fn test_rate_limiter_blocks_at_session_limit() {
         let settings = test_settings();
         let limiter = OAuthRateLimiter::new(&settings);
-        let ip = "10.0.0.2";
         let session = "session:abc123";
-        // Exhaust the session limit
-        for _ in 0..settings.per_session_max {
+        // Use different IPs and projects so we only hit the session limit
+        for i in 0..settings.per_session_max {
+            let ip = format!("10.0.0.{i}");
+            let project = format!("proj-{i}");
             let _ = limiter
-                .increment_and_check(ip, Some(session), Some("proj"))
+                .increment_and_check(&ip, Some(session), Some(&project))
                 .await;
         }
-        // Next request should be blocked
+        // Next request should be blocked by session limit
         let result = limiter
-            .increment_and_check(ip, Some(session), Some("proj"))
+            .increment_and_check("10.0.1.0", Some(session), Some("proj-new"))
             .await;
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), settings.per_session_window_secs);

--- a/src/server/rate_limit.rs
+++ b/src/server/rate_limit.rs
@@ -8,67 +8,72 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+use super::settings::OAuthRateLimitSettings;
+
 /// Rate limiter for OAuth endpoints with three independent limits:
-/// - Per-IP: 10 requests per 5 minutes
-/// - Per-session: 5 requests per 5 minutes (keyed by `rise_jwt` cookie fingerprint)
-/// - Global: 1000 requests per minute
+/// - Per-project: keyed by `{project}:{ip}` (configurable, default 100 req/60s)
+/// - Per-session: keyed by `rise_jwt` cookie hash (configurable, default 30 req/60s)
+/// - Global: shared across all requests (configurable, default 3000 req/60s)
 pub struct OAuthRateLimiter {
-    ip_limiter: Arc<Cache<String, Arc<AtomicU32>>>,
+    project_limiter: Arc<Cache<String, Arc<AtomicU32>>>,
     session_limiter: Arc<Cache<String, Arc<AtomicU32>>>,
     global_limiter: Arc<Cache<String, Arc<AtomicU32>>>,
+    per_project_max: u32,
+    per_project_window_secs: u64,
+    per_session_max: u32,
+    per_session_window_secs: u64,
+    global_max: u32,
+    global_window_secs: u64,
 }
 
 impl OAuthRateLimiter {
-    pub const IP_MAX: u32 = 10;
-    pub const IP_WINDOW_SECS: u64 = 300; // 5 minutes
-    pub const IP_MAX_CAPACITY: u64 = 50_000;
+    const PROJECT_MAX_CAPACITY: u64 = 50_000;
+    const SESSION_MAX_CAPACITY: u64 = 10_000;
+    const GLOBAL_MAX_CAPACITY: u64 = 1;
 
-    pub const SESSION_MAX: u32 = 5;
-    pub const SESSION_WINDOW_SECS: u64 = 300; // 5 minutes
-    pub const SESSION_MAX_CAPACITY: u64 = 10_000;
-
-    pub const GLOBAL_MAX: u32 = 1000;
-    pub const GLOBAL_WINDOW_SECS: u64 = 60; // 1 minute
-    pub const GLOBAL_MAX_CAPACITY: u64 = 1;
-
-    pub fn new() -> Self {
-        let ip_limiter = Arc::new(
+    pub fn new(settings: &OAuthRateLimitSettings) -> Self {
+        let project_limiter = Arc::new(
             Cache::builder()
-                .time_to_live(Duration::from_secs(Self::IP_WINDOW_SECS))
-                .max_capacity(Self::IP_MAX_CAPACITY)
+                .time_to_live(Duration::from_secs(settings.per_project_window_secs))
+                .max_capacity(Self::PROJECT_MAX_CAPACITY)
                 .build(),
         );
         let session_limiter = Arc::new(
             Cache::builder()
-                .time_to_live(Duration::from_secs(Self::SESSION_WINDOW_SECS))
+                .time_to_live(Duration::from_secs(settings.per_session_window_secs))
                 .max_capacity(Self::SESSION_MAX_CAPACITY)
                 .build(),
         );
         let global_limiter = Arc::new(
             Cache::builder()
-                .time_to_live(Duration::from_secs(Self::GLOBAL_WINDOW_SECS))
+                .time_to_live(Duration::from_secs(settings.global_window_secs))
                 .max_capacity(Self::GLOBAL_MAX_CAPACITY)
                 .build(),
         );
         Self {
-            ip_limiter,
+            project_limiter,
             session_limiter,
             global_limiter,
+            per_project_max: settings.per_project_max,
+            per_project_window_secs: settings.per_project_window_secs,
+            per_session_max: settings.per_session_max,
+            per_session_window_secs: settings.per_session_window_secs,
+            global_max: settings.global_max,
+            global_window_secs: settings.global_window_secs,
         }
     }
 
     /// Atomically increment counters and check limits.
     ///
-    /// Uses `AtomicU32` counters stored in the cache so concurrent increments are never lost.
-    /// The cache's `time_to_live` acts as a fixed window: a counter entry is created (with TTL)
-    /// on first access and expires naturally, resetting the count. Subsequent increments within
-    /// the window use the existing entry without refreshing its TTL.
+    /// The `project` parameter scopes the per-IP limit so that each project gets its own
+    /// budget (key: `"{project}:{ip}"`). When `project` is `None`, the key is just the IP.
     ///
     /// Returns `Ok(())` if within limits after incrementing, `Err(retry_after_secs)` if exceeded.
     pub async fn increment_and_check(
         &self,
         ip: &str,
         session_key: Option<&str>,
+        project: Option<&str>,
     ) -> Result<(), u64> {
         // Global
         let global_counter = self
@@ -78,20 +83,24 @@ impl OAuthRateLimiter {
             .await
             .into_value();
         let global_count = global_counter.fetch_add(1, Ordering::Relaxed) + 1;
-        if global_count > Self::GLOBAL_MAX {
-            return Err(Self::GLOBAL_WINDOW_SECS);
+        if global_count > self.global_max {
+            return Err(self.global_window_secs);
         }
 
-        // Per-IP
-        let ip_counter = self
-            .ip_limiter
-            .entry_by_ref(ip)
+        // Per-project+IP
+        let project_key = match project {
+            Some(p) => format!("{p}:{ip}"),
+            None => ip.to_string(),
+        };
+        let project_counter = self
+            .project_limiter
+            .entry_by_ref(&project_key)
             .or_insert_with(std::future::ready(Arc::new(AtomicU32::new(0))))
             .await
             .into_value();
-        let ip_count = ip_counter.fetch_add(1, Ordering::Relaxed) + 1;
-        if ip_count > Self::IP_MAX {
-            return Err(Self::IP_WINDOW_SECS);
+        let project_count = project_counter.fetch_add(1, Ordering::Relaxed) + 1;
+        if project_count > self.per_project_max {
+            return Err(self.per_project_window_secs);
         }
 
         // Per-session
@@ -103,8 +112,8 @@ impl OAuthRateLimiter {
                 .await
                 .into_value();
             let session_count = session_counter.fetch_add(1, Ordering::Relaxed) + 1;
-            if session_count > Self::SESSION_MAX {
-                return Err(Self::SESSION_WINDOW_SECS);
+            if session_count > self.per_session_max {
+                return Err(self.per_session_window_secs);
             }
         }
 
@@ -194,6 +203,17 @@ mod tests {
     use super::*;
     use axum::http::{HeaderMap, HeaderValue};
 
+    fn test_settings() -> OAuthRateLimitSettings {
+        OAuthRateLimitSettings {
+            per_project_max: 10,
+            per_project_window_secs: 300,
+            per_session_max: 5,
+            per_session_window_secs: 300,
+            global_max: 1000,
+            global_window_secs: 60,
+        }
+    }
+
     #[test]
     fn test_extract_client_ip_real_ip_preferred() {
         let mut headers = HeaderMap::new();
@@ -256,37 +276,69 @@ mod tests {
 
     #[tokio::test]
     async fn test_rate_limiter_allows_within_limit() {
-        let limiter = OAuthRateLimiter::new();
-        // First request should be allowed
-        assert!(limiter.increment_and_check("1.2.3.4", None).await.is_ok());
+        let limiter = OAuthRateLimiter::new(&test_settings());
+        assert!(limiter
+            .increment_and_check("1.2.3.4", None, Some("my-project"))
+            .await
+            .is_ok());
     }
 
     #[tokio::test]
-    async fn test_rate_limiter_blocks_at_ip_limit() {
-        let limiter = OAuthRateLimiter::new();
+    async fn test_rate_limiter_blocks_at_project_limit() {
+        let settings = test_settings();
+        let limiter = OAuthRateLimiter::new(&settings);
         let ip = "10.0.0.1";
-        // Exhaust the IP limit
-        for _ in 0..OAuthRateLimiter::IP_MAX {
-            let _ = limiter.increment_and_check(ip, None).await;
+        let project = "my-project";
+        // Exhaust the per-project+IP limit
+        for _ in 0..settings.per_project_max {
+            let _ = limiter.increment_and_check(ip, None, Some(project)).await;
         }
         // Next request should be blocked
-        let result = limiter.increment_and_check(ip, None).await;
+        let result = limiter.increment_and_check(ip, None, Some(project)).await;
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), OAuthRateLimiter::IP_WINDOW_SECS);
+        assert_eq!(result.unwrap_err(), settings.per_project_window_secs);
+    }
+
+    #[tokio::test]
+    async fn test_rate_limiter_different_projects_independent() {
+        let settings = test_settings();
+        let limiter = OAuthRateLimiter::new(&settings);
+        let ip = "10.0.0.1";
+        // Exhaust project-a's limit
+        for _ in 0..settings.per_project_max {
+            let _ = limiter
+                .increment_and_check(ip, None, Some("project-a"))
+                .await;
+        }
+        // project-a should be blocked
+        assert!(limiter
+            .increment_and_check(ip, None, Some("project-a"))
+            .await
+            .is_err());
+        // project-b should still be allowed
+        assert!(limiter
+            .increment_and_check(ip, None, Some("project-b"))
+            .await
+            .is_ok());
     }
 
     #[tokio::test]
     async fn test_rate_limiter_blocks_at_session_limit() {
-        let limiter = OAuthRateLimiter::new();
+        let settings = test_settings();
+        let limiter = OAuthRateLimiter::new(&settings);
         let ip = "10.0.0.2";
         let session = "session:abc123";
         // Exhaust the session limit
-        for _ in 0..OAuthRateLimiter::SESSION_MAX {
-            let _ = limiter.increment_and_check(ip, Some(session)).await;
+        for _ in 0..settings.per_session_max {
+            let _ = limiter
+                .increment_and_check(ip, Some(session), Some("proj"))
+                .await;
         }
         // Next request should be blocked
-        let result = limiter.increment_and_check(ip, Some(session)).await;
+        let result = limiter
+            .increment_and_check(ip, Some(session), Some("proj"))
+            .await;
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), OAuthRateLimiter::SESSION_WINDOW_SECS);
+        assert_eq!(result.unwrap_err(), settings.per_session_window_secs);
     }
 }

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -78,6 +78,54 @@ pub struct ServerSettings {
     /// SSRF validation configuration.
     #[serde(default)]
     pub ssrf: super::ssrf::SsrfConfig,
+
+    /// OAuth endpoint rate limiting configuration.
+    #[serde(default)]
+    pub oauth_rate_limit: OAuthRateLimitSettings,
+}
+
+/// Rate limiting configuration for OAuth endpoints (authorize, callback, token).
+///
+/// Three independent limits are enforced:
+/// - **Per-project**: keyed by `{project_name}:{client_ip}` — limits traffic to each
+///   project independently so one busy project cannot starve others.
+/// - **Per-session**: keyed by a hash of the `rise_jwt` cookie — limits per-user traffic.
+/// - **Global**: shared across all requests — caps total throughput.
+#[derive(Debug, Deserialize, Clone, JsonSchema)]
+pub struct OAuthRateLimitSettings {
+    /// Maximum requests per project+IP per window (default: 100)
+    #[serde(default = "default_oauth_per_project_max")]
+    pub per_project_max: u32,
+    /// Window in seconds for per-project+IP limit (default: 60)
+    #[serde(default = "default_oauth_per_project_window_secs")]
+    pub per_project_window_secs: u64,
+
+    /// Maximum requests per session (rise_jwt cookie) per window (default: 30)
+    #[serde(default = "default_oauth_per_session_max")]
+    pub per_session_max: u32,
+    /// Window in seconds for per-session limit (default: 60)
+    #[serde(default = "default_oauth_per_session_window_secs")]
+    pub per_session_window_secs: u64,
+
+    /// Maximum total OAuth requests per window across all clients (default: 3000)
+    #[serde(default = "default_oauth_global_max")]
+    pub global_max: u32,
+    /// Window in seconds for the global limit (default: 60)
+    #[serde(default = "default_oauth_global_window_secs")]
+    pub global_window_secs: u64,
+}
+
+impl Default for OAuthRateLimitSettings {
+    fn default() -> Self {
+        Self {
+            per_project_max: default_oauth_per_project_max(),
+            per_project_window_secs: default_oauth_per_project_window_secs(),
+            per_session_max: default_oauth_per_session_max(),
+            per_session_window_secs: default_oauth_per_session_window_secs(),
+            global_max: default_oauth_global_max(),
+            global_window_secs: default_oauth_global_window_secs(),
+        }
+    }
 }
 
 fn default_cookie_secure() -> bool {
@@ -98,6 +146,30 @@ fn default_jwt_claims() -> Vec<String> {
 
 fn default_jwt_expiry_seconds() -> u64 {
     86400 // 24 hours
+}
+
+fn default_oauth_per_project_max() -> u32 {
+    100
+}
+
+fn default_oauth_per_project_window_secs() -> u64 {
+    60
+}
+
+fn default_oauth_per_session_max() -> u32 {
+    30
+}
+
+fn default_oauth_per_session_window_secs() -> u64 {
+    60
+}
+
+fn default_oauth_global_max() -> u32 {
+    3000
+}
+
+fn default_oauth_global_window_secs() -> u64 {
+    60
 }
 
 fn default_reconcile_interval() -> u64 {

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -86,19 +86,27 @@ pub struct ServerSettings {
 
 /// Rate limiting configuration for OAuth endpoints (authorize, callback, token).
 ///
-/// Three independent limits are enforced:
-/// - **Per-project**: keyed by `{project_name}:{client_ip}` — limits traffic to each
-///   project independently so one busy project cannot starve others.
+/// Four independent limits are enforced:
+/// - **Per-project**: keyed by project name — limits traffic to each project independently
+///   so one busy project cannot starve others.
+/// - **Per-IP**: keyed by client IP — limits traffic from a single source address.
 /// - **Per-session**: keyed by a hash of the `rise_jwt` cookie — limits per-user traffic.
 /// - **Global**: shared across all requests — caps total throughput.
 #[derive(Debug, Deserialize, Clone, JsonSchema)]
 pub struct OAuthRateLimitSettings {
-    /// Maximum requests per project+IP per window (default: 500)
+    /// Maximum requests per project per window (default: 500)
     #[serde(default = "default_oauth_per_project_max")]
     pub per_project_max: u32,
-    /// Window in seconds for per-project+IP limit (default: 10)
+    /// Window in seconds for per-project limit (default: 10)
     #[serde(default = "default_oauth_per_project_window_secs")]
     pub per_project_window_secs: u64,
+
+    /// Maximum requests per client IP per window (default: 500)
+    #[serde(default = "default_oauth_per_ip_max")]
+    pub per_ip_max: u32,
+    /// Window in seconds for per-IP limit (default: 10)
+    #[serde(default = "default_oauth_per_ip_window_secs")]
+    pub per_ip_window_secs: u64,
 
     /// Maximum requests per session (rise_jwt cookie) per window (default: 30)
     #[serde(default = "default_oauth_per_session_max")]
@@ -120,6 +128,8 @@ impl Default for OAuthRateLimitSettings {
         Self {
             per_project_max: default_oauth_per_project_max(),
             per_project_window_secs: default_oauth_per_project_window_secs(),
+            per_ip_max: default_oauth_per_ip_max(),
+            per_ip_window_secs: default_oauth_per_ip_window_secs(),
             per_session_max: default_oauth_per_session_max(),
             per_session_window_secs: default_oauth_per_session_window_secs(),
             global_max: default_oauth_global_max(),
@@ -153,6 +163,14 @@ fn default_oauth_per_project_max() -> u32 {
 }
 
 fn default_oauth_per_project_window_secs() -> u64 {
+    10
+}
+
+fn default_oauth_per_ip_max() -> u32 {
+    500
+}
+
+fn default_oauth_per_ip_window_secs() -> u64 {
     10
 }
 

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -92,33 +92,36 @@ pub struct ServerSettings {
 /// - **Per-IP**: keyed by client IP — limits traffic from a single source address.
 /// - **Per-session**: keyed by a hash of the `rise_jwt` cookie — limits per-user traffic.
 /// - **Global**: shared across all requests — caps total throughput.
+///
+/// Setting any `*_max` value to `0` effectively blocks all OAuth traffic for that tier
+/// (every request will exceed the limit immediately).
 #[derive(Debug, Deserialize, Clone, JsonSchema)]
 pub struct OAuthRateLimitSettings {
     /// Maximum requests per project per window (default: 500)
     #[serde(default = "default_oauth_per_project_max")]
     pub per_project_max: u32,
-    /// Window in seconds for per-project limit (default: 10)
+    /// Window in seconds for per-project limit (default: 60)
     #[serde(default = "default_oauth_per_project_window_secs")]
     pub per_project_window_secs: u64,
 
-    /// Maximum requests per client IP per window (default: 500)
+    /// Maximum requests per client IP per window (default: 50)
     #[serde(default = "default_oauth_per_ip_max")]
     pub per_ip_max: u32,
-    /// Window in seconds for per-IP limit (default: 10)
+    /// Window in seconds for per-IP limit (default: 60)
     #[serde(default = "default_oauth_per_ip_window_secs")]
     pub per_ip_window_secs: u64,
 
-    /// Maximum requests per session (rise_jwt cookie) per window (default: 30)
+    /// Maximum requests per session (rise_jwt cookie) per window (default: 20)
     #[serde(default = "default_oauth_per_session_max")]
     pub per_session_max: u32,
-    /// Window in seconds for per-session limit (default: 10)
+    /// Window in seconds for per-session limit (default: 60)
     #[serde(default = "default_oauth_per_session_window_secs")]
     pub per_session_window_secs: u64,
 
-    /// Maximum total OAuth requests per window across all clients (default: 1000)
+    /// Maximum total OAuth requests per window across all clients (default: 2000)
     #[serde(default = "default_oauth_global_max")]
     pub global_max: u32,
-    /// Window in seconds for the global limit (default: 10)
+    /// Window in seconds for the global limit (default: 60)
     #[serde(default = "default_oauth_global_window_secs")]
     pub global_window_secs: u64,
 }
@@ -163,31 +166,31 @@ fn default_oauth_per_project_max() -> u32 {
 }
 
 fn default_oauth_per_project_window_secs() -> u64 {
-    10
+    60
 }
 
 fn default_oauth_per_ip_max() -> u32 {
-    500
+    50
 }
 
 fn default_oauth_per_ip_window_secs() -> u64 {
-    10
+    60
 }
 
 fn default_oauth_per_session_max() -> u32 {
-    30
+    20
 }
 
 fn default_oauth_per_session_window_secs() -> u64 {
-    10
+    60
 }
 
 fn default_oauth_global_max() -> u32 {
-    1000
+    2000
 }
 
 fn default_oauth_global_window_secs() -> u64 {
-    10
+    60
 }
 
 fn default_reconcile_interval() -> u64 {

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -93,24 +93,24 @@ pub struct ServerSettings {
 /// - **Global**: shared across all requests — caps total throughput.
 #[derive(Debug, Deserialize, Clone, JsonSchema)]
 pub struct OAuthRateLimitSettings {
-    /// Maximum requests per project+IP per window (default: 100)
+    /// Maximum requests per project+IP per window (default: 500)
     #[serde(default = "default_oauth_per_project_max")]
     pub per_project_max: u32,
-    /// Window in seconds for per-project+IP limit (default: 60)
+    /// Window in seconds for per-project+IP limit (default: 10)
     #[serde(default = "default_oauth_per_project_window_secs")]
     pub per_project_window_secs: u64,
 
     /// Maximum requests per session (rise_jwt cookie) per window (default: 30)
     #[serde(default = "default_oauth_per_session_max")]
     pub per_session_max: u32,
-    /// Window in seconds for per-session limit (default: 60)
+    /// Window in seconds for per-session limit (default: 10)
     #[serde(default = "default_oauth_per_session_window_secs")]
     pub per_session_window_secs: u64,
 
-    /// Maximum total OAuth requests per window across all clients (default: 3000)
+    /// Maximum total OAuth requests per window across all clients (default: 1000)
     #[serde(default = "default_oauth_global_max")]
     pub global_max: u32,
-    /// Window in seconds for the global limit (default: 60)
+    /// Window in seconds for the global limit (default: 10)
     #[serde(default = "default_oauth_global_window_secs")]
     pub global_window_secs: u64,
 }
@@ -149,11 +149,11 @@ fn default_jwt_expiry_seconds() -> u64 {
 }
 
 fn default_oauth_per_project_max() -> u32 {
-    100
+    500
 }
 
 fn default_oauth_per_project_window_secs() -> u64 {
-    60
+    10
 }
 
 fn default_oauth_per_session_max() -> u32 {
@@ -161,15 +161,15 @@ fn default_oauth_per_session_max() -> u32 {
 }
 
 fn default_oauth_per_session_window_secs() -> u64 {
-    60
+    10
 }
 
 fn default_oauth_global_max() -> u32 {
-    3000
+    1000
 }
 
 fn default_oauth_global_window_secs() -> u64 {
-    60
+    10
 }
 
 fn default_reconcile_interval() -> u64 {

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -736,8 +736,14 @@ impl AppState {
         tracing::info!("Initialized encrypt endpoint rate limiter (100 req/hour per user)");
 
         // Initialize OAuth endpoint rate limiter
-        let oauth_rate_limiter = Arc::new(crate::server::rate_limit::OAuthRateLimiter::new());
-        tracing::info!("Initialized OAuth endpoint rate limiter (10 req/5min per IP, 5 req/5min per session, 1000 req/min global)");
+        let rl = &settings.server.oauth_rate_limit;
+        let oauth_rate_limiter = Arc::new(crate::server::rate_limit::OAuthRateLimiter::new(rl));
+        tracing::info!(
+            per_project = %format!("{} req/{}s", rl.per_project_max, rl.per_project_window_secs),
+            per_session = %format!("{} req/{}s", rl.per_session_max, rl.per_session_window_secs),
+            global = %format!("{} req/{}s", rl.global_max, rl.global_window_secs),
+            "Initialized OAuth endpoint rate limiter",
+        );
 
         // Extract access_classes from deployment controller settings
         // Filter out null values (used to remove inherited access classes)

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -740,6 +740,7 @@ impl AppState {
         let oauth_rate_limiter = Arc::new(crate::server::rate_limit::OAuthRateLimiter::new(rl));
         tracing::info!(
             per_project = %format!("{} req/{}s", rl.per_project_max, rl.per_project_window_secs),
+            per_ip = %format!("{} req/{}s", rl.per_ip_max, rl.per_ip_window_secs),
             per_session = %format!("{} req/{}s", rl.per_session_max, rl.per_session_window_secs),
             global = %format!("{} req/{}s", rl.global_max, rl.global_window_secs),
             "Initialized OAuth endpoint rate limiter",


### PR DESCRIPTION
## Summary

- **Four independent rate limit tiers**: The OAuth rate limiter now enforces per-project, per-IP, per-session, and global limits independently. Previously there was a single per-IP limit (10 req/5min) shared across all projects and users behind the same cluster-internal IP.
- **Per-project keying**: Each project gets its own rate limit budget (keyed by project name), so one busy project cannot starve others.
- **Per-IP keying**: Separate limit keyed by client IP, independent of project.
- **Configurable limits**: All four tiers are configurable via `server.oauth_rate_limit` in backend settings with sensible defaults.

### Configuration

All settings are optional and have defaults:

```yaml
server:
  oauth_rate_limit:
    per_project_max: 500          # per project name
    per_project_window_secs: 60
    per_ip_max: 50                # per client IP
    per_ip_window_secs: 60
    per_session_max: 20           # per rise_jwt cookie
    per_session_window_secs: 60
    global_max: 2000              # across all clients
    global_window_secs: 60
```

Setting any `*_max` value to `0` blocks all OAuth traffic for that tier.

## Test plan

- [x] All existing rate limit tests pass
- [x] New tests verify per-project, per-IP, and cross-project independence
- [x] `cargo clippy --all-features` passes
- [x] Config schema regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)