### PR TITLE
Add `--platform` option to override default build platform

### DIFF
--- a/docs/user-guide/builds.md
+++ b/docs/user-guide/builds.md
@@ -2,7 +2,7 @@
 
 Rise supports multiple build backends for creating container images from your application code. Building happens automatically as part of `rise deploy`, or you can build standalone with `rise build`.
 
-> **Note:** Rise currently targets `linux/amd64` exclusively. The `--platform linux/amd64` flag is added to build commands where supported.
+> **Note:** Rise defaults to `linux/amd64` for server compatibility. Override with `--platform`, `RISE_PLATFORM`, or `[build] platform` in `rise.toml`.
 
 ## Build Backends
 
@@ -58,8 +58,8 @@ rise deploy --backend docker:buildx
 
 ### How It Works
 
-- **`docker:build`**: Runs `docker build` with `--build-arg` for environment variables and `--platform linux/amd64`. Does not support SSL certificate injection.
-- **`docker:buildx`**: Runs `docker buildx build` via a managed BuildKit daemon. Adds `--platform linux/amd64` and uses `--load` (local) or `--push` (deploy). SSL certificates are injected by preprocessing the Dockerfile to add BuildKit bind mounts to each `RUN` step.
+- **`docker:build`**: Runs `docker build` with `--build-arg` for environment variables and `--platform` set to the configured target platform. Does not support SSL certificate injection.
+- **`docker:buildx`**: Runs `docker buildx build` via a managed BuildKit daemon. Adds `--platform` and uses `--load` (local) or `--push` (deploy). SSL certificates are injected by preprocessing the Dockerfile to add BuildKit bind mounts to each `RUN` step.
 
 ### Custom Dockerfile Path
 
@@ -188,6 +188,29 @@ Or in `rise.toml`:
 [build]
 no_cache = true
 ```
+
+## Target Platform
+
+By default, Rise builds for `linux/amd64` (the server architecture). Override this for local development on other architectures (e.g., ARM Macs):
+
+```bash
+rise build myapp:latest --platform linux/arm64
+```
+
+Or in `rise.toml`:
+
+```toml
+[build]
+platform = "linux/arm64"
+```
+
+Or via environment variable:
+
+```bash
+RISE_PLATFORM=linux/arm64 rise build myapp:latest
+```
+
+Precedence: `--platform` flag > `RISE_PLATFORM` env var > `rise.toml` > default (`linux/amd64`).
 
 ## SSL and Proxy
 

--- a/src/build/docker.rs
+++ b/src/build/docker.rs
@@ -52,6 +52,7 @@ pub(crate) struct DockerBuildOptions<'a> {
     pub build_context: Option<&'a str>,
     pub build_contexts: &'a std::collections::HashMap<String, String>,
     pub no_cache: bool,
+    pub platform: &'a str,
 }
 
 /// Build image using Docker or Podman with a Dockerfile
@@ -143,7 +144,7 @@ pub(crate) fn build_image_with_dockerfile(options: DockerBuildOptions) -> Result
     }
 
     // Add platform flag for consistent architecture
-    cmd.arg("--platform").arg("linux/amd64");
+    cmd.arg("--platform").arg(options.platform);
 
     // Add SSL certificate using named build context (bind mount)
     // RAII cleanup via SslCertContext drop

--- a/src/build/method.rs
+++ b/src/build/method.rs
@@ -78,6 +78,11 @@ pub struct BuildArgs {
     /// Disable build cache (equivalent to docker build --no-cache, pack build --clear-cache)
     #[arg(long)]
     pub no_cache: bool,
+
+    /// Target platform for the container image build (e.g., linux/amd64, linux/arm64).
+    /// Defaults to linux/amd64 for Rise server compatibility.
+    #[arg(long)]
+    pub platform: Option<String>,
 }
 
 /// Options for building container images
@@ -109,6 +114,8 @@ pub(crate) struct BuildOptions {
     pub build_contexts: std::collections::HashMap<String, String>,
     /// Disable build cache
     pub no_cache: bool,
+    /// Target platform (e.g., "linux/amd64")
+    pub platform: String,
 }
 
 impl BuildOptions {
@@ -244,6 +251,13 @@ impl BuildOptions {
                     .as_ref()
                     .and_then(|c| c.no_cache)
                     .unwrap_or(false),
+
+            platform: build_args
+                .platform
+                .clone()
+                .or_else(|| crate::build::env_var_non_empty("RISE_PLATFORM"))
+                .or_else(|| project_config.as_ref().and_then(|c| c.platform.clone()))
+                .unwrap_or_else(|| crate::build::DEFAULT_PLATFORM.to_string()),
 
             push: false,
         }

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -15,6 +15,11 @@ mod railpack;
 mod registry;
 mod ssl;
 
+/// Default target platform for container image builds.
+/// Rise server nodes run linux/amd64, so this is the default for compatibility.
+/// Users can override with `--platform`, `RISE_PLATFORM`, or `[build] platform` in rise.toml.
+pub const DEFAULT_PLATFORM: &str = "linux/amd64";
+
 pub use method::BuildArgs;
 pub(crate) use method::{BuildMethod, BuildOptions};
 pub(crate) use railpack::{build_with_buildctl, BuildctlFrontend, RailpackBuildOptions};
@@ -187,6 +192,7 @@ pub(crate) fn build_image(options: BuildOptions) -> Result<()> {
                 build_context: resolved_build_context.as_deref(),
                 build_contexts: &resolved_build_contexts,
                 no_cache: options.no_cache,
+                platform: &options.platform,
             })?;
         }
         BuildMethod::Pack => {
@@ -203,6 +209,7 @@ pub(crate) fn build_image(options: BuildOptions) -> Result<()> {
                 &options.buildpacks,
                 &options.env,
                 options.no_cache,
+                &options.platform,
             )?;
 
             // Pack doesn't support push during build, so push separately if requested
@@ -231,6 +238,7 @@ pub(crate) fn build_image(options: BuildOptions) -> Result<()> {
                 buildkit_host: buildkit_host.as_deref(),
                 env: &options.env,
                 no_cache: options.no_cache,
+                platform: &options.platform,
             })?;
         }
         BuildMethod::Buildctl => {
@@ -302,6 +310,7 @@ pub(crate) fn build_image(options: BuildOptions) -> Result<()> {
                 BuildctlFrontend::Dockerfile,
                 options.no_cache,
                 container_cli.command(),
+                &options.platform,
             )?;
 
             // Note: SslCertContext cleanup is automatic via RAII when it goes out of scope

--- a/src/build/pack.rs
+++ b/src/build/pack.rs
@@ -15,6 +15,7 @@ pub(crate) fn build_image_with_buildpacks(
     buildpacks: &[String],
     env: &[String],
     no_cache: bool,
+    platform: &str,
 ) -> Result<()> {
     // Check if pack CLI is available
     let pack_check = Command::new("pack").arg("version").output();
@@ -42,7 +43,7 @@ pub(crate) fn build_image_with_buildpacks(
         .arg("--builder")
         .arg(builder_image)
         .arg("--platform")
-        .arg("linux/amd64");
+        .arg(platform);
 
     // Add clear-cache flag if requested
     if no_cache {

--- a/src/build/railpack.rs
+++ b/src/build/railpack.rs
@@ -32,6 +32,7 @@ pub(crate) struct RailpackBuildOptions<'a> {
     pub buildkit_host: Option<&'a str>,
     pub env: &'a [String],
     pub no_cache: bool,
+    pub platform: &'a str,
 }
 
 /// RAII guard for cleaning up temp files and directories
@@ -201,6 +202,7 @@ pub(crate) fn build_image_with_railpacks(options: RailpackBuildOptions) -> Resul
             BuildctlFrontend::Railpack,
             options.no_cache,
             options.container_cli,
+            options.platform,
         )?;
     } else {
         build_with_buildx(
@@ -213,6 +215,7 @@ pub(crate) fn build_image_with_railpacks(options: RailpackBuildOptions) -> Resul
             options.buildkit_host,
             &all_secrets,
             options.no_cache,
+            options.platform,
         )?;
     }
 
@@ -231,6 +234,7 @@ fn build_with_buildx(
     buildkit_host: Option<&str>,
     secrets: &HashMap<String, String>,
     no_cache: bool,
+    platform: &str,
 ) -> Result<()> {
     // Check buildx availability
     if !super::docker::is_buildx_available(container_cli) {
@@ -262,7 +266,7 @@ fn build_with_buildx(
         .arg("-t")
         .arg(image_tag)
         .arg("--platform")
-        .arg("linux/amd64");
+        .arg(platform);
 
     // Use the managed builder if available
     if let Some(ref builder) = builder_name {
@@ -346,6 +350,7 @@ pub(crate) fn build_with_buildctl(
     frontend: BuildctlFrontend,
     no_cache: bool,
     container_cli: &str,
+    platform: &str,
 ) -> Result<()> {
     // Check buildctl availability
     let buildctl_check = Command::new("buildctl").arg("--version").output();
@@ -413,8 +418,8 @@ pub(crate) fn build_with_buildctl(
     // --output must be last: its value is the next positional arg
     if push {
         cmd.arg("--output").arg(format!(
-            "type=image,name={},push=true,platform=linux/amd64",
-            image_tag
+            "type=image,name={},push=true,platform={}",
+            image_tag, platform
         ));
 
         debug!("Executing command: {:?}", cmd);
@@ -427,8 +432,8 @@ pub(crate) fn build_with_buildctl(
         // Output as docker tar stream and pipe into `docker load` so the
         // image is available in the local Docker daemon.
         cmd.arg("--output").arg(format!(
-            "type=docker,name={},platform=linux/amd64",
-            image_tag
+            "type=docker,name={},platform={}",
+            image_tag, platform
         ));
         cmd.stdout(std::process::Stdio::piped());
 

--- a/src/cli/deployment/core.rs
+++ b/src/cli/deployment/core.rs
@@ -588,8 +588,13 @@ pub async fn create_deployment(
             )
             .await?;
 
-            // Pull the source image for linux/amd64
-            if let Err(e) = build::docker_pull(&container_cli, source_image, "linux/amd64") {
+            // Pull the source image for the configured platform
+            let platform = deploy_opts
+                .build_args
+                .platform
+                .as_deref()
+                .unwrap_or(build::DEFAULT_PLATFORM);
+            if let Err(e) = build::docker_pull(&container_cli, source_image, platform) {
                 update_deployment_status(
                     http_client,
                     backend_url,

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,7 +117,7 @@ struct DeployArgs {
     #[arg(long)]
     http_port: Option<u16>,
     /// Push the --image to the Rise registry instead of deploying it directly.
-    /// Pulls the image locally (platform linux/amd64) and pushes to the internal registry.
+    /// Pulls the image locally and pushes to the internal registry.
     #[arg(long)]
     push_image: bool,
     /// Runtime environment variables (format: KEY=VALUE, can be specified multiple times).

--- a/src/rise_toml.rs
+++ b/src/rise_toml.rs
@@ -90,4 +90,8 @@ pub struct BuildConfig {
 
     /// Disable build cache
     pub no_cache: Option<bool>,
+
+    /// Target platform for the container image build (e.g., "linux/amd64", "linux/arm64").
+    /// Defaults to linux/amd64.
+    pub platform: Option<String>,
 }


### PR DESCRIPTION
## Summary

- Add `--platform` CLI flag, `RISE_PLATFORM` env var, and `[build] platform` in `rise.toml` to override the default `linux/amd64` target platform across all build backends (Docker, Pack, Railpack/buildctl)
- Replace all hardcoded `linux/amd64` references in build code with the configurable platform value
- Update `--push-image` pull to respect the platform setting and update docs with usage examples

## Test plan

- [x] `rise build myapp:latest --platform linux/arm64` builds for ARM — image inspects as `arm64`
- [x] `RISE_PLATFORM=linux/arm64 rise build myapp:latest` reads from env var — image inspects as `arm64`
- [x] `[build] platform = "linux/arm64"` in rise.toml is respected — image inspects as `arm64`
- [x] Default behavior (no flag/env/config) still targets `linux/amd64` — image inspects as `amd64`
- [x] `--push-image` pulls with the correct platform — verified by code review (requires running Rise server)
- [x] Verify all backends: docker ✅, docker:buildx ✅, buildctl ✅ (command line verified), pack ✅ (command line verified), railpack:buildx ✅ (command line verified), railpack:buildctl ✅ (command line verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)