### PR TITLE
add `rise env export` and fix `rise run` environment resolution

### DIFF
--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -88,11 +88,15 @@ pub async fn fetch_preview_env_vars(
     token: &str,
     project: &str,
     deployment_group: &str,
+    environment: Option<&str>,
 ) -> Result<(Vec<(String, String)>, Vec<String>)> {
-    let url = format!(
+    let mut url = format!(
         "{}/api/v1/projects/{}/env/preview?deployment_group={}",
         backend_url, project, deployment_group
     );
+    if let Some(env_name) = environment {
+        url.push_str(&format!("&environment={}", urlencoding::encode(env_name)));
+    }
 
     let response = http_client
         .get(&url)
@@ -609,6 +613,45 @@ pub async fn list_deployment_env(
     println!("Deployment: {}", deployment_id);
     println!("Note: Secret values are always masked for security");
     println!("Note: Deployment environment variables are read-only snapshots");
+
+    Ok(())
+}
+
+/// Export environment variables in dotfile format (KEY=value per line).
+///
+/// Output goes to stdout for clean piping (`rise env export > .env` or
+/// `eval $(rise env export)`). Warnings about protected secrets go to stderr.
+pub async fn export_env(
+    http_client: &Client,
+    backend_url: &str,
+    token: &str,
+    project: &str,
+    environment: Option<&str>,
+) -> Result<()> {
+    let (loadable_vars, protected_keys) = fetch_preview_env_vars(
+        http_client,
+        backend_url,
+        token,
+        project,
+        "default",
+        environment,
+    )
+    .await?;
+
+    if !protected_keys.is_empty() {
+        eprintln!(
+            "warning: {} protected secret{} excluded (cannot be exported):",
+            protected_keys.len(),
+            if protected_keys.len() == 1 { "" } else { "s" }
+        );
+        for key in &protected_keys {
+            eprintln!("  - {}", key);
+        }
+    }
+
+    for (key, value) in &loadable_vars {
+        println!("{}={}", key, value);
+    }
 
     Ok(())
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -14,6 +14,7 @@ pub struct RunOptions<'a> {
     pub project_name: Option<&'a str>,
     pub use_project_env: bool,
     pub path: &'a str,
+    pub environment: Option<&'a str>,
     pub http_port: u16,
     pub expose: u16,
     pub run_env: &'a [(String, String)],
@@ -107,6 +108,7 @@ pub async fn run_locally(
                     &token,
                     project_name,
                     "default",
+                    options.environment,
                 )
                 .await
                 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,22 @@ mod server;
 #[cfg(feature = "cli")]
 use cli::*;
 
+/// Resolve environment from explicit flag or the `default = true` environment in rise.toml.
+#[cfg(feature = "cli")]
+fn resolve_environment(
+    explicit: Option<String>,
+    config: Option<&build::config::ProjectBuildConfig>,
+) -> Option<String> {
+    explicit.or_else(|| {
+        config.and_then(|cfg| {
+            cfg.environments
+                .iter()
+                .find(|(_, env)| env.default)
+                .map(|(name, _)| name.clone())
+        })
+    })
+}
+
 /// Resolve project name from explicit argument or rise.toml fallback.
 #[cfg(feature = "cli")]
 fn resolve_project_name(explicit_project: Option<String>, path: &str) -> Result<String> {
@@ -208,6 +224,9 @@ enum Commands {
         /// Path to the directory containing the application
         #[arg(default_value = ".")]
         path: String,
+        /// Target environment (e.g., 'staging'). Resolved from rise.toml if not specified.
+        #[arg(long, short = 'E')]
+        environment: Option<String>,
         /// HTTP port the application listens on (also sets PORT env var)
         #[arg(long, default_value = "8080")]
         http_port: u16,
@@ -613,6 +632,19 @@ enum EnvCommands {
         /// Lines starting with # are comments
         file: std::path::PathBuf,
         /// Scope imported variables to a specific environment
+        #[arg(long, short = 'E')]
+        environment: Option<String>,
+    },
+    /// Export resolved environment variables in dotfile format (KEY=value)
+    #[command(visible_alias = "x")]
+    Export {
+        /// Project name (optional if rise.toml contains [project] section)
+        #[arg(long, short = 'p')]
+        project: Option<String>,
+        /// Path to rise.toml (defaults to current directory)
+        #[arg(long, default_value = ".")]
+        path: String,
+        /// Target environment (e.g., 'staging'). Resolved from rise.toml if not specified.
         #[arg(long, short = 'E')]
         environment: Option<String>,
     },
@@ -1177,14 +1209,8 @@ async fn main() -> Result<()> {
 
                 // Resolve environment: explicit --environment flag takes precedence,
                 // otherwise fall back to the `default = true` environment from rise.toml.
-                let resolved_environment = args.environment.clone().or_else(|| {
-                    toml_config.as_ref().and_then(|cfg| {
-                        cfg.environments
-                            .iter()
-                            .find(|(_, env)| env.default)
-                            .map(|(name, _)| name.clone())
-                    })
-                });
+                let resolved_environment =
+                    resolve_environment(args.environment.clone(), toml_config.as_ref());
 
                 // Collect runtime env overrides with source tracking.
                 // All toml vars are sent tagged with for_environment; the server
@@ -1566,6 +1592,28 @@ async fn main() -> Result<()> {
                     )
                     .await?;
                 }
+                EnvCommands::Export {
+                    project,
+                    path,
+                    environment,
+                } => {
+                    let toml_config = build::config::load_full_project_config(path)?;
+                    let project_name = resolve_project_name_with_config(
+                        project.clone(),
+                        path,
+                        toml_config.as_ref(),
+                    )?;
+                    let resolved_env =
+                        resolve_environment(environment.clone(), toml_config.as_ref());
+                    env::export_env(
+                        &http_client,
+                        &backend_url,
+                        &token,
+                        &project_name,
+                        resolved_env.as_deref(),
+                    )
+                    .await?;
+                }
                 EnvCommands::ShowDeployment {
                     project,
                     path,
@@ -1695,12 +1743,17 @@ async fn main() -> Result<()> {
             project,
             use_project_env,
             path,
+            environment,
             http_port,
             expose,
             run_env,
             build_args,
         } => {
             let expose_port = expose.unwrap_or(*http_port);
+
+            // Resolve environment from --environment flag or rise.toml default
+            let toml_config = build::config::load_full_project_config(path)?;
+            let resolved_env = resolve_environment(environment.clone(), toml_config.as_ref());
 
             cli::run::run_locally(
                 &http_client,
@@ -1709,6 +1762,7 @@ async fn main() -> Result<()> {
                     project_name: project.as_deref(),
                     use_project_env: *use_project_env,
                     path,
+                    environment: resolved_env.as_deref(),
                     http_port: *http_port,
                     expose: expose_port,
                     run_env,


### PR DESCRIPTION
## Summary
- Add `rise env export` command that outputs resolved environment variables in dotfile format (`KEY=value`) to stdout, with warnings about excluded protected secrets on stderr. Supports `--environment` flag and rise.toml default resolution.
- Extract shared `resolve_environment()` helper used by deploy, run, and env export to resolve the target environment from `--environment` flag or rise.toml `default = true`.
- Fix `rise run --use-project-env` to accept `--environment` (`-E`) and pass it to the preview endpoint, instead of always fetching unscoped vars.

## Test plan
- [x] `rise env export -p <project>` outputs `KEY=value` lines to stdout
- [x] `rise env export -p <project> -E staging` scopes to staging environment
- [x] `rise run -p <project> -E staging` loads staging-scoped env vars
- [x] `rise deploy` continues to resolve environment correctly
- [x] `cargo clippy --all-features --all-targets -- -D warnings` passes
- [x] `cargo test --all-features` passes (non-DB tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)