### PR TITLE
Scope registry credentials endpoint to deployments

### DIFF
--- a/docs/operator-registry-operations.md
+++ b/docs/operator-registry-operations.md
@@ -98,8 +98,12 @@ Use environment variable substitution for secrets and environment-specific value
 Operator reference endpoint:
 
 ```text
-GET /api/v1/registry/credentials?project=<project-name>
+GET /api/v1/projects/<project-name>/deployments/<deployment-id>/registry-credentials
 ```
+
+Credentials are scoped to a specific deployment and are only available while the deployment
+is in a pre-push state (Pending, Building, or Pushing). The endpoint returns 409 Conflict
+if the deployment has already progressed past the Pushing state.
 
 Returned credentials are provider-specific and intended for authenticated clients.
 

--- a/src/cli/deployment/core.rs
+++ b/src/cli/deployment/core.rs
@@ -418,7 +418,58 @@ struct RegistryCredentials {
 struct CreateDeploymentResponse {
     deployment_id: String,
     image_tag: String,
+    /// Deprecated: credentials are now fetched from the deployment-scoped endpoint.
+    /// Kept for deserialization compatibility with older backends.
+    #[allow(dead_code)]
     credentials: RegistryCredentials,
+}
+
+#[derive(Debug, Deserialize)]
+struct GetRegistryCredsResponse {
+    credentials: RegistryCredentials,
+    #[allow(dead_code)]
+    repository: String,
+}
+
+/// Fetch registry push credentials scoped to a specific deployment.
+async fn fetch_deployment_registry_credentials(
+    http_client: &Client,
+    backend_url: &str,
+    token: &str,
+    project_name: &str,
+    deployment_id: &str,
+) -> Result<RegistryCredentials> {
+    let url = format!(
+        "{}/api/v1/projects/{}/deployments/{}/registry-credentials",
+        backend_url, project_name, deployment_id
+    );
+
+    let response = http_client
+        .get(&url)
+        .bearer_auth(token)
+        .send()
+        .await
+        .context("Failed to fetch registry credentials")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let error_text = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "Unknown error".to_string());
+        bail!(
+            "Failed to fetch registry credentials ({}): {}",
+            status,
+            error_text
+        );
+    }
+
+    let resp: GetRegistryCredsResponse = response
+        .json()
+        .await
+        .context("Failed to parse registry credentials response")?;
+
+    Ok(resp.credentials)
 }
 
 /// A runtime environment variable override for a deployment
@@ -577,12 +628,22 @@ pub async fn create_deployment(
                 None => config.get_container_cli().command().to_string(),
             };
 
+            // Fetch deployment-scoped registry credentials
+            let credentials = fetch_deployment_registry_credentials(
+                http_client,
+                backend_url,
+                &token,
+                deploy_opts.project_name,
+                &deployment_info.deployment_id,
+            )
+            .await?;
+
             login_to_registry(
                 http_client,
                 backend_url,
                 &token,
                 &container_cli,
-                &deployment_info.credentials,
+                &credentials,
                 deploy_opts.project_name,
                 &deployment_info.deployment_id,
             )
@@ -693,13 +754,22 @@ pub async fn create_deployment(
             deploy_opts.toml_config,
         );
 
-        // Step 2: Login to registry if credentials provided
+        // Step 2: Fetch deployment-scoped registry credentials and login
+        let credentials = fetch_deployment_registry_credentials(
+            http_client,
+            backend_url,
+            &token,
+            deploy_opts.project_name,
+            &deployment_info.deployment_id,
+        )
+        .await?;
+
         login_to_registry(
             http_client,
             backend_url,
             &token,
             options.container_cli.command(),
-            &deployment_info.credentials,
+            &credentials,
             deploy_opts.project_name,
             &deployment_info.deployment_id,
         )

--- a/src/server/deployment/models.rs
+++ b/src/server/deployment/models.rs
@@ -240,6 +240,9 @@ pub struct CreateDeploymentRequest {
 pub struct CreateDeploymentResponse {
     pub deployment_id: String,
     pub image_tag: String, // Full tag: registry_url/namespace/project:deployment_id
+    /// Deprecated: New clients should fetch credentials from the deployment-scoped
+    /// endpoint `GET /projects/{name}/deployments/{id}/registry-credentials` instead.
+    /// This field is kept for backward compatibility with older CLI versions.
     pub credentials: crate::server::registry::models::RegistryCredentials,
 }
 

--- a/src/server/deployment/state_machine.rs
+++ b/src/server/deployment/state_machine.rs
@@ -21,6 +21,17 @@ pub fn is_active(status: &DeploymentStatus) -> bool {
     )
 }
 
+/// Check if a deployment still needs an image push.
+///
+/// Returns `true` for the pre-"Pushed" states (`Pending`, `Building`, `Pushing`)
+/// where the CLI may still need registry push credentials.
+pub fn needs_image_push(status: &DeploymentStatus) -> bool {
+    matches!(
+        status,
+        DeploymentStatus::Pending | DeploymentStatus::Building | DeploymentStatus::Pushing
+    )
+}
+
 /// Check if a deployment can be cancelled
 /// Only deployments in pre-infrastructure states can be cancelled
 #[cfg_attr(not(test), allow(dead_code))]
@@ -189,6 +200,19 @@ mod tests {
 
         assert!(!is_active(&Deploying));
         assert!(!is_active(&Failed));
+    }
+
+    #[test]
+    fn test_needs_image_push_states() {
+        assert!(needs_image_push(&Pending));
+        assert!(needs_image_push(&Building));
+        assert!(needs_image_push(&Pushing));
+
+        assert!(!needs_image_push(&Pushed));
+        assert!(!needs_image_push(&Deploying));
+        assert!(!needs_image_push(&Healthy));
+        assert!(!needs_image_push(&Failed));
+        assert!(!needs_image_push(&Cancelled));
     }
 
     #[test]

--- a/src/server/registry/handlers.rs
+++ b/src/server/registry/handlers.rs
@@ -1,39 +1,80 @@
 use axum::{
-    extract::{Query, State},
+    extract::{Path, State},
+    http::StatusCode,
     Json,
 };
 
-use super::models::{GetRegistryCredsRequest, GetRegistryCredsResponse};
-use crate::db::projects;
+use super::models::GetRegistryCredsResponse;
+use crate::db::{deployments as db_deployments, projects};
 use crate::server::auth::context::AuthContext;
+use crate::server::deployment::state_machine;
 use crate::server::error::{ServerError, ServerErrorExt};
 use crate::server::project::handlers::ensure_project_access_or_admin;
 use crate::server::state::AppState;
 
-/// Get registry credentials for a project
-pub async fn get_registry_credentials(
+/// Get registry credentials scoped to a specific in-progress deployment.
+///
+/// Credentials are only available while the deployment still needs an image push
+/// (Pending, Building, or Pushing states). Returns 409 Conflict if the deployment
+/// has already progressed past the Pushing state.
+pub async fn get_deployment_registry_credentials(
     State(state): State<AppState>,
     auth: AuthContext,
-    Query(params): Query<GetRegistryCredsRequest>,
+    Path((project_name, deployment_id)): Path<(String, String)>,
 ) -> Result<Json<GetRegistryCredsResponse>, ServerError> {
-    // Query project by name
-    let project = projects::find_by_name(&state.db_pool, &params.project)
+    // Find the project by name
+    let project = projects::find_by_name(&state.db_pool, &project_name)
         .await
-        .internal_err("Failed to query project")
-        .map_err(|e| e.with_context("project_name", &params.project))?
-        .ok_or_else(|| ServerError::not_found(format!("Project '{}' not found", params.project)))?;
+        .internal_err("Failed to find project")
+        .map_err(|e| e.with_context("project_name", &project_name))?
+        .ok_or_else(|| ServerError::not_found(format!("Project '{}' not found", project_name)))?;
 
     // Resolve auth for project scope
-    let (user, is_sa) = auth.resolve_for_project(&state.db_pool, &project).await?;
+    let (user, is_sa) = auth
+        .resolve_for_project(&state.db_pool, &project)
+        .await
+        .map_err(|e| {
+            if e.status == StatusCode::UNAUTHORIZED || e.status == StatusCode::FORBIDDEN {
+                ServerError::not_found(format!("Project '{}' not found", project.name))
+            } else {
+                e
+            }
+        })?;
 
-    // Check if user has permission to deploy to this project (SA access already validated)
+    // Check if user has permission (SA access already validated)
     if !is_sa {
         ensure_project_access_or_admin(&state, &user, &project).await?;
     }
 
+    // Find the deployment
+    let deployment =
+        db_deployments::find_by_deployment_id(&state.db_pool, &deployment_id, project.id)
+            .await
+            .internal_err("Failed to find deployment")
+            .map_err(|e| {
+                e.with_context("project_name", &project_name)
+                    .with_context("deployment_id", &deployment_id)
+            })?
+            .ok_or_else(|| {
+                ServerError::not_found(format!(
+                    "Deployment '{}' not found for project '{}'",
+                    deployment_id, project_name
+                ))
+            })?;
+
+    // Validate that the deployment still needs an image push
+    if !state_machine::needs_image_push(&deployment.status) {
+        return Err(ServerError::new(
+            StatusCode::CONFLICT,
+            format!(
+                "Deployment '{}' is in state '{}' and no longer accepts image pushes",
+                deployment_id, deployment.status
+            ),
+        ));
+    }
+
     // Get credentials from the registry provider
-    // The repository name is typically the project name
-    let repository = params.project.clone();
+    let repository = project.name.clone();
 
     let credentials = state
         .registry_provider
@@ -41,7 +82,7 @@ pub async fn get_registry_credentials(
         .await
         .internal_err("Failed to get registry credentials")
         .map_err(|e| {
-            e.with_context("project_name", &params.project)
+            e.with_context("project_name", &project_name)
                 .with_context("repository", &repository)
         })?;
 

--- a/src/server/registry/models.rs
+++ b/src/server/registry/models.rs
@@ -31,13 +31,6 @@ pub struct RegistryCredentials {
     pub auth_method: RegistryAuthMethod,
 }
 
-/// Registry credentials request
-#[derive(Debug, Deserialize)]
-pub struct GetRegistryCredsRequest {
-    /// Project ID or name
-    pub project: String,
-}
-
 /// Registry credentials response wrapper
 #[derive(Debug, Serialize)]
 pub struct GetRegistryCredsResponse {

--- a/src/server/registry/routes.rs
+++ b/src/server/registry/routes.rs
@@ -4,7 +4,7 @@ use axum::{routing::get, Router};
 
 pub fn routes() -> Router<AppState> {
     Router::new().route(
-        "/registry/credentials",
-        get(handlers::get_registry_credentials),
+        "/projects/{project_name}/deployments/{deployment_id}/registry-credentials",
+        get(handlers::get_deployment_registry_credentials),
     )
 }


### PR DESCRIPTION
## Summary

- Moves the registry credentials endpoint from project-scoped (`GET /registry/credentials?project=<name>`) to deployment-scoped (`GET /projects/{name}/deployments/{id}/registry-credentials`), enforcing that credentials are only available while the deployment is in a pre-push state (Pending/Building/Pushing) — returns 409 Conflict otherwise
- Updates the CLI to fetch credentials from the new endpoint right before pushing, instead of using credentials from `CreateDeploymentResponse`
- Marks the `credentials` field on `CreateDeploymentResponse` as deprecated (kept for backward compatibility with older CLI versions)

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-features --all-targets -- -D warnings` passes
- [x] `cargo test --all-features` passes (317 tests, including new `test_needs_image_push_states`)
- [x] Manual test: deploy from source with the new CLI against a backend with the new endpoint
- [x] Manual test: deploy with `--image --push-image` flag
- [x] Manual test: verify 409 is returned when requesting credentials for a deployment past Pushing state

🤖 Generated with [Claude Code](https://claude.com/claude-code)