### PR TITLE
fix(auth): scope ingress JWTs to app audience and reject them at API

### DIFF
--- a/docs/user-guide/authentication-for-apps.md
+++ b/docs/user-guide/authentication-for-apps.md
@@ -11,6 +11,11 @@ When a user logs into a Rise-deployed application:
 3. The JWT is stored in the `rise_jwt` cookie
 4. Your application can access this cookie to identify the user
 
+> **Token types**: Rise issues HS256-signed JWTs for API/CLI authentication (audience = Rise server)
+> and RS256-signed JWTs for application ingress authentication (audience = application URL).
+> Applications only see RS256 tokens. The different signing algorithms ensure tokens cannot be
+> used across contexts.
+
 ## The `rise_jwt` Cookie
 
 The `rise_jwt` cookie contains a JWT token with the following structure:
@@ -198,9 +203,9 @@ app.get('/admin', requireTeam('admin'), (req: Request, res: Response) => {
 ## Security Considerations
 
 - The `rise_jwt` cookie is **HttpOnly** - JavaScript cannot access it (XSS protection)
+- The `rise_jwt` cookie is **application-scoped** — the `aud` claim is set to the application's URL, making the token unusable for Rise API access. Rise's API rejects tokens with non-matching audiences. Applications **must** validate the `aud` claim to ensure the token was issued for them specifically
 - The JWT is signed with RS256 - public keys fetched via OIDC discovery verify authenticity
 - Tokens expire after 24 hours by default - users must re-authenticate periodically
-- The `aud` claim ties tokens to specific applications - always validate this claim
 
 ## Additional Resources
 

--- a/docs/user-guide/authentication-for-apps.md
+++ b/docs/user-guide/authentication-for-apps.md
@@ -13,8 +13,10 @@ When a user logs into a Rise-deployed application:
 
 > **Token types**: Rise issues HS256-signed JWTs for API/CLI authentication (audience = Rise server)
 > and RS256-signed JWTs for application ingress authentication (audience = application URL).
-> Applications only see RS256 tokens. The different signing algorithms ensure tokens cannot be
-> used across contexts.
+> The different signing algorithms and audiences ensure tokens cannot be used across contexts.
+> Applications should always validate `alg` (expect RS256) and `aud` (expect their own URL).
+> When cookies share a parent domain, an HS256 session cookie may also be present — validating
+> `alg` and `aud` ensures your app only accepts tokens issued for it.
 
 ## The `rise_jwt` Cookie
 
@@ -203,8 +205,8 @@ app.get('/admin', requireTeam('admin'), (req: Request, res: Response) => {
 ## Security Considerations
 
 - The `rise_jwt` cookie is **HttpOnly** - JavaScript cannot access it (XSS protection)
-- The `rise_jwt` cookie is **application-scoped** — the `aud` claim is set to the application's URL, making the token unusable for Rise API access. Rise's API rejects tokens with non-matching audiences. Applications **must** validate the `aud` claim to ensure the token was issued for them specifically
-- The JWT is signed with RS256 - public keys fetched via OIDC discovery verify authenticity
+- The `rise_jwt` cookie is **application-scoped** — the `aud` claim is set to the application's URL, making the token unusable for Rise API access. Rise's API rejects tokens with non-matching audiences. Applications **must** validate both `alg` (expect RS256) and `aud` (expect their own URL) to ensure the token was issued for them specifically
+- The JWT is signed with RS256 - public keys fetched via OIDC discovery verify authenticity. When cookies share a parent domain, HS256 session tokens may also be present — `alg` and `aud` validation filters these out
 - Tokens expire after 24 hours by default - users must re-authenticate periodically
 
 ## Additional Resources

--- a/src/server/auth/handlers.rs
+++ b/src/server/auth/handlers.rs
@@ -20,30 +20,16 @@ use std::collections::HashMap;
 use tera::Tera;
 use tracing::instrument;
 
-/// Extract project URL (scheme + host + port) from a redirect URL
+/// Build the project URL for the `aud` claim from the ingress URL template
 ///
-/// This is used to set the `aud` claim in Rise JWTs for project authentication.
-/// Falls back to public_url if the redirect_url cannot be parsed.
-///
-/// # Arguments
-/// * `redirect_url` - Full URL or relative path to extract base URL from
-/// * `fallback_url` - URL to use if parsing fails (typically Rise public URL)
-///
-/// # Returns
-/// Base URL in the format "https://host:port" (port omitted for 80/443)
-fn extract_project_url_from_redirect(redirect_url: &str, fallback_url: &str) -> String {
-    if let Ok(parsed_url) = url::Url::parse(redirect_url) {
-        if let Some(host) = parsed_url.host_str() {
-            let port_part = match parsed_url.port() {
-                Some(port) if port != 80 && port != 443 => format!(":{}", port),
-                _ => String::new(),
-            };
-            return format!("{}://{}{}", parsed_url.scheme(), host, port_part);
-        }
+/// Returns `None` if no ingress URL template is configured.
+fn build_project_url(state: &AppState, project_name: &str) -> Option<String> {
+    let template = state.production_ingress_url_template.as_ref()?;
+    let host = template.replace("{project_name}", project_name);
+    match state.ingress_port {
+        Some(port) => Some(format!("{}://{}:{}", state.ingress_schema, host, port)),
+        None => Some(format!("{}://{}", state.ingress_schema, host)),
     }
-
-    // Fallback: use provided URL if parsing fails or host missing
-    fallback_url.trim_end_matches('/').to_string()
 }
 
 /// Validate and sanitize a redirect URL to prevent open redirect vulnerabilities
@@ -1322,8 +1308,9 @@ pub async fn oauth_callback(
             })?;
 
         // Issue Rise JWT with user's team memberships
-        // Extract project URL from redirect_url for the aud claim
-        let project_url = extract_project_url_from_redirect(&redirect_url, &state.public_url);
+        // Build project URL from ingress template for the aud claim
+        let project_url = build_project_url(&state, project)
+            .unwrap_or_else(|| state.public_url.trim_end_matches('/').to_string());
 
         let rise_jwt = state
             .jwt_signer

--- a/src/server/auth/handlers.rs
+++ b/src/server/auth/handlers.rs
@@ -25,10 +25,18 @@ use tracing::instrument;
 /// Returns `None` if no ingress URL template is configured.
 fn build_project_url(state: &AppState, project_name: &str) -> Option<String> {
     let template = state.production_ingress_url_template.as_ref()?;
-    let host = template.replace("{project_name}", project_name);
+    let resolved = template.replace("{project_name}", project_name);
+    // Split host from optional path prefix (e.g. "rise.dev/myapp" → host="rise.dev", path="/myapp")
+    let (host, path) = match resolved.find('/') {
+        Some(pos) => (&resolved[..pos], &resolved[pos..]),
+        None => (resolved.as_str(), ""),
+    };
     match state.ingress_port {
-        Some(port) => Some(format!("{}://{}:{}", state.ingress_schema, host, port)),
-        None => Some(format!("{}://{}", state.ingress_schema, host)),
+        Some(port) => Some(format!(
+            "{}://{}:{}{}",
+            state.ingress_schema, host, port, path
+        )),
+        None => Some(format!("{}://{}{}", state.ingress_schema, host, path)),
     }
 }
 
@@ -1308,8 +1316,13 @@ pub async fn oauth_callback(
             })?;
 
         // Issue Rise JWT with user's team memberships
-        // Build project URL from ingress template for the aud claim
-        let project_url = build_project_url(&state, project)
+        // Use custom domain URL as audience when available, otherwise build from ingress template
+        let project_url = claimed_state
+            .data()
+            .custom_domain_base_url
+            .as_deref()
+            .map(|url| url.trim_end_matches('/').to_string())
+            .or_else(|| build_project_url(&state, project))
             .unwrap_or_else(|| state.public_url.trim_end_matches('/').to_string());
 
         let rise_jwt = state

--- a/src/server/auth/jwt_signer.rs
+++ b/src/server/auth/jwt_signer.rs
@@ -377,11 +377,40 @@ impl JwtSigner {
         Ok(token)
     }
 
+    /// Verify and decode a Rise user JWT (HS256 only) with audience validation
+    ///
+    /// This is used by the API middleware to authenticate user requests.
+    /// Only accepts HS256 tokens (user JWTs) and validates that the audience matches
+    /// the Rise public URL, rejecting RS256 ingress tokens.
+    ///
+    /// # Arguments
+    /// * `token` - The JWT token string
+    /// * `expected_aud` - Expected audience (Rise public URL)
+    pub fn verify_user_jwt(
+        &self,
+        token: &str,
+        expected_aud: &str,
+    ) -> Result<RiseClaims, JwtSignerError> {
+        let header = jsonwebtoken::decode_header(token)?;
+        if header.alg != Algorithm::HS256 {
+            return Err(JwtSignerError::SigningFailed(
+                jsonwebtoken::errors::ErrorKind::InvalidAlgorithm.into(),
+            ));
+        }
+
+        let mut validation = Validation::new(Algorithm::HS256);
+        validation.set_issuer(&[&self.issuer]);
+        validation.set_audience(&[expected_aud]);
+
+        let token_data = decode::<RiseClaims>(token, &self.hs256_decoding_key, &validation)?;
+        Ok(token_data.claims)
+    }
+
     /// Verify and decode a Rise JWT without audience validation
     ///
-    /// This is used in the ingress_auth handler where the project URL is not readily available
-    /// and project access is validated separately. For other use cases, consider using
-    /// a more specific validation method if one becomes available.
+    /// Only used by the `ingress_auth` handler where both HS256 (user session) and RS256
+    /// (app-scoped) tokens must be accepted. Project access is validated separately via
+    /// database checks. Do not use this for API authentication — use `verify_user_jwt` instead.
     ///
     /// # Arguments
     /// * `token` - The JWT token string
@@ -504,6 +533,87 @@ mod tests {
         assert_eq!(verified_claims.sub, "user456");
         assert_eq!(verified_claims.email, "user2@example.com");
         assert_eq!(verified_claims.aud, "https://myapp.apps.rise.dev");
+    }
+
+    #[test]
+    fn test_verify_user_jwt_accepts_valid_hs256() {
+        let signer = create_test_signer();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        let claims = RiseClaims {
+            sub: "user123".to_string(),
+            email: "user@example.com".to_string(),
+            name: None,
+            groups: None,
+            iat: now,
+            exp: now + 3600,
+            iss: "https://rise.test".to_string(),
+            aud: "https://rise.test".to_string(),
+        };
+
+        let header = Header::new(Algorithm::HS256);
+        let token = encode(&header, &claims, &signer.hs256_encoding_key).unwrap();
+
+        let verified = signer.verify_user_jwt(&token, "https://rise.test").unwrap();
+        assert_eq!(verified.sub, "user123");
+        assert_eq!(verified.email, "user@example.com");
+        assert_eq!(verified.aud, "https://rise.test");
+    }
+
+    #[test]
+    fn test_verify_user_jwt_rejects_rs256() {
+        let signer = create_test_signer();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        let claims = RiseClaims {
+            sub: "user456".to_string(),
+            email: "user2@example.com".to_string(),
+            name: None,
+            groups: None,
+            iat: now,
+            exp: now + 3600,
+            iss: "https://rise.test".to_string(),
+            aud: "https://rise.test".to_string(),
+        };
+
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(signer.rs256_key_id.to_string());
+        let token = encode(&header, &claims, &signer.rs256_encoding_key).unwrap();
+
+        let result = signer.verify_user_jwt(&token, "https://rise.test");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_verify_user_jwt_rejects_wrong_audience() {
+        let signer = create_test_signer();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        let claims = RiseClaims {
+            sub: "user789".to_string(),
+            email: "user3@example.com".to_string(),
+            name: None,
+            groups: None,
+            iat: now,
+            exp: now + 3600,
+            iss: "https://rise.test".to_string(),
+            aud: "https://myapp.apps.rise.dev".to_string(),
+        };
+
+        let header = Header::new(Algorithm::HS256);
+        let token = encode(&header, &claims, &signer.hs256_encoding_key).unwrap();
+
+        let result = signer.verify_user_jwt(&token, "https://rise.test");
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/server/auth/middleware.rs
+++ b/src/server/auth/middleware.rs
@@ -138,13 +138,16 @@ pub async fn auth_middleware(
     );
 
     if is_rise_issued_jwt(&issuer, &state.public_url) {
-        // Rise-issued JWT (HS256 or RS256) - validate with JwtSigner
+        // Rise-issued JWT — only accept HS256 user tokens with correct audience
         tracing::debug!("Auth middleware: authenticating with Rise-issued JWT");
 
-        let claims = state.jwt_signer.verify_jwt_skip_aud(&token).map_err(|e| {
-            tracing::warn!("Auth middleware: Rise JWT validation failed: {:#}", e);
-            (StatusCode::UNAUTHORIZED, format!("Invalid token: {}", e))
-        })?;
+        let claims = state
+            .jwt_signer
+            .verify_user_jwt(&token, &state.public_url)
+            .map_err(|e| {
+                tracing::warn!("Auth middleware: Rise JWT validation failed: {:#}", e);
+                (StatusCode::UNAUTHORIZED, format!("Invalid token: {}", e))
+            })?;
 
         tracing::debug!("Auth middleware: Rise JWT validation successful");
 
@@ -242,8 +245,10 @@ pub async fn optional_auth_middleware(
                     if let Ok(claims) = serde_json::from_slice::<MinimalClaims>(&decoded) {
                         // Only accept Rise-issued JWTs for optional auth
                         if is_rise_issued_jwt(&claims.iss, &state.public_url) {
-                            // Try to validate Rise JWT
-                            if let Ok(rise_claims) = state.jwt_signer.verify_jwt_skip_aud(&token) {
+                            // Try to validate Rise user JWT (HS256 + correct audience)
+                            if let Ok(rise_claims) =
+                                state.jwt_signer.verify_user_jwt(&token, &state.public_url)
+                            {
                                 let email = &rise_claims.email;
                                 if let Ok(user) = users::find_or_create(&state.db_pool, email).await
                                 {

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -63,6 +63,10 @@ pub struct AppState {
     pub production_ingress_url_template: Option<String>,
     /// Staging ingress URL template (for custom domain validation)
     pub staging_ingress_url_template: Option<String>,
+    /// Ingress URL scheme (e.g., "https" or "http")
+    pub ingress_schema: String,
+    /// Optional ingress port (for development environments)
+    pub ingress_port: Option<u16>,
     /// ResourceBuilder for Metacontroller webhook (builds K8s resource specs)
     #[cfg(feature = "backend")]
     pub resource_builder: Option<Arc<crate::server::deployment::resource_builder::ResourceBuilder>>,
@@ -798,26 +802,41 @@ impl AppState {
 
         // Extract access_classes from deployment controller settings
         // Filter out null values (used to remove inherited access classes)
-        let (access_classes, production_ingress_url_template, staging_ingress_url_template) =
-            if let Some(crate::server::settings::DeploymentControllerSettings::Kubernetes {
-                access_classes,
-                production_ingress_url_template,
-                staging_ingress_url_template,
-                ..
-            }) = &settings.deployment_controller
-            {
-                let filtered: std::collections::HashMap<_, _> = access_classes
-                    .iter()
-                    .filter_map(|(k, v)| v.as_ref().map(|ac| (k.clone(), ac.clone())))
-                    .collect();
-                (
-                    Arc::new(filtered),
-                    Some(production_ingress_url_template.clone()),
-                    staging_ingress_url_template.clone(),
-                )
-            } else {
-                (Arc::new(std::collections::HashMap::new()), None, None)
-            };
+        let (
+            access_classes,
+            production_ingress_url_template,
+            staging_ingress_url_template,
+            ingress_schema,
+            ingress_port,
+        ) = if let Some(crate::server::settings::DeploymentControllerSettings::Kubernetes {
+            access_classes,
+            production_ingress_url_template,
+            staging_ingress_url_template,
+            ingress_schema,
+            ingress_port,
+            ..
+        }) = &settings.deployment_controller
+        {
+            let filtered: std::collections::HashMap<_, _> = access_classes
+                .iter()
+                .filter_map(|(k, v)| v.as_ref().map(|ac| (k.clone(), ac.clone())))
+                .collect();
+            (
+                Arc::new(filtered),
+                Some(production_ingress_url_template.clone()),
+                staging_ingress_url_template.clone(),
+                ingress_schema.clone(),
+                *ingress_port,
+            )
+        } else {
+            (
+                Arc::new(std::collections::HashMap::new()),
+                None,
+                None,
+                "https".to_string(),
+                None,
+            )
+        };
 
         Ok(Self {
             db_pool,
@@ -840,6 +859,8 @@ impl AppState {
             access_classes,
             production_ingress_url_template,
             staging_ingress_url_template,
+            ingress_schema,
+            ingress_port,
             #[cfg(feature = "backend")]
             resource_builder,
             #[cfg(feature = "backend")]


### PR DESCRIPTION
## Summary

- **Fix wrong `aud` claim**: Ingress JWTs for private apps had `aud` set to the Rise server URL instead of the app URL. Root cause was `validate_redirect_url()` blocking app URLs that aren't subdomains of the API host (e.g., `groups.apps.helsing.tech` vs `rise.helsing.tech`). Replaced `extract_project_url_from_redirect()` with `build_project_url()` that constructs the URL directly from the ingress URL template + project name.
- **Reject ingress tokens at API**: Added `verify_user_jwt()` to `JwtSigner` which only accepts HS256 tokens with correct audience. Both `auth_middleware` and `optional_auth_middleware` now use this instead of `verify_jwt_skip_aud()`, preventing RS256 ingress tokens from authenticating API calls.
- **Docs**: Updated `authentication-for-apps.md` with token type explanation and app-scoped security note.

## Test plan

- [x] `cargo fmt --all` — no formatting issues
- [x] `cargo clippy --all-features --all-targets -- -D warnings` — passes clean
- [x] `cargo test --all-features` — 326 tests pass, including 3 new unit tests:
  - `test_verify_user_jwt_accepts_valid_hs256`
  - `test_verify_user_jwt_rejects_rs256`
  - `test_verify_user_jwt_rejects_wrong_audience`
- [ ] Manual: Login to Rise UI → API calls work (HS256 user JWT accepted)
- [ ] Manual: Login to private app → cookie has `aud` = app URL (not Rise URL)
- [ ] Manual: Private app's ingress JWT → API rejects it
- [ ] Manual: User with existing Rise session → can still access private apps seamlessly

🤖 Generated with [Claude Code](https://claude.com/claude-code)