### PR TITLE
Add resource API workspace crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,9 @@ jobs:
         env:
           SQLX_OFFLINE: true
 
+      - name: Run Clippy (resource API crate)
+        run: cargo clippy --package rise-resource-api --all-targets -- -D warnings
+
       - name: Run cargo audit
         run: cargo audit
 
@@ -187,7 +190,7 @@ jobs:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/rise_test
 
       - name: Run tests
-        run: cargo test --all-features
+        run: cargo test --workspace --all-features
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/rise_test
 
@@ -622,7 +625,7 @@ jobs:
         run: mise use -g pack railpack buildkit
 
       - name: Build Rise CLI
-        run: cargo build --release --features cli
+        run: cargo build --release --package rise-deploy --features cli
 
       - name: Run e2e build tests (no proxy)
         run: RISE_BIN=./target/release/rise bash tests/e2e-build/run.sh --no-proxy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4072,6 +4072,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rise-resource-api"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "schemars",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
 name = "ron"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4265,11 +4276,13 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
  "schemars_derive",
  "serde",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,17 @@
+[workspace]
+members = [
+    ".",
+    "crates/rise-resource-api",
+]
+resolver = "2"
+
+[workspace.dependencies]
+chrono = { version = "0.4.38", features = ["serde"] }
+schemars = { version = "1", features = ["chrono04", "uuid1"] }
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
+uuid = { version = "1.18.1", features = ["v4", "serde"] }
+
 [package]
 name = "rise-deploy"
 version = "0.22.0"
@@ -80,16 +94,16 @@ anyhow = "1.0.100"
 async-stream = "0.3"
 base64 = "0.22"
 bytes = "1.9"
-chrono = { version = "0.4.38", features = ["serde"] }
+chrono = { workspace = true }
 futures = "0.3"
 rand = "0.10.0"
 reqwest = { version = "0.13.0", features = ["json", "stream", "form"] }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.145"
+serde = { workspace = true }
+serde_json = { workspace = true }
 tokio = { version = "1.48.0", features = ["full"] }
 tracing = "0.1.43"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
-uuid = { version = "1.18.1", features = ["v4", "serde"] }
+uuid = { workspace = true }
 
 # Shared: CLI + Server
 axum = "0.8.7"
@@ -151,7 +165,7 @@ snowflake-connector-rs = { version = "0.9", optional = true }
 # Server: OAuth2 token endpoint
 subtle = { version = "2.6.1", optional = true }
 serde_urlencoded = { version = "0.7.1", optional = true }
-schemars = { version = "1", optional = true }
+schemars = { workspace = true, optional = true }
 serde_yaml = { version = "0.9", optional = true }
 
 [dev-dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,12 +13,15 @@ RUN apt-get update && apt-get install -y \
 # Stage 2: Generate recipe file for dependencies
 FROM chef AS planner
 
-# Copy single-crate project files
+# Copy workspace project files
 COPY Cargo.toml Cargo.lock ./
+COPY crates/rise-resource-api/Cargo.toml ./crates/rise-resource-api/Cargo.toml
 
-# Create dummy src/main.rs for cargo to be happy
+# Create dummy sources for cargo to be happy
 RUN mkdir -p src && \
-    echo "fn main() {}" > src/main.rs
+    echo "fn main() {}" > src/main.rs && \
+    mkdir -p crates/rise-resource-api/src && \
+    echo "" > crates/rise-resource-api/src/lib.rs
 
 RUN cargo chef prepare --recipe-path recipe.json
 
@@ -54,6 +57,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 
 # Copy project files
 COPY Cargo.toml Cargo.lock ./
+COPY crates ./crates
 COPY src ./src
 COPY migrations ./migrations
 COPY static ./static

--- a/MULTI_TENANCY_PLAN.md
+++ b/MULTI_TENANCY_PLAN.md
@@ -1,0 +1,453 @@
+# Generic Resource Storage And Organizations
+
+## Summary
+
+Introduce Rise's generic resource storage layer, with `Organization` and `ResourceDefinition` as the first built-in resource types. Organizations become the foundation for multi-organization support. ResourceDefinitions allow external controllers to register custom resources that use Rise for generic resource/state storage while owning their own schemas and migrations.
+
+This phase intentionally keeps normal generic resource CRUD operator-only. Controller JWTs may use controller-specific status/finalizer operations. Organization-level end-user RBAC is out of scope for v1 and will be added later without exposing partially implemented multi-tenant access controls.
+
+This phase is still a single-default-Organization compatibility phase for the existing typed APIs. It creates the Organization model, backfills existing typed rows to the default Organization, and prevents new typed rows from being unlinked, but it does not expose real multi-Organization user isolation through the existing typed project/team/deployment APIs yet.
+
+## Design Rationale
+
+Rise needs a Kubernetes-like external controller pattern for resource reconciliation, but Rise must not make Kubernetes itself the control-plane dependency. Kubernetes is one deployment target; future targets such as Snowflake SPCS need the same controller/resource lifecycle model without depending on Kubernetes CRDs. A small generic resource substrate in Rise provides that common control-plane model: external controllers can register resource types, own schemas and migrations, update status/finalizers, and reconcile against Rise state regardless of the deployment backend.
+
+Planning Organizations and generic resources together is intentional. Organization is the first tenant-boundary resource and should be born in the target resource model instead of being introduced as another bespoke typed table that later has to migrate into the generic API. The discipline for this phase is scope: build the narrow resource substrate, Organizations, ResourceDefinitions, operator-only CRUD, controller status/finalizers, and default-Organization linkage, but do not present this as complete multi-Organization isolation for the existing typed APIs.
+
+## Crate Structure
+
+Add only the crates needed for the new resource layer. Do not move the whole backend yet.
+
+- Convert the repository to a Cargo workspace so the new crates can be built and tested locally:
+  - keep the existing `rise` binary/package as the only published/released artifact for now
+  - do not publish the new resource crates in this phase
+  - wire feature flags so `cargo check --workspace --all-features` covers the backend/resource crates
+  - use `[workspace.dependencies]` to pin shared dependency versions (axum, sqlx, serde, tokio, etc.) and avoid cross-crate version conflicts
+  - update repository build/release plumbing for the workspace layout, including Docker/cargo-chef inputs, cargo-dist workspace metadata, SQLx offline metadata generation/checks, and CI commands
+- Add `crates/rise-resource-api`:
+  - shared resource envelope types
+  - object metadata/status types
+  - `Organization` and `ResourceDefinition` API/spec/status types
+  - request/response DTOs for generic resource operations
+  - name/discriminator validation helpers
+  - JSON Schema derivations for public resource API types
+  - no Axum, sqlx, kube, or backend settings dependencies
+- Add `crates/rise-resource-store`:
+  - backend-only resource store trait and DB-backed implementation
+  - generic resource CRUD/list/get/update/delete behavior
+  - optimistic concurrency enforcement
+  - finalizer and deletion behavior
+  - ResourceDefinition registry resolution
+  - spec/status validation orchestration
+  - `migrations/` folder for generic resource infrastructure
+  - migration runner, e.g. `rise_resource_store::run_migrations(&PgPool)`
+- Defer `crates/rise-resource-client` until the HTTP API is implemented enough for external controllers to exercise:
+  - async HTTP SDK for external controllers
+  - controller auth token provider abstraction
+  - helpers for ResourceDefinition registration and resource/status/finalizer operations
+- Keep root/backend ownership of:
+  - existing typed tables and their migrations
+  - adding organization links to users, teams, projects
+  - wiring typed APIs to the default Organization
+  - backend startup ordering
+
+Backend startup migration order:
+
+1. Run existing root migrations.
+2. Run `rise-resource-store` migrations.
+3. Run default Organization bootstrap/backfill under an advisory lock.
+
+## Resource Storage
+
+- Add a generic `resources` table:
+  - `uid UUID PRIMARY KEY`
+  - `api_version TEXT NOT NULL`
+  - `kind TEXT NOT NULL`
+  - `parent_uid UUID NULL REFERENCES resources(uid)`
+  - `name TEXT NOT NULL`
+  - `discriminator VARCHAR(8) NOT NULL`
+  - `metadata JSONB NOT NULL DEFAULT '{}'`
+  - `spec JSONB NOT NULL DEFAULT '{}'`
+  - `status JSONB NOT NULL DEFAULT '{}'`
+  - `revision BIGINT NOT NULL DEFAULT 1`
+  - timestamps
+- Add a dedicated `resource_definitions` table for ResourceDefinition identity and registry lookup:
+  - `uid UUID PRIMARY KEY REFERENCES resources(uid) ON DELETE RESTRICT`
+  - `group_name TEXT NOT NULL`
+  - `kind TEXT NOT NULL`
+  - `plural TEXT NOT NULL`
+  - `scope JSONB NOT NULL`
+  - `versions JSONB NOT NULL`
+  - `allowed_status_controller_ids TEXT[] NOT NULL DEFAULT '{}'`
+  - timestamps
+  - unique indexes for `plural` and ResourceDefinition identity tuples
+- Store the ResourceDefinition envelope/spec/status in `resources`, but treat `resource_definitions` as the canonical indexed projection used for uniqueness, routing, registry resolution, and immutable identity checks.
+- Add database-level checks:
+  - `discriminator` is exactly 8 lowercase DNS-safe characters matching `^[a-z0-9][a-z0-9-]{6}[a-z0-9]$` (no leading or trailing hyphens)
+  - `name` follows the resource name format accepted by the API
+  - `metadata`, `spec`, and `status` are JSON objects
+- Enforce same-level uniqueness:
+  - `(parent_uid, kind, name)`
+  - `(parent_uid, discriminator)`
+  - matching partial unique indexes for root resources where `parent_uid IS NULL`
+- Generate immutable 8-character lowercase DNS-safe discriminators, retrying on same-parent conflicts; cap at 10 attempts and return a 503 if all candidates are exhausted.
+- Standard metadata includes:
+  - `name`
+  - `uid`
+  - `revision`
+  - `discriminator`
+  - `annotations`
+  - `finalizers`
+  - `deletionTimestamp`
+- Standard status defaults to `{}`; the `controllers` key is optional and populated only when a controller first writes its status update. Resources with no controllers have `status: {}` as a valid state.
+- Treat SQL identity columns as canonical. The API must reject client-supplied identity metadata (`uid`, `revision`, `discriminator`, `deletionTimestamp`) on create/update/status paths.
+- Delete behavior:
+  - if child resources exist: reject parent deletion with a conflict
+  - no finalizers and no children: delete row
+  - finalizers present: set `deletionTimestamp`
+  - controllers remove their finalizers after cleanup
+  - do not use `ON DELETE CASCADE` for resource parent/child cleanup because it would bypass child finalizers
+  - additionally block deletion of an Organization that has typed children (teams or projects linked via `organization_resource_uid`); those rows are not `resources` table children so the generic child-detection check does not cover them — this guard must be explicit at the application layer
+
+## Built-In Resources
+
+- Add strongly typed built-in resource registry in Rust.
+- Built-in registrations define:
+  - REST collection name, e.g. `organizations`
+  - `apiVersion`, e.g. `rise.dev/v1alpha1`
+  - `kind`, e.g. `Organization`
+  - scope/root or parent resource kind
+  - typed spec/status validators
+  - schema generation hooks
+- Add built-in `Organization`:
+  - `apiVersion: rise.dev/v1alpha1`
+  - `kind: Organization`
+  - collection: `organizations`
+  - root-scoped
+  - `spec.displayName`
+  - `spec.deploymentControllerClass` — ID of the controller responsible for reconciling the Organization's projects and deployments; matches a configured controller identity; optional, unset means no controller manages this org's deployments
+  - `status.controllers`
+- Add built-in `ResourceDefinition`:
+  - root-scoped
+  - operator-admin managed
+  - describes external resource group/version/kind/plural/scope/schema/status controller ownership
+  - persisted as both a normal built-in resource row and a row in the dedicated `resource_definitions` registry table
+- Reserved collection names (built-ins implemented now or planned for a future phase): `organizations`, `projects`, `users`, `teams`, `environments`, `deployments`, `serviceaccounts`. Reject any ResourceDefinition whose plural matches one of these names.
+
+## External Custom Resources
+
+- External controllers register custom resources by creating `ResourceDefinition` records.
+- A ResourceDefinition includes:
+  - API group
+  - versions with `served`, `storage`, and JSON Schema
+  - kind
+  - plural collection name
+  - scope, initially root or child of Organization
+  - allowed status controller IDs
+- Reject ResourceDefinitions whose plural collection name collides with built-ins or reserved future names.
+- Enforce database-level uniqueness for ResourceDefinitions through the dedicated `resource_definitions` table:
+  - plural collection names are globally unique across external ResourceDefinitions
+  - resource identity tuples, e.g. `(group, version, kind)`, are unique across external ResourceDefinitions
+  - immutable identity fields cannot be changed while resources for that definition exist; enforced via application-layer pre-update check (Postgres has no conditional immutability)
+- External resources are stored in the same `resources` table.
+- Rise validates generic invariants for all resources:
+  - identity, parent scope, name, discriminator, annotations, finalizers, deletion semantics, revision
+- Built-in resources validate `spec/status` using Rust structs.
+- External resources validate `spec` using the registered JSON Schema.
+- External controller status is written under:
+  - `status.controllers["controller-id"]`
+- Controllers may only update their own status key and their own finalizers.
+- External resource migrations are controller-owned:
+  - v1 supports controller-driven migrations by listing old-version records and rewriting them
+  - no conversion webhooks initially
+  - Rise rejects unsupported or unserved `apiVersion/kind`
+  - stored old-version resources must remain listable to their owning controller until the ResourceDefinition marks the version as neither `served` nor `storage`; at that point Rise treats migration complete and may enforce the new schema
+
+## Generic API
+
+- Add generic API routes under `/api/v1/resources`.
+- Initial root routes:
+  - `GET /api/v1/resources/{collection}`
+  - `POST /api/v1/resources/{collection}`
+  - `GET /api/v1/resources/{collection}/{name}`
+  - `PUT /api/v1/resources/{collection}/{name}`
+  - `DELETE /api/v1/resources/{collection}/{name}`
+- Initial organization child routes for future external resources:
+  - `GET /api/v1/resources/organizations/{org}/{collection}`
+  - `POST /api/v1/resources/organizations/{org}/{collection}`
+  - `GET /api/v1/resources/organizations/{org}/{collection}/{name}`
+  - `PUT /api/v1/resources/organizations/{org}/{collection}/{name}`
+  - `DELETE /api/v1/resources/organizations/{org}/{collection}/{name}`
+- Route `{collection}` through the resource registry:
+  - built-in registrations first
+  - external ResourceDefinitions second
+  - reject unknown collections
+- Request bodies follow the Kubernetes-style envelope: `apiVersion`, `kind`, and `metadata` are top-level fields alongside `spec` and `status`. The `/api/v1/` prefix is the Rise HTTP API namespace and is unrelated to `apiVersion` in the body.
+- Require body `apiVersion`, `kind`, and `metadata.name` to match the resolved registration and URL.
+- Use `revision` for optimistic concurrency on updates. PUT must include `metadata.revision`; omitting it is rejected (same semantic as Kubernetes requiring `resourceVersion` on updates).
+- Regular clients cannot write `status`.
+- Status updates use a separate controller-oriented path/helper that writes only the caller's controller key.
+- Restrict all generic resource API access to Rise Operators in v1:
+  - non-operators cannot list, read, create, update, delete, or watch resources
+  - this includes Organization-scoped child resource routes
+  - existing typed project/team/deployment APIs keep their current access behavior
+- Generic resource API status/finalizer operations also accept controller JWTs through a separate controller auth context:
+  - controller JWTs are never treated as user JWTs or existing project service-account JWTs
+  - controller-authenticated callers can use only controller-specific status/finalizer paths
+  - controller-authenticated callers cannot use normal operator CRUD paths unless separately granted as Operators
+
+## Operator Role
+
+- Add a first-class `Operator` role for Rise installation operators.
+- Operators have full access to generic resource storage and built-in resource management.
+- Add `auth.operator_users`, a configured list of email addresses that receive Operator permissions.
+- `auth.operator_users` matching is case-insensitive, matching the existing `auth.admin_users` behavior.
+- Update local development Dex config to grant `ops@example.com` the Operator role.
+- `auth.admin_users` are treated as admins within the default Organization only. They do NOT receive the Operator role and cannot access Organization resources or resources scoped to other Organizations. Operators are a separate, explicitly configured role.
+- Organization-level users/admins are out of scope for this phase.
+- Future work can replace operator-only generic access with org-scoped RBAC once the model is explicit.
+
+## Controller Identity
+
+- Add configured trusted controller identities in backend settings.
+- A controller identity includes:
+  - stable controller ID in Kubernetes label/annotation name format: a DNS subdomain with an optional `/path` suffix (e.g. `controller.example.com` or `controller.example.com/my-controller`); this string becomes the key under `status.controllers`
+  - trusted JWT issuer/JWKS or equivalent verification settings
+  - expected audience
+  - optional subject/claim constraints
+  - resource ownership grants, either explicit or derived from ResourceDefinitions the controller is allowed to manage
+- External controllers authenticate with JWTs trusted by this backend configuration.
+- Controller status/finalizer endpoints authorize by controller identity, not by user identity.
+- Add a dedicated controller auth extractor/context separate from the existing user and project service-account auth context.
+- Generic API controller endpoints accept this controller auth context directly.
+- The existing external JWT service-account path remains project-scoped and must not be reused for controller authorization.
+- Internal same-process controllers should use the same resource domain SDK/service interface without making HTTP requests back into the backend.
+  - Define a resource store/service trait used by both HTTP handlers and internal controllers.
+  - Shared validation, revision, finalizer, ownership, and deletion invariants must live below both call paths.
+  - Internal callers may bypass transport/auth middleware, but must still pass an explicit internal controller identity for status/finalizer ownership checks.
+
+## Multi-Organization Integration
+
+- Link existing typed data to Organization resources:
+  - user-to-organization membership relation
+  - `organization_resource_uid` on teams
+  - `organization_resource_uid` on projects
+- Existing typed APIs remain externally unchanged and automatically use the configured default Organization.
+- New authenticated users are added to the default Organization.
+  - user find-or-create and default Organization membership creation must happen in one idempotent transaction
+  - auth middleware must not create a user row that lacks default Organization membership
+- New teams/projects are created in the default Organization.
+- Team-owned project creation verifies the team belongs to the same Organization.
+- Keep project and team names globally unique for now.
+- Normal generic resource CRUD remains operator-only even though default Organization membership is backfilled.
+
+## Kubernetes Namespace Prefix
+
+- Store namespace prefix as Organization annotation:
+  - `metadata.annotations["kubernetes.rise.dev/namespace-prefix"]`
+- Add default Organization backend config:
+  - `name`
+  - `display_name`
+  - optional `annotations`
+  - optional `kubernetes_namespace_prefix`
+- Add `controller_class_name` to the Kubernetes deployment controller backend config.
+  - This value is the controller class identifier written to the default Organization's `spec.deploymentControllerClass`.
+  - The Kubernetes controller reconciles only Organizations whose `spec.deploymentControllerClass` matches its configured `controller_class_name`.
+  - Default to a stable value for existing installs if omitted, e.g. `kubernetes.rise.dev/default`.
+- Startup bootstrap after migrations:
+  - upsert default Organization
+  - populate namespace-prefix annotation from config
+  - set `spec.deploymentControllerClass` from the configured Kubernetes `controller_class_name`
+  - backfill existing users, teams, and projects to default Organization
+- Kubernetes controller namespace prefix resolution:
+  - use the annotation when present
+  - otherwise use `org-{metadata.discriminator}-`
+- The Kubernetes controller only reconciles projects that belong to an Organization whose `spec.deploymentControllerClass` matches the controller's configured `controller_class_name`; projects in unmatched or unset orgs are ignored.
+- Preserve existing installs:
+  - the existing default Organization must resolve to the same namespace names as before migration
+  - the current default `rise-{project_name}` maps to default Organization namespace prefix `rise-`, preserving `rise-myapp`
+  - known existing installs use the default `rise-` namespace prefix; arbitrary namespace templates are not migrated in this phase
+- The controller should know the default Organization for existing typed projects and use its namespace configuration when resolving namespaces.
+- The Kubernetes controller must not process any typed projects until the default Organization record exists. If the Organization is absent at controller startup, the controller must error and refuse to proceed. Because bootstrap creates the Organization (with namespace prefix annotation) as its first action before backfilling typed rows, and bootstrap completes before the controller begins processing, this is guaranteed by startup ordering.
+
+## Bootstrap And Migrations
+
+- `rise-resource-store` migrations own only generic resource infrastructure:
+  - `resources` table
+  - `resource_definitions` table
+  - generic resource indexes/checks
+  - ResourceDefinition storage mechanics
+- Root migrations own changes to existing typed tables:
+  - user-to-organization membership relation
+  - `organization_resource_uid` on teams
+  - `organization_resource_uid` on projects
+- Bootstrap/backfill must be idempotent and concurrency-safe:
+  - run after all migrations
+  - acquire a PostgreSQL advisory lock before mutating default Organization/linkage state
+  - create or update exactly one configured default Organization (including namespace prefix annotation) as the first bootstrap action, before backfilling any typed rows
+  - backfill all existing users, teams, and projects to the default Organization
+  - preserve unrelated Organization annotations when applying namespace-prefix config
+  - validate that all required typed rows have Organization linkage before startup proceeds
+  - a process crash mid-backfill leaves some rows unlinked; on restart, idempotent backfill re-runs and completes before the validation check fires
+  - fail server startup only if the validation check fails after a full backfill pass — not on a transient mid-backfill crash
+- Prefer a two-phase migration for existing typed tables:
+  - add nullable Organization linkage columns/relations
+  - backfill under bootstrap/advisory lock
+  - add stricter constraints only after validation is reliable
+
+## Schema And Docs
+
+- Derive `JsonSchema` for:
+  - generic resource envelope
+  - object metadata
+  - controller status map
+  - Organization spec/status
+  - ResourceDefinition spec/status
+  - backend default Organization config
+- Add backend command:
+  - `rise backend schemas generate`
+- Generate deterministic schema files into operator docs for:
+  - backend settings
+  - `rise.toml`
+  - generic resource envelope
+  - Organization
+  - ResourceDefinition
+- Add a dedicated operator docs section:
+  - `docs/engineering/src/content/docs/resources/index.mdx`
+  - `docs/engineering/src/content/docs/resources/storage.md`
+  - `docs/engineering/src/content/docs/resources/api.md`
+  - `docs/engineering/src/content/docs/resources/custom-resources.md`
+  - `docs/engineering/src/content/docs/resources/schemas.mdx`
+- Update the Starlight nav config (`astro.config.mjs` or equivalent) to include the new resources section so pages are reachable.
+- Add an Astro component to render generated JSON schemas as browsable reference docs.
+- Wire `rise backend schemas generate` into a `mise run resource:schema:check` task (parallel to `mise run config:schema:check`) and add it to the CI lint pipeline.
+- Document:
+  - generic storage model
+  - lifecycle, finalizers, deletion
+  - revision/concurrency semantics
+  - built-in vs external resources
+  - custom resource registration
+  - controller-owned status
+  - external controller migration responsibilities
+  - Organization namespace prefix behavior
+
+## Test Plan
+
+- Storage:
+  - create/list/get/update/delete generic resources
+  - same-level uniqueness for names and discriminators
+  - database checks reject invalid names/discriminators and non-object JSON fields
+  - discriminator rejects leading/trailing hyphens
+  - discriminator retry ceiling (10 attempts) returns 503
+  - discriminator format and immutability
+  - conflicting client-supplied identity metadata (`uid`, `revision`, `discriminator`, `deletionTimestamp`) is rejected
+  - PUT without `metadata.revision` is rejected
+  - revision increments
+  - finalizer deletion flow
+  - parent deletion with children is rejected
+  - Organization with linked teams or projects (via `organization_resource_uid`) is blocked from deletion at the application layer
+- Built-ins:
+  - Organization validation via Rust structs
+  - ResourceDefinition validation via Rust structs
+  - ResourceDefinition plural cannot collide with built-ins/reserved names
+  - ResourceDefinition plural and group/version/kind uniqueness is enforced across external definitions
+  - ResourceDefinition identity fields cannot be changed while resources for that definition exist
+  - schema generation includes built-ins
+- External resources:
+  - ResourceDefinition registration adds runtime collection resolution
+  - external spec JSON Schema validation works
+  - unknown/unserved API versions are rejected
+  - old stored versions remain available to owning controller for migration
+  - controller status updates are limited to the caller's controller key
+  - controller finalizer updates are limited to the caller's finalizers
+- API:
+  - Operators can manage generic resources, Organizations, and ResourceDefinitions
+  - configured `auth.operator_users` receive Operator access
+  - `auth.admin_users` do not receive Operator access unless also listed in `auth.operator_users`
+  - non-operator users cannot list/read/write any generic resources
+  - URL collection maps to expected `apiVersion/kind`
+  - clients cannot write status through normal create/update
+  - update revision conflicts are rejected
+- Controller auth:
+  - trusted external controller JWT can update only owned status/finalizers
+  - trusted external controller JWT can call controller-specific generic API status/finalizer endpoints
+  - trusted external controller JWT is rejected on normal operator CRUD routes unless separately authorized as an Operator
+  - controller JWTs are not accepted by the existing project service-account auth path
+  - untrusted JWT is rejected
+  - normal user JWT cannot use controller status/finalizer endpoints
+  - internal controller SDK path enforces the same ownership invariants
+- Bootstrap:
+  - default Organization is idempotently created
+  - concurrent startup creates one default Organization and one complete backfill
+  - concurrent first login creates one user and exactly one default Organization membership
+  - namespace-prefix annotation is populated without clobbering unrelated annotations
+  - existing users, teams, and projects are backfilled
+  - startup fails on partial Organization linkage
+- Namespace:
+  - namespace prefix round-trip: bootstrap writes annotation → controller reads annotation → namespace resolves correctly
+  - default org resolves `rise-myapp`
+  - missing annotation resolves `org-{discriminator}-myapp`
+  - controller ignores projects whose Organization has a non-matching or absent `deploymentControllerClass`
+  - bootstrap sets `spec.deploymentControllerClass` on the default Organization from the configured Kubernetes `controller_class_name`
+- Docs:
+  - `rise backend schemas generate` is deterministic
+  - operator docs build with the new resources section
+
+## Implementation Increments
+
+Deliver in the following order. PRs 1–4 avoid existing data model changes, but PR 1 and PR 2 still touch build/release and backend startup plumbing and must be verified through the normal container, CI, and SQLx offline paths. PR 5 is the only increment that touches existing typed data. PR 6 can be drafted in parallel with PR 5.
+
+**PR 1 — Workspace + type crate (`rise-resource-api`)**
+- Convert to Cargo workspace with `[workspace.dependencies]`
+- Update Docker/cargo-chef, cargo-dist workspace metadata, CI commands, and SQLx offline preparation/checks for the workspace layout
+- Scaffold `crates/rise-resource-api`: resource envelope, object metadata, Organization and ResourceDefinition spec/status types, request/response DTOs, name/discriminator validation helpers, JSON Schema derivations
+- No DB, no HTTP, no behavior changes to existing code
+- Critical path: everything else depends on this
+
+**PR 2 — Resource store (`rise-resource-store`)**
+- `resources` and `resource_definitions` table migrations (owned by `rise-resource-store`)
+- Full store implementation: CRUD, optimistic concurrency, discriminator generation with retry cap, finalizer/deletion semantics, ResourceDefinition registry resolution, spec/status validation
+- Wire the resource-store migration runner into backend startup immediately after root migrations, before any bootstrap/controller work
+- Integration tests against a real DB
+- Depends on: PR 1
+
+**PR 3 — Auth: Operator role + controller identity**
+- Add `auth.operator_users` and Operator role checks to settings, middleware, and `platform_access.rs`
+- Add dedicated controller JWT extractor as a separate auth context (does not reuse service-account path)
+- Clarify `auth.admin_users` as default-org-admin only in settings and access checks
+- Update local Dex config to grant `ops@example.com` the Operator role
+- No resource store wiring yet — auth contexts exist but controller one is unused
+- Can be developed in parallel with PR 2
+
+**PR 4 — Generic HTTP API**
+- Routes under `/api/v1/resources` (root and organization-scoped)
+- Resource registry: built-in resolution first, external ResourceDefinitions second
+- Request body validation, operator-only enforcement, controller status/finalizer endpoints
+- Purely additive — no existing routes change
+- Depends on: PR 2, PR 3
+
+**PR 5 — Multi-org linkage, bootstrap, and controller**
+- Root migrations: nullable `organization_resource_uid` on users, teams, projects (two-phase: add nullable, backfill, constrain later)
+- Add Kubernetes deployment backend `controller_class_name` config with a stable default for existing installs
+- Bootstrap logic: advisory lock, default-org upsert with `displayName`, namespace prefix annotation, and `deploymentControllerClass` from `controller_class_name`; idempotent typed-row backfill; startup validation
+- Wire new-user/team/project creation to default Organization
+- Update Kubernetes controller: filter by `deploymentControllerClass`, read namespace prefix annotation, error on missing default org at startup
+- Structure commits within this PR as: migrations → bootstrap → controller → typed API wiring, so reviewers can read each piece independently
+- Depends on: PR 1, PR 2
+
+**PR 6 — Schema generation + docs**
+- `rise backend schemas generate` subcommand
+- `mise run resource:schema:check` task wired into CI lint pipeline
+- Starlight nav config updated for new resources section
+- Five new operator doc pages
+- Astro component for JSON schema rendering
+- Can be drafted in parallel with PR 5; depends on PR 1 for schema types
+
+## Assumptions
+
+- Only Organizations and ResourceDefinitions are built into generic storage in this phase.
+- Existing Projects, Teams, Environments, Deployments, and Extensions stay in current typed tables.
+- Existing typed APIs are default-Organization compatibility APIs in this phase, not general multi-Organization APIs.
+- Normal generic resource CRUD is operator-only in v1; controller JWTs may use controller-specific status/finalizer operations.
+- `auth.admin_users` are org-level admins within the default Organization only; they do not receive Operator access and cannot manage Organization resources.
+- Organization-level admins/users will be modeled later and will eventually replace current platform-level access concepts.

--- a/crates/rise-resource-api/Cargo.toml
+++ b/crates/rise-resource-api/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "rise-resource-api"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/rise-deploy/rise"
+description = "Shared resource API types for Rise"
+publish = false
+
+[dependencies]
+chrono = { workspace = true }
+schemars = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true }

--- a/crates/rise-resource-api/src/lib.rs
+++ b/crates/rise-resource-api/src/lib.rs
@@ -14,6 +14,7 @@ pub const RESOURCE_DEFINITION_COLLECTION: &str = "resourcedefinitions";
 
 pub const RESERVED_COLLECTION_NAMES: &[&str] = &[
     ORGANIZATION_COLLECTION,
+    RESOURCE_DEFINITION_COLLECTION,
     "projects",
     "users",
     "teams",
@@ -22,9 +23,11 @@ pub const RESERVED_COLLECTION_NAMES: &[&str] = &[
     "serviceaccounts",
 ];
 
+pub type JsonObject = BTreeMap<String, serde_json::Value>;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct Resource<TSpec: Default = serde_json::Value, TStatus: Default = serde_json::Value> {
+pub struct Resource<TSpec: Default = JsonObject, TStatus: Default = JsonObject> {
     pub api_version: String,
     pub kind: String,
     pub metadata: ResourceMetadata,
@@ -52,12 +55,49 @@ pub struct ResourceMetadata {
     pub deletion_timestamp: Option<DateTime<Utc>>,
 }
 
-pub type ResourceList<TSpec = serde_json::Value, TStatus = serde_json::Value> =
-    Vec<Resource<TSpec, TStatus>>;
-pub type CreateResourceRequest<TSpec = serde_json::Value> = Resource<TSpec, serde_json::Value>;
-pub type UpdateResourceRequest<TSpec = serde_json::Value> = Resource<TSpec, serde_json::Value>;
-pub type ResourceResponse<TSpec = serde_json::Value, TStatus = serde_json::Value> =
-    Resource<TSpec, TStatus>;
+pub type ResourceList<TSpec = JsonObject, TStatus = JsonObject> = Vec<Resource<TSpec, TStatus>>;
+pub type ResourceResponse<TSpec = JsonObject, TStatus = JsonObject> = Resource<TSpec, TStatus>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateResourceRequest<TSpec: Default = JsonObject> {
+    pub api_version: String,
+    pub kind: String,
+    pub metadata: CreateResourceMetadata,
+    #[serde(default)]
+    pub spec: TSpec,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CreateResourceMetadata {
+    pub name: String,
+    #[serde(default)]
+    pub annotations: BTreeMap<String, String>,
+    #[serde(default)]
+    pub finalizers: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateResourceRequest<TSpec: Default = JsonObject> {
+    pub api_version: String,
+    pub kind: String,
+    pub metadata: UpdateResourceMetadata,
+    #[serde(default)]
+    pub spec: TSpec,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct UpdateResourceMetadata {
+    pub name: String,
+    pub revision: i64,
+    #[serde(default)]
+    pub annotations: BTreeMap<String, String>,
+    #[serde(default)]
+    pub finalizers: Vec<String>,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
 #[serde(rename_all = "camelCase")]
@@ -302,6 +342,7 @@ mod tests {
     #[test]
     fn detects_reserved_collection_names() {
         assert!(is_reserved_collection_name("organizations"));
+        assert!(is_reserved_collection_name("resourcedefinitions"));
         assert!(is_reserved_collection_name("Projects"));
         assert!(!is_reserved_collection_name("widgets"));
     }
@@ -335,6 +376,68 @@ mod tests {
         assert_eq!(value["kind"], ORGANIZATION_KIND);
         assert_eq!(value["metadata"]["name"], "default");
         assert_eq!(value["spec"]["displayName"], "Default");
+    }
+
+    #[test]
+    fn defaults_untyped_spec_and_status_to_empty_objects() {
+        let resource: Resource = serde_json::from_value(serde_json::json!({
+            "apiVersion": "example.dev/v1",
+            "kind": "Widget",
+            "metadata": {
+                "name": "widget-a"
+            }
+        }))
+        .unwrap();
+
+        assert!(resource.spec.is_empty());
+        assert!(resource.status.is_empty());
+
+        let value = serde_json::to_value(resource).unwrap();
+        assert_eq!(value["spec"], serde_json::json!({}));
+        assert_eq!(value["status"], serde_json::json!({}));
+    }
+
+    #[test]
+    fn create_request_rejects_server_controlled_metadata_and_status() {
+        let result: Result<CreateResourceRequest, _> = serde_json::from_value(serde_json::json!({
+            "apiVersion": "example.dev/v1",
+            "kind": "Widget",
+            "metadata": {
+                "name": "widget-a",
+                "uid": "5ac452d8-4e4d-45c9-bd62-5d5aff38095f"
+            },
+            "spec": {},
+            "status": {}
+        }));
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn update_request_accepts_revision_but_rejects_other_identity_metadata() {
+        let valid: UpdateResourceRequest = serde_json::from_value(serde_json::json!({
+            "apiVersion": "example.dev/v1",
+            "kind": "Widget",
+            "metadata": {
+                "name": "widget-a",
+                "revision": 7
+            },
+            "spec": {}
+        }))
+        .unwrap();
+        assert_eq!(valid.metadata.revision, 7);
+
+        let invalid: Result<UpdateResourceRequest, _> = serde_json::from_value(serde_json::json!({
+            "apiVersion": "example.dev/v1",
+            "kind": "Widget",
+            "metadata": {
+                "name": "widget-a",
+                "revision": 7,
+                "discriminator": "abc123de"
+            },
+            "spec": {}
+        }));
+        assert!(invalid.is_err());
     }
 
     #[test]

--- a/crates/rise-resource-api/src/lib.rs
+++ b/crates/rise-resource-api/src/lib.rs
@@ -59,7 +59,7 @@ pub type ResourceList<TSpec = JsonObject, TStatus = JsonObject> = Vec<Resource<T
 pub type ResourceResponse<TSpec = JsonObject, TStatus = JsonObject> = Resource<TSpec, TStatus>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct CreateResourceRequest<TSpec: Default = JsonObject> {
     pub api_version: String,
     pub kind: String,
@@ -79,7 +79,7 @@ pub struct CreateResourceMetadata {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct UpdateResourceRequest<TSpec: Default = JsonObject> {
     pub api_version: String,
     pub kind: String,
@@ -399,12 +399,40 @@ mod tests {
 
     #[test]
     fn create_request_rejects_server_controlled_metadata_and_status() {
-        let result: Result<CreateResourceRequest, _> = serde_json::from_value(serde_json::json!({
+        let server_controlled_metadata: Result<CreateResourceRequest, _> =
+            serde_json::from_value(serde_json::json!({
+                "apiVersion": "example.dev/v1",
+                "kind": "Widget",
+                "metadata": {
+                    "name": "widget-a",
+                    "uid": "5ac452d8-4e4d-45c9-bd62-5d5aff38095f"
+                },
+                "spec": {}
+            }));
+
+        assert!(server_controlled_metadata.is_err());
+
+        let status: Result<CreateResourceRequest, _> = serde_json::from_value(serde_json::json!({
+            "apiVersion": "example.dev/v1",
+            "kind": "Widget",
+            "metadata": {
+                "name": "widget-a"
+            },
+            "spec": {},
+            "status": {}
+        }));
+
+        assert!(status.is_err());
+    }
+
+    #[test]
+    fn update_request_rejects_top_level_status() {
+        let result: Result<UpdateResourceRequest, _> = serde_json::from_value(serde_json::json!({
             "apiVersion": "example.dev/v1",
             "kind": "Widget",
             "metadata": {
                 "name": "widget-a",
-                "uid": "5ac452d8-4e4d-45c9-bd62-5d5aff38095f"
+                "revision": 7
             },
             "spec": {},
             "status": {}

--- a/crates/rise-resource-api/src/lib.rs
+++ b/crates/rise-resource-api/src/lib.rs
@@ -1,0 +1,355 @@
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use uuid::Uuid;
+
+pub const API_VERSION_V1ALPHA1: &str = "rise.dev/v1alpha1";
+
+pub const ORGANIZATION_KIND: &str = "Organization";
+pub const ORGANIZATION_COLLECTION: &str = "organizations";
+
+pub const RESOURCE_DEFINITION_KIND: &str = "ResourceDefinition";
+pub const RESOURCE_DEFINITION_COLLECTION: &str = "resourcedefinitions";
+
+pub const RESERVED_COLLECTION_NAMES: &[&str] = &[
+    ORGANIZATION_COLLECTION,
+    "projects",
+    "users",
+    "teams",
+    "environments",
+    "deployments",
+    "serviceaccounts",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Resource<TSpec: Default = serde_json::Value, TStatus: Default = serde_json::Value> {
+    pub api_version: String,
+    pub kind: String,
+    pub metadata: ResourceMetadata,
+    #[serde(default)]
+    pub spec: TSpec,
+    #[serde(default)]
+    pub status: TStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceMetadata {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uid: Option<Uuid>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revision: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub discriminator: Option<String>,
+    #[serde(default)]
+    pub annotations: BTreeMap<String, String>,
+    #[serde(default)]
+    pub finalizers: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deletion_timestamp: Option<DateTime<Utc>>,
+}
+
+pub type ResourceList<TSpec = serde_json::Value, TStatus = serde_json::Value> =
+    Vec<Resource<TSpec, TStatus>>;
+pub type CreateResourceRequest<TSpec = serde_json::Value> = Resource<TSpec, serde_json::Value>;
+pub type UpdateResourceRequest<TSpec = serde_json::Value> = Resource<TSpec, serde_json::Value>;
+pub type ResourceResponse<TSpec = serde_json::Value, TStatus = serde_json::Value> =
+    Resource<TSpec, TStatus>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ControllerStatusMap {
+    #[serde(default)]
+    pub controllers: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct OrganizationSpec {
+    pub display_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deployment_controller_class: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct OrganizationStatus {
+    #[serde(default)]
+    pub controllers: BTreeMap<String, serde_json::Value>,
+}
+
+pub type OrganizationResource = Resource<OrganizationSpec, OrganizationStatus>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceDefinitionSpec {
+    pub group: String,
+    pub kind: String,
+    pub plural: String,
+    pub scope: ResourceScope,
+    pub versions: Vec<ResourceDefinitionVersion>,
+    #[serde(default)]
+    pub allowed_status_controller_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum ResourceScope {
+    #[default]
+    Root,
+    Organization,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceDefinitionVersion {
+    pub name: String,
+    pub served: bool,
+    pub storage: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceDefinitionStatus {
+    #[serde(default)]
+    pub controllers: BTreeMap<String, serde_json::Value>,
+}
+
+pub type ResourceDefinitionResource = Resource<ResourceDefinitionSpec, ResourceDefinitionStatus>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidationError {
+    message: String,
+}
+
+impl ValidationError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ValidationError {}
+
+pub fn validate_resource_name(value: &str) -> Result<(), ValidationError> {
+    validate_dns_label(value, 63, "resource name")
+}
+
+pub fn validate_discriminator(value: &str) -> Result<(), ValidationError> {
+    if value.len() != 8 {
+        return Err(ValidationError::new(
+            "discriminator must be exactly 8 characters",
+        ));
+    }
+    validate_dns_label(value, 8, "discriminator")
+}
+
+pub fn validate_collection_name(value: &str) -> Result<(), ValidationError> {
+    validate_dns_label(value, 63, "collection name")
+}
+
+pub fn is_reserved_collection_name(value: &str) -> bool {
+    RESERVED_COLLECTION_NAMES
+        .iter()
+        .any(|reserved| reserved.eq_ignore_ascii_case(value))
+}
+
+pub fn validate_resource_group(value: &str) -> Result<(), ValidationError> {
+    validate_dns_subdomain(value, "resource group")
+}
+
+pub fn validate_resource_kind(value: &str) -> Result<(), ValidationError> {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return Err(ValidationError::new("resource kind must not be empty"));
+    };
+    if !first.is_ascii_uppercase() {
+        return Err(ValidationError::new(
+            "resource kind must start with an uppercase ASCII letter",
+        ));
+    }
+    if !chars.all(|c| c.is_ascii_alphanumeric()) {
+        return Err(ValidationError::new(
+            "resource kind must contain only ASCII letters and digits",
+        ));
+    }
+    Ok(())
+}
+
+pub fn validate_resource_version(value: &str) -> Result<(), ValidationError> {
+    if value.is_empty() {
+        return Err(ValidationError::new("resource version must not be empty"));
+    }
+    if !value
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+    {
+        return Err(ValidationError::new(
+            "resource version must contain only lowercase ASCII letters and digits",
+        ));
+    }
+    Ok(())
+}
+
+pub fn validate_controller_id(value: &str) -> Result<(), ValidationError> {
+    let (subdomain, path) = value
+        .split_once('/')
+        .map_or((value, None), |(left, right)| (left, Some(right)));
+    validate_dns_subdomain(subdomain, "controller ID domain")?;
+    if let Some(path) = path {
+        validate_qualified_name_path(path, "controller ID path")?;
+    }
+    Ok(())
+}
+
+fn validate_dns_subdomain(value: &str, label: &str) -> Result<(), ValidationError> {
+    if value.is_empty() || value.len() > 253 {
+        return Err(ValidationError::new(format!(
+            "{label} must be between 1 and 253 characters"
+        )));
+    }
+    for part in value.split('.') {
+        validate_dns_label(part, 63, label)?;
+    }
+    Ok(())
+}
+
+fn validate_dns_label(value: &str, max_len: usize, label: &str) -> Result<(), ValidationError> {
+    if value.is_empty() || value.len() > max_len {
+        return Err(ValidationError::new(format!(
+            "{label} must be between 1 and {max_len} characters"
+        )));
+    }
+    let bytes = value.as_bytes();
+    if !bytes[0].is_ascii_lowercase() && !bytes[0].is_ascii_digit() {
+        return Err(ValidationError::new(format!(
+            "{label} must start with a lowercase ASCII letter or digit"
+        )));
+    }
+    if !bytes[bytes.len() - 1].is_ascii_lowercase() && !bytes[bytes.len() - 1].is_ascii_digit() {
+        return Err(ValidationError::new(format!(
+            "{label} must end with a lowercase ASCII letter or digit"
+        )));
+    }
+    if !bytes
+        .iter()
+        .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || *b == b'-')
+    {
+        return Err(ValidationError::new(format!(
+            "{label} must contain only lowercase ASCII letters, digits, and hyphens"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_qualified_name_path(value: &str, label: &str) -> Result<(), ValidationError> {
+    if value.is_empty() || value.len() > 63 {
+        return Err(ValidationError::new(format!(
+            "{label} must be between 1 and 63 characters"
+        )));
+    }
+    let bytes = value.as_bytes();
+    if !bytes[0].is_ascii_alphanumeric() || !bytes[bytes.len() - 1].is_ascii_alphanumeric() {
+        return Err(ValidationError::new(format!(
+            "{label} must start and end with an ASCII letter or digit"
+        )));
+    }
+    if !bytes
+        .iter()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(*b, b'-' | b'_' | b'.'))
+    {
+        return Err(ValidationError::new(format!(
+            "{label} must contain only ASCII letters, digits, hyphens, underscores, and dots"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_resource_names() {
+        assert!(validate_resource_name("my-app").is_ok());
+        assert!(validate_resource_name("app1").is_ok());
+        assert!(validate_resource_name("-app").is_err());
+        assert!(validate_resource_name("app-").is_err());
+        assert!(validate_resource_name("MyApp").is_err());
+    }
+
+    #[test]
+    fn validates_discriminators() {
+        assert!(validate_discriminator("abc123de").is_ok());
+        assert!(validate_discriminator("-bc123de").is_err());
+        assert!(validate_discriminator("abc123d-").is_err());
+        assert!(validate_discriminator("abc123d").is_err());
+        assert!(validate_discriminator("abc123def").is_err());
+    }
+
+    #[test]
+    fn detects_reserved_collection_names() {
+        assert!(is_reserved_collection_name("organizations"));
+        assert!(is_reserved_collection_name("Projects"));
+        assert!(!is_reserved_collection_name("widgets"));
+    }
+
+    #[test]
+    fn validates_controller_ids() {
+        assert!(validate_controller_id("controller.example.com").is_ok());
+        assert!(validate_controller_id("controller.example.com/my-controller").is_ok());
+        assert!(validate_controller_id("Controller.example.com").is_err());
+        assert!(validate_controller_id("controller.example.com/-bad").is_err());
+    }
+
+    #[test]
+    fn serializes_organization_resource_shape() {
+        let resource = OrganizationResource {
+            api_version: API_VERSION_V1ALPHA1.to_string(),
+            kind: ORGANIZATION_KIND.to_string(),
+            metadata: ResourceMetadata {
+                name: "default".to_string(),
+                ..ResourceMetadata::default()
+            },
+            spec: OrganizationSpec {
+                display_name: "Default".to_string(),
+                deployment_controller_class: Some("kubernetes.rise.dev/default".to_string()),
+            },
+            status: OrganizationStatus::default(),
+        };
+
+        let value = serde_json::to_value(resource).unwrap();
+        assert_eq!(value["apiVersion"], API_VERSION_V1ALPHA1);
+        assert_eq!(value["kind"], ORGANIZATION_KIND);
+        assert_eq!(value["metadata"]["name"], "default");
+        assert_eq!(value["spec"]["displayName"], "Default");
+    }
+
+    #[test]
+    fn generates_builtin_schemas() {
+        let org_schema = serde_json::to_value(schemars::schema_for!(OrganizationResource)).unwrap();
+        let rd_schema =
+            serde_json::to_value(schemars::schema_for!(ResourceDefinitionResource)).unwrap();
+
+        assert!(org_schema["properties"]["spec"]["$ref"]
+            .as_str()
+            .unwrap()
+            .contains("OrganizationSpec"));
+        assert!(rd_schema["properties"]["spec"]["$ref"]
+            .as_str()
+            .unwrap()
+            .contains("ResourceDefinitionSpec"));
+    }
+}

--- a/crates/rise-resource-api/src/lib.rs
+++ b/crates/rise-resource-api/src/lib.rs
@@ -102,7 +102,7 @@ pub struct UpdateResourceMetadata {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ControllerStatusMap {
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub controllers: BTreeMap<String, serde_json::Value>,
 }
 
@@ -117,7 +117,7 @@ pub struct OrganizationSpec {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct OrganizationStatus {
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub controllers: BTreeMap<String, serde_json::Value>,
 }
 
@@ -156,7 +156,7 @@ pub struct ResourceDefinitionVersion {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ResourceDefinitionStatus {
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub controllers: BTreeMap<String, serde_json::Value>,
 }
 
@@ -395,6 +395,37 @@ mod tests {
         let value = serde_json::to_value(resource).unwrap();
         assert_eq!(value["spec"], serde_json::json!({}));
         assert_eq!(value["status"], serde_json::json!({}));
+    }
+
+    #[test]
+    fn skips_empty_controller_status_maps() {
+        let controller_status = serde_json::to_value(ControllerStatusMap::default()).unwrap();
+        let organization_status = serde_json::to_value(OrganizationStatus::default()).unwrap();
+        let resource_definition_status =
+            serde_json::to_value(ResourceDefinitionStatus::default()).unwrap();
+
+        assert_eq!(controller_status, serde_json::json!({}));
+        assert_eq!(organization_status, serde_json::json!({}));
+        assert_eq!(resource_definition_status, serde_json::json!({}));
+
+        let with_controller = OrganizationStatus {
+            controllers: BTreeMap::from([(
+                "controller.example.com".to_string(),
+                serde_json::json!({"ready": true}),
+            )]),
+        };
+
+        let value = serde_json::to_value(with_controller).unwrap();
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "controllers": {
+                    "controller.example.com": {
+                        "ready": true
+                    }
+                }
+            })
+        );
     }
 
     #[test]

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["cargo:."]
+default-members = ["cargo:."]
 
 # Config for 'dist'
 [dist]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,9 @@ services:
   # HashiCorp Vault with JFrog Artifactory secrets plugin.
   # Automatically configures itself and JFrog on startup.
   # Access: VAULT_ADDR=http://localhost:8200 VAULT_TOKEN=root
+  # Start locally with: docker compose --profile jfrog-vault up -d jfrog vault
   vault:
+    profiles: ["jfrog-vault"]
     image: hashicorp/vault:1.21
     container_name: rise-vault
     restart: unless-stopped
@@ -99,7 +101,9 @@ services:
   # JFrog Artifactory JCR for testing the JFrog repository controller.
   # Also serves as a Docker registry at localhost:3082 (repo: rise-docker-local).
   # Login: admin / password
+  # Start locally with: docker compose --profile jfrog-vault up -d jfrog vault
   jfrog:
+    profiles: ["jfrog-vault"]
     image: releases-docker.jfrog.io/jfrog/artifactory-jcr:7.146.12
     container_name: rise-jfrog
     restart: unless-stopped

--- a/mise.toml
+++ b/mise.toml
@@ -79,17 +79,19 @@ mise run backend:run
 
 [tasks."sqlx:prepare"]
 description = "Prepare the SQLX query cache that needs to be committed for building with SQLX_OFFLINE=true."
-run = "cargo sqlx prepare -- --features cli,backend --all-targets"
+run = "cargo sqlx prepare -- --package rise-deploy --features cli,backend --all-targets"
 
 [tasks."sqlx:check"]
 description = "Check that all SQLX queries are valid."
-run = "cargo sqlx prepare --check -- --features cli,backend --all-targets"
+run = "cargo sqlx prepare --check -- --package rise-deploy --features cli,backend --all-targets"
 
 [tasks.lint]
 description = "Run all linting checks (clippy, formatting, sqlx, helm)."
 run = """
 cargo all-features check --all-targets
+cargo check --package rise-resource-api --all-targets
 cargo all-features clippy --all-targets -- -D warnings
+cargo clippy --package rise-resource-api --all-targets -- -D warnings
 cargo fmt --all -- --check
 mise sqlx:check
 helm lint helm/rise
@@ -98,7 +100,7 @@ env.SQLX_OFFLINE = true
 
 [tasks."config:schema:generate"]
 description = "Generate the backend settings JSON schema."
-run = "cargo run --features cli,backend -- backend config-schema > docs/user/public/schemas/backend-settings.schema.json"
+run = "cargo run --package rise-deploy --features cli,backend -- backend config-schema > docs/user/public/schemas/backend-settings.schema.json"
 env.SQLX_OFFLINE = true
 
 [tasks."config:schema:check"]
@@ -108,7 +110,7 @@ env.SQLX_OFFLINE = true
 
 [tasks."rise-toml:schema:generate"]
 description = "Generate the rise.toml JSON schema."
-run = "cargo run --features cli,backend -- backend rise-toml-schema > docs/user/public/schemas/rise-toml-v1.schema.json"
+run = "cargo run --package rise-deploy --features cli,backend -- backend rise-toml-schema > docs/user/public/schemas/rise-toml-v1.schema.json"
 env.SQLX_OFFLINE = true
 
 [tasks."rise-toml:schema:check"]
@@ -118,7 +120,7 @@ env.SQLX_OFFLINE = true
 
 [tasks."crd:generate"]
 description = "Generate the RiseProject CRD YAML for the Helm chart."
-run = "cargo run --features cli,backend -- backend crd-schema > helm/rise/crds/riseproject-crd.yaml"
+run = "cargo run --package rise-deploy --features cli,backend -- backend crd-schema > helm/rise/crds/riseproject-crd.yaml"
 env.SQLX_OFFLINE = true
 
 [tasks."crd:check"]

--- a/scripts/ci/e2e-minikube.sh
+++ b/scripts/ci/e2e-minikube.sh
@@ -62,7 +62,7 @@ rise_cli() {
 wait_for_jfrog_vault() {
   echo "Waiting for Vault-backed JFrog registry setup"
   echo "Streaming Vault setup logs until the Vault role is available"
-  docker compose logs --follow --tail=100 vault &
+  docker compose --profile jfrog-vault logs --follow --tail=100 vault &
   COMPOSE_LOGS_PID=$!
 
   for attempt in {1..120}; do
@@ -76,7 +76,7 @@ wait_for_jfrog_vault() {
     fi
 
     if (( attempt % 6 == 0 )); then
-      docker compose ps jfrog vault || true
+      docker compose --profile jfrog-vault ps jfrog vault || true
     fi
     sleep 5
   done
@@ -94,9 +94,9 @@ collect_jfrog_vault_artifacts() {
   local previous_log="${artifact_dir}/rise-backend-previous.log"
 
   mkdir -p "${artifact_dir}"
-  docker compose ps jfrog vault > "${artifact_dir}/compose-ps.txt" 2>&1 || true
-  docker compose logs --no-color jfrog > "${artifact_dir}/jfrog.log" 2>&1 || true
-  docker compose logs --no-color vault > "${artifact_dir}/vault.log" 2>&1 || true
+  docker compose --profile jfrog-vault ps jfrog vault > "${artifact_dir}/compose-ps.txt" 2>&1 || true
+  docker compose --profile jfrog-vault logs --no-color jfrog > "${artifact_dir}/jfrog.log" 2>&1 || true
+  docker compose --profile jfrog-vault logs --no-color vault > "${artifact_dir}/vault.log" 2>&1 || true
 
   if kubectl cluster-info >/dev/null 2>&1; then
     kubectl get pods -A > "${artifact_dir}/k8s-pods.txt" 2>&1 || true
@@ -159,8 +159,8 @@ cleanup() {
   minikube delete || true
   if [[ "${RISE_E2E_REGISTRY_MODE}" == "jfrog-vault" ]]; then
     echo "Cleaning up JFrog/Vault services"
-    docker compose stop vault jfrog || true
-    docker compose rm -fsv vault jfrog || true
+    docker compose --profile jfrog-vault stop vault jfrog || true
+    docker compose --profile jfrog-vault rm -fsv vault jfrog || true
   fi
 }
 trap cleanup EXIT
@@ -170,7 +170,7 @@ minikube delete || true
 
 if [[ "${RISE_E2E_REGISTRY_MODE}" == "jfrog-vault" ]]; then
   echo "Starting JFrog and Vault services"
-  docker compose up -d jfrog vault
+  docker compose --profile jfrog-vault up -d jfrog vault
   wait_for_jfrog_vault
 fi
 


### PR DESCRIPTION
## Summary
- convert the repo to a Cargo workspace while keeping the existing rise binary as the releasable artifact
- add the initial rise-resource-api crate with shared resource envelopes, Organization/ResourceDefinition types, schema derives, and validation helpers
- update Docker, cargo-dist, CI, mise, and SQLx commands for the workspace layout

## Validation
- cargo test --package rise-resource-api
- cargo fmt --all -- --check
- cargo check --workspace --all-features --all-targets
- SQLX_OFFLINE=true cargo all-features check --all-targets
- SQLX_OFFLINE=true cargo all-features clippy --all-targets -- -D warnings
- cargo sqlx prepare --check -- --features cli,backend --all-targets