### PR TITLE
fix(oauth): reject plain PKCE method, require S256

### DIFF
--- a/docs/user-guide/oauth.md
+++ b/docs/user-guide/oauth.md
@@ -348,7 +348,7 @@ GET /oidc/{project}/{extension}/authorize?redirect_uri=http://localhost:3000/cal
 
 **Query Parameters:**
 - `code_challenge` (optional): PKCE code challenge (base64url-encoded SHA-256 hash of code_verifier)
-- `code_challenge_method` (optional): `S256` (default) or `plain`
+- `code_challenge_method` (optional): Only `S256` is supported (and is the default)
 - `redirect_uri` (optional): Where to redirect after OAuth (localhost or project domain)
 - `state` (optional): Application state passed through OAuth flow
 

--- a/src/server/extensions/providers/oauth/handlers.rs
+++ b/src/server/extensions/providers/oauth/handlers.rs
@@ -1775,6 +1775,13 @@ pub async fn oidc_discovery(
                                 discovery_obj.insert(key.clone(), value.clone());
                             }
                         }
+
+                        // Override code_challenge_methods_supported to only advertise S256,
+                        // regardless of what the upstream provider supports.
+                        discovery_obj.insert(
+                            "code_challenge_methods_supported".to_string(),
+                            serde_json::json!(["S256"]),
+                        );
                     }
                 }
             }

--- a/src/server/extensions/providers/oauth/handlers.rs
+++ b/src/server/extensions/providers/oauth/handlers.rs
@@ -337,7 +337,7 @@ async fn validate_redirect_uri(
 /// - redirect_uri (optional): Where to redirect after auth (for local dev/custom domains)
 /// - state (optional): Application's CSRF state parameter (passed through to final redirect)
 /// - code_challenge (optional): PKCE code challenge for public clients (SPAs)
-/// - code_challenge_method (optional): PKCE method ("S256" or "plain", defaults to "S256")
+/// - code_challenge_method (optional): PKCE method (only "S256" is supported, and is the default)
 pub async fn authorize(
     State(state): State<AppState>,
     Path((project_name, extension_name)): Path<(String, String)>,
@@ -421,11 +421,11 @@ pub async fn authorize(
         }
 
         let method = req.code_challenge_method.as_deref().unwrap_or("S256");
-        if method != "S256" && method != "plain" {
+        if method != "S256" {
             return Err((
                 StatusCode::BAD_REQUEST,
                 format!(
-                    "Unsupported code_challenge_method '{}'. Only 'S256' and 'plain' are supported.",
+                    "Unsupported code_challenge_method '{}'. Only 'S256' is supported.",
                     method
                 ),
             ));
@@ -1030,13 +1030,6 @@ fn validate_pkce(code_verifier: &str, code_challenge: &str, code_challenge_metho
 
             // Constant-time comparison
             computed_challenge
-                .as_bytes()
-                .ct_eq(code_challenge.as_bytes())
-                .into()
-        }
-        "plain" => {
-            // Direct comparison
-            code_verifier
                 .as_bytes()
                 .ct_eq(code_challenge.as_bytes())
                 .into()
@@ -1732,7 +1725,7 @@ pub async fn oidc_discovery(
             "token_endpoint": format!("{}/token", rise_oidc_base),
             "response_types_supported": ["code"],
             "grant_types_supported": ["authorization_code", "refresh_token"],
-            "code_challenge_methods_supported": ["S256", "plain"],
+            "code_challenge_methods_supported": ["S256"],
             "token_endpoint_auth_methods_supported": ["client_secret_post", "none"]
         });
 
@@ -1817,7 +1810,7 @@ pub async fn oidc_discovery(
                     "token_endpoint": format!("{}/token", rise_oidc_base),
                     "response_types_supported": ["code"],
                     "grant_types_supported": ["authorization_code", "refresh_token"],
-                    "code_challenge_methods_supported": ["S256", "plain"],
+                    "code_challenge_methods_supported": ["S256"],
                     "token_endpoint_auth_methods_supported": ["client_secret_post", "none"]
                 });
 

--- a/src/server/extensions/providers/oauth/models.rs
+++ b/src/server/extensions/providers/oauth/models.rs
@@ -120,7 +120,7 @@ pub struct OAuthCodeState {
     /// PKCE code challenge from client (if PKCE flow)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub code_challenge: Option<String>,
-    /// PKCE code challenge method ("S256" or "plain")
+    /// PKCE code challenge method (only "S256" is supported)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub code_challenge_method: Option<String>,
     /// Raw encrypted token response body from upstream provider (cached as-is, no parsing)
@@ -140,7 +140,7 @@ pub struct AuthorizeFlowQuery {
     pub state: Option<String>,
     /// PKCE code challenge (for public clients/SPAs)
     pub code_challenge: Option<String>,
-    /// PKCE code challenge method ("S256" or "plain", defaults to "S256")
+    /// PKCE code challenge method (only "S256" is supported, defaults to "S256")
     pub code_challenge_method: Option<String>,
 }
 


### PR DESCRIPTION
## Summary
- Drop support for the `plain` PKCE `code_challenge_method` in the OAuth extension proxy, only accepting `S256`
- Aligns with the OAuth 2.1 draft specification which removes `plain` entirely
- Updates OIDC discovery responses, validation logic, doc comments, and user-facing documentation

## Test plan
- [ ] Verify OAuth extension authorize endpoint rejects `code_challenge_method=plain` with 400
- [ ] Verify OAuth extension authorize endpoint accepts `code_challenge_method=S256` (and omitted, which defaults to S256)
- [ ] Verify OIDC discovery endpoint only advertises `["S256"]` in `code_challenge_methods_supported`

🤖 Generated with [Claude Code](https://claude.com/claude-code)