### PR TITLE
fix: allow ingress controller traffic to main HTTP port in NetworkPolicy

### DIFF
--- a/helm/rise/templates/networkpolicy-webhook.yaml
+++ b/helm/rise/templates/networkpolicy-webhook.yaml
@@ -13,6 +13,15 @@ spec:
   policyTypes:
   - Ingress
   ingress:
+  # Allow traffic to the main HTTP port (e.g. from the Ingress controller)
+  - ports:
+    - port: {{ .Values.service.targetPort }}
+      protocol: TCP
+    {{- with .Values.networkPolicy.httpIngressFrom }}
+    from:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  # Allow metacontroller to reach the webhook port
   - ports:
     - port: {{ .Values.metacontroller.webhookPort | default 3001 }}
       protocol: TCP

--- a/helm/rise/values.yaml
+++ b/helm/rise/values.yaml
@@ -90,6 +90,22 @@ tolerations: []
 
 affinity: {}
 
+# Network policy for the server pods.
+# Only created when metacontroller is enabled (the policy also covers the webhook port).
+networkPolicy:
+  # Restrict which pods can reach the main HTTP port.
+  # By default no "from" selector is set, allowing any pod in the cluster.
+  # Set this to a list of NetworkPolicy peer entries to restrict access.
+  httpIngressFrom: []
+  # Example: only allow the ingress-nginx controller
+  # httpIngressFrom:
+  #   - podSelector:
+  #       matchLabels:
+  #         app.kubernetes.io/name: ingress-nginx
+  #     namespaceSelector:
+  #       matchLabels:
+  #         kubernetes.io/metadata.name: ingress-nginx
+
 # Metacontroller integration
 # See: https://metacontroller.github.io/metacontroller/
 metacontroller:


### PR DESCRIPTION
## Summary
- The webhook NetworkPolicy only permitted ingress on port 3001 (metacontroller webhook), blocking the ingress controller from reaching port 3000 (main backend HTTP port)
- Added an ingress rule for the main HTTP port, open to any cluster-internal traffic by default
- Added configurable `networkPolicy.httpIngressFrom` value to restrict which pods can reach the HTTP port (e.g. limit to ingress-nginx pods only)

## Test plan
- [ ] `helm lint helm/rise` passes
- [ ] `helm template` renders correctly with default values (no `from` on HTTP port rule)
- [ ] `helm template` renders correctly with custom `httpIngressFrom` (restricted `from` on HTTP port rule)
- [ ] Deploy and verify ingress controller can reach backend on port 3000

🤖 Generated with [Claude Code](https://claude.com/claude-code)