### PR TITLE
Add resource store crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,7 +117,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -114,7 +128,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -847,6 +861,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -883,6 +912,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,6 +932,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "byteorder"
@@ -1553,7 +1594,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1704,6 +1745,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1736,7 +1786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1769,6 +1819,17 @@ checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1817,6 +1878,17 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
 ]
 
 [[package]]
@@ -1870,6 +1942,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -2707,6 +2789,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161c33c3ec738cfea3288c5c53dfcdb32fd4fc2954de86ea06f71b5a1a40bfcd"
+dependencies = [
+ "ahash",
+ "base64 0.22.1",
+ "bytecount",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "once_cell",
+ "percent-encoding",
+ "referencing",
+ "regex-syntax",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "uuid-simd",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3076,7 +3183,21 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
 ]
 
 [[package]]
@@ -3106,6 +3227,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3127,6 +3263,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -3853,6 +4000,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a64b3a635fad9000648b4d8a59c8710c523ab61a23d392a7d91d47683f5adc"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3895,6 +4056,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http 1.4.0",
@@ -4044,6 +4206,7 @@ dependencies = [
  "rand 0.10.1",
  "regex",
  "reqwest 0.13.3",
+ "rise-resource-store",
  "rsa",
  "rustls",
  "schemars",
@@ -4079,6 +4242,25 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "rise-resource-store"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "jsonschema",
+ "rand 0.10.1",
+ "rise-resource-api",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
  "uuid",
 ]
 
@@ -4151,7 +4333,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4210,7 +4392,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4695,7 +4877,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5027,7 +5209,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5534,6 +5716,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "uuid",
+ "vsimd",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5807,7 +6000,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,14 +2,22 @@
 members = [
     ".",
     "crates/rise-resource-api",
+    "crates/rise-resource-store",
 ]
 resolver = "2"
 
 [workspace.dependencies]
+anyhow = "1.0.100"
+async-trait = "0.1"
 chrono = { version = "0.4.38", features = ["serde"] }
+rand = "0.10.0"
 schemars = { version = "1", features = ["chrono04", "uuid1"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
+sqlx = { version = "0.8", features = ["runtime-tokio-native-tls", "postgres", "uuid", "chrono", "migrate", "json"] }
+thiserror = "2.0"
+tokio = { version = "1.48.0", features = ["full"] }
+tracing = "0.1.43"
 uuid = { version = "1.18.1", features = ["v4", "serde"] }
 
 [package]
@@ -53,6 +61,7 @@ cli = [
 ]
 backend = [
     # Server core (former "server" feature)
+    "dep:rise-resource-store",
     "dep:config",
     "dep:openssl",
     "dep:rsa",
@@ -89,6 +98,9 @@ backend = [
 ]
 
 [dependencies]
+# Workspace crates (backend only)
+rise-resource-store = { path = "crates/rise-resource-store", optional = true }
+
 # Common (always enabled - shared across features)
 anyhow = "1.0.100"
 async-stream = "0.3"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,15 @@ FROM chef AS planner
 # Copy workspace project files
 COPY Cargo.toml Cargo.lock ./
 COPY crates/rise-resource-api/Cargo.toml ./crates/rise-resource-api/Cargo.toml
+COPY crates/rise-resource-store/Cargo.toml ./crates/rise-resource-store/Cargo.toml
 
 # Create dummy sources for cargo to be happy
 RUN mkdir -p src && \
     echo "fn main() {}" > src/main.rs && \
     mkdir -p crates/rise-resource-api/src && \
-    echo "" > crates/rise-resource-api/src/lib.rs
+    echo "" > crates/rise-resource-api/src/lib.rs && \
+    mkdir -p crates/rise-resource-store/src && \
+    echo "" > crates/rise-resource-store/src/lib.rs
 
 RUN cargo chef prepare --recipe-path recipe.json
 

--- a/MULTI_TENANCY_PLAN.md
+++ b/MULTI_TENANCY_PLAN.md
@@ -101,13 +101,17 @@ Backend startup migration order:
   - `deletionTimestamp`
 - Standard status defaults to `{}`; the `controllers` key is optional and populated only when a controller first writes its status update. Resources with no controllers have `status: {}` as a valid state.
 - Treat SQL identity columns as canonical. The API must reject client-supplied identity metadata (`uid`, `revision`, `discriminator`, `deletionTimestamp`) on create/update/status paths.
-- Delete behavior:
-  - if child resources exist: reject parent deletion with a conflict
-  - no finalizers and no children: delete row
-  - finalizers present: set `deletionTimestamp`
-  - controllers remove their finalizers after cleanup
-  - do not use `ON DELETE CASCADE` for resource parent/child cleanup because it would bypass child finalizers
-  - additionally block deletion of an Organization that has typed children (teams or projects linked via `organization_resource_uid`); those rows are not `resources` table children so the generic child-detection check does not cover them — this guard must be explicit at the application layer
+- Delete behavior (Kubernetes-style cascade via finalizers):
+  - `delete` accepts a propagation policy: `Cascade` (default) or `Orphan`. The store collapses Kubernetes' Foreground/Background distinction into a single `Cascade` mode — tombstones are always visible, so client-observable ordering and server-side gating are the same mechanism.
+  - `Cascade`: stamp `deletionTimestamp` on the target; if children exist, append a `system.rise.dev/cascade-deletion` system finalizer and stamp `deletionTimestamp` on **immediate children only** in the same transaction. A background GC worker fans out down the tree as each subtree's controllers drain their finalizers. The parent is hard-deleted only once all children are gone and finalizers are clear.
+  - `Orphan`: detach children in the same transaction (`UPDATE resources SET parent_uid = NULL WHERE parent_uid = $1`), then proceed with normal mark/hard-delete on the parent. Admin-only — gated at the API layer, not in the store.
+  - no finalizers and no children: hard-delete the row immediately
+  - finalizers present: set `deletionTimestamp` and wait for finalizers to clear
+  - controllers remove their controller-scoped finalizers after cleanup; the `system.rise.dev/*` prefix is reserved for store-internal finalizers and is rejected by `update_controller_finalizers` regardless of `controller_id`
+  - GC sweep operates via `try_collect(uid)` (hard-deletes a tombstoned row when collectable, else stamps the next layer of children) and `list_pending_collection()` (enumerates candidates)
+  - do not use `ON DELETE CASCADE` for resource parent/child cleanup because it would bypass child finalizers; the cascade-stamping + GC sweep is the substitute
+  - tombstoned rows (with `deletionTimestamp` set) remain visible from `get`, `list`, `resolve_path`, and the HTTP API by default; filtering them out is opt-in via an explicit query param (deferred until a concrete use case appears)
+  - additionally block deletion of an Organization that has typed children (teams or projects linked via `organization_resource_uid`); those rows are not `resources` table children so the generic child-detection check does not cover them — this guard must be explicit at the application layer until those typed APIs migrate to the generic resource model
 
 ## Built-In Resources
 
@@ -178,6 +182,11 @@ Backend startup migration order:
   - `GET /api/v1/resources/organizations/{org}/{collection}/{name}`
   - `PUT /api/v1/resources/organizations/{org}/{collection}/{name}`
   - `DELETE /api/v1/resources/organizations/{org}/{collection}/{name}`
+- Path grammar is uniform `<kind>/<identifier>` per segment. The identifier is either a name or a UID-prefixed token (`uid:<uuid>`), e.g. `/api/v1/resources/organizations/acme/projects/uid:a1b2c3d4-...`. The kind is always present, so response shape is statically determinable from the URL and the store can verify that the UID's row actually has the expected kind (mismatches return 404). The HTTP layer resolves the path through the store's `resolve_path(&[PathSegment])` in a single round-trip.
+- `DELETE` accepts a `propagationPolicy` query parameter (`Cascade` default, `Orphan` admin-only).
+- Break-glass / discovery endpoints:
+  - `GET /api/v1/resources/orphans` — children of tombstoned parents (`list_orphans`)
+  - `POST /api/v1/resources/{collection}/{name}/reparent` — atomic move to a new parent, admin-only; rejects cycles and uniqueness conflicts at the destination
 - Route `{collection}` through the resource registry:
   - built-in registrations first
   - external ResourceDefinitions second
@@ -344,7 +353,14 @@ Backend startup migration order:
   - PUT without `metadata.revision` is rejected
   - revision increments
   - finalizer deletion flow
-  - parent deletion with children is rejected
+  - `Cascade` delete stamps `deletionTimestamp` on parent and immediate children and injects `system.rise.dev/cascade-deletion` on the parent
+  - `try_collect` hard-deletes a tombstoned row only when finalizers are clear AND no children remain; otherwise stamps the next layer of children
+  - cascade subtree drains bottom-up via repeated `try_collect` as controllers shed their finalizers
+  - `Orphan` delete detaches children (`parent_uid = NULL`) and then proceeds with normal mark/hard-delete on the parent
+  - controllers cannot add or remove `system.rise.dev/*` finalizers via `update_controller_finalizers`
+  - `resolve_path` walks `Name` and `Uid` segments, returns the full ancestor chain (including tombstoned rows), and rejects kind mismatches on UID segments
+  - `list_orphans` returns children of tombstoned parents, optionally scoped under a subtree
+  - `reparent` moves a resource, rejects cycles, and surfaces destination uniqueness conflicts as `NameConflict`
   - Organization with linked teams or projects (via `organization_resource_uid`) is blocked from deletion at the application layer
 - Built-ins:
   - Organization validation via Rust structs
@@ -421,10 +437,21 @@ Deliver in the following order. PRs 1–4 avoid existing data model changes, but
 
 **PR 4 — Generic HTTP API**
 - Routes under `/api/v1/resources` (root and organization-scoped)
+- Uniform `<kind>/<identifier>` path grammar with `uid:` token support; backed by store's `resolve_path`
 - Resource registry: built-in resolution first, external ResourceDefinitions second
 - Request body validation, operator-only enforcement, controller status/finalizer endpoints
+- `DELETE` accepts `propagationPolicy` (`Cascade`|`Orphan`); `Orphan` rejected for non-admin callers at the handler layer
+- Break-glass endpoints: `GET /api/v1/resources/orphans`, `POST .../{name}/reparent` (admin-only)
+- Audit logging for `Orphan` propagation and reparent operations
 - Purely additive — no existing routes change
 - Depends on: PR 2, PR 3
+
+**PR 4b — Resource GC worker**
+- Background task that periodically polls `list_pending_collection()` and drives `try_collect()` per row
+- Fans cascade down the tree as each subtree's controllers shed their finalizers
+- Until this lands, cascade-marked subtrees do not actually drain
+- Quota / fan-out rate limits and observability (metrics for backlog, time-to-collect, stuck finalizers) belong here
+- Depends on: PR 2
 
 **PR 5 — Multi-org linkage, bootstrap, and controller**
 - Root migrations: nullable `organization_resource_uid` on users, teams, projects (two-phase: add nullable, backfill, constrain later)
@@ -451,3 +478,8 @@ Deliver in the following order. PRs 1–4 avoid existing data model changes, but
 - Normal generic resource CRUD is operator-only in v1; controller JWTs may use controller-specific status/finalizer operations.
 - `auth.admin_users` are org-level admins within the default Organization only; they do not receive Operator access and cannot manage Organization resources.
 - Organization-level admins/users will be modeled later and will eventually replace current platform-level access concepts.
+- Cascade delete propagation is the default; `Orphan` is an admin-only break-glass operation. Reparent is the supported way to relocate a resource without going through orphaning.
+- Tombstoned rows are always visible to the API; controllers and operators rely on observing in-progress teardown to do their work. An `exclude_deleted` filter can be added later when there is a concrete need.
+- Reparent permission model (owner-of-source, owner-of-destination, both, admin-only) is deferred to the API layer and will be decided when reparent is exposed.
+- Orphaning a child whose kind also exists at root with the same name will fail with a `NameConflict` via the partial unique index `resources_root_kind_name_unique`; remediation (force-rename on orphan, etc.) is an API-layer policy decision and is out of scope for the store.
+- Recursive-CTE optimization for `resolve_path` is deferred; the initial implementation is a per-segment loop in a single transaction, which is fine for typical hierarchy depths.

--- a/crates/rise-resource-store/Cargo.toml
+++ b/crates/rise-resource-store/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "rise-resource-store"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+rise-resource-api = { path = "../rise-resource-api" }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+chrono = { workspace = true }
+jsonschema = "0.29"
+rand = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sqlx = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/crates/rise-resource-store/README.md
+++ b/crates/rise-resource-store/README.md
@@ -1,0 +1,103 @@
+# rise-resource-store
+
+Backend-only DB layer for generic resource storage. Implements the `ResourceStore` trait
+backed by PostgreSQL.
+
+## Storage model
+
+The `resources` table holds every resource (Organizations, ResourceDefinitions, and any
+user-defined kind). Hierarchy is encoded by a single FK:
+
+```sql
+parent_uid UUID NULL REFERENCES resources(uid)
+```
+
+Uniqueness of `(kind, name)` within a parent scope is enforced by partial unique indexes —
+one for `parent_uid IS NULL` (root) and one for `parent_uid IS NOT NULL`.
+
+`resource_definitions` is a projection table holding the indexed/queryable identity fields
+(group, kind, plural, scope) of `ResourceDefinition` rows; it stays in sync via
+`register_resource_definition` and `update_resource_definition`.
+
+## Deletion model
+
+Inspired by Kubernetes finalizers, but adapted to a hierarchical store with a hard FK.
+
+### Lifecycle
+
+1. `delete(uid, policy)` marks the row (`deletion_timestamp = NOW()`) and reacts to children
+   per `policy`.
+2. Controllers observe `deletion_timestamp`, do their teardown work, and clear their own
+   finalizers via `update_controller_finalizers`.
+3. A GC worker iterates `list_pending_collection()` and calls `try_collect(uid)` on each
+   tombstoned row. When the row has no children and no remaining finalizers, `try_collect`
+   hard-deletes it.
+
+### Visibility contract
+
+Tombstoned rows are **visible by default** in `get`, `get_by_name`, `list`, and
+`resolve_path`. Filtering them out is the caller's responsibility — controllers, operators,
+and resolution paths all need to observe in-progress teardown.
+
+### Propagation policy
+
+`PropagationPolicy` controls what happens to children when a parent is deleted.
+
+- **`Cascade`** (default). Stamps `deletion_timestamp` on the parent and its **immediate
+  children**, and attaches the store-managed finalizer
+  `system.rise.dev/cascade-deletion` to the parent (if children exist). Subsequent GC
+  sweeps via `try_collect` fan out down the tree as each level drains. The parent stays
+  observable until the entire subtree has been collected.
+
+- **`Orphan`**. Detaches immediate children (`UPDATE resources SET parent_uid = NULL WHERE
+  parent_uid = $1`) and then deletes the parent normally. Children continue as root-level
+  resources. This is an admin/break-glass operation; **admin gating is the caller's
+  responsibility** (the store accepts the policy unconditionally).
+
+### Finalizer ownership
+
+Two kinds of finalizers live in the `finalizers` array:
+
+- **Controller finalizers** — anything matching `<controller_id>` or
+  `<controller_id>/<path>`. Added and removed by the owning controller via
+  `update_controller_finalizers`.
+- **System finalizers** — prefix `system.rise.dev/`. Reserved for the store itself.
+  `update_controller_finalizers` rejects any attempt by a controller to add or remove
+  them with `StoreError::ReservedFinalizer`.
+
+## Path resolution
+
+`resolve_path(&[PathSegment])` walks a path of `(kind, identifier)` pairs in a single
+transaction and returns the full ancestor chain (leaf is the last element). Two segment
+forms:
+
+```rust
+PathSegment::Name { kind, name }    // "widgets/foo"
+PathSegment::Uid  { kind, uid }     // "widgets/uid:aaaa-bbbb"
+```
+
+`kind` is always required, even for UID-addressed segments. This lets the API layer:
+
+- Determine the response shape from the URL alone (no resolve-before-route round-trip).
+- Surface `KindMismatch` when a UUID was copy-pasted into the wrong slot.
+- Catch cross-subtree references (`ParentNotFound`) — a UID whose `parent_uid` doesn't
+  match the resolved ancestor chain.
+
+## Orphan discovery
+
+`list_orphans(parent_uid)` returns rows whose parent has `deletion_timestamp IS NOT NULL`
+(i.e. children of an in-progress teardown). Scoped optionally to a single subtree. Useful
+for admin tooling that needs to inspect or repair in-flight cascade operations.
+
+Note: the FK on `parent_uid` makes "dangling" orphans (parent row gone) impossible. Orphan
+mode explicitly nulls `parent_uid` instead.
+
+## Reparenting
+
+`reparent(uid, new_parent_uid)` atomically moves a resource. Rejects:
+
+- `ReparentCycle` — self-loop or moving a node under one of its own descendants.
+- `NameConflict` — destination scope already has a row with the same `(kind, name)` or
+  discriminator.
+
+Use this in preference to delete-then-recreate, which loses the UID and revision history.

--- a/crates/rise-resource-store/migrations/20260519000000_create_resource_store_schema.sql
+++ b/crates/rise-resource-store/migrations/20260519000000_create_resource_store_schema.sql
@@ -1,0 +1,5 @@
+-- All resource-store tables (and the `_sqlx_migrations` tracking table written by
+-- sqlx during this crate's migration run) live in a dedicated `resource_store`
+-- schema so they stay isolated from the root rise-deploy crate, which owns its
+-- own migrations against the same database.
+CREATE SCHEMA IF NOT EXISTS resource_store;

--- a/crates/rise-resource-store/migrations/20260519000001_create_resources.sql
+++ b/crates/rise-resource-store/migrations/20260519000001_create_resources.sql
@@ -20,14 +20,14 @@ ALTER TABLE resources
     CHECK (discriminator ~ '^[a-z0-9][a-z0-9-]{6}[a-z0-9]$');
 
 -- Names follow the DNS-label format for regular resources (my-org) and the DNS-subdomain
--- format for ResourceDefinitions (widgets.example.dev). Both share the same rule: starts
--- and ends with an alphanumeric character, no consecutive dots, no leading/trailing hyphens
--- per segment, max 253 chars (DNS subdomain limit).
+-- format for ResourceDefinitions (widgets.example.dev). Per RFC 1123: each dot-separated
+-- segment is a DNS label (starts and ends with alphanumeric, hyphens allowed in the middle,
+-- max 63 chars). Total length capped at 253 (DNS subdomain limit).
 ALTER TABLE resources
     ADD CONSTRAINT resources_name_format
     CHECK (
-        name ~ '^[a-z0-9]([a-z0-9.-]{0,251}[a-z0-9])?$'
-        AND position('..' in name) = 0
+        name ~ '^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*$'
+        AND length(name) <= 253
     );
 
 ALTER TABLE resources

--- a/crates/rise-resource-store/migrations/20260519000001_create_resources.sql
+++ b/crates/rise-resource-store/migrations/20260519000001_create_resources.sql
@@ -1,8 +1,8 @@
-CREATE TABLE resources (
+CREATE TABLE resource_store.resources (
     uid                UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
     api_version        TEXT        NOT NULL,
     kind               TEXT        NOT NULL,
-    parent_uid         UUID        NULL REFERENCES resources(uid),
+    parent_uid         UUID        NULL REFERENCES resource_store.resources(uid),
     name               TEXT        NOT NULL,
     discriminator      VARCHAR(8)  NOT NULL,
     metadata           JSONB       NOT NULL DEFAULT '{}',
@@ -15,7 +15,7 @@ CREATE TABLE resources (
     updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
-ALTER TABLE resources
+ALTER TABLE resource_store.resources
     ADD CONSTRAINT resources_discriminator_format
     CHECK (discriminator ~ '^[a-z0-9][a-z0-9-]{6}[a-z0-9]$');
 
@@ -23,44 +23,44 @@ ALTER TABLE resources
 -- format for ResourceDefinitions (widgets.example.dev). Per RFC 1123: each dot-separated
 -- segment is a DNS label (starts and ends with alphanumeric, hyphens allowed in the middle,
 -- max 63 chars). Total length capped at 253 (DNS subdomain limit).
-ALTER TABLE resources
+ALTER TABLE resource_store.resources
     ADD CONSTRAINT resources_name_format
     CHECK (
         name ~ '^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*$'
         AND length(name) <= 253
     );
 
-ALTER TABLE resources
+ALTER TABLE resource_store.resources
     ADD CONSTRAINT resources_metadata_is_object
     CHECK (jsonb_typeof(metadata) = 'object');
 
-ALTER TABLE resources
+ALTER TABLE resource_store.resources
     ADD CONSTRAINT resources_spec_is_object
     CHECK (jsonb_typeof(spec) = 'object');
 
-ALTER TABLE resources
+ALTER TABLE resource_store.resources
     ADD CONSTRAINT resources_status_is_object
     CHECK (jsonb_typeof(status) = 'object');
 
 -- Same-level name uniqueness
 CREATE UNIQUE INDEX resources_child_kind_name_unique
-    ON resources (parent_uid, kind, name)
+    ON resource_store.resources (parent_uid, kind, name)
     WHERE parent_uid IS NOT NULL;
 
 CREATE UNIQUE INDEX resources_root_kind_name_unique
-    ON resources (kind, name)
+    ON resource_store.resources (kind, name)
     WHERE parent_uid IS NULL;
 
 -- Same-level discriminator uniqueness
 CREATE UNIQUE INDEX resources_child_discriminator_unique
-    ON resources (parent_uid, discriminator)
+    ON resource_store.resources (parent_uid, discriminator)
     WHERE parent_uid IS NOT NULL;
 
 CREATE UNIQUE INDEX resources_root_discriminator_unique
-    ON resources (discriminator)
+    ON resource_store.resources (discriminator)
     WHERE parent_uid IS NULL;
 
-CREATE OR REPLACE FUNCTION resources_set_updated_at()
+CREATE OR REPLACE FUNCTION resource_store.resources_set_updated_at()
 RETURNS TRIGGER AS $$
 BEGIN
     NEW.updated_at = NOW();
@@ -69,5 +69,5 @@ END;
 $$ LANGUAGE plpgsql;
 
 CREATE TRIGGER resources_updated_at
-    BEFORE UPDATE ON resources
-    FOR EACH ROW EXECUTE FUNCTION resources_set_updated_at();
+    BEFORE UPDATE ON resource_store.resources
+    FOR EACH ROW EXECUTE FUNCTION resource_store.resources_set_updated_at();

--- a/crates/rise-resource-store/migrations/20260519000001_create_resources.sql
+++ b/crates/rise-resource-store/migrations/20260519000001_create_resources.sql
@@ -19,6 +19,17 @@ ALTER TABLE resources
     ADD CONSTRAINT resources_discriminator_format
     CHECK (discriminator ~ '^[a-z0-9][a-z0-9-]{6}[a-z0-9]$');
 
+-- Names follow the DNS-label format for regular resources (my-org) and the DNS-subdomain
+-- format for ResourceDefinitions (widgets.example.dev). Both share the same rule: starts
+-- and ends with an alphanumeric character, no consecutive dots, no leading/trailing hyphens
+-- per segment, max 253 chars (DNS subdomain limit).
+ALTER TABLE resources
+    ADD CONSTRAINT resources_name_format
+    CHECK (
+        name ~ '^[a-z0-9]([a-z0-9.-]{0,251}[a-z0-9])?$'
+        AND position('..' in name) = 0
+    );
+
 ALTER TABLE resources
     ADD CONSTRAINT resources_metadata_is_object
     CHECK (jsonb_typeof(metadata) = 'object');

--- a/crates/rise-resource-store/migrations/20260519000001_create_resources.sql
+++ b/crates/rise-resource-store/migrations/20260519000001_create_resources.sql
@@ -1,0 +1,62 @@
+CREATE TABLE resources (
+    uid                UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    api_version        TEXT        NOT NULL,
+    kind               TEXT        NOT NULL,
+    parent_uid         UUID        NULL REFERENCES resources(uid),
+    name               TEXT        NOT NULL,
+    discriminator      VARCHAR(8)  NOT NULL,
+    metadata           JSONB       NOT NULL DEFAULT '{}',
+    spec               JSONB       NOT NULL DEFAULT '{}',
+    status             JSONB       NOT NULL DEFAULT '{}',
+    revision           BIGINT      NOT NULL DEFAULT 1,
+    finalizers         TEXT[]      NOT NULL DEFAULT '{}',
+    deletion_timestamp TIMESTAMPTZ NULL,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE resources
+    ADD CONSTRAINT resources_discriminator_format
+    CHECK (discriminator ~ '^[a-z0-9][a-z0-9-]{6}[a-z0-9]$');
+
+ALTER TABLE resources
+    ADD CONSTRAINT resources_metadata_is_object
+    CHECK (jsonb_typeof(metadata) = 'object');
+
+ALTER TABLE resources
+    ADD CONSTRAINT resources_spec_is_object
+    CHECK (jsonb_typeof(spec) = 'object');
+
+ALTER TABLE resources
+    ADD CONSTRAINT resources_status_is_object
+    CHECK (jsonb_typeof(status) = 'object');
+
+-- Same-level name uniqueness
+CREATE UNIQUE INDEX resources_child_kind_name_unique
+    ON resources (parent_uid, kind, name)
+    WHERE parent_uid IS NOT NULL;
+
+CREATE UNIQUE INDEX resources_root_kind_name_unique
+    ON resources (kind, name)
+    WHERE parent_uid IS NULL;
+
+-- Same-level discriminator uniqueness
+CREATE UNIQUE INDEX resources_child_discriminator_unique
+    ON resources (parent_uid, discriminator)
+    WHERE parent_uid IS NOT NULL;
+
+CREATE UNIQUE INDEX resources_root_discriminator_unique
+    ON resources (discriminator)
+    WHERE parent_uid IS NULL;
+
+CREATE OR REPLACE FUNCTION resources_set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER resources_updated_at
+    BEFORE UPDATE ON resources
+    FOR EACH ROW EXECUTE FUNCTION resources_set_updated_at();

--- a/crates/rise-resource-store/migrations/20260519000002_create_resource_definitions.sql
+++ b/crates/rise-resource-store/migrations/20260519000002_create_resource_definitions.sql
@@ -1,0 +1,29 @@
+CREATE TABLE resource_definitions (
+    uid                          UUID        PRIMARY KEY REFERENCES resources(uid) ON DELETE RESTRICT,
+    group_name                   TEXT        NOT NULL,
+    kind                         TEXT        NOT NULL,
+    plural                       TEXT        NOT NULL,
+    scope                        JSONB       NOT NULL,
+    versions                     JSONB       NOT NULL,
+    allowed_status_controller_ids TEXT[]     NOT NULL DEFAULT '{}',
+    created_at                   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at                   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX resource_definitions_plural_unique
+    ON resource_definitions (plural);
+
+CREATE UNIQUE INDEX resource_definitions_group_kind_unique
+    ON resource_definitions (group_name, kind);
+
+CREATE OR REPLACE FUNCTION resource_definitions_set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER resource_definitions_updated_at
+    BEFORE UPDATE ON resource_definitions
+    FOR EACH ROW EXECUTE FUNCTION resource_definitions_set_updated_at();

--- a/crates/rise-resource-store/migrations/20260519000002_create_resource_definitions.sql
+++ b/crates/rise-resource-store/migrations/20260519000002_create_resource_definitions.sql
@@ -1,5 +1,5 @@
-CREATE TABLE resource_definitions (
-    uid                          UUID        PRIMARY KEY REFERENCES resources(uid) ON DELETE RESTRICT,
+CREATE TABLE resource_store.resource_definitions (
+    uid                          UUID        PRIMARY KEY REFERENCES resource_store.resources(uid) ON DELETE RESTRICT,
     group_name                   TEXT        NOT NULL,
     kind                         TEXT        NOT NULL,
     plural                       TEXT        NOT NULL,
@@ -11,12 +11,12 @@ CREATE TABLE resource_definitions (
 );
 
 CREATE UNIQUE INDEX resource_definitions_plural_unique
-    ON resource_definitions (plural);
+    ON resource_store.resource_definitions (plural);
 
 CREATE UNIQUE INDEX resource_definitions_group_kind_unique
-    ON resource_definitions (group_name, kind);
+    ON resource_store.resource_definitions (group_name, kind);
 
-CREATE OR REPLACE FUNCTION resource_definitions_set_updated_at()
+CREATE OR REPLACE FUNCTION resource_store.resource_definitions_set_updated_at()
 RETURNS TRIGGER AS $$
 BEGIN
     NEW.updated_at = NOW();
@@ -25,5 +25,5 @@ END;
 $$ LANGUAGE plpgsql;
 
 CREATE TRIGGER resource_definitions_updated_at
-    BEFORE UPDATE ON resource_definitions
-    FOR EACH ROW EXECUTE FUNCTION resource_definitions_set_updated_at();
+    BEFORE UPDATE ON resource_store.resource_definitions
+    FOR EACH ROW EXECUTE FUNCTION resource_store.resource_definitions_set_updated_at();

--- a/crates/rise-resource-store/migrations/20260519000003_pending_collection_index.sql
+++ b/crates/rise-resource-store/migrations/20260519000003_pending_collection_index.sql
@@ -1,0 +1,5 @@
+-- Backs `list_pending_collection` and the GC sweep that calls `try_collect` on
+-- tombstoned rows. Partial so the index stays small relative to total resource count.
+CREATE INDEX resources_pending_collection
+    ON resources (deletion_timestamp)
+    WHERE deletion_timestamp IS NOT NULL;

--- a/crates/rise-resource-store/migrations/20260519000003_pending_collection_index.sql
+++ b/crates/rise-resource-store/migrations/20260519000003_pending_collection_index.sql
@@ -1,5 +1,5 @@
 -- Backs `list_pending_collection` and the GC sweep that calls `try_collect` on
 -- tombstoned rows. Partial so the index stays small relative to total resource count.
 CREATE INDEX resources_pending_collection
-    ON resources (deletion_timestamp)
+    ON resource_store.resources (deletion_timestamp)
     WHERE deletion_timestamp IS NOT NULL;

--- a/crates/rise-resource-store/src/discriminator.rs
+++ b/crates/rise-resource-store/src/discriminator.rs
@@ -1,0 +1,10 @@
+use rand::RngExt;
+
+const CHARSET: &[u8] = b"abcdefghijklmnopqrstuvwxyz0123456789";
+
+pub fn generate() -> String {
+    let mut rng = rand::rng();
+    (0..8)
+        .map(|_| CHARSET[rng.random_range(0..CHARSET.len())] as char)
+        .collect()
+}

--- a/crates/rise-resource-store/src/error.rs
+++ b/crates/rise-resource-store/src/error.rs
@@ -1,0 +1,25 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum StoreError {
+    #[error("resource not found")]
+    NotFound,
+
+    #[error("revision conflict: expected {expected}, found {found}")]
+    RevisionConflict { expected: i64, found: i64 },
+
+    #[error("a resource with this name already exists in this scope")]
+    NameConflict,
+
+    #[error("could not generate a unique discriminator after maximum retries")]
+    DiscriminatorExhausted,
+
+    #[error("resource has child resources and cannot be deleted")]
+    HasChildren,
+
+    #[error("validation error: {0}")]
+    Validation(String),
+
+    #[error("database error: {0}")]
+    Database(#[from] sqlx::Error),
+}

--- a/crates/rise-resource-store/src/error.rs
+++ b/crates/rise-resource-store/src/error.rs
@@ -14,8 +14,20 @@ pub enum StoreError {
     #[error("could not generate a unique discriminator after maximum retries")]
     DiscriminatorExhausted,
 
-    #[error("resource has child resources and cannot be deleted")]
-    HasChildren,
+    #[error("path segment kind mismatch: expected '{expected}', got '{got}'")]
+    KindMismatch { expected: String, got: String },
+
+    #[error("intermediate path segment not found")]
+    ParentNotFound,
+
+    #[error("reparent would create a cycle")]
+    ReparentCycle,
+
+    #[error("reserved finalizer namespace: '{0}'")]
+    ReservedFinalizer(String),
+
+    #[error("path resolution requires at least one segment")]
+    EmptyPath,
 
     #[error("validation error: {0}")]
     Validation(String),

--- a/crates/rise-resource-store/src/lib.rs
+++ b/crates/rise-resource-store/src/lib.rs
@@ -18,12 +18,30 @@ pub use validation::{
     SpecValidator,
 };
 
+/// Run resource-store migrations in their own Postgres schema (`resource_store`),
+/// keeping both the application tables and the `_sqlx_migrations` tracking table
+/// isolated from the root rise-deploy crate, which owns its own migrations against
+/// the same database.
+///
+/// sqlx 0.8 hard-codes the unqualified `_sqlx_migrations` name, so we acquire a
+/// dedicated connection, ensure the schema exists, switch `search_path` so the
+/// migrator resolves `_sqlx_migrations` inside `resource_store`, run migrations,
+/// then reset `search_path` before the connection returns to the pool.
 pub async fn run_migrations(pool: &sqlx::PgPool) -> Result<(), sqlx::migrate::MigrateError> {
-    // Both this crate and the root rise-deploy crate share the same `_sqlx_migrations`
-    // table. Without ignore_missing, this migrator would error on root migrations it
-    // doesn't know about (and vice versa). Each migrator only manages its own set.
-    let mut migrator = sqlx::migrate!("./migrations");
-    migrator.set_ignore_missing(true);
-    migrator.run(pool).await?;
-    Ok(())
+    use sqlx::Executor;
+
+    let mut conn = pool.acquire().await?;
+
+    conn.execute("CREATE SCHEMA IF NOT EXISTS resource_store")
+        .await?;
+    conn.execute("SET search_path TO resource_store, public")
+        .await?;
+
+    let result = sqlx::migrate!("./migrations").run(&mut *conn).await;
+
+    // Reset before the connection returns to the pool so other consumers see the
+    // default search_path. Best-effort: if migrate failed we still try to reset.
+    let _ = conn.execute("RESET search_path").await;
+
+    result
 }

--- a/crates/rise-resource-store/src/lib.rs
+++ b/crates/rise-resource-store/src/lib.rs
@@ -10,7 +10,8 @@ pub use error::StoreError;
 pub use models::ResourceRow;
 pub use pg_store::PgResourceStore;
 pub use store::{
-    CollectionInfo, CreateResourceParams, DeleteOutcome, ResourceStore, UpdateResourceParams,
+    CollectionInfo, CreateResourceParams, DeleteOutcome, PathSegment, PropagationPolicy,
+    ResourceStore, UpdateResourceParams, CASCADE_DELETION_FINALIZER, SYSTEM_FINALIZER_PREFIX,
 };
 pub use validation::{
     JsonSchemaValidator, NoOpValidator, OrganizationValidator, ResourceDefinitionValidator,

--- a/crates/rise-resource-store/src/lib.rs
+++ b/crates/rise-resource-store/src/lib.rs
@@ -1,0 +1,22 @@
+pub mod error;
+pub mod models;
+pub mod pg_store;
+pub mod store;
+pub mod validation;
+
+mod discriminator;
+
+pub use error::StoreError;
+pub use models::ResourceRow;
+pub use pg_store::PgResourceStore;
+pub use store::{
+    CollectionInfo, CreateResourceParams, DeleteOutcome, ResourceStore, UpdateResourceParams,
+};
+pub use validation::{
+    JsonSchemaValidator, NoOpValidator, OrganizationValidator, ResourceDefinitionValidator,
+    SpecValidator,
+};
+
+pub async fn run_migrations(pool: &sqlx::PgPool) -> Result<(), sqlx::migrate::MigrateError> {
+    sqlx::migrate!("./migrations").run(pool).await
+}

--- a/crates/rise-resource-store/src/lib.rs
+++ b/crates/rise-resource-store/src/lib.rs
@@ -19,5 +19,11 @@ pub use validation::{
 };
 
 pub async fn run_migrations(pool: &sqlx::PgPool) -> Result<(), sqlx::migrate::MigrateError> {
-    sqlx::migrate!("./migrations").run(pool).await
+    // Both this crate and the root rise-deploy crate share the same `_sqlx_migrations`
+    // table. Without ignore_missing, this migrator would error on root migrations it
+    // doesn't know about (and vice versa). Each migrator only manages its own set.
+    let mut migrator = sqlx::migrate!("./migrations");
+    migrator.set_ignore_missing(true);
+    migrator.run(pool).await?;
+    Ok(())
 }

--- a/crates/rise-resource-store/src/models.rs
+++ b/crates/rise-resource-store/src/models.rs
@@ -1,0 +1,57 @@
+use chrono::{DateTime, Utc};
+use rise_resource_api::{Resource, ResourceMetadata};
+use serde::de::DeserializeOwned;
+use std::collections::BTreeMap;
+use uuid::Uuid;
+
+use crate::error::StoreError;
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct ResourceRow {
+    pub uid: Uuid,
+    pub api_version: String,
+    pub kind: String,
+    pub parent_uid: Option<Uuid>,
+    pub name: String,
+    pub discriminator: String,
+    pub metadata: serde_json::Value,
+    pub spec: serde_json::Value,
+    pub status: serde_json::Value,
+    pub revision: i64,
+    pub finalizers: Vec<String>,
+    pub deletion_timestamp: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl ResourceRow {
+    pub fn to_resource<TSpec, TStatus>(&self) -> Result<Resource<TSpec, TStatus>, StoreError>
+    where
+        TSpec: Default + DeserializeOwned,
+        TStatus: Default + DeserializeOwned,
+    {
+        let spec: TSpec = serde_json::from_value(self.spec.clone())
+            .map_err(|e| StoreError::Validation(format!("invalid spec: {e}")))?;
+        let status: TStatus = serde_json::from_value(self.status.clone())
+            .map_err(|e| StoreError::Validation(format!("invalid status: {e}")))?;
+
+        let annotations: BTreeMap<String, String> =
+            serde_json::from_value(self.metadata.clone()).unwrap_or_default();
+
+        Ok(Resource {
+            api_version: self.api_version.clone(),
+            kind: self.kind.clone(),
+            metadata: ResourceMetadata {
+                name: self.name.clone(),
+                uid: Some(self.uid),
+                revision: Some(self.revision),
+                discriminator: Some(self.discriminator.clone()),
+                annotations,
+                finalizers: self.finalizers.clone(),
+                deletion_timestamp: self.deletion_timestamp,
+            },
+            spec,
+            status,
+        })
+    }
+}

--- a/crates/rise-resource-store/src/pg_store.rs
+++ b/crates/rise-resource-store/src/pg_store.rs
@@ -13,7 +13,8 @@ use crate::discriminator;
 use crate::error::StoreError;
 use crate::models::ResourceRow;
 use crate::store::{
-    CollectionInfo, CreateResourceParams, DeleteOutcome, ResourceStore, UpdateResourceParams,
+    CollectionInfo, CreateResourceParams, DeleteOutcome, PathSegment, PropagationPolicy,
+    ResourceStore, UpdateResourceParams, CASCADE_DELETION_FINALIZER, SYSTEM_FINALIZER_PREFIX,
 };
 use crate::validation::{
     JsonSchemaValidator, NoOpValidator, OrganizationValidator, ResourceDefinitionValidator,
@@ -254,38 +255,99 @@ impl ResourceStore for PgResourceStore {
         })
     }
 
-    async fn delete(&self, uid: Uuid) -> Result<DeleteOutcome, StoreError> {
+    async fn delete(
+        &self,
+        uid: Uuid,
+        policy: PropagationPolicy,
+    ) -> Result<DeleteOutcome, StoreError> {
         let row = self.get(uid).await?.ok_or(StoreError::NotFound)?;
 
-        // Reject if children exist in the resources table
+        let mut tx = self.pool.begin().await?;
+
         let child_count: i64 =
             sqlx::query_scalar("SELECT COUNT(*) FROM resources WHERE parent_uid = $1")
                 .bind(uid)
-                .fetch_one(&self.pool)
+                .fetch_one(&mut *tx)
                 .await?;
-        if child_count > 0 {
-            return Err(StoreError::HasChildren);
+
+        match policy {
+            PropagationPolicy::Cascade => {
+                if child_count > 0 {
+                    // Stamp immediate children that aren't already marked. A future GC sweep
+                    // (try_collect) drives the fan-out down the remaining levels.
+                    sqlx::query(
+                        r#"
+                        UPDATE resources
+                        SET deletion_timestamp = NOW()
+                        WHERE parent_uid = $1 AND deletion_timestamp IS NULL
+                        "#,
+                    )
+                    .bind(uid)
+                    .execute(&mut *tx)
+                    .await?;
+
+                    // Stamp the parent and attach the cascade finalizer (idempotent).
+                    let marked = sqlx::query_as::<_, ResourceRow>(
+                        r#"
+                        UPDATE resources
+                        SET deletion_timestamp = COALESCE(deletion_timestamp, NOW()),
+                            finalizers = CASE
+                                WHEN $2 = ANY(finalizers) THEN finalizers
+                                ELSE array_append(finalizers, $2)
+                            END
+                        WHERE uid = $1
+                        RETURNING *
+                        "#,
+                    )
+                    .bind(uid)
+                    .bind(CASCADE_DELETION_FINALIZER)
+                    .fetch_one(&mut *tx)
+                    .await?;
+                    tx.commit().await?;
+                    return Ok(DeleteOutcome::MarkedForDeletion(Box::new(marked)));
+                }
+            }
+            PropagationPolicy::Orphan => {
+                if child_count > 0 {
+                    // Detach children. The partial unique index on (kind, name) WHERE
+                    // parent_uid IS NULL may reject this if a name collides at the root scope.
+                    let result = sqlx::query(
+                        r#"
+                        UPDATE resources
+                        SET parent_uid = NULL
+                        WHERE parent_uid = $1
+                        "#,
+                    )
+                    .bind(uid)
+                    .execute(&mut *tx)
+                    .await;
+                    if let Err(e) = result {
+                        if Self::is_name_conflict(&e) {
+                            return Err(StoreError::NameConflict);
+                        }
+                        return Err(StoreError::Database(e));
+                    }
+                }
+            }
         }
 
-        // Finalizers present → mark for deletion instead of deleting
+        // No (remaining) children. Mark if finalizers, else hard-delete.
         if !row.finalizers.is_empty() {
             let marked = sqlx::query_as::<_, ResourceRow>(
                 r#"
                 UPDATE resources
-                SET deletion_timestamp = NOW(), updated_at = NOW()
+                SET deletion_timestamp = COALESCE(deletion_timestamp, NOW())
                 WHERE uid = $1
                 RETURNING *
                 "#,
             )
             .bind(uid)
-            .fetch_one(&self.pool)
+            .fetch_one(&mut *tx)
             .await?;
+            tx.commit().await?;
             return Ok(DeleteOutcome::MarkedForDeletion(Box::new(marked)));
         }
 
-        // Hard delete in a transaction. Delete from the resource_definitions projection
-        // table first (ON DELETE RESTRICT prevents deleting the resources row otherwise).
-        let mut tx = self.pool.begin().await?;
         sqlx::query("DELETE FROM resource_definitions WHERE uid = $1")
             .bind(uid)
             .execute(&mut *tx)
@@ -297,6 +359,283 @@ impl ResourceStore for PgResourceStore {
         tx.commit().await?;
 
         Ok(DeleteOutcome::Deleted)
+    }
+
+    async fn try_collect(&self, uid: Uuid) -> Result<DeleteOutcome, StoreError> {
+        let mut tx = self.pool.begin().await?;
+
+        let row =
+            sqlx::query_as::<_, ResourceRow>("SELECT * FROM resources WHERE uid = $1 FOR UPDATE")
+                .bind(uid)
+                .fetch_optional(&mut *tx)
+                .await?
+                .ok_or(StoreError::NotFound)?;
+
+        // Not tombstoned: nothing to collect, return current state.
+        if row.deletion_timestamp.is_none() {
+            return Ok(DeleteOutcome::MarkedForDeletion(Box::new(row)));
+        }
+
+        let child_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM resources WHERE parent_uid = $1")
+                .bind(uid)
+                .fetch_one(&mut *tx)
+                .await?;
+
+        if child_count > 0 {
+            // Fan out: stamp any unmarked children. Ensure the cascade finalizer is present
+            // (in case the row was tombstoned by some other path that didn't add it).
+            sqlx::query(
+                r#"
+                UPDATE resources
+                SET deletion_timestamp = NOW()
+                WHERE parent_uid = $1 AND deletion_timestamp IS NULL
+                "#,
+            )
+            .bind(uid)
+            .execute(&mut *tx)
+            .await?;
+
+            let row = sqlx::query_as::<_, ResourceRow>(
+                r#"
+                UPDATE resources
+                SET finalizers = CASE
+                        WHEN $2 = ANY(finalizers) THEN finalizers
+                        ELSE array_append(finalizers, $2)
+                    END
+                WHERE uid = $1
+                RETURNING *
+                "#,
+            )
+            .bind(uid)
+            .bind(CASCADE_DELETION_FINALIZER)
+            .fetch_one(&mut *tx)
+            .await?;
+            tx.commit().await?;
+            return Ok(DeleteOutcome::MarkedForDeletion(Box::new(row)));
+        }
+
+        // No children. Drop the cascade finalizer if present.
+        let row = sqlx::query_as::<_, ResourceRow>(
+            r#"
+            UPDATE resources
+            SET finalizers = array_remove(finalizers, $2)
+            WHERE uid = $1
+            RETURNING *
+            "#,
+        )
+        .bind(uid)
+        .bind(CASCADE_DELETION_FINALIZER)
+        .fetch_one(&mut *tx)
+        .await?;
+
+        if !row.finalizers.is_empty() {
+            tx.commit().await?;
+            return Ok(DeleteOutcome::MarkedForDeletion(Box::new(row)));
+        }
+
+        // Clear: hard-delete.
+        sqlx::query("DELETE FROM resource_definitions WHERE uid = $1")
+            .bind(uid)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM resources WHERE uid = $1")
+            .bind(uid)
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
+
+        Ok(DeleteOutcome::Deleted)
+    }
+
+    async fn list_pending_collection(&self, limit: i64) -> Result<Vec<ResourceRow>, StoreError> {
+        let rows = sqlx::query_as::<_, ResourceRow>(
+            r#"
+            SELECT * FROM resources
+            WHERE deletion_timestamp IS NOT NULL
+            ORDER BY deletion_timestamp ASC
+            LIMIT $1
+            "#,
+        )
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    async fn resolve_path(&self, segments: &[PathSegment]) -> Result<Vec<ResourceRow>, StoreError> {
+        if segments.is_empty() {
+            return Err(StoreError::EmptyPath);
+        }
+
+        let mut tx = self.pool.begin().await?;
+        let mut chain: Vec<ResourceRow> = Vec::with_capacity(segments.len());
+        let mut current_parent: Option<Uuid> = None;
+
+        for (idx, segment) in segments.iter().enumerate() {
+            let row = match segment {
+                PathSegment::Name { kind, name } => {
+                    let row: Option<ResourceRow> = match current_parent {
+                        None => sqlx::query_as::<_, ResourceRow>(
+                            "SELECT * FROM resources WHERE kind = $1 AND name = $2 AND parent_uid IS NULL",
+                        )
+                        .bind(kind)
+                        .bind(name)
+                        .fetch_optional(&mut *tx)
+                        .await?,
+                        Some(pid) => sqlx::query_as::<_, ResourceRow>(
+                            "SELECT * FROM resources WHERE kind = $1 AND name = $2 AND parent_uid = $3",
+                        )
+                        .bind(kind)
+                        .bind(name)
+                        .bind(pid)
+                        .fetch_optional(&mut *tx)
+                        .await?,
+                    };
+                    match row {
+                        Some(r) => r,
+                        None if idx + 1 == segments.len() => return Err(StoreError::NotFound),
+                        None => return Err(StoreError::ParentNotFound),
+                    }
+                }
+                PathSegment::Uid { kind, uid } => {
+                    let row: ResourceRow = match sqlx::query_as::<_, ResourceRow>(
+                        "SELECT * FROM resources WHERE uid = $1",
+                    )
+                    .bind(uid)
+                    .fetch_optional(&mut *tx)
+                    .await?
+                    {
+                        Some(r) => r,
+                        None if idx + 1 == segments.len() => return Err(StoreError::NotFound),
+                        None => return Err(StoreError::ParentNotFound),
+                    };
+                    if row.kind != *kind {
+                        return Err(StoreError::KindMismatch {
+                            expected: kind.clone(),
+                            got: row.kind,
+                        });
+                    }
+                    if row.parent_uid != current_parent {
+                        // UID is from a different subtree.
+                        return Err(StoreError::ParentNotFound);
+                    }
+                    row
+                }
+            };
+
+            current_parent = Some(row.uid);
+            chain.push(row);
+        }
+
+        tx.commit().await?;
+        Ok(chain)
+    }
+
+    async fn list_orphans(&self, parent_uid: Option<Uuid>) -> Result<Vec<ResourceRow>, StoreError> {
+        let rows = match parent_uid {
+            None => {
+                sqlx::query_as::<_, ResourceRow>(
+                    r#"
+                SELECT c.*
+                FROM resources c
+                JOIN resources p ON c.parent_uid = p.uid
+                WHERE p.deletion_timestamp IS NOT NULL
+                ORDER BY c.kind, c.name
+                "#,
+                )
+                .fetch_all(&self.pool)
+                .await?
+            }
+            Some(pid) => {
+                sqlx::query_as::<_, ResourceRow>(
+                    r#"
+                SELECT c.*
+                FROM resources c
+                JOIN resources p ON c.parent_uid = p.uid
+                WHERE p.deletion_timestamp IS NOT NULL AND p.uid = $1
+                ORDER BY c.kind, c.name
+                "#,
+                )
+                .bind(pid)
+                .fetch_all(&self.pool)
+                .await?
+            }
+        };
+        Ok(rows)
+    }
+
+    async fn reparent(
+        &self,
+        uid: Uuid,
+        new_parent_uid: Option<Uuid>,
+    ) -> Result<ResourceRow, StoreError> {
+        let mut tx = self.pool.begin().await?;
+
+        // Lock the target row.
+        let target =
+            sqlx::query_as::<_, ResourceRow>("SELECT * FROM resources WHERE uid = $1 FOR UPDATE")
+                .bind(uid)
+                .fetch_optional(&mut *tx)
+                .await?
+                .ok_or(StoreError::NotFound)?;
+
+        if target.parent_uid == new_parent_uid {
+            tx.commit().await?;
+            return Ok(target);
+        }
+
+        if let Some(new_pid) = new_parent_uid {
+            if new_pid == uid {
+                return Err(StoreError::ReparentCycle);
+            }
+
+            // Verify the new parent exists and isn't an ancestor in our own subtree.
+            // Walk up from the new parent; if we hit `uid`, it would be a cycle.
+            let is_descendant: bool = sqlx::query_scalar(
+                r#"
+                WITH RECURSIVE ancestors AS (
+                    SELECT uid, parent_uid FROM resources WHERE uid = $1
+                    UNION ALL
+                    SELECT r.uid, r.parent_uid
+                    FROM resources r
+                    JOIN ancestors a ON r.uid = a.parent_uid
+                )
+                SELECT EXISTS (SELECT 1 FROM ancestors WHERE uid = $2)
+                "#,
+            )
+            .bind(new_pid)
+            .bind(uid)
+            .fetch_one(&mut *tx)
+            .await?;
+
+            if is_descendant {
+                return Err(StoreError::ReparentCycle);
+            }
+        }
+
+        let result = sqlx::query_as::<_, ResourceRow>(
+            r#"
+            UPDATE resources
+            SET parent_uid = $2
+            WHERE uid = $1
+            RETURNING *
+            "#,
+        )
+        .bind(uid)
+        .bind(new_parent_uid)
+        .fetch_one(&mut *tx)
+        .await;
+
+        let row = match result {
+            Ok(r) => r,
+            Err(e) if Self::is_name_conflict(&e) => return Err(StoreError::NameConflict),
+            Err(e) if Self::is_discriminator_conflict(&e) => return Err(StoreError::NameConflict),
+            Err(e) => return Err(StoreError::Database(e)),
+        };
+
+        tx.commit().await?;
+        Ok(row)
     }
 
     async fn update_controller_status(
@@ -340,8 +679,11 @@ impl ResourceStore for PgResourceStore {
     ) -> Result<ResourceRow, StoreError> {
         validate_controller_id(controller_id).map_err(|e| StoreError::Validation(e.to_string()))?;
 
-        // All modified finalizers must be prefixed by this controller's ID
+        // Store-managed finalizers (system.rise.dev/*) cannot be added or removed by controllers.
         for f in add.iter().chain(remove.iter()) {
+            if f.starts_with(SYSTEM_FINALIZER_PREFIX) {
+                return Err(StoreError::ReservedFinalizer(f.clone()));
+            }
             if !is_controller_finalizer(f, controller_id) {
                 return Err(StoreError::Validation(format!(
                     "finalizer '{f}' is not owned by controller '{controller_id}'"

--- a/crates/rise-resource-store/src/pg_store.rs
+++ b/crates/rise-resource-store/src/pg_store.rs
@@ -1,0 +1,534 @@
+use std::sync::Arc;
+use uuid::Uuid;
+
+use rise_resource_api::{
+    ResourceDefinitionSpec, ResourceScope, API_VERSION_V1ALPHA1, ORGANIZATION_COLLECTION,
+    ORGANIZATION_KIND, RESOURCE_DEFINITION_COLLECTION, RESOURCE_DEFINITION_KIND,
+};
+use sqlx::PgPool;
+
+use crate::discriminator;
+use crate::error::StoreError;
+use crate::models::ResourceRow;
+use crate::store::{
+    CollectionInfo, CreateResourceParams, DeleteOutcome, ResourceStore, UpdateResourceParams,
+};
+use crate::validation::{
+    JsonSchemaValidator, NoOpValidator, OrganizationValidator, ResourceDefinitionValidator,
+    SpecValidator,
+};
+
+pub struct PgResourceStore {
+    pool: PgPool,
+}
+
+impl PgResourceStore {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    async fn discriminator_exists(
+        &self,
+        parent_uid: Option<Uuid>,
+        disc: &str,
+    ) -> Result<bool, StoreError> {
+        let exists: bool = match parent_uid {
+            None => {
+                sqlx::query_scalar(
+                    "SELECT EXISTS(SELECT 1 FROM resources WHERE parent_uid IS NULL AND discriminator = $1)",
+                )
+                .bind(disc)
+                .fetch_one(&self.pool)
+                .await?
+            }
+            Some(pid) => {
+                sqlx::query_scalar(
+                    "SELECT EXISTS(SELECT 1 FROM resources WHERE parent_uid = $1 AND discriminator = $2)",
+                )
+                .bind(pid)
+                .bind(disc)
+                .fetch_one(&self.pool)
+                .await?
+            }
+        };
+        Ok(exists)
+    }
+
+    async fn generate_discriminator(&self, parent_uid: Option<Uuid>) -> Result<String, StoreError> {
+        for _ in 0..10 {
+            let disc = discriminator::generate();
+            if !self.discriminator_exists(parent_uid, &disc).await? {
+                return Ok(disc);
+            }
+        }
+        Err(StoreError::DiscriminatorExhausted)
+    }
+
+    fn is_name_conflict(err: &sqlx::Error) -> bool {
+        if let sqlx::Error::Database(db) = err {
+            let constraint = db.constraint().unwrap_or("");
+            return constraint == "resources_child_kind_name_unique"
+                || constraint == "resources_root_kind_name_unique";
+        }
+        false
+    }
+
+    fn builtin_collection_info(collection: &str) -> Option<CollectionInfo> {
+        match collection {
+            ORGANIZATION_COLLECTION => Some(CollectionInfo {
+                api_version: API_VERSION_V1ALPHA1.to_string(),
+                kind: ORGANIZATION_KIND.to_string(),
+                scope: ResourceScope::Root,
+                spec_validator: Arc::new(OrganizationValidator),
+                allowed_status_controller_ids: vec![],
+            }),
+            RESOURCE_DEFINITION_COLLECTION => Some(CollectionInfo {
+                api_version: API_VERSION_V1ALPHA1.to_string(),
+                kind: RESOURCE_DEFINITION_KIND.to_string(),
+                scope: ResourceScope::Root,
+                spec_validator: Arc::new(ResourceDefinitionValidator),
+                allowed_status_controller_ids: vec![],
+            }),
+            _ => None,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ResourceStore for PgResourceStore {
+    async fn create(&self, params: CreateResourceParams) -> Result<ResourceRow, StoreError> {
+        rise_resource_api::validate_resource_name(&params.name)
+            .map_err(|e| StoreError::Validation(e.to_string()))?;
+
+        if let Some(v) = &params.validator {
+            v.validate_spec(&params.spec)?;
+        }
+
+        let discriminator = self.generate_discriminator(params.parent_uid).await?;
+        let metadata = serde_json::to_value(&params.annotations).unwrap_or_default();
+
+        let row = sqlx::query_as::<_, ResourceRow>(
+            r#"
+            INSERT INTO resources
+                (api_version, kind, parent_uid, name, discriminator, metadata, spec, finalizers)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            RETURNING *
+            "#,
+        )
+        .bind(&params.api_version)
+        .bind(&params.kind)
+        .bind(params.parent_uid)
+        .bind(&params.name)
+        .bind(&discriminator)
+        .bind(metadata)
+        .bind(&params.spec)
+        .bind(&params.finalizers)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| {
+            if Self::is_name_conflict(&e) {
+                StoreError::NameConflict
+            } else {
+                StoreError::Database(e)
+            }
+        })?;
+
+        Ok(row)
+    }
+
+    async fn get(&self, uid: Uuid) -> Result<Option<ResourceRow>, StoreError> {
+        let row = sqlx::query_as::<_, ResourceRow>("SELECT * FROM resources WHERE uid = $1")
+            .bind(uid)
+            .fetch_optional(&self.pool)
+            .await?;
+        Ok(row)
+    }
+
+    async fn get_by_name(
+        &self,
+        kind: &str,
+        name: &str,
+        parent_uid: Option<Uuid>,
+    ) -> Result<Option<ResourceRow>, StoreError> {
+        let row =
+            match parent_uid {
+                None => sqlx::query_as::<_, ResourceRow>(
+                    "SELECT * FROM resources WHERE kind = $1 AND name = $2 AND parent_uid IS NULL",
+                )
+                .bind(kind)
+                .bind(name)
+                .fetch_optional(&self.pool)
+                .await?,
+                Some(pid) => {
+                    sqlx::query_as::<_, ResourceRow>(
+                        "SELECT * FROM resources WHERE kind = $1 AND name = $2 AND parent_uid = $3",
+                    )
+                    .bind(kind)
+                    .bind(name)
+                    .bind(pid)
+                    .fetch_optional(&self.pool)
+                    .await?
+                }
+            };
+        Ok(row)
+    }
+
+    async fn list(
+        &self,
+        kind: &str,
+        parent_uid: Option<Uuid>,
+    ) -> Result<Vec<ResourceRow>, StoreError> {
+        let rows =
+            match parent_uid {
+                None => sqlx::query_as::<_, ResourceRow>(
+                    "SELECT * FROM resources WHERE kind = $1 AND parent_uid IS NULL ORDER BY name",
+                )
+                .bind(kind)
+                .fetch_all(&self.pool)
+                .await?,
+                Some(pid) => {
+                    sqlx::query_as::<_, ResourceRow>(
+                        "SELECT * FROM resources WHERE kind = $1 AND parent_uid = $2 ORDER BY name",
+                    )
+                    .bind(kind)
+                    .bind(pid)
+                    .fetch_all(&self.pool)
+                    .await?
+                }
+            };
+        Ok(rows)
+    }
+
+    async fn update(
+        &self,
+        uid: Uuid,
+        params: UpdateResourceParams,
+    ) -> Result<ResourceRow, StoreError> {
+        let current = self.get(uid).await?.ok_or(StoreError::NotFound)?;
+
+        if current.revision != params.revision {
+            return Err(StoreError::RevisionConflict {
+                expected: params.revision,
+                found: current.revision,
+            });
+        }
+
+        if let Some(v) = &params.validator {
+            v.validate_spec(&params.spec)?;
+        }
+
+        let metadata = serde_json::to_value(&params.annotations).unwrap_or_default();
+
+        let row = sqlx::query_as::<_, ResourceRow>(
+            r#"
+            UPDATE resources
+            SET metadata   = $1,
+                spec       = $2,
+                finalizers = $3,
+                revision   = revision + 1,
+                updated_at = NOW()
+            WHERE uid = $4
+            RETURNING *
+            "#,
+        )
+        .bind(metadata)
+        .bind(&params.spec)
+        .bind(&params.finalizers)
+        .bind(uid)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    async fn delete(&self, uid: Uuid) -> Result<DeleteOutcome, StoreError> {
+        let row = self.get(uid).await?.ok_or(StoreError::NotFound)?;
+
+        // Reject if children exist in the resources table
+        let child_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM resources WHERE parent_uid = $1")
+                .bind(uid)
+                .fetch_one(&self.pool)
+                .await?;
+        if child_count > 0 {
+            return Err(StoreError::HasChildren);
+        }
+
+        // Finalizers present → mark for deletion instead of deleting
+        if !row.finalizers.is_empty() {
+            let marked = sqlx::query_as::<_, ResourceRow>(
+                r#"
+                UPDATE resources
+                SET deletion_timestamp = NOW(), updated_at = NOW()
+                WHERE uid = $1
+                RETURNING *
+                "#,
+            )
+            .bind(uid)
+            .fetch_one(&self.pool)
+            .await?;
+            return Ok(DeleteOutcome::MarkedForDeletion(Box::new(marked)));
+        }
+
+        sqlx::query("DELETE FROM resources WHERE uid = $1")
+            .bind(uid)
+            .execute(&self.pool)
+            .await?;
+
+        Ok(DeleteOutcome::Deleted)
+    }
+
+    async fn update_controller_status(
+        &self,
+        uid: Uuid,
+        controller_id: &str,
+        status_value: serde_json::Value,
+    ) -> Result<ResourceRow, StoreError> {
+        let row = sqlx::query_as::<_, ResourceRow>(
+            r#"
+            UPDATE resources
+            SET status = status || jsonb_build_object(
+                    'controllers',
+                    COALESCE(status->'controllers', '{}'::jsonb)
+                    || jsonb_build_object($2::text, $3::jsonb)
+                ),
+                revision   = revision + 1,
+                updated_at = NOW()
+            WHERE uid = $1
+            RETURNING *
+            "#,
+        )
+        .bind(uid)
+        .bind(controller_id)
+        .bind(status_value)
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or(StoreError::NotFound)?;
+
+        Ok(row)
+    }
+
+    async fn update_controller_finalizers(
+        &self,
+        uid: Uuid,
+        controller_id: &str,
+        add: &[String],
+        remove: &[String],
+    ) -> Result<ResourceRow, StoreError> {
+        // Validate ownership: all modified finalizers must be prefixed by controller_id
+        for f in add.iter().chain(remove.iter()) {
+            if !is_controller_finalizer(f, controller_id) {
+                return Err(StoreError::Validation(format!(
+                    "finalizer '{f}' is not owned by controller '{controller_id}'"
+                )));
+            }
+        }
+
+        let current = self.get(uid).await?.ok_or(StoreError::NotFound)?;
+
+        let remove_set: std::collections::HashSet<&str> =
+            remove.iter().map(String::as_str).collect();
+        let mut new_finalizers: Vec<String> = current
+            .finalizers
+            .into_iter()
+            .filter(|f| !remove_set.contains(f.as_str()))
+            .collect();
+        for f in add {
+            if !new_finalizers.contains(f) {
+                new_finalizers.push(f.clone());
+            }
+        }
+
+        let row = sqlx::query_as::<_, ResourceRow>(
+            r#"
+            UPDATE resources
+            SET finalizers = $1, revision = revision + 1, updated_at = NOW()
+            WHERE uid = $2
+            RETURNING *
+            "#,
+        )
+        .bind(&new_finalizers)
+        .bind(uid)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    async fn resolve_collection(
+        &self,
+        collection: &str,
+    ) -> Result<Option<CollectionInfo>, StoreError> {
+        // Built-ins take priority
+        if let Some(info) = Self::builtin_collection_info(collection) {
+            return Ok(Some(info));
+        }
+
+        // Look up external ResourceDefinitions
+        let row = sqlx::query(
+            r#"
+            SELECT rd.uid, rd.group_name, rd.kind, rd.scope, rd.versions,
+                   rd.allowed_status_controller_ids
+            FROM resource_definitions rd
+            WHERE rd.plural = $1
+            "#,
+        )
+        .bind(collection)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        let Some(row) = row else {
+            return Ok(None);
+        };
+
+        let scope: ResourceScope = serde_json::from_value(
+            row.try_get("scope").map_err(StoreError::Database)?,
+        )
+        .map_err(|e| StoreError::Validation(format!("invalid scope in ResourceDefinition: {e}")))?;
+
+        let versions: Vec<rise_resource_api::ResourceDefinitionVersion> =
+            serde_json::from_value(row.try_get("versions").map_err(StoreError::Database)?)
+                .map_err(|e| {
+                    StoreError::Validation(format!("invalid versions in ResourceDefinition: {e}"))
+                })?;
+
+        let allowed: Vec<String> = row
+            .try_get("allowed_status_controller_ids")
+            .map_err(StoreError::Database)?;
+
+        let group_name: String = row.try_get("group_name").map_err(StoreError::Database)?;
+        let kind: String = row.try_get("kind").map_err(StoreError::Database)?;
+
+        let storage_version = versions
+            .iter()
+            .find(|v| v.storage)
+            .map(|v| v.name.clone())
+            .unwrap_or_else(|| "v1".to_string());
+
+        let api_version = format!("{}/{}", group_name, storage_version);
+
+        // Build a JSON schema validator from the storage version's schema (if present)
+        let schema_validator: Arc<dyn SpecValidator> = versions
+            .iter()
+            .find(|v| v.storage)
+            .and_then(|v| v.schema.clone())
+            .map(|s| Arc::new(JsonSchemaValidator::new(s)) as Arc<dyn SpecValidator>)
+            .unwrap_or_else(|| Arc::new(NoOpValidator));
+
+        Ok(Some(CollectionInfo {
+            api_version,
+            kind,
+            scope,
+            spec_validator: schema_validator,
+            allowed_status_controller_ids: allowed,
+        }))
+    }
+
+    async fn register_resource_definition(
+        &self,
+        params: CreateResourceParams,
+    ) -> Result<ResourceRow, StoreError> {
+        // Validate the spec first (checks reserved names, format, etc.)
+        let validator = Arc::new(ResourceDefinitionValidator);
+        validator.validate_spec(&params.spec)?;
+
+        let spec: ResourceDefinitionSpec = serde_json::from_value(params.spec.clone())
+            .map_err(|e| StoreError::Validation(format!("invalid ResourceDefinition spec: {e}")))?;
+
+        let mut tx = self.pool.begin().await?;
+
+        // Insert the base resource row
+        let discriminator = self.generate_discriminator(params.parent_uid).await?;
+        let metadata = serde_json::to_value(&params.annotations).unwrap_or_default();
+
+        let resource_row = sqlx::query_as::<_, ResourceRow>(
+            r#"
+            INSERT INTO resources
+                (api_version, kind, parent_uid, name, discriminator, metadata, spec, finalizers)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            RETURNING *
+            "#,
+        )
+        .bind(&params.api_version)
+        .bind(&params.kind)
+        .bind(params.parent_uid)
+        .bind(&params.name)
+        .bind(&discriminator)
+        .bind(metadata)
+        .bind(&params.spec)
+        .bind(&params.finalizers)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(|e| {
+            if Self::is_name_conflict(&e) {
+                StoreError::NameConflict
+            } else {
+                StoreError::Database(e)
+            }
+        })?;
+
+        // Insert into the resource_definitions projection table
+        let scope_val = serde_json::to_value(&spec.scope).unwrap_or_default();
+        let versions_val = serde_json::to_value(&spec.versions).unwrap_or_default();
+
+        sqlx::query(
+            r#"
+            INSERT INTO resource_definitions
+                (uid, group_name, kind, plural, scope, versions, allowed_status_controller_ids)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            "#,
+        )
+        .bind(resource_row.uid)
+        .bind(&spec.group)
+        .bind(&spec.kind)
+        .bind(&spec.plural)
+        .bind(scope_val)
+        .bind(versions_val)
+        .bind(&spec.allowed_status_controller_ids)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| {
+            if let sqlx::Error::Database(ref db) = e {
+                let constraint = db.constraint().unwrap_or("");
+                if constraint == "resource_definitions_plural_unique" {
+                    return StoreError::Validation(format!(
+                        "a ResourceDefinition with plural '{}' already exists",
+                        spec.plural
+                    ));
+                }
+                if constraint == "resource_definitions_group_kind_unique" {
+                    return StoreError::Validation(format!(
+                        "a ResourceDefinition for group '{}' kind '{}' already exists",
+                        spec.group, spec.kind
+                    ));
+                }
+            }
+            StoreError::Database(e)
+        })?;
+
+        tx.commit().await?;
+
+        Ok(resource_row)
+    }
+}
+
+fn is_controller_finalizer(finalizer: &str, controller_id: &str) -> bool {
+    finalizer == controller_id || finalizer.starts_with(&format!("{controller_id}/"))
+}
+
+// Helpers to extract typed values from a sqlx::postgres::PgRow
+trait PgRowExt {
+    fn try_get<'r, T: sqlx::Decode<'r, sqlx::Postgres> + sqlx::Type<sqlx::Postgres>>(
+        &'r self,
+        column: &str,
+    ) -> Result<T, sqlx::Error>;
+}
+
+impl PgRowExt for sqlx::postgres::PgRow {
+    fn try_get<'r, T: sqlx::Decode<'r, sqlx::Postgres> + sqlx::Type<sqlx::Postgres>>(
+        &'r self,
+        column: &str,
+    ) -> Result<T, sqlx::Error> {
+        sqlx::Row::try_get(self, column)
+    }
+}

--- a/crates/rise-resource-store/src/pg_store.rs
+++ b/crates/rise-resource-store/src/pg_store.rs
@@ -85,7 +85,7 @@ impl PgResourceStore {
             let discriminator = discriminator::generate();
             let result = sqlx::query_as::<_, ResourceRow>(
                 r#"
-                INSERT INTO resources
+                INSERT INTO resource_store.resources
                     (api_version, kind, parent_uid, name, discriminator, metadata, spec, finalizers)
                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
                 RETURNING *
@@ -130,10 +130,12 @@ impl ResourceStore for PgResourceStore {
     }
 
     async fn get(&self, uid: Uuid) -> Result<Option<ResourceRow>, StoreError> {
-        let row = sqlx::query_as::<_, ResourceRow>("SELECT * FROM resources WHERE uid = $1")
-            .bind(uid)
-            .fetch_optional(&self.pool)
-            .await?;
+        let row = sqlx::query_as::<_, ResourceRow>(
+            "SELECT * FROM resource_store.resources WHERE uid = $1",
+        )
+        .bind(uid)
+        .fetch_optional(&self.pool)
+        .await?;
         Ok(row)
     }
 
@@ -146,7 +148,7 @@ impl ResourceStore for PgResourceStore {
         let row =
             match parent_uid {
                 None => sqlx::query_as::<_, ResourceRow>(
-                    "SELECT * FROM resources WHERE kind = $1 AND name = $2 AND parent_uid IS NULL",
+                    "SELECT * FROM resource_store.resources WHERE kind = $1 AND name = $2 AND parent_uid IS NULL",
                 )
                 .bind(kind)
                 .bind(name)
@@ -154,7 +156,7 @@ impl ResourceStore for PgResourceStore {
                 .await?,
                 Some(pid) => {
                     sqlx::query_as::<_, ResourceRow>(
-                        "SELECT * FROM resources WHERE kind = $1 AND name = $2 AND parent_uid = $3",
+                        "SELECT * FROM resource_store.resources WHERE kind = $1 AND name = $2 AND parent_uid = $3",
                     )
                     .bind(kind)
                     .bind(name)
@@ -174,14 +176,14 @@ impl ResourceStore for PgResourceStore {
         let rows =
             match parent_uid {
                 None => sqlx::query_as::<_, ResourceRow>(
-                    "SELECT * FROM resources WHERE kind = $1 AND parent_uid IS NULL ORDER BY name",
+                    "SELECT * FROM resource_store.resources WHERE kind = $1 AND parent_uid IS NULL ORDER BY name",
                 )
                 .bind(kind)
                 .fetch_all(&self.pool)
                 .await?,
                 Some(pid) => {
                     sqlx::query_as::<_, ResourceRow>(
-                        "SELECT * FROM resources WHERE kind = $1 AND parent_uid = $2 ORDER BY name",
+                        "SELECT * FROM resource_store.resources WHERE kind = $1 AND parent_uid = $2 ORDER BY name",
                     )
                     .bind(kind)
                     .bind(pid)
@@ -199,10 +201,11 @@ impl ResourceStore for PgResourceStore {
     ) -> Result<ResourceRow, StoreError> {
         // ResourceDefinitions must go through update_resource_definition to keep the
         // resource_definitions projection table in sync.
-        let kind: Option<String> = sqlx::query_scalar("SELECT kind FROM resources WHERE uid = $1")
-            .bind(uid)
-            .fetch_optional(&self.pool)
-            .await?;
+        let kind: Option<String> =
+            sqlx::query_scalar("SELECT kind FROM resource_store.resources WHERE uid = $1")
+                .bind(uid)
+                .fetch_optional(&self.pool)
+                .await?;
         match kind.as_deref() {
             None => return Err(StoreError::NotFound),
             Some(RESOURCE_DEFINITION_KIND) => {
@@ -225,7 +228,7 @@ impl ResourceStore for PgResourceStore {
         // to be affected, which we detect and map to RevisionConflict.
         let updated = sqlx::query_as::<_, ResourceRow>(
             r#"
-            UPDATE resources
+            UPDATE resource_store.resources
             SET metadata   = $1,
                 spec       = $2,
                 finalizers = $3,
@@ -264,18 +267,20 @@ impl ResourceStore for PgResourceStore {
 
         // Lock the row inside the transaction so a concurrent update_controller_finalizers()
         // can't add a finalizer between our read and the hard-delete branch below.
-        let row =
-            sqlx::query_as::<_, ResourceRow>("SELECT * FROM resources WHERE uid = $1 FOR UPDATE")
-                .bind(uid)
-                .fetch_optional(&mut *tx)
-                .await?
-                .ok_or(StoreError::NotFound)?;
+        let row = sqlx::query_as::<_, ResourceRow>(
+            "SELECT * FROM resource_store.resources WHERE uid = $1 FOR UPDATE",
+        )
+        .bind(uid)
+        .fetch_optional(&mut *tx)
+        .await?
+        .ok_or(StoreError::NotFound)?;
 
-        let child_count: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM resources WHERE parent_uid = $1")
-                .bind(uid)
-                .fetch_one(&mut *tx)
-                .await?;
+        let child_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM resource_store.resources WHERE parent_uid = $1",
+        )
+        .bind(uid)
+        .fetch_one(&mut *tx)
+        .await?;
 
         match policy {
             PropagationPolicy::Cascade => {
@@ -285,7 +290,7 @@ impl ResourceStore for PgResourceStore {
                     // revision on each affected child so concurrent updates see the change.
                     sqlx::query(
                         r#"
-                        UPDATE resources
+                        UPDATE resource_store.resources
                         SET deletion_timestamp = NOW(),
                             revision = revision + 1
                         WHERE parent_uid = $1 AND deletion_timestamp IS NULL
@@ -298,7 +303,7 @@ impl ResourceStore for PgResourceStore {
                     // Stamp the parent and attach the cascade finalizer (idempotent).
                     let marked = sqlx::query_as::<_, ResourceRow>(
                         r#"
-                        UPDATE resources
+                        UPDATE resource_store.resources
                         SET deletion_timestamp = COALESCE(deletion_timestamp, NOW()),
                             finalizers = CASE
                                 WHEN $2 = ANY(finalizers) THEN finalizers
@@ -324,7 +329,7 @@ impl ResourceStore for PgResourceStore {
                     // Bump revision so the detach is observable.
                     let result = sqlx::query(
                         r#"
-                        UPDATE resources
+                        UPDATE resource_store.resources
                         SET parent_uid = NULL,
                             revision = revision + 1
                         WHERE parent_uid = $1
@@ -351,7 +356,7 @@ impl ResourceStore for PgResourceStore {
         if !row.finalizers.is_empty() {
             let marked = sqlx::query_as::<_, ResourceRow>(
                 r#"
-                UPDATE resources
+                UPDATE resource_store.resources
                 SET deletion_timestamp = COALESCE(deletion_timestamp, NOW()),
                     revision = revision + 1
                 WHERE uid = $1
@@ -365,11 +370,11 @@ impl ResourceStore for PgResourceStore {
             return Ok(DeleteOutcome::MarkedForDeletion(Box::new(marked)));
         }
 
-        sqlx::query("DELETE FROM resource_definitions WHERE uid = $1")
+        sqlx::query("DELETE FROM resource_store.resource_definitions WHERE uid = $1")
             .bind(uid)
             .execute(&mut *tx)
             .await?;
-        sqlx::query("DELETE FROM resources WHERE uid = $1")
+        sqlx::query("DELETE FROM resource_store.resources WHERE uid = $1")
             .bind(uid)
             .execute(&mut *tx)
             .await?;
@@ -381,23 +386,25 @@ impl ResourceStore for PgResourceStore {
     async fn try_collect(&self, uid: Uuid) -> Result<DeleteOutcome, StoreError> {
         let mut tx = self.pool.begin().await?;
 
-        let row =
-            sqlx::query_as::<_, ResourceRow>("SELECT * FROM resources WHERE uid = $1 FOR UPDATE")
-                .bind(uid)
-                .fetch_optional(&mut *tx)
-                .await?
-                .ok_or(StoreError::NotFound)?;
+        let row = sqlx::query_as::<_, ResourceRow>(
+            "SELECT * FROM resource_store.resources WHERE uid = $1 FOR UPDATE",
+        )
+        .bind(uid)
+        .fetch_optional(&mut *tx)
+        .await?
+        .ok_or(StoreError::NotFound)?;
 
         // Not tombstoned: nothing to collect, return current state.
         if row.deletion_timestamp.is_none() {
             return Ok(DeleteOutcome::MarkedForDeletion(Box::new(row)));
         }
 
-        let child_count: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM resources WHERE parent_uid = $1")
-                .bind(uid)
-                .fetch_one(&mut *tx)
-                .await?;
+        let child_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM resource_store.resources WHERE parent_uid = $1",
+        )
+        .bind(uid)
+        .fetch_one(&mut *tx)
+        .await?;
 
         if child_count > 0 {
             // Fan out: stamp any unmarked children. Ensure the cascade finalizer is present
@@ -405,7 +412,7 @@ impl ResourceStore for PgResourceStore {
             // revision on every row we mutate so observers see the change.
             sqlx::query(
                 r#"
-                UPDATE resources
+                UPDATE resource_store.resources
                 SET deletion_timestamp = NOW(),
                     revision = revision + 1
                 WHERE parent_uid = $1 AND deletion_timestamp IS NULL
@@ -417,7 +424,7 @@ impl ResourceStore for PgResourceStore {
 
             let row = sqlx::query_as::<_, ResourceRow>(
                 r#"
-                UPDATE resources
+                UPDATE resource_store.resources
                 SET finalizers = CASE
                         WHEN $2 = ANY(finalizers) THEN finalizers
                         ELSE array_append(finalizers, $2)
@@ -442,7 +449,7 @@ impl ResourceStore for PgResourceStore {
         // finalizer was actually removed so idempotent re-calls don't churn the version.
         let row = sqlx::query_as::<_, ResourceRow>(
             r#"
-            UPDATE resources
+            UPDATE resource_store.resources
             SET finalizers = array_remove(finalizers, $2),
                 revision = CASE
                     WHEN $2 = ANY(finalizers) THEN revision + 1
@@ -463,11 +470,11 @@ impl ResourceStore for PgResourceStore {
         }
 
         // Clear: hard-delete.
-        sqlx::query("DELETE FROM resource_definitions WHERE uid = $1")
+        sqlx::query("DELETE FROM resource_store.resource_definitions WHERE uid = $1")
             .bind(uid)
             .execute(&mut *tx)
             .await?;
-        sqlx::query("DELETE FROM resources WHERE uid = $1")
+        sqlx::query("DELETE FROM resource_store.resources WHERE uid = $1")
             .bind(uid)
             .execute(&mut *tx)
             .await?;
@@ -479,7 +486,7 @@ impl ResourceStore for PgResourceStore {
     async fn list_pending_collection(&self, limit: i64) -> Result<Vec<ResourceRow>, StoreError> {
         let rows = sqlx::query_as::<_, ResourceRow>(
             r#"
-            SELECT * FROM resources
+            SELECT * FROM resource_store.resources
             WHERE deletion_timestamp IS NOT NULL
             ORDER BY deletion_timestamp ASC
             LIMIT $1
@@ -505,14 +512,14 @@ impl ResourceStore for PgResourceStore {
                 PathSegment::Name { kind, name } => {
                     let row: Option<ResourceRow> = match current_parent {
                         None => sqlx::query_as::<_, ResourceRow>(
-                            "SELECT * FROM resources WHERE kind = $1 AND name = $2 AND parent_uid IS NULL",
+                            "SELECT * FROM resource_store.resources WHERE kind = $1 AND name = $2 AND parent_uid IS NULL",
                         )
                         .bind(kind)
                         .bind(name)
                         .fetch_optional(&mut *tx)
                         .await?,
                         Some(pid) => sqlx::query_as::<_, ResourceRow>(
-                            "SELECT * FROM resources WHERE kind = $1 AND name = $2 AND parent_uid = $3",
+                            "SELECT * FROM resource_store.resources WHERE kind = $1 AND name = $2 AND parent_uid = $3",
                         )
                         .bind(kind)
                         .bind(name)
@@ -528,7 +535,7 @@ impl ResourceStore for PgResourceStore {
                 }
                 PathSegment::Uid { kind, uid } => {
                     let row: ResourceRow = match sqlx::query_as::<_, ResourceRow>(
-                        "SELECT * FROM resources WHERE uid = $1",
+                        "SELECT * FROM resource_store.resources WHERE uid = $1",
                     )
                     .bind(uid)
                     .fetch_optional(&mut *tx)
@@ -566,8 +573,8 @@ impl ResourceStore for PgResourceStore {
                 sqlx::query_as::<_, ResourceRow>(
                     r#"
                 SELECT c.*
-                FROM resources c
-                JOIN resources p ON c.parent_uid = p.uid
+                FROM resource_store.resources c
+                JOIN resource_store.resources p ON c.parent_uid = p.uid
                 WHERE p.deletion_timestamp IS NOT NULL
                 ORDER BY c.kind, c.name
                 "#,
@@ -579,8 +586,8 @@ impl ResourceStore for PgResourceStore {
                 sqlx::query_as::<_, ResourceRow>(
                     r#"
                 SELECT c.*
-                FROM resources c
-                JOIN resources p ON c.parent_uid = p.uid
+                FROM resource_store.resources c
+                JOIN resource_store.resources p ON c.parent_uid = p.uid
                 WHERE p.deletion_timestamp IS NOT NULL AND p.uid = $1
                 ORDER BY c.kind, c.name
                 "#,
@@ -601,12 +608,13 @@ impl ResourceStore for PgResourceStore {
         let mut tx = self.pool.begin().await?;
 
         // Lock the target row.
-        let target =
-            sqlx::query_as::<_, ResourceRow>("SELECT * FROM resources WHERE uid = $1 FOR UPDATE")
-                .bind(uid)
-                .fetch_optional(&mut *tx)
-                .await?
-                .ok_or(StoreError::NotFound)?;
+        let target = sqlx::query_as::<_, ResourceRow>(
+            "SELECT * FROM resource_store.resources WHERE uid = $1 FOR UPDATE",
+        )
+        .bind(uid)
+        .fetch_optional(&mut *tx)
+        .await?
+        .ok_or(StoreError::NotFound)?;
 
         if target.parent_uid == new_parent_uid {
             tx.commit().await?;
@@ -623,10 +631,10 @@ impl ResourceStore for PgResourceStore {
             let is_descendant: bool = sqlx::query_scalar(
                 r#"
                 WITH RECURSIVE ancestors AS (
-                    SELECT uid, parent_uid FROM resources WHERE uid = $1
+                    SELECT uid, parent_uid FROM resource_store.resources WHERE uid = $1
                     UNION ALL
                     SELECT r.uid, r.parent_uid
-                    FROM resources r
+                    FROM resource_store.resources r
                     JOIN ancestors a ON r.uid = a.parent_uid
                 )
                 SELECT EXISTS (SELECT 1 FROM ancestors WHERE uid = $2)
@@ -644,7 +652,7 @@ impl ResourceStore for PgResourceStore {
 
         let result = sqlx::query_as::<_, ResourceRow>(
             r#"
-            UPDATE resources
+            UPDATE resource_store.resources
             SET parent_uid = $2,
                 revision = revision + 1
             WHERE uid = $1
@@ -677,7 +685,7 @@ impl ResourceStore for PgResourceStore {
 
         let row = sqlx::query_as::<_, ResourceRow>(
             r#"
-            UPDATE resources
+            UPDATE resource_store.resources
             SET status = status || jsonb_build_object(
                     'controllers',
                     COALESCE(status->'controllers', '{}'::jsonb)
@@ -724,12 +732,13 @@ impl ResourceStore for PgResourceStore {
         // mutations from different controllers on the same resource, preventing lost updates.
         let mut tx = self.pool.begin().await?;
 
-        let current =
-            sqlx::query_as::<_, ResourceRow>("SELECT * FROM resources WHERE uid = $1 FOR UPDATE")
-                .bind(uid)
-                .fetch_optional(&mut *tx)
-                .await?
-                .ok_or(StoreError::NotFound)?;
+        let current = sqlx::query_as::<_, ResourceRow>(
+            "SELECT * FROM resource_store.resources WHERE uid = $1 FOR UPDATE",
+        )
+        .bind(uid)
+        .fetch_optional(&mut *tx)
+        .await?
+        .ok_or(StoreError::NotFound)?;
 
         let remove_set: std::collections::HashSet<&str> =
             remove.iter().map(String::as_str).collect();
@@ -746,7 +755,7 @@ impl ResourceStore for PgResourceStore {
 
         let row = sqlx::query_as::<_, ResourceRow>(
             r#"
-            UPDATE resources
+            UPDATE resource_store.resources
             SET finalizers = $1, revision = revision + 1, updated_at = NOW()
             WHERE uid = $2
             RETURNING *
@@ -782,7 +791,7 @@ impl ResourceStore for PgResourceStore {
             r#"
             SELECT rd.uid, rd.group_name, rd.kind, rd.scope, rd.versions,
                    rd.allowed_status_controller_ids
-            FROM resource_definitions rd
+            FROM resource_store.resource_definitions rd
             WHERE rd.plural = $1
             "#,
         )
@@ -900,7 +909,7 @@ impl ResourceStore for PgResourceStore {
 
         sqlx::query(
             r#"
-            INSERT INTO resource_definitions
+            INSERT INTO resource_store.resource_definitions
                 (uid, group_name, kind, plural, scope, versions, allowed_status_controller_ids)
             VALUES ($1, $2, $3, $4, $5, $6, $7)
             "#,
@@ -968,12 +977,13 @@ impl ResourceStore for PgResourceStore {
         let mut tx = self.pool.begin().await?;
 
         // Lock the row and fetch current state
-        let current =
-            sqlx::query_as::<_, ResourceRow>("SELECT * FROM resources WHERE uid = $1 FOR UPDATE")
-                .bind(uid)
-                .fetch_optional(&mut *tx)
-                .await?
-                .ok_or(StoreError::NotFound)?;
+        let current = sqlx::query_as::<_, ResourceRow>(
+            "SELECT * FROM resource_store.resources WHERE uid = $1 FOR UPDATE",
+        )
+        .bind(uid)
+        .fetch_optional(&mut *tx)
+        .await?
+        .ok_or(StoreError::NotFound)?;
 
         if current.kind != RESOURCE_DEFINITION_KIND {
             return Err(StoreError::Validation(
@@ -1003,7 +1013,7 @@ impl ResourceStore for PgResourceStore {
         // Update the resources row with optimistic concurrency
         let updated = sqlx::query_as::<_, ResourceRow>(
             r#"
-            UPDATE resources
+            UPDATE resource_store.resources
             SET metadata   = $1,
                 spec       = $2,
                 finalizers = $3,
@@ -1035,7 +1045,7 @@ impl ResourceStore for PgResourceStore {
         let versions_val = serde_json::to_value(&new_spec.versions).unwrap_or_default();
         sqlx::query(
             r#"
-            UPDATE resource_definitions
+            UPDATE resource_store.resource_definitions
             SET versions = $1, allowed_status_controller_ids = $2
             WHERE uid = $3
             "#,

--- a/crates/rise-resource-store/src/pg_store.rs
+++ b/crates/rise-resource-store/src/pg_store.rs
@@ -334,7 +334,11 @@ impl ResourceStore for PgResourceStore {
                     .execute(&mut *tx)
                     .await;
                     if let Err(e) = result {
-                        if Self::is_name_conflict(&e) {
+                        // A child's name or discriminator may collide at the root scope
+                        // (partial unique indexes on (kind, name) and discriminator when
+                        // parent_uid IS NULL). Surface both as NameConflict for parity
+                        // with reparent() rather than leaking an internal Database error.
+                        if Self::is_name_conflict(&e) || Self::is_discriminator_conflict(&e) {
                             return Err(StoreError::NameConflict);
                         }
                         return Err(StoreError::Database(e));

--- a/crates/rise-resource-store/src/pg_store.rs
+++ b/crates/rise-resource-store/src/pg_store.rs
@@ -1,12 +1,13 @@
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
 use uuid::Uuid;
 
 use rise_resource_api::{
-    validate_controller_id, ResourceDefinitionSpec, ResourceScope, API_VERSION_V1ALPHA1,
-    ORGANIZATION_COLLECTION, ORGANIZATION_KIND, RESOURCE_DEFINITION_COLLECTION,
-    RESOURCE_DEFINITION_KIND,
+    validate_controller_id, validate_resource_name, ResourceDefinitionSpec, ResourceScope,
+    API_VERSION_V1ALPHA1, ORGANIZATION_COLLECTION, ORGANIZATION_KIND,
+    RESOURCE_DEFINITION_COLLECTION, RESOURCE_DEFINITION_KIND,
 };
-use sqlx::PgPool;
+use sqlx::{PgPool, Row};
 
 use crate::discriminator;
 use crate::error::StoreError;
@@ -21,11 +22,17 @@ use crate::validation::{
 
 pub struct PgResourceStore {
     pool: PgPool,
+    /// Cache of compiled JSON schema validators keyed by collection plural name.
+    /// Populated on first resolve_collection call; invalidated on register/update.
+    schema_cache: RwLock<HashMap<String, Arc<dyn SpecValidator>>>,
 }
 
 impl PgResourceStore {
     pub fn new(pool: PgPool) -> Self {
-        Self { pool }
+        Self {
+            pool,
+            schema_cache: RwLock::new(HashMap::new()),
+        }
     }
 
     fn is_name_conflict(err: &sqlx::Error) -> bool {
@@ -65,23 +72,14 @@ impl PgResourceStore {
             _ => None,
         }
     }
-}
 
-#[async_trait::async_trait]
-impl ResourceStore for PgResourceStore {
-    async fn create(&self, params: CreateResourceParams) -> Result<ResourceRow, StoreError> {
-        rise_resource_api::validate_resource_name(&params.name)
-            .map_err(|e| StoreError::Validation(e.to_string()))?;
-
-        if let Some(v) = &params.validator {
-            v.validate_spec(&params.spec)?;
-        }
-
-        let metadata = serde_json::to_value(&params.annotations).unwrap_or_default();
-
-        // Retry the INSERT up to 10 times, generating a new discriminator on each
-        // discriminator collision. This handles concurrent creators racing to the same
-        // randomly generated discriminator without a pre-check TOCTOU window.
+    /// Retry an INSERT into `resources` up to 10 times, generating a fresh discriminator on each
+    /// discriminator collision. Returns the inserted row or a `StoreError`.
+    async fn insert_resource_row_with_retry(
+        conn: &mut sqlx::PgConnection,
+        params: &CreateResourceParams,
+        metadata: serde_json::Value,
+    ) -> Result<ResourceRow, StoreError> {
         for _ in 0..10 {
             let discriminator = discriminator::generate();
             let result = sqlx::query_as::<_, ResourceRow>(
@@ -100,7 +98,7 @@ impl ResourceStore for PgResourceStore {
             .bind(metadata.clone())
             .bind(&params.spec)
             .bind(&params.finalizers)
-            .fetch_one(&self.pool)
+            .fetch_one(&mut *conn)
             .await;
 
             match result {
@@ -112,6 +110,22 @@ impl ResourceStore for PgResourceStore {
         }
 
         Err(StoreError::DiscriminatorExhausted)
+    }
+}
+
+#[async_trait::async_trait]
+impl ResourceStore for PgResourceStore {
+    async fn create(&self, params: CreateResourceParams) -> Result<ResourceRow, StoreError> {
+        validate_resource_name(&params.name).map_err(|e| StoreError::Validation(e.to_string()))?;
+
+        if let Some(v) = &params.validator {
+            v.validate_spec(&params.spec)?;
+        }
+
+        let metadata = serde_json::to_value(&params.annotations).unwrap_or_default();
+
+        let mut conn = self.pool.acquire().await.map_err(StoreError::Database)?;
+        Self::insert_resource_row_with_retry(&mut conn, &params, metadata).await
     }
 
     async fn get(&self, uid: Uuid) -> Result<Option<ResourceRow>, StoreError> {
@@ -182,6 +196,23 @@ impl ResourceStore for PgResourceStore {
         uid: Uuid,
         params: UpdateResourceParams,
     ) -> Result<ResourceRow, StoreError> {
+        // ResourceDefinitions must go through update_resource_definition to keep the
+        // resource_definitions projection table in sync.
+        let kind: Option<String> = sqlx::query_scalar("SELECT kind FROM resources WHERE uid = $1")
+            .bind(uid)
+            .fetch_optional(&self.pool)
+            .await?;
+        match kind.as_deref() {
+            None => return Err(StoreError::NotFound),
+            Some(RESOURCE_DEFINITION_KIND) => {
+                return Err(StoreError::Validation(
+                    "ResourceDefinitions must be updated through update_resource_definition"
+                        .to_string(),
+                ))
+            }
+            _ => {}
+        }
+
         if let Some(v) = &params.validator {
             v.validate_spec(&params.spec)?;
         }
@@ -215,14 +246,12 @@ impl ResourceStore for PgResourceStore {
             return Ok(row);
         }
 
-        // Zero rows affected — determine why so we can return the right error
-        match self.get(uid).await? {
-            None => Err(StoreError::NotFound),
-            Some(current) => Err(StoreError::RevisionConflict {
-                expected: params.revision,
-                found: current.revision,
-            }),
-        }
+        // Zero rows affected — revision mismatch (NotFound already handled above)
+        let current = self.get(uid).await?.ok_or(StoreError::NotFound)?;
+        Err(StoreError::RevisionConflict {
+            expected: params.revision,
+            found: current.revision,
+        })
     }
 
     async fn delete(&self, uid: Uuid) -> Result<DeleteOutcome, StoreError> {
@@ -320,7 +349,16 @@ impl ResourceStore for PgResourceStore {
             }
         }
 
-        let current = self.get(uid).await?.ok_or(StoreError::NotFound)?;
+        // Use SELECT FOR UPDATE inside a transaction to serialise concurrent finalizer
+        // mutations from different controllers on the same resource, preventing lost updates.
+        let mut tx = self.pool.begin().await?;
+
+        let current =
+            sqlx::query_as::<_, ResourceRow>("SELECT * FROM resources WHERE uid = $1 FOR UPDATE")
+                .bind(uid)
+                .fetch_optional(&mut *tx)
+                .await?
+                .ok_or(StoreError::NotFound)?;
 
         let remove_set: std::collections::HashSet<&str> =
             remove.iter().map(String::as_str).collect();
@@ -345,8 +383,10 @@ impl ResourceStore for PgResourceStore {
         )
         .bind(&new_finalizers)
         .bind(uid)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *tx)
         .await?;
+
+        tx.commit().await?;
 
         Ok(row)
     }
@@ -360,7 +400,13 @@ impl ResourceStore for PgResourceStore {
             return Ok(Some(info));
         }
 
-        // Look up external ResourceDefinitions
+        // Check for a pre-compiled validator to avoid re-compiling JSON schema on every call
+        let cached_validator = self
+            .schema_cache
+            .read()
+            .ok()
+            .and_then(|c| c.get(collection).cloned());
+
         let row = sqlx::query(
             r#"
             SELECT rd.uid, rd.group_name, rd.kind, rd.scope, rd.versions,
@@ -403,17 +449,26 @@ impl ResourceStore for PgResourceStore {
 
         let api_version = format!("{group_name}/{storage_version}");
 
-        // Build a pre-compiled JSON schema validator from the storage version's schema
-        let schema_validator: Arc<dyn SpecValidator> = versions
-            .iter()
-            .find(|v| v.storage)
-            .and_then(|v| v.schema.clone())
-            .map(|s| {
-                JsonSchemaValidator::new(s)
-                    .map(|v| Arc::new(v) as Arc<dyn SpecValidator>)
-                    .unwrap_or_else(|_| Arc::new(NoOpValidator))
-            })
-            .unwrap_or_else(|| Arc::new(NoOpValidator));
+        // Use the cached validator, or compile one and store it in the cache
+        let schema_validator: Arc<dyn SpecValidator> = match cached_validator {
+            Some(v) => v,
+            None => {
+                let v: Arc<dyn SpecValidator> = versions
+                    .iter()
+                    .find(|v| v.storage)
+                    .and_then(|v| v.schema.clone())
+                    .map(|s| {
+                        JsonSchemaValidator::new(s)
+                            .map(|v| Arc::new(v) as Arc<dyn SpecValidator>)
+                            .unwrap_or_else(|_| Arc::new(NoOpValidator))
+                    })
+                    .unwrap_or_else(|| Arc::new(NoOpValidator));
+                if let Ok(mut cache) = self.schema_cache.write() {
+                    cache.insert(collection.to_string(), v.clone());
+                }
+                v
+            }
+        };
 
         Ok(Some(CollectionInfo {
             api_version,
@@ -428,51 +483,31 @@ impl ResourceStore for PgResourceStore {
         &self,
         params: CreateResourceParams,
     ) -> Result<ResourceRow, StoreError> {
-        // Validate the spec first (checks reserved names, format, etc.)
-        let validator = Arc::new(ResourceDefinitionValidator);
-        validator.validate_spec(&params.spec)?;
+        // ResourceDefinition names follow the {plural}.{group} convention so dots are allowed,
+        // unlike instance resource names. Reject empty segments (e.g. "widgets..dev").
+        if params.name.is_empty()
+            || params.name.starts_with('.')
+            || params.name.ends_with('.')
+            || params.name.contains("..")
+        {
+            return Err(StoreError::Validation(
+                "ResourceDefinition name must be a non-empty dot-separated string with no empty segments"
+                    .to_string(),
+            ));
+        }
 
+        // Validate spec format and reserved-name rules
+        ResourceDefinitionValidator.validate_spec(&params.spec)?;
+
+        // Parse once; safe to unwrap because validate_spec succeeded above
         let spec: ResourceDefinitionSpec = serde_json::from_value(params.spec.clone())
-            .map_err(|e| StoreError::Validation(format!("invalid ResourceDefinition spec: {e}")))?;
+            .expect("spec parseable: ResourceDefinitionValidator.validate_spec succeeded");
 
         let mut tx = self.pool.begin().await?;
 
         let metadata = serde_json::to_value(&params.annotations).unwrap_or_default();
 
-        // Retry INSERT up to 10 times on discriminator collision (same as create())
-        let resource_row = 'retry: {
-            for _ in 0..10 {
-                let discriminator = discriminator::generate();
-                let result = sqlx::query_as::<_, ResourceRow>(
-                    r#"
-                    INSERT INTO resources
-                        (api_version, kind, parent_uid, name, discriminator, metadata, spec, finalizers)
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-                    RETURNING *
-                    "#,
-                )
-                .bind(&params.api_version)
-                .bind(&params.kind)
-                .bind(params.parent_uid)
-                .bind(&params.name)
-                .bind(&discriminator)
-                .bind(metadata.clone())
-                .bind(&params.spec)
-                .bind(&params.finalizers)
-                .fetch_one(&mut *tx)
-                .await;
-
-                match result {
-                    Ok(row) => break 'retry row,
-                    Err(ref e) if Self::is_name_conflict(e) => {
-                        return Err(StoreError::NameConflict)
-                    }
-                    Err(ref e) if Self::is_discriminator_conflict(e) => continue,
-                    Err(e) => return Err(StoreError::Database(e)),
-                }
-            }
-            return Err(StoreError::DiscriminatorExhausted);
-        };
+        let resource_row = Self::insert_resource_row_with_retry(&mut tx, &params, metadata).await?;
 
         // Insert into the resource_definitions projection table
         let scope_val = serde_json::to_value(&spec.scope).unwrap_or_default();
@@ -515,27 +550,117 @@ impl ResourceStore for PgResourceStore {
 
         tx.commit().await?;
 
+        // Evict any stale cached validator for this plural
+        if let Ok(mut cache) = self.schema_cache.write() {
+            cache.remove(&spec.plural);
+        }
+
         Ok(resource_row)
+    }
+
+    async fn update_resource_definition(
+        &self,
+        uid: Uuid,
+        params: UpdateResourceParams,
+    ) -> Result<ResourceRow, StoreError> {
+        // Validate the new spec
+        ResourceDefinitionValidator.validate_spec(&params.spec)?;
+
+        let new_spec: ResourceDefinitionSpec = serde_json::from_value(params.spec.clone())
+            .expect("spec parseable: ResourceDefinitionValidator.validate_spec succeeded");
+
+        let mut tx = self.pool.begin().await?;
+
+        // Lock the row and fetch current state
+        let current =
+            sqlx::query_as::<_, ResourceRow>("SELECT * FROM resources WHERE uid = $1 FOR UPDATE")
+                .bind(uid)
+                .fetch_optional(&mut *tx)
+                .await?
+                .ok_or(StoreError::NotFound)?;
+
+        if current.kind != RESOURCE_DEFINITION_KIND {
+            return Err(StoreError::Validation(
+                "resource is not a ResourceDefinition".to_string(),
+            ));
+        }
+
+        // Enforce immutability of identity fields
+        let old_spec: ResourceDefinitionSpec = serde_json::from_value(current.spec.clone())
+            .map_err(|e| {
+                StoreError::Validation(format!("stored ResourceDefinition spec is invalid: {e}"))
+            })?;
+
+        if new_spec.group != old_spec.group
+            || new_spec.kind != old_spec.kind
+            || new_spec.plural != old_spec.plural
+            || new_spec.scope != old_spec.scope
+        {
+            return Err(StoreError::Validation(
+                "ResourceDefinition identity fields (group, kind, plural, scope) are immutable"
+                    .to_string(),
+            ));
+        }
+
+        let metadata = serde_json::to_value(&params.annotations).unwrap_or_default();
+
+        // Update the resources row with optimistic concurrency
+        let updated = sqlx::query_as::<_, ResourceRow>(
+            r#"
+            UPDATE resources
+            SET metadata   = $1,
+                spec       = $2,
+                finalizers = $3,
+                revision   = revision + 1,
+                updated_at = NOW()
+            WHERE uid = $4 AND revision = $5
+            RETURNING *
+            "#,
+        )
+        .bind(metadata)
+        .bind(&params.spec)
+        .bind(&params.finalizers)
+        .bind(uid)
+        .bind(params.revision)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let row = match updated {
+            Some(r) => r,
+            None => {
+                return Err(StoreError::RevisionConflict {
+                    expected: params.revision,
+                    found: current.revision,
+                })
+            }
+        };
+
+        // Sync the projection table (mutable fields only: versions and allowed controllers)
+        let versions_val = serde_json::to_value(&new_spec.versions).unwrap_or_default();
+        sqlx::query(
+            r#"
+            UPDATE resource_definitions
+            SET versions = $1, allowed_status_controller_ids = $2
+            WHERE uid = $3
+            "#,
+        )
+        .bind(versions_val)
+        .bind(&new_spec.allowed_status_controller_ids)
+        .bind(uid)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+
+        // Evict stale cached validator for this collection
+        if let Ok(mut cache) = self.schema_cache.write() {
+            cache.remove(&new_spec.plural);
+        }
+
+        Ok(row)
     }
 }
 
 fn is_controller_finalizer(finalizer: &str, controller_id: &str) -> bool {
     finalizer == controller_id || finalizer.starts_with(&format!("{controller_id}/"))
-}
-
-// Helpers to extract typed values from a sqlx::postgres::PgRow
-trait PgRowExt {
-    fn try_get<'r, T: sqlx::Decode<'r, sqlx::Postgres> + sqlx::Type<sqlx::Postgres>>(
-        &'r self,
-        column: &str,
-    ) -> Result<T, sqlx::Error>;
-}
-
-impl PgRowExt for sqlx::postgres::PgRow {
-    fn try_get<'r, T: sqlx::Decode<'r, sqlx::Postgres> + sqlx::Type<sqlx::Postgres>>(
-        &'r self,
-        column: &str,
-    ) -> Result<T, sqlx::Error> {
-        sqlx::Row::try_get(self, column)
-    }
 }

--- a/crates/rise-resource-store/src/pg_store.rs
+++ b/crates/rise-resource-store/src/pg_store.rs
@@ -2,8 +2,9 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 use rise_resource_api::{
-    ResourceDefinitionSpec, ResourceScope, API_VERSION_V1ALPHA1, ORGANIZATION_COLLECTION,
-    ORGANIZATION_KIND, RESOURCE_DEFINITION_COLLECTION, RESOURCE_DEFINITION_KIND,
+    validate_controller_id, ResourceDefinitionSpec, ResourceScope, API_VERSION_V1ALPHA1,
+    ORGANIZATION_COLLECTION, ORGANIZATION_KIND, RESOURCE_DEFINITION_COLLECTION,
+    RESOURCE_DEFINITION_KIND,
 };
 use sqlx::PgPool;
 
@@ -27,48 +28,20 @@ impl PgResourceStore {
         Self { pool }
     }
 
-    async fn discriminator_exists(
-        &self,
-        parent_uid: Option<Uuid>,
-        disc: &str,
-    ) -> Result<bool, StoreError> {
-        let exists: bool = match parent_uid {
-            None => {
-                sqlx::query_scalar(
-                    "SELECT EXISTS(SELECT 1 FROM resources WHERE parent_uid IS NULL AND discriminator = $1)",
-                )
-                .bind(disc)
-                .fetch_one(&self.pool)
-                .await?
-            }
-            Some(pid) => {
-                sqlx::query_scalar(
-                    "SELECT EXISTS(SELECT 1 FROM resources WHERE parent_uid = $1 AND discriminator = $2)",
-                )
-                .bind(pid)
-                .bind(disc)
-                .fetch_one(&self.pool)
-                .await?
-            }
-        };
-        Ok(exists)
-    }
-
-    async fn generate_discriminator(&self, parent_uid: Option<Uuid>) -> Result<String, StoreError> {
-        for _ in 0..10 {
-            let disc = discriminator::generate();
-            if !self.discriminator_exists(parent_uid, &disc).await? {
-                return Ok(disc);
-            }
-        }
-        Err(StoreError::DiscriminatorExhausted)
-    }
-
     fn is_name_conflict(err: &sqlx::Error) -> bool {
         if let sqlx::Error::Database(db) = err {
-            let constraint = db.constraint().unwrap_or("");
-            return constraint == "resources_child_kind_name_unique"
-                || constraint == "resources_root_kind_name_unique";
+            let c = db.constraint().unwrap_or("");
+            return c == "resources_child_kind_name_unique"
+                || c == "resources_root_kind_name_unique";
+        }
+        false
+    }
+
+    fn is_discriminator_conflict(err: &sqlx::Error) -> bool {
+        if let sqlx::Error::Database(db) = err {
+            let c = db.constraint().unwrap_or("");
+            return c == "resources_child_discriminator_unique"
+                || c == "resources_root_discriminator_unique";
         }
         false
     }
@@ -104,36 +77,41 @@ impl ResourceStore for PgResourceStore {
             v.validate_spec(&params.spec)?;
         }
 
-        let discriminator = self.generate_discriminator(params.parent_uid).await?;
         let metadata = serde_json::to_value(&params.annotations).unwrap_or_default();
 
-        let row = sqlx::query_as::<_, ResourceRow>(
-            r#"
-            INSERT INTO resources
-                (api_version, kind, parent_uid, name, discriminator, metadata, spec, finalizers)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-            RETURNING *
-            "#,
-        )
-        .bind(&params.api_version)
-        .bind(&params.kind)
-        .bind(params.parent_uid)
-        .bind(&params.name)
-        .bind(&discriminator)
-        .bind(metadata)
-        .bind(&params.spec)
-        .bind(&params.finalizers)
-        .fetch_one(&self.pool)
-        .await
-        .map_err(|e| {
-            if Self::is_name_conflict(&e) {
-                StoreError::NameConflict
-            } else {
-                StoreError::Database(e)
-            }
-        })?;
+        // Retry the INSERT up to 10 times, generating a new discriminator on each
+        // discriminator collision. This handles concurrent creators racing to the same
+        // randomly generated discriminator without a pre-check TOCTOU window.
+        for _ in 0..10 {
+            let discriminator = discriminator::generate();
+            let result = sqlx::query_as::<_, ResourceRow>(
+                r#"
+                INSERT INTO resources
+                    (api_version, kind, parent_uid, name, discriminator, metadata, spec, finalizers)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                RETURNING *
+                "#,
+            )
+            .bind(&params.api_version)
+            .bind(&params.kind)
+            .bind(params.parent_uid)
+            .bind(&params.name)
+            .bind(&discriminator)
+            .bind(metadata.clone())
+            .bind(&params.spec)
+            .bind(&params.finalizers)
+            .fetch_one(&self.pool)
+            .await;
 
-        Ok(row)
+            match result {
+                Ok(row) => return Ok(row),
+                Err(ref e) if Self::is_name_conflict(e) => return Err(StoreError::NameConflict),
+                Err(ref e) if Self::is_discriminator_conflict(e) => continue,
+                Err(e) => return Err(StoreError::Database(e)),
+            }
+        }
+
+        Err(StoreError::DiscriminatorExhausted)
     }
 
     async fn get(&self, uid: Uuid) -> Result<Option<ResourceRow>, StoreError> {
@@ -204,22 +182,16 @@ impl ResourceStore for PgResourceStore {
         uid: Uuid,
         params: UpdateResourceParams,
     ) -> Result<ResourceRow, StoreError> {
-        let current = self.get(uid).await?.ok_or(StoreError::NotFound)?;
-
-        if current.revision != params.revision {
-            return Err(StoreError::RevisionConflict {
-                expected: params.revision,
-                found: current.revision,
-            });
-        }
-
         if let Some(v) = &params.validator {
             v.validate_spec(&params.spec)?;
         }
 
         let metadata = serde_json::to_value(&params.annotations).unwrap_or_default();
 
-        let row = sqlx::query_as::<_, ResourceRow>(
+        // Include the expected revision in the WHERE clause so the update is atomic:
+        // a concurrent write that already incremented the revision will cause zero rows
+        // to be affected, which we detect and map to RevisionConflict.
+        let updated = sqlx::query_as::<_, ResourceRow>(
             r#"
             UPDATE resources
             SET metadata   = $1,
@@ -227,7 +199,7 @@ impl ResourceStore for PgResourceStore {
                 finalizers = $3,
                 revision   = revision + 1,
                 updated_at = NOW()
-            WHERE uid = $4
+            WHERE uid = $4 AND revision = $5
             RETURNING *
             "#,
         )
@@ -235,10 +207,22 @@ impl ResourceStore for PgResourceStore {
         .bind(&params.spec)
         .bind(&params.finalizers)
         .bind(uid)
-        .fetch_one(&self.pool)
+        .bind(params.revision)
+        .fetch_optional(&self.pool)
         .await?;
 
-        Ok(row)
+        if let Some(row) = updated {
+            return Ok(row);
+        }
+
+        // Zero rows affected — determine why so we can return the right error
+        match self.get(uid).await? {
+            None => Err(StoreError::NotFound),
+            Some(current) => Err(StoreError::RevisionConflict {
+                expected: params.revision,
+                found: current.revision,
+            }),
+        }
     }
 
     async fn delete(&self, uid: Uuid) -> Result<DeleteOutcome, StoreError> {
@@ -270,10 +254,18 @@ impl ResourceStore for PgResourceStore {
             return Ok(DeleteOutcome::MarkedForDeletion(Box::new(marked)));
         }
 
+        // Hard delete in a transaction. Delete from the resource_definitions projection
+        // table first (ON DELETE RESTRICT prevents deleting the resources row otherwise).
+        let mut tx = self.pool.begin().await?;
+        sqlx::query("DELETE FROM resource_definitions WHERE uid = $1")
+            .bind(uid)
+            .execute(&mut *tx)
+            .await?;
         sqlx::query("DELETE FROM resources WHERE uid = $1")
             .bind(uid)
-            .execute(&self.pool)
+            .execute(&mut *tx)
             .await?;
+        tx.commit().await?;
 
         Ok(DeleteOutcome::Deleted)
     }
@@ -284,6 +276,8 @@ impl ResourceStore for PgResourceStore {
         controller_id: &str,
         status_value: serde_json::Value,
     ) -> Result<ResourceRow, StoreError> {
+        validate_controller_id(controller_id).map_err(|e| StoreError::Validation(e.to_string()))?;
+
         let row = sqlx::query_as::<_, ResourceRow>(
             r#"
             UPDATE resources
@@ -315,7 +309,9 @@ impl ResourceStore for PgResourceStore {
         add: &[String],
         remove: &[String],
     ) -> Result<ResourceRow, StoreError> {
-        // Validate ownership: all modified finalizers must be prefixed by controller_id
+        validate_controller_id(controller_id).map_err(|e| StoreError::Validation(e.to_string()))?;
+
+        // All modified finalizers must be prefixed by this controller's ID
         for f in add.iter().chain(remove.iter()) {
             if !is_controller_finalizer(f, controller_id) {
                 return Err(StoreError::Validation(format!(
@@ -405,14 +401,18 @@ impl ResourceStore for PgResourceStore {
             .map(|v| v.name.clone())
             .unwrap_or_else(|| "v1".to_string());
 
-        let api_version = format!("{}/{}", group_name, storage_version);
+        let api_version = format!("{group_name}/{storage_version}");
 
-        // Build a JSON schema validator from the storage version's schema (if present)
+        // Build a pre-compiled JSON schema validator from the storage version's schema
         let schema_validator: Arc<dyn SpecValidator> = versions
             .iter()
             .find(|v| v.storage)
             .and_then(|v| v.schema.clone())
-            .map(|s| Arc::new(JsonSchemaValidator::new(s)) as Arc<dyn SpecValidator>)
+            .map(|s| {
+                JsonSchemaValidator::new(s)
+                    .map(|v| Arc::new(v) as Arc<dyn SpecValidator>)
+                    .unwrap_or_else(|_| Arc::new(NoOpValidator))
+            })
             .unwrap_or_else(|| Arc::new(NoOpValidator));
 
         Ok(Some(CollectionInfo {
@@ -437,35 +437,42 @@ impl ResourceStore for PgResourceStore {
 
         let mut tx = self.pool.begin().await?;
 
-        // Insert the base resource row
-        let discriminator = self.generate_discriminator(params.parent_uid).await?;
         let metadata = serde_json::to_value(&params.annotations).unwrap_or_default();
 
-        let resource_row = sqlx::query_as::<_, ResourceRow>(
-            r#"
-            INSERT INTO resources
-                (api_version, kind, parent_uid, name, discriminator, metadata, spec, finalizers)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-            RETURNING *
-            "#,
-        )
-        .bind(&params.api_version)
-        .bind(&params.kind)
-        .bind(params.parent_uid)
-        .bind(&params.name)
-        .bind(&discriminator)
-        .bind(metadata)
-        .bind(&params.spec)
-        .bind(&params.finalizers)
-        .fetch_one(&mut *tx)
-        .await
-        .map_err(|e| {
-            if Self::is_name_conflict(&e) {
-                StoreError::NameConflict
-            } else {
-                StoreError::Database(e)
+        // Retry INSERT up to 10 times on discriminator collision (same as create())
+        let resource_row = 'retry: {
+            for _ in 0..10 {
+                let discriminator = discriminator::generate();
+                let result = sqlx::query_as::<_, ResourceRow>(
+                    r#"
+                    INSERT INTO resources
+                        (api_version, kind, parent_uid, name, discriminator, metadata, spec, finalizers)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                    RETURNING *
+                    "#,
+                )
+                .bind(&params.api_version)
+                .bind(&params.kind)
+                .bind(params.parent_uid)
+                .bind(&params.name)
+                .bind(&discriminator)
+                .bind(metadata.clone())
+                .bind(&params.spec)
+                .bind(&params.finalizers)
+                .fetch_one(&mut *tx)
+                .await;
+
+                match result {
+                    Ok(row) => break 'retry row,
+                    Err(ref e) if Self::is_name_conflict(e) => {
+                        return Err(StoreError::NameConflict)
+                    }
+                    Err(ref e) if Self::is_discriminator_conflict(e) => continue,
+                    Err(e) => return Err(StoreError::Database(e)),
+                }
             }
-        })?;
+            return Err(StoreError::DiscriminatorExhausted);
+        };
 
         // Insert into the resource_definitions projection table
         let scope_val = serde_json::to_value(&spec.scope).unwrap_or_default();

--- a/crates/rise-resource-store/src/pg_store.rs
+++ b/crates/rise-resource-store/src/pg_store.rs
@@ -260,9 +260,16 @@ impl ResourceStore for PgResourceStore {
         uid: Uuid,
         policy: PropagationPolicy,
     ) -> Result<DeleteOutcome, StoreError> {
-        let row = self.get(uid).await?.ok_or(StoreError::NotFound)?;
-
         let mut tx = self.pool.begin().await?;
+
+        // Lock the row inside the transaction so a concurrent update_controller_finalizers()
+        // can't add a finalizer between our read and the hard-delete branch below.
+        let row =
+            sqlx::query_as::<_, ResourceRow>("SELECT * FROM resources WHERE uid = $1 FOR UPDATE")
+                .bind(uid)
+                .fetch_optional(&mut *tx)
+                .await?
+                .ok_or(StoreError::NotFound)?;
 
         let child_count: i64 =
             sqlx::query_scalar("SELECT COUNT(*) FROM resources WHERE parent_uid = $1")
@@ -274,11 +281,13 @@ impl ResourceStore for PgResourceStore {
             PropagationPolicy::Cascade => {
                 if child_count > 0 {
                     // Stamp immediate children that aren't already marked. A future GC sweep
-                    // (try_collect) drives the fan-out down the remaining levels.
+                    // (try_collect) drives the fan-out down the remaining levels. Bump
+                    // revision on each affected child so concurrent updates see the change.
                     sqlx::query(
                         r#"
                         UPDATE resources
-                        SET deletion_timestamp = NOW()
+                        SET deletion_timestamp = NOW(),
+                            revision = revision + 1
                         WHERE parent_uid = $1 AND deletion_timestamp IS NULL
                         "#,
                     )
@@ -294,7 +303,8 @@ impl ResourceStore for PgResourceStore {
                             finalizers = CASE
                                 WHEN $2 = ANY(finalizers) THEN finalizers
                                 ELSE array_append(finalizers, $2)
-                            END
+                            END,
+                            revision = revision + 1
                         WHERE uid = $1
                         RETURNING *
                         "#,
@@ -311,10 +321,12 @@ impl ResourceStore for PgResourceStore {
                 if child_count > 0 {
                     // Detach children. The partial unique index on (kind, name) WHERE
                     // parent_uid IS NULL may reject this if a name collides at the root scope.
+                    // Bump revision so the detach is observable.
                     let result = sqlx::query(
                         r#"
                         UPDATE resources
-                        SET parent_uid = NULL
+                        SET parent_uid = NULL,
+                            revision = revision + 1
                         WHERE parent_uid = $1
                         "#,
                     )
@@ -336,7 +348,8 @@ impl ResourceStore for PgResourceStore {
             let marked = sqlx::query_as::<_, ResourceRow>(
                 r#"
                 UPDATE resources
-                SET deletion_timestamp = COALESCE(deletion_timestamp, NOW())
+                SET deletion_timestamp = COALESCE(deletion_timestamp, NOW()),
+                    revision = revision + 1
                 WHERE uid = $1
                 RETURNING *
                 "#,
@@ -384,11 +397,13 @@ impl ResourceStore for PgResourceStore {
 
         if child_count > 0 {
             // Fan out: stamp any unmarked children. Ensure the cascade finalizer is present
-            // (in case the row was tombstoned by some other path that didn't add it).
+            // (in case the row was tombstoned by some other path that didn't add it). Bump
+            // revision on every row we mutate so observers see the change.
             sqlx::query(
                 r#"
                 UPDATE resources
-                SET deletion_timestamp = NOW()
+                SET deletion_timestamp = NOW(),
+                    revision = revision + 1
                 WHERE parent_uid = $1 AND deletion_timestamp IS NULL
                 "#,
             )
@@ -402,6 +417,10 @@ impl ResourceStore for PgResourceStore {
                 SET finalizers = CASE
                         WHEN $2 = ANY(finalizers) THEN finalizers
                         ELSE array_append(finalizers, $2)
+                    END,
+                    revision = CASE
+                        WHEN $2 = ANY(finalizers) THEN revision
+                        ELSE revision + 1
                     END
                 WHERE uid = $1
                 RETURNING *
@@ -415,11 +434,16 @@ impl ResourceStore for PgResourceStore {
             return Ok(DeleteOutcome::MarkedForDeletion(Box::new(row)));
         }
 
-        // No children. Drop the cascade finalizer if present.
+        // No children. Drop the cascade finalizer if present. Only bump revision when the
+        // finalizer was actually removed so idempotent re-calls don't churn the version.
         let row = sqlx::query_as::<_, ResourceRow>(
             r#"
             UPDATE resources
-            SET finalizers = array_remove(finalizers, $2)
+            SET finalizers = array_remove(finalizers, $2),
+                revision = CASE
+                    WHEN $2 = ANY(finalizers) THEN revision + 1
+                    ELSE revision
+                END
             WHERE uid = $1
             RETURNING *
             "#,
@@ -617,7 +641,8 @@ impl ResourceStore for PgResourceStore {
         let result = sqlx::query_as::<_, ResourceRow>(
             r#"
             UPDATE resources
-            SET parent_uid = $2
+            SET parent_uid = $2,
+                revision = revision + 1
             WHERE uid = $1
             RETURNING *
             "#,
@@ -791,20 +816,23 @@ impl ResourceStore for PgResourceStore {
 
         let api_version = format!("{group_name}/{storage_version}");
 
-        // Use the cached validator, or compile one and store it in the cache
+        // Use the cached validator, or compile one and store it in the cache. A schema that
+        // fails to compile is a hard error: silently falling back to NoOpValidator would let
+        // invalid specs through. Registration validates compilability up front, so this
+        // branch only fires for rows that bypassed validation (e.g. via direct SQL).
         let schema_validator: Arc<dyn SpecValidator> = match cached_validator {
             Some(v) => v,
             None => {
-                let v: Arc<dyn SpecValidator> = versions
-                    .iter()
-                    .find(|v| v.storage)
-                    .and_then(|v| v.schema.clone())
-                    .map(|s| {
-                        JsonSchemaValidator::new(s)
-                            .map(|v| Arc::new(v) as Arc<dyn SpecValidator>)
-                            .unwrap_or_else(|_| Arc::new(NoOpValidator))
-                    })
-                    .unwrap_or_else(|| Arc::new(NoOpValidator));
+                let storage_version = versions.iter().find(|v| v.storage);
+                let v: Arc<dyn SpecValidator> = match storage_version.and_then(|v| v.schema.clone())
+                {
+                    Some(schema) => Arc::new(JsonSchemaValidator::new(schema).map_err(|e| {
+                        StoreError::Validation(format!(
+                            "ResourceDefinition '{collection}' has an invalid JSON schema: {e}"
+                        ))
+                    })?) as Arc<dyn SpecValidator>,
+                    None => Arc::new(NoOpValidator),
+                };
                 if let Ok(mut cache) = self.schema_cache.write() {
                     cache.insert(collection.to_string(), v.clone());
                 }
@@ -825,25 +853,36 @@ impl ResourceStore for PgResourceStore {
         &self,
         params: CreateResourceParams,
     ) -> Result<ResourceRow, StoreError> {
-        // ResourceDefinition names follow the {plural}.{group} convention so dots are allowed,
-        // unlike instance resource names. Reject empty segments (e.g. "widgets..dev").
-        if params.name.is_empty()
-            || params.name.starts_with('.')
-            || params.name.ends_with('.')
-            || params.name.contains("..")
-        {
-            return Err(StoreError::Validation(
-                "ResourceDefinition name must be a non-empty dot-separated string with no empty segments"
-                    .to_string(),
-            ));
-        }
-
-        // Validate spec format and reserved-name rules
+        // Validate spec format and reserved-name rules first so plural/group are sound.
         ResourceDefinitionValidator.validate_spec(&params.spec)?;
 
         // Parse once; safe to unwrap because validate_spec succeeded above
         let spec: ResourceDefinitionSpec = serde_json::from_value(params.spec.clone())
             .expect("spec parseable: ResourceDefinitionValidator.validate_spec succeeded");
+
+        // ResourceDefinition names follow the {plural}.{group} convention. Identity fields are
+        // immutable post-creation, so an inconsistent name becomes permanent — reject upfront.
+        let expected_name = format!("{}.{}", spec.plural, spec.group);
+        if params.name != expected_name {
+            return Err(StoreError::Validation(format!(
+                "ResourceDefinition name must equal '{{plural}}.{{group}}' \
+                 (expected '{expected_name}', got '{}')",
+                params.name
+            )));
+        }
+
+        // Validate the embedded JSON schema compiles. The `resources_name_format` DB constraint
+        // enforces DNS-label segments, so we don't re-check structure here.
+        if let Some(storage_version) = spec.versions.iter().find(|v| v.storage) {
+            if let Some(schema) = storage_version.schema.clone() {
+                JsonSchemaValidator::new(schema).map_err(|e| {
+                    StoreError::Validation(format!(
+                        "ResourceDefinition '{}' has an invalid JSON schema: {e}",
+                        params.name
+                    ))
+                })?;
+            }
+        }
 
         let mut tx = self.pool.begin().await?;
 
@@ -910,6 +949,17 @@ impl ResourceStore for PgResourceStore {
 
         let new_spec: ResourceDefinitionSpec = serde_json::from_value(params.spec.clone())
             .expect("spec parseable: ResourceDefinitionValidator.validate_spec succeeded");
+
+        // Validate that the new spec's JSON schema (if any) compiles. Symmetric with register.
+        if let Some(storage_version) = new_spec.versions.iter().find(|v| v.storage) {
+            if let Some(schema) = storage_version.schema.clone() {
+                JsonSchemaValidator::new(schema).map_err(|e| {
+                    StoreError::Validation(format!(
+                        "ResourceDefinition has an invalid JSON schema: {e}"
+                    ))
+                })?;
+            }
+        }
 
         let mut tx = self.pool.begin().await?;
 

--- a/crates/rise-resource-store/src/store.rs
+++ b/crates/rise-resource-store/src/store.rs
@@ -8,6 +8,14 @@ use crate::error::StoreError;
 use crate::models::ResourceRow;
 use crate::validation::SpecValidator;
 
+/// Reserved finalizer prefix for store-managed finalizers. Controllers cannot add or remove
+/// finalizers in this namespace via `update_controller_finalizers`.
+pub const SYSTEM_FINALIZER_PREFIX: &str = "system.rise.dev/";
+
+/// Finalizer added to a parent resource when it is deleted with `PropagationPolicy::Cascade`
+/// and still has children. Removed by the store once the subtree has drained.
+pub const CASCADE_DELETION_FINALIZER: &str = "system.rise.dev/cascade-deletion";
+
 pub struct CreateResourceParams {
     pub api_version: String,
     pub kind: String,
@@ -25,6 +33,32 @@ pub struct UpdateResourceParams {
     pub finalizers: Vec<String>,
     pub spec: serde_json::Value,
     pub validator: Option<Arc<dyn SpecValidator>>,
+}
+
+/// Controls how child resources are handled when a parent is deleted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PropagationPolicy {
+    /// Default. Stamp `deletion_timestamp` on the parent and its immediate children, and attach a
+    /// `system.rise.dev/cascade-deletion` finalizer to the parent. A background GC sweep (via
+    /// `try_collect`) drives the rest of the subtree to completion bottom-up.
+    #[default]
+    Cascade,
+
+    /// Detach all immediate children (`parent_uid = NULL`) and then delete the parent normally.
+    /// Children continue to exist as root-level resources. This is an admin/break-glass operation;
+    /// it should be gated at the API layer.
+    Orphan,
+}
+
+/// One segment of a resource path. Always carries the kind so the response shape and ancestor
+/// integrity can be verified without a round-trip.
+#[derive(Debug, Clone)]
+pub enum PathSegment {
+    /// Address by name within the parent scope (root if first segment).
+    Name { kind: String, name: String },
+    /// Address by UID. The kind is still required and checked against the stored row; mismatches
+    /// surface as `StoreError::KindMismatch`.
+    Uid { kind: String, uid: Uuid },
 }
 
 pub enum DeleteOutcome {
@@ -74,7 +108,53 @@ pub trait ResourceStore: Send + Sync {
         params: UpdateResourceParams,
     ) -> Result<ResourceRow, StoreError>;
 
-    async fn delete(&self, uid: Uuid) -> Result<DeleteOutcome, StoreError>;
+    /// Delete (or mark for deletion) a resource. `policy` controls child handling.
+    ///
+    /// - `Cascade`: stamps `deletion_timestamp` on the parent and its immediate children, and
+    ///   attaches `system.rise.dev/cascade-deletion` to the parent if children exist. The actual
+    ///   removal of the parent row happens when the subtree has drained and all finalizers are
+    ///   gone, via `try_collect`.
+    /// - `Orphan`: clears `parent_uid` on immediate children, then deletes the parent normally
+    ///   (marked if it carries finalizers, hard-deleted otherwise). Admin gate is the caller's
+    ///   responsibility.
+    async fn delete(
+        &self,
+        uid: Uuid,
+        policy: PropagationPolicy,
+    ) -> Result<DeleteOutcome, StoreError>;
+
+    /// GC sweep entry point. Idempotent.
+    ///
+    /// - If the row is not tombstoned, returns `MarkedForDeletion` with the current row unchanged
+    ///   when it has children (so callers can observe state) — but does not mutate anything; if it
+    ///   has no `deletion_timestamp` it returns `NotFound` to signal "no work here".
+    /// - If tombstoned with children: stamps any still-unstamped children (continues the fan-out),
+    ///   ensures `system.rise.dev/cascade-deletion` is set, returns `MarkedForDeletion`.
+    /// - If tombstoned without children: removes `system.rise.dev/cascade-deletion` if present;
+    ///   if no other finalizers remain, hard-deletes and returns `Deleted`; otherwise returns
+    ///   `MarkedForDeletion`.
+    async fn try_collect(&self, uid: Uuid) -> Result<DeleteOutcome, StoreError>;
+
+    /// List rows with a `deletion_timestamp`, oldest first. The caller (GC worker) iterates this
+    /// and calls `try_collect` on each.
+    async fn list_pending_collection(&self, limit: i64) -> Result<Vec<ResourceRow>, StoreError>;
+
+    /// Resolve a path of segments to the full ancestor chain. The leaf is the last element.
+    /// Tombstoned rows are returned (callers decide how to handle them).
+    async fn resolve_path(&self, segments: &[PathSegment]) -> Result<Vec<ResourceRow>, StoreError>;
+
+    /// List children whose parent is currently tombstoned (`deletion_timestamp IS NOT NULL`).
+    /// Optionally scoped to a single parent. Useful for break-glass discovery of in-progress
+    /// teardowns.
+    async fn list_orphans(&self, parent_uid: Option<Uuid>) -> Result<Vec<ResourceRow>, StoreError>;
+
+    /// Atomically move a resource to a new parent (or to root with `None`). Rejects cycles and
+    /// respects the partial unique indexes on name/discriminator at the destination scope.
+    async fn reparent(
+        &self,
+        uid: Uuid,
+        new_parent_uid: Option<Uuid>,
+    ) -> Result<ResourceRow, StoreError>;
 
     async fn update_controller_status(
         &self,

--- a/crates/rise-resource-store/src/store.rs
+++ b/crates/rise-resource-store/src/store.rs
@@ -1,0 +1,103 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use rise_resource_api::ResourceScope;
+
+use crate::error::StoreError;
+use crate::models::ResourceRow;
+use crate::validation::SpecValidator;
+
+pub struct CreateResourceParams {
+    pub api_version: String,
+    pub kind: String,
+    pub name: String,
+    pub parent_uid: Option<Uuid>,
+    pub annotations: BTreeMap<String, String>,
+    pub finalizers: Vec<String>,
+    pub spec: serde_json::Value,
+    pub validator: Option<Arc<dyn SpecValidator>>,
+}
+
+pub struct UpdateResourceParams {
+    pub revision: i64,
+    pub annotations: BTreeMap<String, String>,
+    pub finalizers: Vec<String>,
+    pub spec: serde_json::Value,
+    pub validator: Option<Arc<dyn SpecValidator>>,
+}
+
+pub enum DeleteOutcome {
+    Deleted,
+    MarkedForDeletion(Box<ResourceRow>),
+}
+
+impl std::fmt::Debug for DeleteOutcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Deleted => write!(f, "Deleted"),
+            Self::MarkedForDeletion(_) => write!(f, "MarkedForDeletion"),
+        }
+    }
+}
+
+pub struct CollectionInfo {
+    pub api_version: String,
+    pub kind: String,
+    pub scope: ResourceScope,
+    pub spec_validator: Arc<dyn SpecValidator>,
+    pub allowed_status_controller_ids: Vec<String>,
+}
+
+#[async_trait::async_trait]
+pub trait ResourceStore: Send + Sync {
+    async fn create(&self, params: CreateResourceParams) -> Result<ResourceRow, StoreError>;
+
+    async fn get(&self, uid: Uuid) -> Result<Option<ResourceRow>, StoreError>;
+
+    async fn get_by_name(
+        &self,
+        kind: &str,
+        name: &str,
+        parent_uid: Option<Uuid>,
+    ) -> Result<Option<ResourceRow>, StoreError>;
+
+    async fn list(
+        &self,
+        kind: &str,
+        parent_uid: Option<Uuid>,
+    ) -> Result<Vec<ResourceRow>, StoreError>;
+
+    async fn update(
+        &self,
+        uid: Uuid,
+        params: UpdateResourceParams,
+    ) -> Result<ResourceRow, StoreError>;
+
+    async fn delete(&self, uid: Uuid) -> Result<DeleteOutcome, StoreError>;
+
+    async fn update_controller_status(
+        &self,
+        uid: Uuid,
+        controller_id: &str,
+        status_value: serde_json::Value,
+    ) -> Result<ResourceRow, StoreError>;
+
+    async fn update_controller_finalizers(
+        &self,
+        uid: Uuid,
+        controller_id: &str,
+        add: &[String],
+        remove: &[String],
+    ) -> Result<ResourceRow, StoreError>;
+
+    async fn resolve_collection(
+        &self,
+        collection: &str,
+    ) -> Result<Option<CollectionInfo>, StoreError>;
+
+    async fn register_resource_definition(
+        &self,
+        params: CreateResourceParams,
+    ) -> Result<ResourceRow, StoreError>;
+}

--- a/crates/rise-resource-store/src/store.rs
+++ b/crates/rise-resource-store/src/store.rs
@@ -100,4 +100,13 @@ pub trait ResourceStore: Send + Sync {
         &self,
         params: CreateResourceParams,
     ) -> Result<ResourceRow, StoreError>;
+
+    /// Update a ResourceDefinition resource. Keeps the `resource_definitions` projection table in
+    /// sync with the `resources` row and enforces that identity fields (group, kind, plural, scope)
+    /// are immutable once set.
+    async fn update_resource_definition(
+        &self,
+        uid: Uuid,
+        params: UpdateResourceParams,
+    ) -> Result<ResourceRow, StoreError>;
 }

--- a/crates/rise-resource-store/src/store.rs
+++ b/crates/rise-resource-store/src/store.rs
@@ -125,9 +125,10 @@ pub trait ResourceStore: Send + Sync {
 
     /// GC sweep entry point. Idempotent.
     ///
-    /// - If the row is not tombstoned, returns `MarkedForDeletion` with the current row unchanged
-    ///   when it has children (so callers can observe state) — but does not mutate anything; if it
-    ///   has no `deletion_timestamp` it returns `NotFound` to signal "no work here".
+    /// - If the row is not tombstoned, returns `MarkedForDeletion` with the current row unchanged.
+    ///   No mutations are performed. (The GC normally only invokes this on rows that came back
+    ///   from `list_pending_collection`, so non-tombstoned rows are an unexpected race; returning
+    ///   the row unchanged lets the caller log/observe and move on without raising an error.)
     /// - If tombstoned with children: stamps any still-unstamped children (continues the fan-out),
     ///   ensures `system.rise.dev/cascade-deletion` is set, returns `MarkedForDeletion`.
     /// - If tombstoned without children: removes `system.rise.dev/cascade-deletion` if present;

--- a/crates/rise-resource-store/src/validation.rs
+++ b/crates/rise-resource-store/src/validation.rs
@@ -1,0 +1,125 @@
+use rise_resource_api::{
+    is_reserved_collection_name, validate_collection_name, validate_controller_id,
+    validate_resource_group, validate_resource_kind, validate_resource_version, OrganizationSpec,
+    OrganizationStatus, ResourceDefinitionSpec, ResourceDefinitionStatus,
+};
+
+use crate::error::StoreError;
+
+pub trait SpecValidator: Send + Sync {
+    fn validate_spec(&self, spec: &serde_json::Value) -> Result<(), StoreError>;
+    fn validate_status(&self, status: &serde_json::Value) -> Result<(), StoreError>;
+}
+
+pub struct OrganizationValidator;
+
+impl SpecValidator for OrganizationValidator {
+    fn validate_spec(&self, spec: &serde_json::Value) -> Result<(), StoreError> {
+        let parsed: OrganizationSpec = serde_json::from_value(spec.clone())
+            .map_err(|e| StoreError::Validation(format!("invalid Organization spec: {e}")))?;
+        if parsed.display_name.trim().is_empty() {
+            return Err(StoreError::Validation(
+                "Organization spec.displayName must not be empty".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_status(&self, status: &serde_json::Value) -> Result<(), StoreError> {
+        serde_json::from_value::<OrganizationStatus>(status.clone())
+            .map_err(|e| StoreError::Validation(format!("invalid Organization status: {e}")))?;
+        Ok(())
+    }
+}
+
+pub struct ResourceDefinitionValidator;
+
+impl SpecValidator for ResourceDefinitionValidator {
+    fn validate_spec(&self, spec: &serde_json::Value) -> Result<(), StoreError> {
+        let parsed: ResourceDefinitionSpec = serde_json::from_value(spec.clone())
+            .map_err(|e| StoreError::Validation(format!("invalid ResourceDefinition spec: {e}")))?;
+
+        validate_resource_group(&parsed.group)
+            .map_err(|e| StoreError::Validation(e.to_string()))?;
+        validate_resource_kind(&parsed.kind).map_err(|e| StoreError::Validation(e.to_string()))?;
+        validate_collection_name(&parsed.plural)
+            .map_err(|e| StoreError::Validation(e.to_string()))?;
+
+        if is_reserved_collection_name(&parsed.plural) {
+            return Err(StoreError::Validation(format!(
+                "plural '{}' is a reserved collection name",
+                parsed.plural
+            )));
+        }
+
+        if parsed.versions.is_empty() {
+            return Err(StoreError::Validation(
+                "ResourceDefinition must have at least one version".into(),
+            ));
+        }
+        let storage_count = parsed.versions.iter().filter(|v| v.storage).count();
+        if storage_count != 1 {
+            return Err(StoreError::Validation(
+                "ResourceDefinition must have exactly one storage version".into(),
+            ));
+        }
+        for v in &parsed.versions {
+            validate_resource_version(&v.name)
+                .map_err(|e| StoreError::Validation(e.to_string()))?;
+        }
+
+        for id in &parsed.allowed_status_controller_ids {
+            validate_controller_id(id).map_err(|e| StoreError::Validation(e.to_string()))?;
+        }
+
+        Ok(())
+    }
+
+    fn validate_status(&self, status: &serde_json::Value) -> Result<(), StoreError> {
+        serde_json::from_value::<ResourceDefinitionStatus>(status.clone()).map_err(|e| {
+            StoreError::Validation(format!("invalid ResourceDefinition status: {e}"))
+        })?;
+        Ok(())
+    }
+}
+
+pub struct JsonSchemaValidator {
+    schema: serde_json::Value,
+}
+
+impl JsonSchemaValidator {
+    pub fn new(schema: serde_json::Value) -> Self {
+        Self { schema }
+    }
+}
+
+impl SpecValidator for JsonSchemaValidator {
+    fn validate_spec(&self, spec: &serde_json::Value) -> Result<(), StoreError> {
+        let compiled = jsonschema::validator_for(&self.schema).map_err(|e| {
+            StoreError::Validation(format!("invalid JSON schema in ResourceDefinition: {e}"))
+        })?;
+        let errors: Vec<String> = compiled.iter_errors(spec).map(|e| e.to_string()).collect();
+        if !errors.is_empty() {
+            return Err(StoreError::Validation(format!(
+                "spec validation failed: {}",
+                errors.join("; ")
+            )));
+        }
+        Ok(())
+    }
+
+    fn validate_status(&self, _status: &serde_json::Value) -> Result<(), StoreError> {
+        Ok(())
+    }
+}
+
+pub struct NoOpValidator;
+
+impl SpecValidator for NoOpValidator {
+    fn validate_spec(&self, _spec: &serde_json::Value) -> Result<(), StoreError> {
+        Ok(())
+    }
+    fn validate_status(&self, _status: &serde_json::Value) -> Result<(), StoreError> {
+        Ok(())
+    }
+}

--- a/crates/rise-resource-store/src/validation.rs
+++ b/crates/rise-resource-store/src/validation.rs
@@ -84,21 +84,25 @@ impl SpecValidator for ResourceDefinitionValidator {
 }
 
 pub struct JsonSchemaValidator {
-    schema: serde_json::Value,
+    validator: jsonschema::Validator,
 }
 
 impl JsonSchemaValidator {
-    pub fn new(schema: serde_json::Value) -> Self {
-        Self { schema }
+    pub fn new(schema: serde_json::Value) -> Result<Self, StoreError> {
+        let validator = jsonschema::validator_for(&schema).map_err(|e| {
+            StoreError::Validation(format!("invalid JSON schema in ResourceDefinition: {e}"))
+        })?;
+        Ok(Self { validator })
     }
 }
 
 impl SpecValidator for JsonSchemaValidator {
     fn validate_spec(&self, spec: &serde_json::Value) -> Result<(), StoreError> {
-        let compiled = jsonschema::validator_for(&self.schema).map_err(|e| {
-            StoreError::Validation(format!("invalid JSON schema in ResourceDefinition: {e}"))
-        })?;
-        let errors: Vec<String> = compiled.iter_errors(spec).map(|e| e.to_string()).collect();
+        let errors: Vec<String> = self
+            .validator
+            .iter_errors(spec)
+            .map(|e| e.to_string())
+            .collect();
         if !errors.is_empty() {
             return Err(StoreError::Validation(format!(
                 "spec validation failed: {}",

--- a/crates/rise-resource-store/tests/integration_tests.rs
+++ b/crates/rise-resource-store/tests/integration_tests.rs
@@ -1,0 +1,530 @@
+use rise_resource_api::{API_VERSION_V1ALPHA1, ORGANIZATION_KIND, RESOURCE_DEFINITION_KIND};
+use rise_resource_store::{
+    CreateResourceParams, DeleteOutcome, PgResourceStore, ResourceStore, StoreError,
+    UpdateResourceParams,
+};
+use serde_json::json;
+use std::collections::BTreeMap;
+use uuid::Uuid;
+
+#[sqlx::test]
+async fn create_and_get_resource(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+
+    let params = CreateResourceParams {
+        api_version: API_VERSION_V1ALPHA1.to_string(),
+        kind: ORGANIZATION_KIND.to_string(),
+        name: "my-org".to_string(),
+        parent_uid: None,
+        annotations: BTreeMap::new(),
+        finalizers: vec![],
+        spec: json!({"displayName": "My Org"}),
+        validator: None,
+    };
+
+    let row = store.create(params).await.unwrap();
+    assert_eq!(row.name, "my-org");
+    assert_eq!(row.kind, ORGANIZATION_KIND);
+    assert_eq!(row.revision, 1);
+    assert_eq!(row.discriminator.len(), 8);
+    assert!(row.deletion_timestamp.is_none());
+
+    let fetched = store.get(row.uid).await.unwrap().unwrap();
+    assert_eq!(fetched.uid, row.uid);
+    assert_eq!(fetched.name, "my-org");
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn list_resources(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+
+    for name in ["beta", "alpha", "gamma"] {
+        store
+            .create(CreateResourceParams {
+                api_version: API_VERSION_V1ALPHA1.to_string(),
+                kind: ORGANIZATION_KIND.to_string(),
+                name: name.to_string(),
+                parent_uid: None,
+                annotations: BTreeMap::new(),
+                finalizers: vec![],
+                spec: json!({"displayName": name}),
+                validator: None,
+            })
+            .await
+            .unwrap();
+    }
+
+    let list = store.list(ORGANIZATION_KIND, None).await.unwrap();
+    assert_eq!(list.len(), 3);
+    // Returned in name order
+    assert_eq!(list[0].name, "alpha");
+    assert_eq!(list[1].name, "beta");
+    assert_eq!(list[2].name, "gamma");
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn update_resource_increments_revision(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+
+    let row = store
+        .create(CreateResourceParams {
+            api_version: API_VERSION_V1ALPHA1.to_string(),
+            kind: ORGANIZATION_KIND.to_string(),
+            name: "my-org".to_string(),
+            parent_uid: None,
+            annotations: BTreeMap::new(),
+            finalizers: vec![],
+            spec: json!({"displayName": "My Org"}),
+            validator: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(row.revision, 1);
+
+    let updated = store
+        .update(
+            row.uid,
+            UpdateResourceParams {
+                revision: 1,
+                annotations: BTreeMap::new(),
+                finalizers: vec![],
+                spec: json!({"displayName": "Updated Org"}),
+                validator: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(updated.revision, 2);
+    assert_eq!(updated.spec["displayName"], "Updated Org");
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn update_rejects_wrong_revision(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+
+    let row = store
+        .create(CreateResourceParams {
+            api_version: API_VERSION_V1ALPHA1.to_string(),
+            kind: ORGANIZATION_KIND.to_string(),
+            name: "my-org".to_string(),
+            parent_uid: None,
+            annotations: BTreeMap::new(),
+            finalizers: vec![],
+            spec: json!({"displayName": "My Org"}),
+            validator: None,
+        })
+        .await
+        .unwrap();
+
+    let err = store
+        .update(
+            row.uid,
+            UpdateResourceParams {
+                revision: 99, // wrong
+                annotations: BTreeMap::new(),
+                finalizers: vec![],
+                spec: json!({"displayName": "Updated"}),
+                validator: None,
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        StoreError::RevisionConflict {
+            expected: 99,
+            found: 1
+        }
+    ));
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn duplicate_name_returns_conflict(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+
+    let params = || CreateResourceParams {
+        api_version: API_VERSION_V1ALPHA1.to_string(),
+        kind: ORGANIZATION_KIND.to_string(),
+        name: "same-name".to_string(),
+        parent_uid: None,
+        annotations: BTreeMap::new(),
+        finalizers: vec![],
+        spec: json!({"displayName": "Org"}),
+        validator: None,
+    };
+
+    store.create(params()).await.unwrap();
+    let err = store.create(params()).await.unwrap_err();
+    assert!(matches!(err, StoreError::NameConflict));
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn delete_without_finalizers_removes_row(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+
+    let row = store
+        .create(CreateResourceParams {
+            api_version: API_VERSION_V1ALPHA1.to_string(),
+            kind: ORGANIZATION_KIND.to_string(),
+            name: "to-delete".to_string(),
+            parent_uid: None,
+            annotations: BTreeMap::new(),
+            finalizers: vec![],
+            spec: json!({"displayName": "Delete Me"}),
+            validator: None,
+        })
+        .await
+        .unwrap();
+
+    let outcome = store.delete(row.uid).await.unwrap();
+    assert!(matches!(outcome, DeleteOutcome::Deleted));
+    assert!(store.get(row.uid).await.unwrap().is_none());
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn delete_with_finalizers_marks_deletion_timestamp(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+
+    let row = store
+        .create(CreateResourceParams {
+            api_version: API_VERSION_V1ALPHA1.to_string(),
+            kind: ORGANIZATION_KIND.to_string(),
+            name: "finalized".to_string(),
+            parent_uid: None,
+            annotations: BTreeMap::new(),
+            finalizers: vec!["controller.example.com/cleanup".to_string()],
+            spec: json!({"displayName": "Org"}),
+            validator: None,
+        })
+        .await
+        .unwrap();
+
+    let outcome = store.delete(row.uid).await.unwrap();
+    let marked = match outcome {
+        DeleteOutcome::MarkedForDeletion(r) => *r,
+        DeleteOutcome::Deleted => panic!("expected MarkedForDeletion"),
+    };
+    assert!(marked.deletion_timestamp.is_some());
+    assert_eq!(marked.finalizers.len(), 1);
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn delete_with_children_rejected(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+
+    let parent = store
+        .create(CreateResourceParams {
+            api_version: API_VERSION_V1ALPHA1.to_string(),
+            kind: ORGANIZATION_KIND.to_string(),
+            name: "parent-org".to_string(),
+            parent_uid: None,
+            annotations: BTreeMap::new(),
+            finalizers: vec![],
+            spec: json!({"displayName": "Parent"}),
+            validator: None,
+        })
+        .await
+        .unwrap();
+
+    store
+        .create(CreateResourceParams {
+            api_version: "example.dev/v1".to_string(),
+            kind: "Widget".to_string(),
+            name: "widget-a".to_string(),
+            parent_uid: Some(parent.uid),
+            annotations: BTreeMap::new(),
+            finalizers: vec![],
+            spec: json!({}),
+            validator: None,
+        })
+        .await
+        .unwrap();
+
+    let err = store.delete(parent.uid).await.unwrap_err();
+    assert!(matches!(err, StoreError::HasChildren));
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn finalizer_flow_completes_deletion(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    let controller = "controller.example.com";
+    let finalizer = "controller.example.com/cleanup";
+
+    let row = store
+        .create(CreateResourceParams {
+            api_version: API_VERSION_V1ALPHA1.to_string(),
+            kind: ORGANIZATION_KIND.to_string(),
+            name: "with-finalizer".to_string(),
+            parent_uid: None,
+            annotations: BTreeMap::new(),
+            finalizers: vec![finalizer.to_string()],
+            spec: json!({"displayName": "Org"}),
+            validator: None,
+        })
+        .await
+        .unwrap();
+
+    // Delete marks timestamp but doesn't remove
+    let outcome = store.delete(row.uid).await.unwrap();
+    assert!(matches!(outcome, DeleteOutcome::MarkedForDeletion(_)));
+
+    // Controller removes its finalizer
+    let without_finalizer = store
+        .update_controller_finalizers(row.uid, controller, &[], &[finalizer.to_string()])
+        .await
+        .unwrap();
+    assert!(without_finalizer.finalizers.is_empty());
+
+    // Second delete should now succeed
+    let outcome2 = store.delete(row.uid).await.unwrap();
+    assert!(matches!(outcome2, DeleteOutcome::Deleted));
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn controller_status_update_merges_key(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+
+    let row = store
+        .create(CreateResourceParams {
+            api_version: API_VERSION_V1ALPHA1.to_string(),
+            kind: ORGANIZATION_KIND.to_string(),
+            name: "status-org".to_string(),
+            parent_uid: None,
+            annotations: BTreeMap::new(),
+            finalizers: vec![],
+            spec: json!({"displayName": "Org"}),
+            validator: None,
+        })
+        .await
+        .unwrap();
+
+    let updated = store
+        .update_controller_status(row.uid, "controller.example.com", json!({"ready": true}))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        updated.status["controllers"]["controller.example.com"]["ready"],
+        true
+    );
+    assert_eq!(updated.revision, 2);
+
+    // Second update only affects that controller's key
+    let updated2 = store
+        .update_controller_status(row.uid, "other.example.com", json!({"synced": true}))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        updated2.status["controllers"]["controller.example.com"]["ready"],
+        true
+    );
+    assert_eq!(
+        updated2.status["controllers"]["other.example.com"]["synced"],
+        true
+    );
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn controller_finalizers_enforces_ownership(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+
+    let row = store
+        .create(CreateResourceParams {
+            api_version: API_VERSION_V1ALPHA1.to_string(),
+            kind: ORGANIZATION_KIND.to_string(),
+            name: "owned".to_string(),
+            parent_uid: None,
+            annotations: BTreeMap::new(),
+            finalizers: vec![],
+            spec: json!({"displayName": "Org"}),
+            validator: None,
+        })
+        .await
+        .unwrap();
+
+    // Adding a finalizer owned by a different controller should fail
+    let err = store
+        .update_controller_finalizers(
+            row.uid,
+            "controller.example.com",
+            &["other.example.com/cleanup".to_string()],
+            &[],
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, StoreError::Validation(_)));
+
+    // Adding an owned finalizer succeeds
+    store
+        .update_controller_finalizers(
+            row.uid,
+            "controller.example.com",
+            &["controller.example.com/cleanup".to_string()],
+            &[],
+        )
+        .await
+        .unwrap();
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn resolve_builtin_collection(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+
+    let org_info = store.resolve_collection("organizations").await.unwrap();
+    assert!(org_info.is_some());
+    let info = org_info.unwrap();
+    assert_eq!(info.kind, ORGANIZATION_KIND);
+    assert_eq!(info.api_version, API_VERSION_V1ALPHA1);
+
+    let rd_info = store
+        .resolve_collection("resourcedefinitions")
+        .await
+        .unwrap();
+    assert!(rd_info.is_some());
+    assert_eq!(rd_info.unwrap().kind, RESOURCE_DEFINITION_KIND);
+
+    let none = store.resolve_collection("unknown").await.unwrap();
+    assert!(none.is_none());
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn register_resource_definition(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+
+    let spec = json!({
+        "group": "example.dev",
+        "kind": "Widget",
+        "plural": "widgets",
+        "scope": "Root",
+        "versions": [{"name": "v1", "served": true, "storage": true}],
+        "allowedStatusControllerIds": []
+    });
+
+    let row = store
+        .register_resource_definition(CreateResourceParams {
+            api_version: API_VERSION_V1ALPHA1.to_string(),
+            kind: RESOURCE_DEFINITION_KIND.to_string(),
+            name: "widgets.example.dev".to_string(),
+            parent_uid: None,
+            annotations: BTreeMap::new(),
+            finalizers: vec![],
+            spec,
+            validator: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(row.kind, RESOURCE_DEFINITION_KIND);
+
+    // Should now resolve via the collection
+    let info = store.resolve_collection("widgets").await.unwrap().unwrap();
+    assert_eq!(info.kind, "Widget");
+    assert_eq!(info.api_version, "example.dev/v1");
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn register_resource_definition_rejects_reserved_plural(
+    pool: sqlx::PgPool,
+) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+
+    let spec = json!({
+        "group": "example.dev",
+        "kind": "Organization",
+        "plural": "organizations",
+        "scope": "Root",
+        "versions": [{"name": "v1", "served": true, "storage": true}],
+        "allowedStatusControllerIds": []
+    });
+
+    let err = store
+        .register_resource_definition(CreateResourceParams {
+            api_version: API_VERSION_V1ALPHA1.to_string(),
+            kind: RESOURCE_DEFINITION_KIND.to_string(),
+            name: "organizations.example.dev".to_string(),
+            parent_uid: None,
+            annotations: BTreeMap::new(),
+            finalizers: vec![],
+            spec,
+            validator: None,
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, StoreError::Validation(_)));
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn get_by_name(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+
+    store
+        .create(CreateResourceParams {
+            api_version: API_VERSION_V1ALPHA1.to_string(),
+            kind: ORGANIZATION_KIND.to_string(),
+            name: "lookup-org".to_string(),
+            parent_uid: None,
+            annotations: BTreeMap::new(),
+            finalizers: vec![],
+            spec: json!({"displayName": "Lookup Org"}),
+            validator: None,
+        })
+        .await
+        .unwrap();
+
+    let found = store
+        .get_by_name(ORGANIZATION_KIND, "lookup-org", None)
+        .await
+        .unwrap();
+    assert!(found.is_some());
+    assert_eq!(found.unwrap().name, "lookup-org");
+
+    let not_found = store
+        .get_by_name(ORGANIZATION_KIND, "nonexistent", None)
+        .await
+        .unwrap();
+    assert!(not_found.is_none());
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn get_returns_none_for_unknown_uid(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    let result = store.get(Uuid::new_v4()).await.unwrap();
+    assert!(result.is_none());
+    Ok(())
+}

--- a/crates/rise-resource-store/tests/integration_tests.rs
+++ b/crates/rise-resource-store/tests/integration_tests.rs
@@ -1,7 +1,7 @@
 use rise_resource_api::{API_VERSION_V1ALPHA1, ORGANIZATION_KIND, RESOURCE_DEFINITION_KIND};
 use rise_resource_store::{
-    CreateResourceParams, DeleteOutcome, PgResourceStore, ResourceStore, StoreError,
-    UpdateResourceParams,
+    CreateResourceParams, DeleteOutcome, PathSegment, PgResourceStore, PropagationPolicy,
+    ResourceStore, StoreError, UpdateResourceParams, CASCADE_DELETION_FINALIZER,
 };
 use serde_json::json;
 use std::collections::BTreeMap;
@@ -189,7 +189,10 @@ async fn delete_without_finalizers_removes_row(pool: sqlx::PgPool) -> sqlx::Resu
         .await
         .unwrap();
 
-    let outcome = store.delete(row.uid).await.unwrap();
+    let outcome = store
+        .delete(row.uid, PropagationPolicy::Cascade)
+        .await
+        .unwrap();
     assert!(matches!(outcome, DeleteOutcome::Deleted));
     assert!(store.get(row.uid).await.unwrap().is_none());
 
@@ -214,51 +217,16 @@ async fn delete_with_finalizers_marks_deletion_timestamp(pool: sqlx::PgPool) -> 
         .await
         .unwrap();
 
-    let outcome = store.delete(row.uid).await.unwrap();
+    let outcome = store
+        .delete(row.uid, PropagationPolicy::Cascade)
+        .await
+        .unwrap();
     let marked = match outcome {
         DeleteOutcome::MarkedForDeletion(r) => *r,
         DeleteOutcome::Deleted => panic!("expected MarkedForDeletion"),
     };
     assert!(marked.deletion_timestamp.is_some());
     assert_eq!(marked.finalizers.len(), 1);
-
-    Ok(())
-}
-
-#[sqlx::test]
-async fn delete_with_children_rejected(pool: sqlx::PgPool) -> sqlx::Result<()> {
-    let store = PgResourceStore::new(pool);
-
-    let parent = store
-        .create(CreateResourceParams {
-            api_version: API_VERSION_V1ALPHA1.to_string(),
-            kind: ORGANIZATION_KIND.to_string(),
-            name: "parent-org".to_string(),
-            parent_uid: None,
-            annotations: BTreeMap::new(),
-            finalizers: vec![],
-            spec: json!({"displayName": "Parent"}),
-            validator: None,
-        })
-        .await
-        .unwrap();
-
-    store
-        .create(CreateResourceParams {
-            api_version: "example.dev/v1".to_string(),
-            kind: "Widget".to_string(),
-            name: "widget-a".to_string(),
-            parent_uid: Some(parent.uid),
-            annotations: BTreeMap::new(),
-            finalizers: vec![],
-            spec: json!({}),
-            validator: None,
-        })
-        .await
-        .unwrap();
-
-    let err = store.delete(parent.uid).await.unwrap_err();
-    assert!(matches!(err, StoreError::HasChildren));
 
     Ok(())
 }
@@ -284,7 +252,10 @@ async fn finalizer_flow_completes_deletion(pool: sqlx::PgPool) -> sqlx::Result<(
         .unwrap();
 
     // Delete marks timestamp but doesn't remove
-    let outcome = store.delete(row.uid).await.unwrap();
+    let outcome = store
+        .delete(row.uid, PropagationPolicy::Cascade)
+        .await
+        .unwrap();
     assert!(matches!(outcome, DeleteOutcome::MarkedForDeletion(_)));
 
     // Controller removes its finalizer
@@ -294,8 +265,8 @@ async fn finalizer_flow_completes_deletion(pool: sqlx::PgPool) -> sqlx::Result<(
         .unwrap();
     assert!(without_finalizer.finalizers.is_empty());
 
-    // Second delete should now succeed
-    let outcome2 = store.delete(row.uid).await.unwrap();
+    // try_collect now succeeds: row is tombstoned, no finalizers, no children.
+    let outcome2 = store.try_collect(row.uid).await.unwrap();
     assert!(matches!(outcome2, DeleteOutcome::Deleted));
 
     Ok(())
@@ -605,12 +576,27 @@ async fn delete_already_marked_resource_is_idempotent(pool: sqlx::PgPool) -> sql
         .unwrap();
 
     // First delete: marks for deletion
-    let outcome1 = store.delete(row.uid).await.unwrap();
-    assert!(matches!(outcome1, DeleteOutcome::MarkedForDeletion(_)));
+    let outcome1 = store
+        .delete(row.uid, PropagationPolicy::Cascade)
+        .await
+        .unwrap();
+    let first_ts = match outcome1 {
+        DeleteOutcome::MarkedForDeletion(r) => r.deletion_timestamp,
+        DeleteOutcome::Deleted => panic!("expected MarkedForDeletion"),
+    };
+    assert!(first_ts.is_some());
 
-    // Second delete while finalizers are still present: re-marks (idempotent)
-    let outcome2 = store.delete(row.uid).await.unwrap();
-    assert!(matches!(outcome2, DeleteOutcome::MarkedForDeletion(_)));
+    // Second delete while finalizers are still present: re-marks (idempotent) and preserves
+    // the original deletion_timestamp.
+    let outcome2 = store
+        .delete(row.uid, PropagationPolicy::Cascade)
+        .await
+        .unwrap();
+    let second = match outcome2 {
+        DeleteOutcome::MarkedForDeletion(r) => *r,
+        DeleteOutcome::Deleted => panic!("expected MarkedForDeletion"),
+    };
+    assert_eq!(second.deletion_timestamp, first_ts);
 
     Ok(())
 }
@@ -785,6 +771,538 @@ async fn update_rejects_resource_definition(pool: sqlx::PgPool) -> sqlx::Result<
         matches!(err, StoreError::Validation(_)),
         "expected Validation error, got {err:?}"
     );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------------------------
+// Cascade / orphan deletion
+// ---------------------------------------------------------------------------------------------
+
+async fn create_org(store: &PgResourceStore, name: &str) -> rise_resource_store::ResourceRow {
+    store
+        .create(CreateResourceParams {
+            api_version: API_VERSION_V1ALPHA1.to_string(),
+            kind: ORGANIZATION_KIND.to_string(),
+            name: name.to_string(),
+            parent_uid: None,
+            annotations: BTreeMap::new(),
+            finalizers: vec![],
+            spec: json!({"displayName": name}),
+            validator: None,
+        })
+        .await
+        .unwrap()
+}
+
+async fn create_child(
+    store: &PgResourceStore,
+    parent: Uuid,
+    kind: &str,
+    name: &str,
+    finalizers: Vec<String>,
+) -> rise_resource_store::ResourceRow {
+    store
+        .create(CreateResourceParams {
+            api_version: "example.dev/v1".to_string(),
+            kind: kind.to_string(),
+            name: name.to_string(),
+            parent_uid: Some(parent),
+            annotations: BTreeMap::new(),
+            finalizers,
+            spec: json!({}),
+            validator: None,
+        })
+        .await
+        .unwrap()
+}
+
+#[sqlx::test]
+async fn cascade_delete_stamps_immediate_children(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    let parent = create_org(&store, "cascade-org").await;
+    let c1 = create_child(&store, parent.uid, "Widget", "w1", vec![]).await;
+    let c2 = create_child(&store, parent.uid, "Widget", "w2", vec![]).await;
+
+    let outcome = store
+        .delete(parent.uid, PropagationPolicy::Cascade)
+        .await
+        .unwrap();
+    let marked = match outcome {
+        DeleteOutcome::MarkedForDeletion(r) => *r,
+        DeleteOutcome::Deleted => panic!("parent still has children, should be MarkedForDeletion"),
+    };
+    assert!(marked.deletion_timestamp.is_some());
+    assert!(
+        marked
+            .finalizers
+            .contains(&CASCADE_DELETION_FINALIZER.to_string()),
+        "parent missing cascade finalizer: {:?}",
+        marked.finalizers
+    );
+
+    let c1_after = store.get(c1.uid).await.unwrap().unwrap();
+    let c2_after = store.get(c2.uid).await.unwrap().unwrap();
+    assert!(c1_after.deletion_timestamp.is_some());
+    assert!(c2_after.deletion_timestamp.is_some());
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn cascade_delete_idempotent(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    let parent = create_org(&store, "cascade-org").await;
+    create_child(&store, parent.uid, "Widget", "w1", vec![]).await;
+
+    let first = match store
+        .delete(parent.uid, PropagationPolicy::Cascade)
+        .await
+        .unwrap()
+    {
+        DeleteOutcome::MarkedForDeletion(r) => r.deletion_timestamp,
+        _ => panic!("expected MarkedForDeletion"),
+    };
+    let second = match store
+        .delete(parent.uid, PropagationPolicy::Cascade)
+        .await
+        .unwrap()
+    {
+        DeleteOutcome::MarkedForDeletion(r) => {
+            let count = r
+                .finalizers
+                .iter()
+                .filter(|f| f.as_str() == CASCADE_DELETION_FINALIZER)
+                .count();
+            assert_eq!(count, 1, "cascade finalizer duplicated: {:?}", r.finalizers);
+            r.deletion_timestamp
+        }
+        _ => panic!("expected MarkedForDeletion"),
+    };
+    assert_eq!(
+        first, second,
+        "deletion_timestamp must be preserved on re-delete"
+    );
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn cascade_collection_drains_bottom_up(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    let parent = create_org(&store, "drain-org").await;
+    let child = create_child(
+        &store,
+        parent.uid,
+        "Widget",
+        "w1",
+        vec!["controller.example.com/cleanup".to_string()],
+    )
+    .await;
+
+    // Delete the parent. Child gets stamped, parent gets cascade finalizer.
+    store
+        .delete(parent.uid, PropagationPolicy::Cascade)
+        .await
+        .unwrap();
+
+    // try_collect on parent while child still exists: stays marked, cascade finalizer persists.
+    let outcome = store.try_collect(parent.uid).await.unwrap();
+    let p_marked = match outcome {
+        DeleteOutcome::MarkedForDeletion(r) => *r,
+        _ => panic!("parent should still be marked"),
+    };
+    assert!(p_marked
+        .finalizers
+        .contains(&CASCADE_DELETION_FINALIZER.to_string()));
+
+    // try_collect on the child while it has controller finalizers: still marked, no hard delete.
+    let outcome = store.try_collect(child.uid).await.unwrap();
+    assert!(matches!(outcome, DeleteOutcome::MarkedForDeletion(_)));
+    assert!(store.get(child.uid).await.unwrap().is_some());
+
+    // Controller clears its finalizer.
+    store
+        .update_controller_finalizers(
+            child.uid,
+            "controller.example.com",
+            &[],
+            &["controller.example.com/cleanup".to_string()],
+        )
+        .await
+        .unwrap();
+
+    // try_collect on child now hard-deletes it.
+    let outcome = store.try_collect(child.uid).await.unwrap();
+    assert!(matches!(outcome, DeleteOutcome::Deleted));
+    assert!(store.get(child.uid).await.unwrap().is_none());
+
+    // try_collect on parent: no remaining children → cascade finalizer cleared, hard-delete.
+    let outcome = store.try_collect(parent.uid).await.unwrap();
+    assert!(matches!(outcome, DeleteOutcome::Deleted));
+    assert!(store.get(parent.uid).await.unwrap().is_none());
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn try_collect_on_live_row_is_noop(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    let parent = create_org(&store, "live-org").await;
+
+    let outcome = store.try_collect(parent.uid).await.unwrap();
+    match outcome {
+        DeleteOutcome::MarkedForDeletion(r) => {
+            assert!(r.deletion_timestamp.is_none());
+        }
+        DeleteOutcome::Deleted => panic!("live row should not be deleted"),
+    }
+    assert!(store.get(parent.uid).await.unwrap().is_some());
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn list_pending_collection_returns_tombstoned_only(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    let alive = create_org(&store, "alive-org").await;
+    let dying = create_org(&store, "dying-org").await;
+
+    store
+        .update_controller_finalizers(
+            dying.uid,
+            "controller.example.com",
+            &["controller.example.com/cleanup".to_string()],
+            &[],
+        )
+        .await
+        .unwrap();
+    store
+        .delete(dying.uid, PropagationPolicy::Cascade)
+        .await
+        .unwrap();
+
+    let pending = store.list_pending_collection(100).await.unwrap();
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].uid, dying.uid);
+    assert!(pending.iter().all(|r| r.uid != alive.uid));
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn orphan_delete_detaches_children(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    let parent = create_org(&store, "orphan-org").await;
+    let c1 = create_child(&store, parent.uid, "Widget", "w1", vec![]).await;
+    let c2 = create_child(&store, parent.uid, "Widget", "w2", vec![]).await;
+
+    let outcome = store
+        .delete(parent.uid, PropagationPolicy::Orphan)
+        .await
+        .unwrap();
+    assert!(matches!(outcome, DeleteOutcome::Deleted));
+    assert!(store.get(parent.uid).await.unwrap().is_none());
+
+    let c1_after = store.get(c1.uid).await.unwrap().unwrap();
+    let c2_after = store.get(c2.uid).await.unwrap().unwrap();
+    assert_eq!(c1_after.parent_uid, None);
+    assert_eq!(c2_after.parent_uid, None);
+    assert!(c1_after.deletion_timestamp.is_none());
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn cascade_finalizer_not_addable_by_controller(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    let row = create_org(&store, "guarded").await;
+
+    let err = store
+        .update_controller_finalizers(
+            row.uid,
+            "controller.example.com",
+            &[CASCADE_DELETION_FINALIZER.to_string()],
+            &[],
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, StoreError::ReservedFinalizer(_)),
+        "expected ReservedFinalizer, got {err:?}"
+    );
+
+    let err = store
+        .update_controller_finalizers(
+            row.uid,
+            "controller.example.com",
+            &[],
+            &[CASCADE_DELETION_FINALIZER.to_string()],
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(err, StoreError::ReservedFinalizer(_)));
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------------------------
+// Path resolution
+// ---------------------------------------------------------------------------------------------
+
+#[sqlx::test]
+async fn resolve_path_walks_named_segments(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    let org = create_org(&store, "acme").await;
+    let widget = create_child(&store, org.uid, "Widget", "w1", vec![]).await;
+
+    let chain = store
+        .resolve_path(&[
+            PathSegment::Name {
+                kind: ORGANIZATION_KIND.to_string(),
+                name: "acme".to_string(),
+            },
+            PathSegment::Name {
+                kind: "Widget".to_string(),
+                name: "w1".to_string(),
+            },
+        ])
+        .await
+        .unwrap();
+    assert_eq!(chain.len(), 2);
+    assert_eq!(chain[0].uid, org.uid);
+    assert_eq!(chain[1].uid, widget.uid);
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn resolve_path_supports_uid_segments(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    let org = create_org(&store, "acme").await;
+    let widget = create_child(&store, org.uid, "Widget", "w1", vec![]).await;
+
+    let chain = store
+        .resolve_path(&[
+            PathSegment::Uid {
+                kind: ORGANIZATION_KIND.to_string(),
+                uid: org.uid,
+            },
+            PathSegment::Name {
+                kind: "Widget".to_string(),
+                name: "w1".to_string(),
+            },
+        ])
+        .await
+        .unwrap();
+    assert_eq!(chain.len(), 2);
+    assert_eq!(chain[1].uid, widget.uid);
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn resolve_path_rejects_kind_mismatch(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    let org = create_org(&store, "acme").await;
+
+    let err = store
+        .resolve_path(&[PathSegment::Uid {
+            kind: "Widget".to_string(),
+            uid: org.uid,
+        }])
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, StoreError::KindMismatch { .. }),
+        "expected KindMismatch, got {err:?}"
+    );
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn resolve_path_rejects_wrong_subtree(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    let org_a = create_org(&store, "org-a").await;
+    let org_b = create_org(&store, "org-b").await;
+    let widget_b = create_child(&store, org_b.uid, "Widget", "w1", vec![]).await;
+
+    let err = store
+        .resolve_path(&[
+            PathSegment::Uid {
+                kind: ORGANIZATION_KIND.to_string(),
+                uid: org_a.uid,
+            },
+            PathSegment::Uid {
+                kind: "Widget".to_string(),
+                uid: widget_b.uid,
+            },
+        ])
+        .await
+        .unwrap_err();
+    assert!(matches!(err, StoreError::ParentNotFound));
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn resolve_path_returns_tombstoned_rows(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    let org = create_org(&store, "acme").await;
+    let widget = create_child(
+        &store,
+        org.uid,
+        "Widget",
+        "w1",
+        vec!["controller.example.com/cleanup".to_string()],
+    )
+    .await;
+    store
+        .delete(widget.uid, PropagationPolicy::Cascade)
+        .await
+        .unwrap();
+
+    let chain = store
+        .resolve_path(&[
+            PathSegment::Name {
+                kind: ORGANIZATION_KIND.to_string(),
+                name: "acme".to_string(),
+            },
+            PathSegment::Name {
+                kind: "Widget".to_string(),
+                name: "w1".to_string(),
+            },
+        ])
+        .await
+        .unwrap();
+    assert_eq!(chain.len(), 2);
+    assert!(chain[1].deletion_timestamp.is_some());
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn resolve_path_empty_returns_error(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    let err = store.resolve_path(&[]).await.unwrap_err();
+    assert!(matches!(err, StoreError::EmptyPath));
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------------------------
+// Orphan discovery / reparent
+// ---------------------------------------------------------------------------------------------
+
+#[sqlx::test]
+async fn list_orphans_returns_children_of_tombstoned_parent(
+    pool: sqlx::PgPool,
+) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    let dying_parent = create_org(&store, "dying").await;
+    store
+        .update_controller_finalizers(
+            dying_parent.uid,
+            "controller.example.com",
+            &["controller.example.com/cleanup".to_string()],
+            &[],
+        )
+        .await
+        .unwrap();
+    let child_dying = create_child(&store, dying_parent.uid, "Widget", "w1", vec![]).await;
+
+    let alive_parent = create_org(&store, "alive").await;
+    let _child_alive = create_child(&store, alive_parent.uid, "Widget", "w2", vec![]).await;
+
+    store
+        .delete(dying_parent.uid, PropagationPolicy::Cascade)
+        .await
+        .unwrap();
+
+    let orphans = store.list_orphans(None).await.unwrap();
+    assert_eq!(orphans.len(), 1);
+    assert_eq!(orphans[0].uid, child_dying.uid);
+
+    let scoped = store.list_orphans(Some(dying_parent.uid)).await.unwrap();
+    assert_eq!(scoped.len(), 1);
+
+    let none_scoped = store.list_orphans(Some(alive_parent.uid)).await.unwrap();
+    assert!(none_scoped.is_empty());
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn reparent_moves_resource(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    let org_a = create_org(&store, "org-a").await;
+    let org_b = create_org(&store, "org-b").await;
+    let widget = create_child(&store, org_a.uid, "Widget", "w1", vec![]).await;
+
+    let moved = store.reparent(widget.uid, Some(org_b.uid)).await.unwrap();
+    assert_eq!(moved.parent_uid, Some(org_b.uid));
+
+    let under_a = store.list("Widget", Some(org_a.uid)).await.unwrap();
+    assert!(under_a.is_empty());
+    let under_b = store.list("Widget", Some(org_b.uid)).await.unwrap();
+    assert_eq!(under_b.len(), 1);
+    assert_eq!(under_b[0].uid, widget.uid);
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn reparent_to_root(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    let org_a = create_org(&store, "org-a").await;
+    let child_org = store
+        .create(CreateResourceParams {
+            api_version: API_VERSION_V1ALPHA1.to_string(),
+            kind: ORGANIZATION_KIND.to_string(),
+            name: "child".to_string(),
+            parent_uid: Some(org_a.uid),
+            annotations: BTreeMap::new(),
+            finalizers: vec![],
+            spec: json!({"displayName": "Child"}),
+            validator: None,
+        })
+        .await
+        .unwrap();
+
+    let moved = store.reparent(child_org.uid, None).await.unwrap();
+    assert_eq!(moved.parent_uid, None);
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn reparent_rejects_cycle(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    let org = create_org(&store, "root").await;
+    let child = create_child(&store, org.uid, "Widget", "w1", vec![]).await;
+
+    let err = store.reparent(org.uid, Some(org.uid)).await.unwrap_err();
+    assert!(matches!(err, StoreError::ReparentCycle));
+
+    let err = store.reparent(org.uid, Some(child.uid)).await.unwrap_err();
+    assert!(matches!(err, StoreError::ReparentCycle));
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn reparent_respects_uniqueness(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    let org_a = create_org(&store, "org-a").await;
+    let org_b = create_org(&store, "org-b").await;
+    let _existing = create_child(&store, org_b.uid, "Widget", "shared", vec![]).await;
+    let moving = create_child(&store, org_a.uid, "Widget", "shared", vec![]).await;
+
+    let err = store
+        .reparent(moving.uid, Some(org_b.uid))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, StoreError::NameConflict));
 
     Ok(())
 }

--- a/crates/rise-resource-store/tests/integration_tests.rs
+++ b/crates/rise-resource-store/tests/integration_tests.rs
@@ -424,7 +424,7 @@ async fn register_resource_definition(pool: sqlx::PgPool) -> sqlx::Result<()> {
         "group": "example.dev",
         "kind": "Widget",
         "plural": "widgets",
-        "scope": "Root",
+        "scope": "root",
         "versions": [{"name": "v1", "served": true, "storage": true}],
         "allowedStatusControllerIds": []
     });
@@ -463,7 +463,7 @@ async fn register_resource_definition_rejects_reserved_plural(
         "group": "example.dev",
         "kind": "Organization",
         "plural": "organizations",
-        "scope": "Root",
+        "scope": "root",
         "versions": [{"name": "v1", "served": true, "storage": true}],
         "allowedStatusControllerIds": []
     });
@@ -526,5 +526,265 @@ async fn get_returns_none_for_unknown_uid(pool: sqlx::PgPool) -> sqlx::Result<()
     let store = PgResourceStore::new(pool);
     let result = store.get(Uuid::new_v4()).await.unwrap();
     assert!(result.is_none());
+    Ok(())
+}
+
+#[sqlx::test]
+async fn create_rejects_invalid_name(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+
+    // Leading hyphen violates the name format constraint
+    let err = store
+        .create(CreateResourceParams {
+            api_version: API_VERSION_V1ALPHA1.to_string(),
+            kind: ORGANIZATION_KIND.to_string(),
+            name: "--bad-name".to_string(),
+            parent_uid: None,
+            annotations: BTreeMap::new(),
+            finalizers: vec![],
+            spec: json!({"displayName": "Bad"}),
+            validator: None,
+        })
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, StoreError::Validation(_)),
+        "expected Validation error, got {err:?}"
+    );
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn create_invokes_spec_validator(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    use rise_resource_store::OrganizationValidator;
+    use std::sync::Arc;
+
+    let store = PgResourceStore::new(pool);
+
+    // OrganizationValidator requires a non-empty displayName
+    let err = store
+        .create(CreateResourceParams {
+            api_version: API_VERSION_V1ALPHA1.to_string(),
+            kind: ORGANIZATION_KIND.to_string(),
+            name: "bad-spec-org".to_string(),
+            parent_uid: None,
+            annotations: BTreeMap::new(),
+            finalizers: vec![],
+            spec: json!({"displayName": "   "}),
+            validator: Some(Arc::new(OrganizationValidator)),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, StoreError::Validation(_)),
+        "expected Validation error, got {err:?}"
+    );
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn delete_already_marked_resource_is_idempotent(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+
+    let row = store
+        .create(CreateResourceParams {
+            api_version: API_VERSION_V1ALPHA1.to_string(),
+            kind: ORGANIZATION_KIND.to_string(),
+            name: "marked-org".to_string(),
+            parent_uid: None,
+            annotations: BTreeMap::new(),
+            finalizers: vec!["controller.example.com/cleanup".to_string()],
+            spec: json!({"displayName": "Org"}),
+            validator: None,
+        })
+        .await
+        .unwrap();
+
+    // First delete: marks for deletion
+    let outcome1 = store.delete(row.uid).await.unwrap();
+    assert!(matches!(outcome1, DeleteOutcome::MarkedForDeletion(_)));
+
+    // Second delete while finalizers are still present: re-marks (idempotent)
+    let outcome2 = store.delete(row.uid).await.unwrap();
+    assert!(matches!(outcome2, DeleteOutcome::MarkedForDeletion(_)));
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn update_resource_definition_updates_projection(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+
+    let spec_v1 = json!({
+        "group": "example.dev",
+        "kind": "Widget",
+        "plural": "widgets",
+        "scope": "root",
+        "versions": [{"name": "v1", "served": true, "storage": true}],
+        "allowedStatusControllerIds": []
+    });
+
+    let row = store
+        .register_resource_definition(CreateResourceParams {
+            api_version: API_VERSION_V1ALPHA1.to_string(),
+            kind: RESOURCE_DEFINITION_KIND.to_string(),
+            name: "widgets.example.dev".to_string(),
+            parent_uid: None,
+            annotations: BTreeMap::new(),
+            finalizers: vec![],
+            spec: spec_v1,
+            validator: None,
+        })
+        .await
+        .unwrap();
+
+    // Add a v2 version (identity fields unchanged)
+    let spec_v2 = json!({
+        "group": "example.dev",
+        "kind": "Widget",
+        "plural": "widgets",
+        "scope": "root",
+        "versions": [
+            {"name": "v1", "served": true, "storage": false},
+            {"name": "v2", "served": true, "storage": true}
+        ],
+        "allowedStatusControllerIds": []
+    });
+
+    let updated = store
+        .update_resource_definition(
+            row.uid,
+            UpdateResourceParams {
+                revision: row.revision,
+                annotations: BTreeMap::new(),
+                finalizers: vec![],
+                spec: spec_v2,
+                validator: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(updated.revision, 2);
+
+    // resolve_collection should reflect the new storage version
+    let info = store.resolve_collection("widgets").await.unwrap().unwrap();
+    assert_eq!(info.api_version, "example.dev/v2");
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn update_resource_definition_rejects_identity_change(
+    pool: sqlx::PgPool,
+) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+
+    let spec = json!({
+        "group": "example.dev",
+        "kind": "Widget",
+        "plural": "widgets",
+        "scope": "root",
+        "versions": [{"name": "v1", "served": true, "storage": true}],
+        "allowedStatusControllerIds": []
+    });
+
+    let row = store
+        .register_resource_definition(CreateResourceParams {
+            api_version: API_VERSION_V1ALPHA1.to_string(),
+            kind: RESOURCE_DEFINITION_KIND.to_string(),
+            name: "widgets.example.dev".to_string(),
+            parent_uid: None,
+            annotations: BTreeMap::new(),
+            finalizers: vec![],
+            spec,
+            validator: None,
+        })
+        .await
+        .unwrap();
+
+    // Attempt to change the group — must be rejected
+    let changed_group_spec = json!({
+        "group": "changed.dev",
+        "kind": "Widget",
+        "plural": "widgets",
+        "scope": "root",
+        "versions": [{"name": "v1", "served": true, "storage": true}],
+        "allowedStatusControllerIds": []
+    });
+
+    let err = store
+        .update_resource_definition(
+            row.uid,
+            UpdateResourceParams {
+                revision: row.revision,
+                annotations: BTreeMap::new(),
+                finalizers: vec![],
+                spec: changed_group_spec,
+                validator: None,
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, StoreError::Validation(_)),
+        "expected Validation error for identity change, got {err:?}"
+    );
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn update_rejects_resource_definition(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+
+    let spec = json!({
+        "group": "example.dev",
+        "kind": "Gadget",
+        "plural": "gadgets",
+        "scope": "root",
+        "versions": [{"name": "v1", "served": true, "storage": true}],
+        "allowedStatusControllerIds": []
+    });
+
+    let row = store
+        .register_resource_definition(CreateResourceParams {
+            api_version: API_VERSION_V1ALPHA1.to_string(),
+            kind: RESOURCE_DEFINITION_KIND.to_string(),
+            name: "gadgets.example.dev".to_string(),
+            parent_uid: None,
+            annotations: BTreeMap::new(),
+            finalizers: vec![],
+            spec: spec.clone(),
+            validator: None,
+        })
+        .await
+        .unwrap();
+
+    // Calling update() on a ResourceDefinition must be rejected
+    let err = store
+        .update(
+            row.uid,
+            UpdateResourceParams {
+                revision: row.revision,
+                annotations: BTreeMap::new(),
+                finalizers: vec![],
+                spec,
+                validator: None,
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, StoreError::Validation(_)),
+        "expected Validation error, got {err:?}"
+    );
+
     Ok(())
 }

--- a/mise.toml
+++ b/mise.toml
@@ -85,13 +85,23 @@ run = "cargo sqlx prepare -- --package rise-deploy --features cli,backend --all-
 description = "Check that all SQLX queries are valid."
 run = "cargo sqlx prepare --check -- --package rise-deploy --features cli,backend --all-targets"
 
+[tasks."resource-store:sqlx:prepare"]
+description = "Prepare the SQLX query cache for rise-resource-store (requires running DB)."
+run = "cargo sqlx prepare --package rise-resource-store"
+
+[tasks."resource-store:sqlx:check"]
+description = "Verify the SQLX query cache for rise-resource-store is up to date."
+run = "cargo sqlx prepare --check --package rise-resource-store"
+
 [tasks.lint]
 description = "Run all linting checks (clippy, formatting, sqlx, helm)."
 run = """
 cargo all-features check --all-targets
 cargo check --package rise-resource-api --all-targets
+cargo check --package rise-resource-store --all-targets
 cargo all-features clippy --all-targets -- -D warnings
 cargo clippy --package rise-resource-api --all-targets -- -D warnings
+cargo clippy --package rise-resource-store --all-targets -- -D warnings
 cargo fmt --all -- --check
 mise sqlx:check
 helm lint helm/rise

--- a/mise.toml
+++ b/mise.toml
@@ -87,11 +87,11 @@ run = "cargo sqlx prepare --check -- --package rise-deploy --features cli,backen
 
 [tasks."resource-store:sqlx:prepare"]
 description = "Prepare the SQLX query cache for rise-resource-store (requires running DB)."
-run = "cargo sqlx prepare --package rise-resource-store"
+run = "cargo sqlx prepare -- --package rise-resource-store --all-targets"
 
 [tasks."resource-store:sqlx:check"]
 description = "Verify the SQLX query cache for rise-resource-store is up to date."
-run = "cargo sqlx prepare --check --package rise-resource-store"
+run = "cargo sqlx prepare --check -- --package rise-resource-store --all-targets"
 
 [tasks.lint]
 description = "Run all linting checks (clippy, formatting, sqlx, helm)."

--- a/src/db/leader_leases.rs
+++ b/src/db/leader_leases.rs
@@ -201,9 +201,25 @@ async fn is_held_db(pool: &PgPool, name: &str, holder_id: Uuid) -> Result<bool> 
 mod tests {
     use super::*;
 
-    /// Generous wait for the background task to complete its first DB round-trip.
+    /// Generous wait for the background task to complete its first DB round-trip
+    /// in cases where we expect it *not* to acquire (negative assertions).
     /// 100ms was too tight under CI load (all 300+ tests share the DB).
     const ACQUIRE_WAIT: Duration = Duration::from_millis(500);
+
+    /// Maximum time to wait for an elector to become leader. Polls in small steps so
+    /// the happy path returns nearly instantly while CI jitter doesn't trip the test.
+    const LEADER_TIMEOUT: Duration = Duration::from_secs(5);
+
+    async fn wait_for_leader(election: &LeaderElection, timeout: Duration) -> bool {
+        let deadline = tokio::time::Instant::now() + timeout;
+        while tokio::time::Instant::now() < deadline {
+            if election.is_leader() {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        election.is_leader()
+    }
 
     #[sqlx::test]
     async fn is_leader_starts_false_then_becomes_true(pool: PgPool) -> Result<()> {
@@ -217,9 +233,8 @@ mod tests {
             !election.is_leader(),
             "should be false before first acquisition"
         );
-        tokio::time::sleep(ACQUIRE_WAIT).await;
         assert!(
-            election.is_leader(),
+            wait_for_leader(&election, LEADER_TIMEOUT).await,
             "should be true after background task acquires"
         );
         Ok(())
@@ -233,8 +248,7 @@ mod tests {
             Uuid::new_v4(),
             Duration::from_millis(1500),
         );
-        tokio::time::sleep(ACQUIRE_WAIT).await;
-        assert!(first.is_leader());
+        assert!(wait_for_leader(&first, LEADER_TIMEOUT).await);
 
         let second = LeaderElection::spawn(
             pool.clone(),
@@ -258,12 +272,14 @@ mod tests {
             Uuid::new_v4(),
             Duration::from_millis(1500),
         );
-        tokio::time::sleep(ACQUIRE_WAIT).await;
-        assert!(first.is_leader());
+        assert!(wait_for_leader(&first, LEADER_TIMEOUT).await);
 
-        drop(first); // aborts heartbeat; lease expires within 1500ms
+        drop(first); // aborts heartbeat; the existing row's expires_at decays.
 
-        tokio::time::sleep(Duration::from_millis(1600)).await;
+        // The last heartbeat may fire just before drop, pushing expires_at to
+        // ~NOW + lease_duration. Wait 2 * lease_duration to leave generous headroom
+        // for the row to be considered expired before `second` tries to take over.
+        tokio::time::sleep(Duration::from_millis(3000)).await;
 
         let second = LeaderElection::spawn(
             pool.clone(),
@@ -271,9 +287,8 @@ mod tests {
             Uuid::new_v4(),
             Duration::from_millis(1500),
         );
-        tokio::time::sleep(ACQUIRE_WAIT).await;
         assert!(
-            second.is_leader(),
+            wait_for_leader(&second, LEADER_TIMEOUT).await,
             "second should acquire after first's lease expires"
         );
         Ok(())
@@ -293,9 +308,7 @@ mod tests {
             Uuid::new_v4(),
             Duration::from_millis(1500),
         );
-        tokio::time::sleep(ACQUIRE_WAIT).await;
-
-        assert!(holder.is_leader());
+        assert!(wait_for_leader(&holder, LEADER_TIMEOUT).await);
         assert!(!non_holder.is_leader());
 
         holder.assert_leader().await?;
@@ -314,8 +327,7 @@ mod tests {
             Uuid::new_v4(),
             Duration::from_millis(1500),
         );
-        tokio::time::sleep(ACQUIRE_WAIT).await;
-        assert!(election.is_leader());
+        assert!(wait_for_leader(&election, LEADER_TIMEOUT).await);
 
         // Wait longer than the lease TTL — heartbeat should keep it alive
         tokio::time::sleep(Duration::from_millis(2000)).await;

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -206,11 +206,7 @@ impl AppState {
     /// Run database migrations
     async fn run_migrations(pool: &PgPool) -> Result<()> {
         tracing::info!("Running database migrations...");
-        // Ignore migrations recorded in `_sqlx_migrations` that we don't own — the
-        // `rise-resource-store` crate uses the same table for its own migrations.
-        let mut migrator = sqlx::migrate!("./migrations");
-        migrator.set_ignore_missing(true);
-        migrator
+        sqlx::migrate!("./migrations")
             .run(pool)
             .await
             .context("Failed to run migrations")?;

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -206,7 +206,11 @@ impl AppState {
     /// Run database migrations
     async fn run_migrations(pool: &PgPool) -> Result<()> {
         tracing::info!("Running database migrations...");
-        sqlx::migrate!("./migrations")
+        // Ignore migrations recorded in `_sqlx_migrations` that we don't own — the
+        // `rise-resource-store` crate uses the same table for its own migrations.
+        let mut migrator = sqlx::migrate!("./migrations");
+        migrator.set_ignore_missing(true);
+        migrator
             .run(pool)
             .await
             .context("Failed to run migrations")?;

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -227,8 +227,13 @@ impl AppState {
 
         tracing::info!("Successfully connected to PostgreSQL");
 
-        // Run migrations (server-only)
+        // Run root migrations
         Self::run_migrations(&db_pool).await?;
+
+        // Run resource-store migrations immediately after root migrations
+        rise_resource_store::run_migrations(&db_pool)
+            .await
+            .context("Failed to run resource store migrations")?;
 
         // Initialize JWT validator (JWKS is fetched on-demand)
         let jwt_validator = Arc::new(JwtValidator::new(settings.server.ssrf.clone()));


### PR DESCRIPTION
## Summary

- Introduces `crates/rise-resource-store`: backend-only DB layer for generic resource storage, implementing the `ResourceStore` trait backed by PostgreSQL
- Adds migrations for `resources` and `resource_definitions` tables with discriminator format constraints, name format constraints (DNS-label and DNS-subdomain), JSON object checks, and partial unique indexes for same-level name and discriminator uniqueness; wires `rise_resource_store::run_migrations` into backend startup immediately after root migrations
- Provides full CRUD with optimistic concurrency, 10-attempt discriminator generation, finalizer/deletion semantics (soft-delete on finalizers, hard-delete when clear), controller status/finalizer scoping, ResourceDefinition registry resolution, and typed validators for `Organization`, `ResourceDefinition`, and external JSON Schema resources
- `update_resource_definition` method keeps the `resource_definitions` projection table in sync and enforces identity field (group, kind, plural, scope) immutability; `update()` guards against accidentally bypassing this
- `update_controller_finalizers` serialised with `SELECT FOR UPDATE` to prevent concurrent lost-update races
- Compiled JSON schema validators cached in `PgResourceStore` to avoid recompiling on every `resolve_collection` call

## Test plan

- [ ] `cargo check --package rise-resource-store --all-targets` passes
- [ ] `cargo clippy --package rise-resource-store --all-targets -- -D warnings` passes
- [ ] `cargo fmt --all -- --check` passes
- [ ] Start local DB (`mise run db:migrate`) and run `cargo test --package rise-resource-store` — all 22 integration tests pass
- [ ] `cargo build --features backend` succeeds (resource-store migrations run on backend startup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)