### PR TITLE
Update package publishing targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: niklasrosenstein/rise
-  BUILDER_IMAGE_NAME: niklasrosenstein/rise-builder
-  CHART_REGISTRY: ghcr.io/niklasrosenstein/rise
+  IMAGE_NAME: rise-deploy/rise
+  BUILDER_IMAGE_NAME: rise-deploy/rise-builder
+  CHART_REGISTRY: ghcr.io/rise-deploy
   # renovate: datasource=github-tags depName=rust packageName=rust-lang/rust extractVersion=^(?<version>\d+\.\d+\.\d+)$
   RUST_VERSION: "1.95.0"
 
@@ -310,6 +310,7 @@ jobs:
           set -euo pipefail
           ci_version="${{ needs.prepare.outputs.ci_version }}"
           image_tag="${{ needs.prepare.outputs.image_tag }}"
+          sed -i "s/^name: .*/name: rise-helm/" helm/rise/Chart.yaml
           sed -i "s/^version: .*/version: ${ci_version}/" helm/rise/Chart.yaml
           sed -i "s/^appVersion: .*/appVersion: \"${image_tag}\"/" helm/rise/Chart.yaml
           cat helm/rise/Chart.yaml
@@ -414,7 +415,7 @@ jobs:
   e2e-minikube:
     name: Minikube end-to-end smoke tests
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/develop') || (github.event_name == 'pull_request' && needs.prepare.outputs.is_trusted_pr == 'true')
     needs:
       - prepare
       - package-image

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "rise-deploy"
 version = "0.21.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/NiklasRosenstein/rise"
+repository = "https://github.com/rise-deploy/rise"
 description = "A simple and powerful CLI for deploying containerized applications"
 
 [package.metadata.cargo-all-features]

--- a/helm/rise/Chart.yaml
+++ b/helm/rise/Chart.yaml
@@ -8,9 +8,9 @@ keywords:
   - kubernetes
   - deployment
   - paas
-home: https://github.com/niklasrosenstein/rise
+home: https://github.com/rise-deploy/rise
 sources:
-  - https://github.com/niklasrosenstein/rise
+  - https://github.com/rise-deploy/rise
 dependencies:
   - name: metacontroller-helm
     version: "4.15.0"

--- a/helm/rise/README.md
+++ b/helm/rise/README.md
@@ -22,7 +22,7 @@ Create a `values-prod.yaml` file:
 
 ```yaml
 image:
-  repository: ghcr.io/niklasrosenstein/rise
+  repository: ghcr.io/rise-deploy/rise
   tag: "0.4.0"
   pullPolicy: IfNotPresent
 
@@ -137,7 +137,7 @@ The following table lists the configurable parameters of the Rise chart and thei
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `replicaCount` | Number of server replicas | `1` |
-| `image.repository` | Image repository | `ghcr.io/niklasrosenstein/rise` |
+| `image.repository` | Image repository | `ghcr.io/rise-deploy/rise` |
 | `image.tag` | Image tag | `""` (uses Chart appVersion) |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `config` | Rise configuration in YAML format | See values.yaml |

--- a/helm/rise/values-ci.yaml
+++ b/helm/rise/values-ci.yaml
@@ -6,6 +6,8 @@ postgresql:
 
 dex:
   enabled: true
+  config:
+    issuer: http://rise-ci-chart-dex.rise-ci.svc.cluster.local:5556/dex
 
 ingress:
   enabled: false
@@ -16,7 +18,7 @@ config:
     jwt_signing_secret: dGVzdC1qd3Qtc2VjcmV0LWtleS1mb3ItY2ktdGVzdGluZy1vbmx5LW5vdC1zZWN1cmU=
 
   auth:
-    issuer: http://dex:5556/dex
+    issuer: http://rise-ci-chart-dex.rise-ci.svc.cluster.local:5556/dex
     client_id: rise-backend
     client_secret: rise-backend-secret
 

--- a/helm/rise/values-ci.yaml
+++ b/helm/rise/values-ci.yaml
@@ -13,7 +13,7 @@ ingress:
 config:
   server:
     public_url: http://rise.local
-    jwt_signing_secret: test-jwt-secret-key-for-ci-testing-only-not-secure
+    jwt_signing_secret: dGVzdC1qd3Qtc2VjcmV0LWtleS1mb3ItY2ktdGVzdGluZy1vbmx5LW5vdC1zZWN1cmU=
 
   auth:
     issuer: http://dex:5556/dex
@@ -29,6 +29,8 @@ config:
   deployment_controller:
     type: kubernetes
     production_ingress_url_template: "{project_name}.apps.rise.local"
+    staging_ingress_url_template: "{project_name}-{deployment_group}.preview.rise.local"
+    environment_ingress_url_template: "{project_name}-{environment}.preview.rise.local"
     namespace_format: "rise-{project_name}"
     ingress_schema: http
     access_classes:

--- a/helm/rise/values-ci.yaml
+++ b/helm/rise/values-ci.yaml
@@ -22,6 +22,10 @@ config:
     client_id: rise-backend
     client_secret: rise-backend-secret
 
+  encryption:
+    type: aes-gcm-256
+    key: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+
   registry:
     type: oci-client-auth
     registry_url: localhost:5000

--- a/helm/rise/values.yaml
+++ b/helm/rise/values.yaml
@@ -2,7 +2,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/niklasrosenstein/rise
+  repository: ghcr.io/rise-deploy/rise
   pullPolicy: IfNotPresent
   tag: ""  # Overrides the image tag whose default is the chart appVersion
 

--- a/scripts/ci/e2e-minikube.sh
+++ b/scripts/ci/e2e-minikube.sh
@@ -93,7 +93,11 @@ PF_PID=$!
 sleep 5
 
 echo "Smoke test: /health endpoint"
-curl --fail --silent --show-error --connect-timeout 5 --max-time 30 "http://127.0.0.1:3000/health" | grep -qi "ok"
+http_code="$(curl --silent --show-error --connect-timeout 5 --max-time 30 --output /dev/null --write-out "%{http_code}" "http://127.0.0.1:3000/health")"
+if [[ "${http_code}" != "200" ]]; then
+  echo "Expected 200 for health check, got ${http_code}"
+  exit 1
+fi
 
 echo "Smoke test: protected API returns auth error"
 http_code="$(curl --silent --show-error --connect-timeout 5 --max-time 30 --output /dev/null --write-out "%{http_code}" "http://127.0.0.1:3000/api/v1/projects")"

--- a/scripts/ci/e2e-minikube.sh
+++ b/scripts/ci/e2e-minikube.sh
@@ -5,6 +5,31 @@ NAMESPACE="${NAMESPACE:-rise-ci}"
 RELEASE_NAME="${RELEASE_NAME:-rise-ci}"
 IMAGE_REPOSITORY="${RISE_IMAGE_REPOSITORY:?RISE_IMAGE_REPOSITORY is required}"
 IMAGE_TAG="${RISE_IMAGE_TAG:?RISE_IMAGE_TAG is required}"
+RISE_PUBLIC_URL="http://rise.local"
+RISE_CI_JWT_SIGNING_SECRET_B64="dGVzdC1qd3Qtc2VjcmV0LWtleS1mb3ItY2ktdGVzdGluZy1vbmx5LW5vdC1zZWN1cmU="
+
+base64url() {
+  openssl base64 -A | tr '+/' '-_' | tr -d '='
+}
+
+create_rise_ci_token() {
+  local now exp header payload key_hex signature
+  now="$(date +%s)"
+  exp="$((now + 3600))"
+  header="$(printf '{"alg":"HS256","typ":"JWT"}' | base64url)"
+  payload="$(printf '{"sub":"rise-ci","email":"rise-ci@example.com","name":"Rise CI","iat":%s,"exp":%s,"iss":"%s","aud":"%s"}' "${now}" "${exp}" "${RISE_PUBLIC_URL}" "${RISE_PUBLIC_URL}" | base64url)"
+  key_hex="$(printf '%s' "${RISE_CI_JWT_SIGNING_SECRET_B64}" | openssl base64 -d -A | od -An -tx1 -v | tr -d ' \n')"
+  signature="$(printf '%s.%s' "${header}" "${payload}" | openssl dgst -sha256 -mac HMAC -macopt "hexkey:${key_hex}" -binary | base64url)"
+  printf '%s.%s.%s' "${header}" "${payload}" "${signature}"
+}
+
+rise_cli() {
+  docker run --rm --network host \
+    -e "RISE_URL=http://127.0.0.1:3000" \
+    -e "RISE_TOKEN=${RISE_TOKEN}" \
+    "${IMAGE_REPOSITORY}:${IMAGE_TAG}" \
+    "$@"
+}
 
 cleanup() {
   local exit_code=$?
@@ -14,6 +39,16 @@ cleanup() {
   if [[ $exit_code -ne 0 ]]; then
     kubectl get pods -A || true
     kubectl get events -A --sort-by=.metadata.creationTimestamp | tail -n 200 || true
+    kubectl logs -n "${NAMESPACE}" -l "app.kubernetes.io/instance=${RELEASE_NAME}" --all-containers --tail=200 || true
+    kubectl logs -n "${NAMESPACE}" -l "app.kubernetes.io/instance=${RELEASE_NAME}" --all-containers --previous --tail=200 || true
+    if [[ -n "${APP_NAMESPACE:-}" ]]; then
+      kubectl get all -n "${APP_NAMESPACE}" || true
+      kubectl describe deployments -n "${APP_NAMESPACE}" || true
+      while IFS= read -r pod; do
+        kubectl logs -n "${APP_NAMESPACE}" "${pod}" --all-containers --tail=200 || true
+      done < <(kubectl get pods -n "${APP_NAMESPACE}" -o name 2>/dev/null || true)
+    fi
+    cat /tmp/rise-e2e-port-forward.log || true
   fi
   echo "Cleaning up Minikube"
   minikube delete || true
@@ -30,6 +65,7 @@ minikube addons enable ingress
 echo "Installing chart with CI image ${IMAGE_REPOSITORY}:${IMAGE_TAG}"
 echo "Using CI values from helm/rise/values-ci.yaml"
 cat helm/rise/values-ci.yaml
+helm dependency build helm/rise
 
 helm upgrade --install "${RELEASE_NAME}" ./helm/rise \
   --namespace "${NAMESPACE}" \
@@ -57,12 +93,57 @@ PF_PID=$!
 sleep 5
 
 echo "Smoke test: /health endpoint"
-curl --fail --silent --show-error "http://127.0.0.1:3000/health" | grep -qi "ok"
+curl --fail --silent --show-error --connect-timeout 5 --max-time 30 "http://127.0.0.1:3000/health" | grep -qi "ok"
 
 echo "Smoke test: protected API returns auth error"
-http_code="$(curl --silent --show-error --output /dev/null --write-out "%{http_code}" "http://127.0.0.1:3000/api/v1/projects")"
+http_code="$(curl --silent --show-error --connect-timeout 5 --max-time 30 --output /dev/null --write-out "%{http_code}" "http://127.0.0.1:3000/api/v1/projects")"
 if [[ "${http_code}" != "401" && "${http_code}" != "403" ]]; then
   echo "Expected 401/403 for unauthenticated request, got ${http_code}"
+  exit 1
+fi
+
+echo "Smoke test: rise project create and rise deploy"
+RISE_TOKEN="$(create_rise_ci_token)"
+export RISE_TOKEN
+PROJECT_NAME="e2e-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-1}"
+APP_NAMESPACE="rise-${PROJECT_NAME}"
+rise_cli project create "${PROJECT_NAME}" --access-class public --no-rise-toml
+rise_cli deploy --project "${PROJECT_NAME}" --image nginxinc/nginx-unprivileged:alpine --http-port 8080 --replicas 1
+
+echo "Waiting for app namespace ${APP_NAMESPACE}"
+for _ in {1..60}; do
+  if kubectl get namespace "${APP_NAMESPACE}" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+done
+kubectl get namespace "${APP_NAMESPACE}" >/dev/null
+
+echo "Waiting for deployed app workload to become available"
+for _ in {1..60}; do
+  if [[ -n "$(kubectl get deployments -n "${APP_NAMESPACE}" -o name 2>/dev/null)" ]]; then
+    break
+  fi
+  sleep 5
+done
+if [[ -z "$(kubectl get deployments -n "${APP_NAMESPACE}" -o name 2>/dev/null)" ]]; then
+  echo "Expected at least one app deployment in ${APP_NAMESPACE}"
+  exit 1
+fi
+kubectl wait --namespace "${APP_NAMESPACE}" --for=condition=Available deployment --all --timeout=5m
+
+echo "Waiting for Rise to mark deployment healthy"
+deployment_list=""
+for _ in {1..30}; do
+  deployment_list="$(rise_cli deployment list --project "${PROJECT_NAME}" --limit 5)"
+  printf '%s\n' "${deployment_list}"
+  if [[ "${deployment_list}" == *"Healthy"* ]]; then
+    break
+  fi
+  sleep 5
+done
+if [[ "${deployment_list}" != *"Healthy"* ]]; then
+  echo "Expected Rise deployment status to become Healthy"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- publish images to ghcr.io/rise-deploy/rise and ghcr.io/rise-deploy/rise-builder
- package the Helm chart as rise-helm under ghcr.io/rise-deploy
- run the Minikube smoke test on trusted PRs and build Helm dependencies before install

## Validation
- bash -n scripts/ci/e2e-minikube.sh
- helm lint helm/rise
- helm template rise-ci helm/rise --values helm/rise/values-ci.yaml --set image.repository=ghcr.io/rise-deploy/rise --set image.tag=test --set image.pullPolicy=Always
- git diff --check
- helm package check produced rise-helm-0.21.1.tgz