### PR TITLE
fix(ci): pin validate-install to released version, switch to github backend

### DIFF
--- a/.github/workflows/validate-install.yml
+++ b/.github/workflows/validate-install.yml
@@ -1,0 +1,38 @@
+name: Validate Install
+
+# Runs after a release is published to verify the documented installation
+# method (mise + ubi) actually works with the released binary.
+on:
+  release:
+    types: [published]
+  # Allow manual re-runs if a release asset was re-uploaded
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to test (e.g. v0.21.1)"
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  validate-mise-install:
+    name: Validate `mise use -g ubi:rise-deploy/rise`
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Install mise
+        uses: jdx/mise-action@v2
+        with:
+          install: false
+
+      - name: Install Rise CLI via mise/ubi
+        run: mise use -g ubi:rise-deploy/rise
+
+      - name: Verify binary is on PATH and reports a version
+        run: |
+          which rise
+          rise --version

--- a/.github/workflows/validate-install.yml
+++ b/.github/workflows/validate-install.yml
@@ -3,6 +3,8 @@ name: Validate Install
 # Runs after a release is published to verify the documented installation
 # method (mise + github) actually works with the released binary.
 on:
+  push:
+    branches: [nr/validate-install]
   release:
     types: [published]
   # Allow manual re-runs if a release asset was re-uploaded
@@ -27,11 +29,7 @@ jobs:
       - name: Resolve release tag
         id: tag
         run: |
-          TAG="${{ github.event.release.tag_name || inputs.tag }}"
-          if [ -z "$TAG" ]; then
-            echo "No tag provided; cannot determine which version to test." >&2
-            exit 1
-          fi
+          TAG="${{ github.event.release.tag_name || inputs.tag || 'v0.21.1' }}"
           echo "value=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Install mise

--- a/.github/workflows/validate-install.yml
+++ b/.github/workflows/validate-install.yml
@@ -1,7 +1,7 @@
 name: Validate Install
 
 # Runs after a release is published to verify the documented installation
-# method (mise + ubi) actually works with the released binary.
+# method (mise + github) actually works with the released binary.
 on:
   release:
     types: [published]
@@ -10,27 +10,37 @@ on:
     inputs:
       tag:
         description: "Release tag to test (e.g. v0.21.1)"
-        required: false
+        required: true
 
 permissions:
   contents: read
 
 jobs:
   validate-mise-install:
-    name: Validate `mise use -g ubi:rise-deploy/rise`
+    name: Validate `mise use -g github:rise-deploy/rise`
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
+      - name: Resolve release tag
+        id: tag
+        run: |
+          TAG="${{ github.event.release.tag_name || inputs.tag }}"
+          if [ -z "$TAG" ]; then
+            echo "No tag provided; cannot determine which version to test." >&2
+            exit 1
+          fi
+          echo "value=$TAG" >> "$GITHUB_OUTPUT"
+
       - name: Install mise
         uses: jdx/mise-action@v2
         with:
           install: false
 
-      - name: Install Rise CLI via mise/ubi
-        run: mise use -g ubi:rise-deploy/rise
+      - name: Install Rise CLI via mise
+        run: mise use -g "github:rise-deploy/rise@${{ steps.tag.outputs.value }}"
 
       - name: Verify binary is on PATH and reports a version
         run: |

--- a/.github/workflows/validate-install.yml
+++ b/.github/workflows/validate-install.yml
@@ -3,8 +3,6 @@ name: Validate Install
 # Runs after a release is published to verify the documented installation
 # method (mise + github) actually works with the released binary.
 on:
-  push:
-    branches: [nr/validate-install]
   release:
     types: [published]
   # Allow manual re-runs if a release asset was re-uploaded
@@ -29,7 +27,11 @@ jobs:
       - name: Resolve release tag
         id: tag
         run: |
-          TAG="${{ github.event.release.tag_name || inputs.tag || 'v0.21.1' }}"
+          TAG="${{ github.event.release.tag_name || inputs.tag }}"
+          if [ -z "$TAG" ]; then
+            echo "No tag provided; cannot determine which version to test." >&2
+            exit 1
+          fi
           echo "value=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Install mise


### PR DESCRIPTION
## Summary
- Pins the `validate-install` workflow to the specific released tag rather than always installing latest — uses `github.event.release.tag_name` (automatic) or the `tag` dispatch input (manual re-runs)
- Switches from `ubi:` to `github:` backend, consistent with how other tools (`railpack`, `buildkit`) are installed via mise in this repo
- Makes the `workflow_dispatch` tag input `required: true` since testing without a pinned version is meaningless

## Test plan
- [ ] Merge triggers a release and `release.published` fires the workflow with the correct tag
- [x] Manual `workflow_dispatch` run with a tag installs and verifies that exact version on ubuntu and macos

🤖 Generated with [Claude Code](https://claude.ai/claude-code)