### PR TITLE
Add controller authentication and operator role support

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -28,6 +28,11 @@ auth:
   client_secret: "rise-backend-secret"
   admin_users:
     - "admin@example.com"
+  # Operator role allowlist. Separate from admin_users — an Operator must
+  # also be listed in admin_users or platform_access.allowed_user_emails to
+  # use the typed CLI/UI (e.g. to log in via the frontend).
+  operator_users:
+    - "ops@example.com"
   # Allow all users to create teams (default: true). Set to false to restrict team creation to admins only.
   allow_team_creation: true
   # Allow all users to list all teams (default: true). Set to false so non-admins only see their own teams.
@@ -37,6 +42,7 @@ auth:
     allowed_user_emails:
       - "admin@example.com"
       - "dev@example.com"
+      - "ops@example.com"
 
 registry:
   type: "oci-client-auth"

--- a/dev/dex/config.yaml
+++ b/dev/dex/config.yaml
@@ -37,6 +37,11 @@ staticPasswords:
   username: user
   userID: a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d
 
+- email: ops@example.com
+  hash: $2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W  # password
+  username: ops
+  userID: b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e
+
 oauth2:
   skipApprovalScreen: true
   passwordConnector: local

--- a/docs/engineering/src/content/docs/configuration.md
+++ b/docs/engineering/src/content/docs/configuration.md
@@ -192,13 +192,35 @@ server:
 
 ```yaml
 auth:
-  issuer: "http://..."         # OIDC issuer URL
-  client_id: "rise-backend"   # OAuth2 client ID
-  client_secret: "..."        # OAuth2 client secret
-  admin_users: ["email@..."]  # Admin user emails (array)
-  allow_team_creation: true   # Allow regular users to create teams (default: true)
-                              # When false, only admins can create teams
+  issuer: "http://..."          # OIDC issuer URL
+  client_id: "rise-backend"     # OAuth2 client ID
+  client_secret: "..."          # OAuth2 client secret
+  admin_users: ["email@..."]    # Default-organization admin emails (array)
+  operator_users: ["ops@..."]   # Operator role allowlist (array, optional)
+  controllers: []               # Trusted external controller identities (array, optional)
+  allow_team_creation: true     # Allow regular users to create teams (default: true)
+                                # When false, only admins can create teams
 ```
+
+**Roles:**
+- `admin_users`: Admins of the default organization. Admins do **not** implicitly receive the Operator role.
+- `operator_users`: Operators have full access to generic resource storage and built-in resource management. Operators do **not** implicitly receive platform (typed CLI/UI) access — list the email in `admin_users` or `platform_access.allowed_user_emails` separately if both are needed.
+
+**Controllers (`auth.controllers`):**
+Trusted external controllers authenticate to Rise with OIDC JWTs. Each entry registers a `ControllerIdentity` that the auth middleware uses to validate incoming tokens. PR3 only wires the auth context; generic-resource controller endpoints land in a later increment.
+
+```yaml
+auth:
+  controllers:
+    - id: "controller.example.com/my-ctrl"  # DNS subdomain + optional /name suffix
+      issuer: "https://controller-idp.example.com"
+      audience: "rise"                       # optional, exact match on `aud`
+      subject: "my-controller-*"             # optional, wildcard match on `sub`
+      claims:                                # optional, wildcard match per claim
+        scope: "controller"
+```
+
+When a JWT's `iss` matches a configured controller identity, the controller path runs first. If no identity's claim constraints match, the request is rejected without falling back to the service-account path.
 
 **Team Creation Control:**
 - `allow_team_creation = true` (default): All authenticated users can create teams

--- a/docs/engineering/src/content/docs/configuration.md
+++ b/docs/engineering/src/content/docs/configuration.md
@@ -207,7 +207,7 @@ auth:
 - `operator_users`: Operators have full access to generic resource storage and built-in resource management. Operators do **not** implicitly receive platform (typed CLI/UI) access — list the email in `admin_users` or `platform_access.allowed_user_emails` separately if both are needed.
 
 **Controllers (`auth.controllers`):**
-Trusted external controllers authenticate to Rise with OIDC JWTs. Each entry registers a `ControllerIdentity` that controller endpoints use to validate incoming tokens. PR3 only wires the auth context; generic-resource controller endpoints land in a later increment. Use a dedicated issuer or a dedicated audience for controllers.
+Trusted external controllers authenticate to Rise with OIDC JWTs. Each entry registers a `ControllerIdentity` that controller endpoints use to validate incoming tokens. Controller endpoints are not yet available; this configuration takes effect when the generic resource API is introduced in a future release. Use a dedicated issuer or a dedicated audience per controller to keep identities unambiguous.
 
 ```yaml
 auth:

--- a/docs/engineering/src/content/docs/configuration.md
+++ b/docs/engineering/src/content/docs/configuration.md
@@ -207,20 +207,20 @@ auth:
 - `operator_users`: Operators have full access to generic resource storage and built-in resource management. Operators do **not** implicitly receive platform (typed CLI/UI) access — list the email in `admin_users` or `platform_access.allowed_user_emails` separately if both are needed.
 
 **Controllers (`auth.controllers`):**
-Trusted external controllers authenticate to Rise with OIDC JWTs. Each entry registers a `ControllerIdentity` that the auth middleware uses to validate incoming tokens. PR3 only wires the auth context; generic-resource controller endpoints land in a later increment.
+Trusted external controllers authenticate to Rise with OIDC JWTs. Each entry registers a `ControllerIdentity` that the auth middleware uses to validate incoming tokens. PR3 only wires the auth context; generic-resource controller endpoints land in a later increment. Use a dedicated issuer or a dedicated audience for controllers; controller issuer routing is operator-owned configuration, and a JWT whose `iss` matches a configured controller issuer is evaluated as a controller token first.
 
 ```yaml
 auth:
   controllers:
     - id: "controller.example.com/my-ctrl"  # DNS subdomain + optional /name suffix
       issuer: "https://controller-idp.example.com"
-      audience: "rise"                       # optional, exact match on `aud`
-      subject: "my-controller-*"             # optional, wildcard match on `sub`
-      claims:                                # optional, wildcard match per claim
+      claims:                                # required; wildcard match per claim
+        aud: "rise-controller"               # required; string or array JWT `aud` may match
+        sub: "my-controller-*"               # optional subject constraint
         scope: "controller"
 ```
 
-When a JWT's `iss` matches a configured controller identity, the controller path runs first. If no identity's claim constraints match, the request is rejected without falling back to the service-account path.
+`claims.aud` is required for every controller identity. Other constraints, including `sub`, are configured in `claims`. When a JWT's `iss` matches a configured controller identity, the controller path runs first. If no identity's claim constraints match, the request is rejected without falling back to the service-account path.
 
 **Team Creation Control:**
 - `allow_team_creation = true` (default): All authenticated users can create teams

--- a/docs/engineering/src/content/docs/configuration.md
+++ b/docs/engineering/src/content/docs/configuration.md
@@ -207,7 +207,7 @@ auth:
 - `operator_users`: Operators have full access to generic resource storage and built-in resource management. Operators do **not** implicitly receive platform (typed CLI/UI) access — list the email in `admin_users` or `platform_access.allowed_user_emails` separately if both are needed.
 
 **Controllers (`auth.controllers`):**
-Trusted external controllers authenticate to Rise with OIDC JWTs. Each entry registers a `ControllerIdentity` that the auth middleware uses to validate incoming tokens. PR3 only wires the auth context; generic-resource controller endpoints land in a later increment. Use a dedicated issuer or a dedicated audience for controllers; controller issuer routing is operator-owned configuration, and a JWT whose `iss` matches a configured controller issuer is evaluated as a controller token first.
+Trusted external controllers authenticate to Rise with OIDC JWTs. Each entry registers a `ControllerIdentity` that controller endpoints use to validate incoming tokens. PR3 only wires the auth context; generic-resource controller endpoints land in a later increment. Use a dedicated issuer or a dedicated audience for controllers.
 
 ```yaml
 auth:
@@ -220,7 +220,7 @@ auth:
         scope: "controller"
 ```
 
-`claims.aud` is required for every controller identity. Other constraints, including `sub`, are configured in `claims`. When a JWT's `iss` matches a configured controller identity, the controller path runs first. If no identity's claim constraints match, the request is rejected without falling back to the service-account path.
+`claims.aud` is required for every controller identity. Other constraints, including `sub`, are configured in `claims`. Controller endpoints require a token that matches one configured controller identity. Service-account endpoints still use project-scoped service-account claims; a token that matches a configured controller identity is rejected as a service-account token.
 
 **Team Creation Control:**
 - `allow_team_creation = true` (default): All authenticated users can create teams

--- a/docs/user/public/schemas/backend-settings.schema.json
+++ b/docs/user/public/schemas/backend-settings.schema.json
@@ -88,7 +88,7 @@
         },
         "admin_users": {
           "default": [],
-          "description": "List of admin user emails (have full permissions)",
+          "description": "List of admin user emails for the default organization. Admins do NOT\nimplicitly receive the Operator role — list the email in\n`operator_users` separately if needed.",
           "items": {
             "type": "string"
           },
@@ -118,6 +118,14 @@
         "client_secret": {
           "type": "string"
         },
+        "controllers": {
+          "default": [],
+          "description": "Trusted external controller identities. Each entry binds a stable\ncontroller ID to an OIDC issuer plus optional claim constraints.\nUsed by generic-resource controller endpoints.",
+          "items": {
+            "$ref": "#/$defs/ControllerIdentity"
+          },
+          "type": "array"
+        },
         "idp_group_sync_enabled": {
           "default": true,
           "description": "Enable IdP group synchronization (default: true)\nWhen enabled, user team memberships are automatically synced from IdP groups claim on login",
@@ -125,6 +133,14 @@
         },
         "issuer": {
           "type": "string"
+        },
+        "operator_users": {
+          "default": [],
+          "description": "List of Operator user emails. Operators have full access to generic\nresource storage and built-in resource management. This is a separate\nrole from `admin_users`.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "platform_access": {
           "$ref": "#/$defs/PlatformAccessConfig",
@@ -143,6 +159,48 @@
         "issuer",
         "client_id",
         "client_secret"
+      ],
+      "type": "object"
+    },
+    "ControllerIdentity": {
+      "description": "A trusted external controller identity configured under `auth.controllers`.\n\nEach entry binds a stable controller ID (the key used under\n`status.controllers`) to an OIDC issuer plus optional claim constraints\n(`audience`, `subject`, free-form `claims`). Wildcards in\n`subject`/`claims` follow `JwtValidator::validate_custom_claims` rules.",
+      "properties": {
+        "audience": {
+          "default": null,
+          "description": "Expected `aud` claim. Exact match when set.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "claims": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "description": "Additional claim constraints. Wildcards supported.",
+          "type": "object"
+        },
+        "id": {
+          "description": "Stable controller ID written under `status.controllers`. Must be a\nDNS subdomain with an optional single `/name` suffix, e.g.\n`controller.example.com` or `controller.example.com/my-ctrl`.",
+          "type": "string"
+        },
+        "issuer": {
+          "description": "OIDC issuer URL. Used for JWKS discovery and `iss` validation.",
+          "type": "string"
+        },
+        "subject": {
+          "default": null,
+          "description": "Expected `sub` claim. Wildcards supported.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "issuer"
       ],
       "type": "object"
     },

--- a/docs/user/public/schemas/backend-settings.schema.json
+++ b/docs/user/public/schemas/backend-settings.schema.json
@@ -163,11 +163,11 @@
       "type": "object"
     },
     "ControllerIdentity": {
-      "description": "A trusted external controller identity configured under `auth.controllers`.\n\nEach entry binds a stable controller ID (the key used under\n`status.controllers`) to an OIDC issuer plus optional claim constraints\n(`audience`, `subject`, free-form `claims`). Wildcards in\n`subject`/`claims` follow `JwtValidator::validate_custom_claims` rules.",
+      "description": "A trusted external controller identity configured under `auth.controllers`.\n\nEach entry binds a stable controller ID (the key used under\n`status.controllers`) to an OIDC issuer plus optional claim constraints\n(`audience`, `subject`, free-form `claims`). Wildcards in\n`audience`/`subject`/`claims` follow `JwtValidator::validate_custom_claims`\nglob rules (`*` matches any sequence of characters).",
       "properties": {
         "audience": {
           "default": null,
-          "description": "Expected `aud` claim. Exact match when set.",
+          "description": "Expected `aud` claim. Per RFC 7519 the JWT `aud` may be either a\nstring or an array of strings — the match succeeds when the expected\nvalue equals the string `aud`, or when it appears in the `aud` array.\nGlob `*` supported.",
           "type": [
             "string",
             "null"
@@ -178,7 +178,7 @@
             "type": "string"
           },
           "default": {},
-          "description": "Additional claim constraints. Wildcards supported.",
+          "description": "Additional string-valued claim constraints. Glob `*` supported.",
           "type": "object"
         },
         "id": {
@@ -191,7 +191,7 @@
         },
         "subject": {
           "default": null,
-          "description": "Expected `sub` claim. Wildcards supported.",
+          "description": "Expected `sub` claim. Glob `*` supported.",
           "type": [
             "string",
             "null"

--- a/docs/user/public/schemas/backend-settings.schema.json
+++ b/docs/user/public/schemas/backend-settings.schema.json
@@ -184,8 +184,7 @@
       },
       "required": [
         "id",
-        "issuer",
-        "claims"
+        "issuer"
       ],
       "type": "object"
     },

--- a/docs/user/public/schemas/backend-settings.schema.json
+++ b/docs/user/public/schemas/backend-settings.schema.json
@@ -120,7 +120,7 @@
         },
         "controllers": {
           "default": [],
-          "description": "Trusted external controller identities. Each entry binds a stable\ncontroller ID to an OIDC issuer plus optional claim constraints.\nUsed by generic-resource controller endpoints.",
+          "description": "Trusted external controller identities. Each entry binds a stable\ncontroller ID to an OIDC issuer plus required claim constraints.\nUsed by generic-resource controller endpoints.",
           "items": {
             "$ref": "#/$defs/ControllerIdentity"
           },
@@ -163,22 +163,14 @@
       "type": "object"
     },
     "ControllerIdentity": {
-      "description": "A trusted external controller identity configured under `auth.controllers`.\n\nEach entry binds a stable controller ID (the key used under\n`status.controllers`) to an OIDC issuer plus optional claim constraints\n(`audience`, `subject`, free-form `claims`). Wildcards in\n`audience`/`subject`/`claims` follow `JwtValidator::validate_custom_claims`\nglob rules (`*` matches any sequence of characters).",
+      "description": "A trusted external controller identity configured under `auth.controllers`.\n\nEach entry binds a stable controller ID (the key used under\n`status.controllers`) to an OIDC issuer plus required claim constraints.\n`claims.aud` is mandatory. Wildcards follow `JwtValidator::validate_custom_claims`\nglob rules (`*` matches any sequence of characters).",
       "properties": {
-        "audience": {
-          "default": null,
-          "description": "Expected `aud` claim. Per RFC 7519 the JWT `aud` may be either a\nstring or an array of strings — the match succeeds when the expected\nvalue equals the string `aud`, or when it appears in the `aud` array.\nGlob `*` supported.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "claims": {
           "additionalProperties": {
             "type": "string"
           },
           "default": {},
-          "description": "Additional string-valued claim constraints. Glob `*` supported.",
+          "description": "Expected string-valued claim constraints. `aud` is required and may\nmatch either a string JWT `aud` or one member of an array JWT `aud`.\nPut `sub` here when a subject constraint is needed. Glob `*` supported.",
           "type": "object"
         },
         "id": {
@@ -188,14 +180,6 @@
         "issuer": {
           "description": "OIDC issuer URL. Used for JWKS discovery and `iss` validation.",
           "type": "string"
-        },
-        "subject": {
-          "default": null,
-          "description": "Expected `sub` claim. Glob `*` supported.",
-          "type": [
-            "string",
-            "null"
-          ]
         }
       },
       "required": [

--- a/docs/user/public/schemas/backend-settings.schema.json
+++ b/docs/user/public/schemas/backend-settings.schema.json
@@ -184,7 +184,8 @@
       },
       "required": [
         "id",
-        "issuer"
+        "issuer",
+        "claims"
       ],
       "type": "object"
     },

--- a/src/server/auth/admin.rs
+++ b/src/server/auth/admin.rs
@@ -15,6 +15,17 @@ pub fn is_admin_user(admin_users: &[String], user_email: &str) -> bool {
         .any(|admin| admin.eq_ignore_ascii_case(user_email))
 }
 
+/// Check if a user has the Operator role (case-insensitive email match).
+///
+/// Operators are a separate role from admins: admins do NOT implicitly receive
+/// Operator access. List the email in both `auth.admin_users` and
+/// `auth.operator_users` if a user needs both.
+pub fn is_operator_user(operator_users: &[String], user_email: &str) -> bool {
+    operator_users
+        .iter()
+        .any(|op| op.eq_ignore_ascii_case(user_email))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -44,5 +55,25 @@ mod tests {
     fn test_is_admin_user_empty_list() {
         let admin_users: Vec<String> = vec![];
         assert!(!is_admin_user(&admin_users, "admin@example.com"));
+    }
+
+    #[test]
+    fn test_is_operator_user_case_insensitive() {
+        let operator_users = vec!["Ops@Example.Com".to_string(), "second@test.org".to_string()];
+
+        assert!(is_operator_user(&operator_users, "Ops@Example.Com"));
+        assert!(is_operator_user(&operator_users, "ops@example.com"));
+        assert!(is_operator_user(&operator_users, "OPS@EXAMPLE.COM"));
+        assert!(is_operator_user(&operator_users, "second@test.org"));
+        assert!(is_operator_user(&operator_users, "SECOND@TEST.ORG"));
+
+        assert!(!is_operator_user(&operator_users, "other@example.com"));
+        assert!(!is_operator_user(&operator_users, ""));
+    }
+
+    #[test]
+    fn test_is_operator_user_empty_list() {
+        let operator_users: Vec<String> = vec![];
+        assert!(!is_operator_user(&operator_users, "ops@example.com"));
     }
 }

--- a/src/server/auth/context.rs
+++ b/src/server/auth/context.rs
@@ -90,7 +90,7 @@ impl AuthContext {
                                 "Token matched multiple controller identities; configuration is ambiguous",
                             ));
                         }
-                        ControllerMatch::None(_) => {}
+                        ControllerMatch::Unmatched(_) => {}
                     }
                 }
 

--- a/src/server/auth/context.rs
+++ b/src/server/auth/context.rs
@@ -1,5 +1,8 @@
 use crate::db::models::User;
 use crate::db::service_accounts;
+use crate::server::auth::controller::{
+    match_controller_identity, ControllerIdentity, ControllerMatch,
+};
 use crate::server::auth::jwt::JwtValidator;
 use crate::server::error::{ServerError, ServerErrorExt};
 use crate::server::state::AppState;
@@ -57,10 +60,40 @@ impl AuthContext {
         &self,
         pool: &PgPool,
         project: &crate::db::models::Project,
+        controllers_by_issuer: &HashMap<String, Vec<ControllerIdentity>>,
     ) -> Result<(User, bool), ServerError> {
         match self {
             AuthContext::User(user) => Ok((user.clone(), false)),
             AuthContext::ExternalToken(token) => {
+                if let Some(controller_candidates) = controllers_by_issuer.get(&token.issuer) {
+                    match match_controller_identity(&token.claims, controller_candidates) {
+                        ControllerMatch::Single(ident) => {
+                            tracing::warn!(
+                                "Controller token {} from issuer '{}' attempted service-account auth for project '{}'",
+                                ident.id,
+                                token.issuer,
+                                project.name
+                            );
+                            return Err(ServerError::unauthorized(
+                                "Controller tokens cannot be used as service accounts",
+                            ));
+                        }
+                        ControllerMatch::Multiple(matched) => {
+                            let ids: Vec<&str> =
+                                matched.iter().map(|ident| ident.id.as_str()).collect();
+                            tracing::error!(
+                                "Multiple controller identities matched JWT from issuer '{}' during service-account auth: {:?}",
+                                token.issuer,
+                                ids
+                            );
+                            return Err(ServerError::conflict(
+                                "Token matched multiple controller identities; configuration is ambiguous",
+                            ));
+                        }
+                        ControllerMatch::None(_) => {}
+                    }
+                }
+
                 // Find service accounts for this project + issuer
                 let service_accounts =
                     service_accounts::find_by_project_and_issuer(pool, project.id, &token.issuer)
@@ -186,6 +219,10 @@ mod tests {
     use crate::db::{models::ProjectStatus, projects, service_accounts, users};
     use axum::http::StatusCode;
 
+    fn empty_controller_index() -> HashMap<String, Vec<ControllerIdentity>> {
+        HashMap::new()
+    }
+
     /// Helper: create a project and an external token auth context.
     async fn setup(
         pool: &PgPool,
@@ -224,7 +261,11 @@ mod tests {
 
         let (project, auth) = setup(&pool, "https://gitlab.com", &expected, token_claims).await;
 
-        let (user, is_sa) = auth.resolve_for_project(&pool, &project).await.unwrap();
+        let controllers_by_issuer = empty_controller_index();
+        let (user, is_sa) = auth
+            .resolve_for_project(&pool, &project, &controllers_by_issuer)
+            .await
+            .unwrap();
         assert!(is_sa);
         assert!(user.email.contains("test-project"));
     }
@@ -238,9 +279,83 @@ mod tests {
 
         let (project, auth) = setup(&pool, "https://gitlab.com", &expected, token_claims).await;
 
-        let err = auth.resolve_for_project(&pool, &project).await.unwrap_err();
+        let controllers_by_issuer = empty_controller_index();
+        let err = auth
+            .resolve_for_project(&pool, &project, &controllers_by_issuer)
+            .await
+            .unwrap_err();
         assert_eq!(err.status, StatusCode::UNAUTHORIZED);
         assert!(err.message.contains("do not match"));
+    }
+
+    #[sqlx::test]
+    async fn test_resolve_rejects_controller_token_before_sa_match(pool: PgPool) {
+        let mut expected = HashMap::new();
+        expected.insert("aud".to_string(), "rise-controller".to_string());
+        expected.insert("sub".to_string(), "deploy-bot".to_string());
+
+        let token_claims = serde_json::json!({
+            "aud": "rise-controller",
+            "sub": "deploy-bot",
+            "iss": "https://issuer.example.com"
+        });
+
+        let (project, auth) =
+            setup(&pool, "https://issuer.example.com", &expected, token_claims).await;
+        let controllers_by_issuer = HashMap::from([(
+            "https://issuer.example.com".to_string(),
+            vec![ControllerIdentity {
+                id: "controller.example.com".to_string(),
+                issuer: "https://issuer.example.com".to_string(),
+                claims: HashMap::from([
+                    ("aud".to_string(), "rise-controller".to_string()),
+                    ("sub".to_string(), "deploy-bot".to_string()),
+                ]),
+            }],
+        )]);
+
+        let err = auth
+            .resolve_for_project(&pool, &project, &controllers_by_issuer)
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.status, StatusCode::UNAUTHORIZED);
+        assert!(err.message.contains("Controller tokens cannot be used"));
+    }
+
+    #[sqlx::test]
+    async fn test_resolve_allows_same_issuer_different_audience_sa(pool: PgPool) {
+        let mut expected = HashMap::new();
+        expected.insert("aud".to_string(), "rise-service-account".to_string());
+        expected.insert("sub".to_string(), "deploy-bot".to_string());
+
+        let token_claims = serde_json::json!({
+            "aud": "rise-service-account",
+            "sub": "deploy-bot",
+            "iss": "https://issuer.example.com"
+        });
+
+        let (project, auth) =
+            setup(&pool, "https://issuer.example.com", &expected, token_claims).await;
+        let controllers_by_issuer = HashMap::from([(
+            "https://issuer.example.com".to_string(),
+            vec![ControllerIdentity {
+                id: "controller.example.com".to_string(),
+                issuer: "https://issuer.example.com".to_string(),
+                claims: HashMap::from([
+                    ("aud".to_string(), "rise-controller".to_string()),
+                    ("sub".to_string(), "deploy-bot".to_string()),
+                ]),
+            }],
+        )]);
+
+        let (user, is_sa) = auth
+            .resolve_for_project(&pool, &project, &controllers_by_issuer)
+            .await
+            .unwrap();
+
+        assert!(is_sa);
+        assert!(user.email.contains("test-project"));
     }
 
     #[sqlx::test]
@@ -255,7 +370,11 @@ mod tests {
             .await
             .unwrap();
 
-        let err = auth.resolve_for_project(&pool, &project).await.unwrap_err();
+        let controllers_by_issuer = empty_controller_index();
+        let err = auth
+            .resolve_for_project(&pool, &project, &controllers_by_issuer)
+            .await
+            .unwrap_err();
         assert_eq!(err.status, StatusCode::CONFLICT);
     }
 
@@ -290,7 +409,11 @@ mod tests {
             claims: serde_json::json!({"sub": "12345"}),
         });
 
-        let err = auth.resolve_for_project(&pool, &project).await.unwrap_err();
+        let controllers_by_issuer = empty_controller_index();
+        let err = auth
+            .resolve_for_project(&pool, &project, &controllers_by_issuer)
+            .await
+            .unwrap_err();
         assert_eq!(err.status, StatusCode::INTERNAL_SERVER_ERROR);
         assert!(err.message.contains("Invalid service account claims"));
     }
@@ -311,7 +434,11 @@ mod tests {
         .unwrap();
 
         let auth = AuthContext::User(user.clone());
-        let (resolved_user, is_sa) = auth.resolve_for_project(&pool, &project).await.unwrap();
+        let controllers_by_issuer = empty_controller_index();
+        let (resolved_user, is_sa) = auth
+            .resolve_for_project(&pool, &project, &controllers_by_issuer)
+            .await
+            .unwrap();
         assert!(!is_sa);
         assert_eq!(resolved_user.id, user.id);
     }

--- a/src/server/auth/controller.rs
+++ b/src/server/auth/controller.rs
@@ -1,0 +1,260 @@
+//! Controller identity authentication context.
+//!
+//! Defines the configuration type, the request-extension token type, and the
+//! Axum extractor used by generic-resource controller endpoints. The controller
+//! auth context is intentionally separate from `AuthContext` (which covers user
+//! JWTs and project-scoped service-account JWTs) so the type system rules out
+//! mixing controller tokens with user/SA flows.
+//!
+//! Wiring is added in PR3 but no HTTP route consumes the extractor yet — that
+//! lands with PR4 (the generic resource API).
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+use anyhow::{anyhow, bail, Context, Result};
+use axum::{extract::FromRequestParts, http::request::Parts};
+use regex::Regex;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::server::error::ServerError;
+use crate::server::state::AppState;
+
+/// A trusted external controller identity configured under `auth.controllers`.
+///
+/// Each entry binds a stable controller ID (the key used under
+/// `status.controllers`) to an OIDC issuer plus optional claim constraints
+/// (`audience`, `subject`, free-form `claims`). Wildcards in
+/// `subject`/`claims` follow `JwtValidator::validate_custom_claims` rules.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct ControllerIdentity {
+    /// Stable controller ID written under `status.controllers`. Must be a
+    /// DNS subdomain with an optional single `/name` suffix, e.g.
+    /// `controller.example.com` or `controller.example.com/my-ctrl`.
+    pub id: String,
+    /// OIDC issuer URL. Used for JWKS discovery and `iss` validation.
+    pub issuer: String,
+    /// Expected `aud` claim. Exact match when set.
+    #[serde(default)]
+    pub audience: Option<String>,
+    /// Expected `sub` claim. Wildcards supported.
+    #[serde(default)]
+    pub subject: Option<String>,
+    /// Additional claim constraints. Wildcards supported.
+    #[serde(default)]
+    pub claims: HashMap<String, String>,
+}
+
+/// A JWKS-validated controller token, injected into request extensions by
+/// `auth_middleware` after `JwtValidator::validate_token` succeeds AND the
+/// matching `ControllerIdentity`'s claim constraints are satisfied.
+///
+/// `#[allow(dead_code)]` until the generic resource controller endpoints
+/// (a later PR) consume the fields.
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
+pub struct VerifiedControllerToken {
+    pub identity_id: String,
+    pub issuer: String,
+    pub claims: serde_json::Value,
+}
+
+/// Axum extractor — yields the verified controller token or 401.
+///
+/// `#[allow(dead_code)]` until the generic resource controller endpoints
+/// (a later PR) take it as a handler argument.
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
+pub struct ControllerAuthContext(pub VerifiedControllerToken);
+
+impl FromRequestParts<AppState> for ControllerAuthContext {
+    type Rejection = ServerError;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        _state: &AppState,
+    ) -> std::result::Result<Self, Self::Rejection> {
+        parts
+            .extensions
+            .get::<VerifiedControllerToken>()
+            .cloned()
+            .map(ControllerAuthContext)
+            .ok_or_else(|| ServerError::unauthorized("Controller authentication required"))
+    }
+}
+
+// DNS-1123 subdomain followed by an optional single `/name` suffix.
+// - Host: one or more lowercase DNS labels joined by `.`, at least one `.` (so
+//   single-word hosts like `localhost` are rejected — controller IDs must be
+//   fully-qualified to act as Kubernetes annotation key prefixes).
+// - Optional path segment after `/`: `[A-Za-z0-9_.-]+` (matches Kubernetes
+//   annotation key name format).
+static CONTROLLER_ID_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)+(/[A-Za-z0-9_.-]+)?$",
+    )
+    .expect("controller id regex compiles")
+});
+
+/// Validate a controller `id` value.
+///
+/// Format: DNS-1123 subdomain (at least one `.`) optionally followed by a
+/// single `/name` segment, max 253 chars total.
+pub fn validate_controller_id(id: &str) -> Result<()> {
+    if id.is_empty() {
+        bail!("controller id is empty");
+    }
+    if id.len() > 253 {
+        bail!("controller id too long (>{} chars)", 253);
+    }
+    if !CONTROLLER_ID_RE.is_match(id) {
+        bail!(
+            "invalid controller id {:?}: expected DNS subdomain with optional /name suffix",
+            id
+        );
+    }
+    Ok(())
+}
+
+/// Maps used by middleware to look up controller identities at request time.
+pub type ControllerIndexes = (
+    HashMap<String, ControllerIdentity>,
+    HashMap<String, Vec<ControllerIdentity>>,
+);
+
+/// Index a list of `ControllerIdentity` values by id and by issuer.
+///
+/// Validates each id, rejects duplicate ids, and returns
+/// `(by_id, by_issuer)`. Multiple identities may share an issuer (they get
+/// disambiguated by `audience`/`subject`/`claims` at request time).
+pub fn build_controller_indexes(controllers: &[ControllerIdentity]) -> Result<ControllerIndexes> {
+    let mut by_id: HashMap<String, ControllerIdentity> = HashMap::new();
+    let mut by_issuer: HashMap<String, Vec<ControllerIdentity>> = HashMap::new();
+
+    for c in controllers {
+        validate_controller_id(&c.id)
+            .with_context(|| format!("invalid controller id for entry {:?}", c.id))?;
+        if c.issuer.is_empty() {
+            return Err(anyhow!("controller {:?} has empty issuer", c.id));
+        }
+        if by_id.insert(c.id.clone(), c.clone()).is_some() {
+            return Err(anyhow!("duplicate controller id: {:?}", c.id));
+        }
+        by_issuer
+            .entry(c.issuer.clone())
+            .or_default()
+            .push(c.clone());
+    }
+
+    Ok((by_id, by_issuer))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_controller_id_accepts_valid_forms() {
+        for id in [
+            "controller.example.com",
+            "controller.example.com/my-ctrl",
+            "k8s.rise.dev/default",
+            "a.b",
+            "a.b/c",
+            "deep.sub.domain.example.com",
+            "deep.sub.domain.example.com/Ctrl_1.0",
+        ] {
+            validate_controller_id(id)
+                .unwrap_or_else(|e| panic!("expected {:?} to be valid: {}", id, e));
+        }
+    }
+
+    #[test]
+    fn test_validate_controller_id_rejects_invalid_forms() {
+        for id in [
+            "",
+            "controller",                        // no dot — not a subdomain
+            "Controller.example.com",            // uppercase in host
+            "-bad.example.com",                  // leading hyphen
+            "bad-.example.com",                  // trailing hyphen on label
+            "controller.example.com/",           // trailing slash
+            "/controller",                       // leading slash, no host
+            "controller.example.com/a/b",        // nested path segments not allowed
+            "controller.example.com//x",         // empty path segment
+            "controller.example.com/with space", // invalid path char
+        ] {
+            assert!(
+                validate_controller_id(id).is_err(),
+                "expected {:?} to be rejected",
+                id
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_controller_id_rejects_too_long() {
+        // Build a 254-char id: many short labels.
+        let host = (0..50).map(|_| "ab").collect::<Vec<_>>().join(".");
+        // host is 50 labels of 2 chars + 49 dots = 100 + 49 = 149 chars
+        let mut id = host.clone();
+        while id.len() <= 253 {
+            id.push_str(".ab");
+        }
+        assert!(id.len() > 253);
+        // Strip until valid form check would matter; format may also fail format check
+        // but length check fires first.
+        let err = validate_controller_id(&id).unwrap_err().to_string();
+        assert!(err.contains("too long"), "got: {err}");
+    }
+
+    fn ident(id: &str, issuer: &str) -> ControllerIdentity {
+        ControllerIdentity {
+            id: id.to_string(),
+            issuer: issuer.to_string(),
+            audience: None,
+            subject: None,
+            claims: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn test_build_indexes_happy_path() {
+        let c1 = ident("a.example.com", "https://issuer.example.com");
+        let c2 = ident("b.example.com/x", "https://issuer.example.com");
+        let c3 = ident("c.example.com", "https://other.example.com");
+
+        let (by_id, by_iss) = build_controller_indexes(&[c1, c2, c3]).unwrap();
+
+        assert_eq!(by_id.len(), 3);
+        assert!(by_id.contains_key("a.example.com"));
+        assert!(by_id.contains_key("b.example.com/x"));
+        assert!(by_id.contains_key("c.example.com"));
+
+        assert_eq!(by_iss.len(), 2);
+        assert_eq!(by_iss["https://issuer.example.com"].len(), 2);
+        assert_eq!(by_iss["https://other.example.com"].len(), 1);
+    }
+
+    #[test]
+    fn test_build_indexes_rejects_duplicate_id() {
+        let c = ident("a.example.com", "https://issuer.example.com");
+        let err = build_controller_indexes(&[c.clone(), c])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("duplicate controller id"), "got: {err}");
+    }
+
+    #[test]
+    fn test_build_indexes_rejects_invalid_id() {
+        let c = ident("not-a-subdomain", "https://issuer.example.com");
+        let err = build_controller_indexes(&[c]).unwrap_err().to_string();
+        assert!(err.contains("invalid controller id"), "got: {err}");
+    }
+
+    #[test]
+    fn test_build_indexes_rejects_empty_issuer() {
+        let c = ident("a.example.com", "");
+        let err = build_controller_indexes(&[c]).unwrap_err().to_string();
+        assert!(err.contains("empty issuer"), "got: {err}");
+    }
+}

--- a/src/server/auth/controller.rs
+++ b/src/server/auth/controller.rs
@@ -23,9 +23,8 @@ use crate::server::state::AppState;
 /// A trusted external controller identity configured under `auth.controllers`.
 ///
 /// Each entry binds a stable controller ID (the key used under
-/// `status.controllers`) to an OIDC issuer plus optional claim constraints
-/// (`audience`, `subject`, free-form `claims`). Wildcards in
-/// `audience`/`subject`/`claims` follow `JwtValidator::validate_custom_claims`
+/// `status.controllers`) to an OIDC issuer plus required claim constraints.
+/// `claims.aud` is mandatory. Wildcards follow `JwtValidator::validate_custom_claims`
 /// glob rules (`*` matches any sequence of characters).
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct ControllerIdentity {
@@ -35,16 +34,9 @@ pub struct ControllerIdentity {
     pub id: String,
     /// OIDC issuer URL. Used for JWKS discovery and `iss` validation.
     pub issuer: String,
-    /// Expected `aud` claim. Per RFC 7519 the JWT `aud` may be either a
-    /// string or an array of strings — the match succeeds when the expected
-    /// value equals the string `aud`, or when it appears in the `aud` array.
-    /// Glob `*` supported.
-    #[serde(default)]
-    pub audience: Option<String>,
-    /// Expected `sub` claim. Glob `*` supported.
-    #[serde(default)]
-    pub subject: Option<String>,
-    /// Additional string-valued claim constraints. Glob `*` supported.
+    /// Expected string-valued claim constraints. `aud` is required and may
+    /// match either a string JWT `aud` or one member of an array JWT `aud`.
+    /// Put `sub` here when a subject constraint is needed. Glob `*` supported.
     #[serde(default)]
     pub claims: HashMap<String, String>,
 }
@@ -189,13 +181,9 @@ fn audience_matches(claim: &serde_json::Value, expected: &str) -> bool {
 /// without spinning up JWKS. Caller is responsible for verifying that the
 /// JWT signature and `iss` are correct before invoking.
 ///
-/// Each identity's constraints are applied as follows:
-/// - `audience`: matched against the JWT `aud` claim, accepting either a
-///   string or an array of strings (RFC 7519 §4.1.3). Glob `*` allowed.
-/// - `subject`: matched against the JWT `sub` claim via
-///   `validate_custom_claims` (string with glob `*`).
-/// - `claims`: matched via `validate_custom_claims` (string-valued claims
-///   with glob `*`).
+/// Each identity's `claims` constraints are applied via
+/// `validate_custom_claims` (string-valued claims with glob `*`), except `aud`,
+/// which accepts either a string or an array of strings per RFC 7519 §4.1.3.
 ///
 /// Returns `Single` when exactly one identity satisfies all constraints,
 /// `Multiple` when two or more do (ambiguous configuration), and `None` with
@@ -208,21 +196,28 @@ pub fn match_controller_identity<'a>(
     let mut last_err: Option<String> = None;
 
     for ident in candidates {
-        if let Some(expected_aud) = &ident.audience {
-            let aud_claim = token_claims.get("aud").unwrap_or(&serde_json::Value::Null);
-            if !audience_matches(aud_claim, expected_aud) {
-                last_err = Some(format!(
-                    "identity {:?}: aud claim does not match expected audience {:?}",
-                    ident.id, expected_aud
-                ));
-                continue;
-            }
+        let Some(expected_aud) = ident.claims.get("aud") else {
+            last_err = Some(format!(
+                "identity {:?}: missing required claims.aud constraint",
+                ident.id
+            ));
+            continue;
+        };
+        let aud_claim = token_claims.get("aud").unwrap_or(&serde_json::Value::Null);
+        if !audience_matches(aud_claim, expected_aud) {
+            last_err = Some(format!(
+                "identity {:?}: aud claim does not match expected audience {:?}",
+                ident.id, expected_aud
+            ));
+            continue;
         }
 
-        let mut expected_string_claims = ident.claims.clone();
-        if let Some(sub) = &ident.subject {
-            expected_string_claims.insert("sub".to_string(), sub.clone());
-        }
+        let expected_string_claims: HashMap<String, String> = ident
+            .claims
+            .iter()
+            .filter(|(key, _)| key.as_str() != "aud")
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
         match crate::server::auth::jwt::JwtValidator::validate_custom_claims(
             token_claims,
             &expected_string_claims,
@@ -245,7 +240,7 @@ pub fn match_controller_identity<'a>(
 ///
 /// Validates each id, rejects duplicate ids, and returns
 /// `(by_id, by_issuer)`. Multiple identities may share an issuer (they get
-/// disambiguated by `audience`/`subject`/`claims` at request time).
+/// disambiguated by claim constraints at request time).
 pub fn build_controller_indexes(controllers: &[ControllerIdentity]) -> Result<ControllerIndexes> {
     let mut by_id: HashMap<String, ControllerIdentity> = HashMap::new();
     let mut by_issuer: HashMap<String, Vec<ControllerIdentity>> = HashMap::new();
@@ -255,6 +250,12 @@ pub fn build_controller_indexes(controllers: &[ControllerIdentity]) -> Result<Co
             .with_context(|| format!("invalid controller id for entry {:?}", c.id))?;
         if c.issuer.is_empty() {
             return Err(anyhow!("controller {:?} has empty issuer", c.id));
+        }
+        let Some(aud) = c.claims.get("aud") else {
+            return Err(anyhow!("controller {:?} must configure claims.aud", c.id));
+        };
+        if aud.is_empty() {
+            return Err(anyhow!("controller {:?} has empty claims.aud", c.id));
         }
         if by_id.insert(c.id.clone(), c.clone()).is_some() {
             return Err(anyhow!("duplicate controller id: {:?}", c.id));
@@ -351,9 +352,7 @@ mod tests {
         ControllerIdentity {
             id: id.to_string(),
             issuer: issuer.to_string(),
-            audience: None,
-            subject: None,
-            claims: HashMap::new(),
+            claims: HashMap::from([("aud".to_string(), "rise".to_string())]),
         }
     }
 
@@ -396,6 +395,28 @@ mod tests {
         let c = ident("a.example.com", "");
         let err = build_controller_indexes(&[c]).unwrap_err().to_string();
         assert!(err.contains("empty issuer"), "got: {err}");
+    }
+
+    #[test]
+    fn test_build_indexes_rejects_missing_audience_claim() {
+        let c = ControllerIdentity {
+            id: "a.example.com".to_string(),
+            issuer: "https://issuer.example.com".to_string(),
+            claims: HashMap::new(),
+        };
+        let err = build_controller_indexes(&[c]).unwrap_err().to_string();
+        assert!(err.contains("claims.aud"), "got: {err}");
+    }
+
+    #[test]
+    fn test_build_indexes_rejects_empty_audience_claim() {
+        let c = ControllerIdentity {
+            id: "a.example.com".to_string(),
+            issuer: "https://issuer.example.com".to_string(),
+            claims: HashMap::from([("aud".to_string(), "".to_string())]),
+        };
+        let err = build_controller_indexes(&[c]).unwrap_err().to_string();
+        assert!(err.contains("empty claims.aud"), "got: {err}");
     }
 
     // --- audience_matches ---
@@ -447,17 +468,10 @@ mod tests {
 
     // --- match_controller_identity ---
 
-    fn ident_full(
-        id: &str,
-        audience: Option<&str>,
-        subject: Option<&str>,
-        claims: &[(&str, &str)],
-    ) -> ControllerIdentity {
+    fn ident_full(id: &str, claims: &[(&str, &str)]) -> ControllerIdentity {
         ControllerIdentity {
             id: id.to_string(),
             issuer: "https://issuer.example.com".to_string(),
-            audience: audience.map(String::from),
-            subject: subject.map(String::from),
             claims: claims
                 .iter()
                 .map(|(k, v)| (k.to_string(), v.to_string()))
@@ -466,13 +480,13 @@ mod tests {
     }
 
     #[test]
-    fn test_match_single_no_constraints() {
-        let candidates = [ident_full("a.example.com", None, None, &[])];
+    fn test_match_none_without_audience_constraint() {
+        let candidates = [ident_full("a.example.com", &[])];
         let claims = serde_json::json!({"sub": "anyone", "aud": "anything"});
         let m = match_controller_identity(&claims, &candidates);
         match m {
-            ControllerMatch::Single(i) => assert_eq!(i.id, "a.example.com"),
-            other => panic!("expected Single, got {other:?}"),
+            ControllerMatch::None(detail) => assert!(detail.contains("claims.aud"), "{detail}"),
+            other => panic!("expected None, got {other:?}"),
         }
     }
 
@@ -480,9 +494,7 @@ mod tests {
     fn test_match_single_with_constraints() {
         let candidates = [ident_full(
             "a.example.com",
-            Some("rise"),
-            Some("ctrl-*"),
-            &[("scope", "controller")],
+            &[("aud", "rise"), ("sub", "ctrl-*"), ("scope", "controller")],
         )];
         let claims = serde_json::json!({
             "sub": "ctrl-abc",
@@ -495,7 +507,7 @@ mod tests {
 
     #[test]
     fn test_match_audience_array() {
-        let candidates = [ident_full("a.example.com", Some("rise"), None, &[])];
+        let candidates = [ident_full("a.example.com", &[("aud", "rise")])];
         let claims = serde_json::json!({
             "sub": "x",
             "aud": ["other", "rise"],
@@ -506,7 +518,7 @@ mod tests {
 
     #[test]
     fn test_match_audience_array_no_match() {
-        let candidates = [ident_full("a.example.com", Some("rise"), None, &[])];
+        let candidates = [ident_full("a.example.com", &[("aud", "rise")])];
         let claims = serde_json::json!({"sub": "x", "aud": ["other"]});
         let m = match_controller_identity(&claims, &candidates);
         match m {
@@ -519,8 +531,11 @@ mod tests {
 
     #[test]
     fn test_match_none_when_subject_mismatches() {
-        let candidates = [ident_full("a.example.com", None, Some("ctrl-*"), &[])];
-        let claims = serde_json::json!({"sub": "other-bot"});
+        let candidates = [ident_full(
+            "a.example.com",
+            &[("aud", "rise"), ("sub", "ctrl-*")],
+        )];
+        let claims = serde_json::json!({"aud": "rise", "sub": "other-bot"});
         let m = match_controller_identity(&claims, &candidates);
         match m {
             ControllerMatch::None(detail) => assert!(detail.contains("a.example.com"), "{detail}"),
@@ -532,23 +547,21 @@ mod tests {
     fn test_match_none_when_extra_claim_missing() {
         let candidates = [ident_full(
             "a.example.com",
-            None,
-            None,
-            &[("scope", "controller")],
+            &[("aud", "rise"), ("scope", "controller")],
         )];
-        let claims = serde_json::json!({"sub": "x"});
+        let claims = serde_json::json!({"aud": "rise", "sub": "x"});
         let m = match_controller_identity(&claims, &candidates);
         assert!(matches!(m, ControllerMatch::None(_)), "got {m:?}");
     }
 
     #[test]
     fn test_match_multiple_when_constraints_ambiguous() {
-        // Two identities with no constraints both match any token.
+        // Two identities with the same audience both match the token.
         let candidates = [
-            ident_full("a.example.com", None, None, &[]),
-            ident_full("b.example.com", None, None, &[]),
+            ident_full("a.example.com", &[("aud", "rise")]),
+            ident_full("b.example.com", &[("aud", "rise")]),
         ];
-        let claims = serde_json::json!({"sub": "x"});
+        let claims = serde_json::json!({"aud": "rise", "sub": "x"});
         let m = match_controller_identity(&claims, &candidates);
         match m {
             ControllerMatch::Multiple(matches) => {
@@ -565,8 +578,8 @@ mod tests {
     fn test_match_disambiguates_by_audience() {
         // Same issuer, different audiences; only one should match.
         let candidates = [
-            ident_full("a.example.com", Some("rise-a"), None, &[]),
-            ident_full("b.example.com", Some("rise-b"), None, &[]),
+            ident_full("a.example.com", &[("aud", "rise-a")]),
+            ident_full("b.example.com", &[("aud", "rise-b")]),
         ];
         let claims = serde_json::json!({"sub": "x", "aud": "rise-b"});
         let m = match_controller_identity(&claims, &candidates);
@@ -579,10 +592,10 @@ mod tests {
     #[test]
     fn test_match_disambiguates_by_subject() {
         let candidates = [
-            ident_full("a.example.com", None, Some("ctrl-a"), &[]),
-            ident_full("b.example.com", None, Some("ctrl-b"), &[]),
+            ident_full("a.example.com", &[("aud", "rise"), ("sub", "ctrl-a")]),
+            ident_full("b.example.com", &[("aud", "rise"), ("sub", "ctrl-b")]),
         ];
-        let claims = serde_json::json!({"sub": "ctrl-b"});
+        let claims = serde_json::json!({"aud": "rise", "sub": "ctrl-b"});
         let m = match_controller_identity(&claims, &candidates);
         match m {
             ControllerMatch::Single(i) => assert_eq!(i.id, "b.example.com"),

--- a/src/server/auth/controller.rs
+++ b/src/server/auth/controller.rs
@@ -17,6 +17,7 @@ use regex::Regex;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::server::auth::context::VerifiedExternalToken;
 use crate::server::error::ServerError;
 use crate::server::state::AppState;
 
@@ -41,9 +42,9 @@ pub struct ControllerIdentity {
     pub claims: HashMap<String, String>,
 }
 
-/// A JWKS-validated controller token, injected into request extensions by
-/// `auth_middleware` after `JwtValidator::validate_token` succeeds AND the
-/// matching `ControllerIdentity`'s claim constraints are satisfied.
+/// A JWKS-validated controller token, produced by `ControllerAuthContext` after
+/// `auth_middleware` verifies the external JWT and the matching
+/// `ControllerIdentity`'s claim constraints are satisfied.
 ///
 /// `#[allow(dead_code)]` until the generic resource controller endpoints
 /// (a later PR) consume the fields.
@@ -68,14 +69,47 @@ impl FromRequestParts<AppState> for ControllerAuthContext {
 
     async fn from_request_parts(
         parts: &mut Parts,
-        _state: &AppState,
+        state: &AppState,
     ) -> std::result::Result<Self, Self::Rejection> {
-        parts
+        let token = parts
             .extensions
-            .get::<VerifiedControllerToken>()
+            .get::<VerifiedExternalToken>()
             .cloned()
-            .map(ControllerAuthContext)
-            .ok_or_else(|| ServerError::unauthorized("Controller authentication required"))
+            .ok_or_else(|| ServerError::unauthorized("Controller authentication required"))?;
+
+        let candidates = state
+            .controllers_by_issuer
+            .get(&token.issuer)
+            .ok_or_else(|| ServerError::unauthorized("Controller authentication required"))?;
+
+        match match_controller_identity(&token.claims, candidates) {
+            ControllerMatch::Single(ident) => Ok(ControllerAuthContext(VerifiedControllerToken {
+                identity_id: ident.id.clone(),
+                issuer: token.issuer,
+                claims: token.claims,
+            })),
+            ControllerMatch::None(detail) => {
+                tracing::warn!(
+                    "Controller JWT for issuer '{}' did not match any configured identity: {}",
+                    token.issuer,
+                    detail
+                );
+                Err(ServerError::unauthorized(
+                    "Token did not match any configured controller identity",
+                ))
+            }
+            ControllerMatch::Multiple(matched) => {
+                let ids: Vec<&str> = matched.iter().map(|i| i.id.as_str()).collect();
+                tracing::error!(
+                    "Multiple controller identities matched JWT from issuer '{}': {:?}",
+                    token.issuer,
+                    ids
+                );
+                Err(ServerError::conflict(
+                    "Token matched multiple controller identities; configuration is ambiguous",
+                ))
+            }
+        }
     }
 }
 

--- a/src/server/auth/controller.rs
+++ b/src/server/auth/controller.rs
@@ -150,6 +150,14 @@ pub fn validate_controller_id(id: &str) -> Result<()> {
     if id.len() > 253 {
         bail!("controller id too long (>{} chars)", 253);
     }
+    let host = id.split('/').next().unwrap_or(id);
+    if let Some(label) = host.split('.').find(|label| label.len() > 63) {
+        bail!(
+            "controller id DNS label too long ({} > 63 chars): {:?}",
+            label.len(),
+            label
+        );
+    }
     if let Some(slash_pos) = id.find('/') {
         let name = &id[slash_pos + 1..];
         if name.len() > CONTROLLER_ID_NAME_MAX_LEN {
@@ -369,6 +377,13 @@ mod tests {
         assert!(id.len() > 253);
         let err = validate_controller_id(&id).unwrap_err().to_string();
         assert!(err.contains("too long"), "got: {err}");
+    }
+
+    #[test]
+    fn test_validate_controller_id_rejects_too_long_dns_label() {
+        let id = format!("{}.example.com", "a".repeat(64));
+        let err = validate_controller_id(&id).unwrap_err().to_string();
+        assert!(err.contains("DNS label too long"), "got: {err}");
     }
 
     #[test]

--- a/src/server/auth/controller.rs
+++ b/src/server/auth/controller.rs
@@ -6,8 +6,8 @@
 //! JWTs and project-scoped service-account JWTs) so the type system rules out
 //! mixing controller tokens with user/SA flows.
 //!
-//! Wiring is added in PR3 but no HTTP route consumes the extractor yet — that
-//! lands with PR4 (the generic resource API).
+//! No HTTP route consumes the extractor yet — that lands with the generic
+//! resource API in a future release.
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
@@ -88,7 +88,7 @@ impl FromRequestParts<AppState> for ControllerAuthContext {
                 issuer: token.issuer,
                 claims: token.claims,
             })),
-            ControllerMatch::None(detail) => {
+            ControllerMatch::Unmatched(detail) => {
                 tracing::warn!(
                     "Controller JWT for issuer '{}' did not match any configured identity: {}",
                     token.issuer,
@@ -169,11 +169,14 @@ pub fn validate_controller_id(id: &str) -> Result<()> {
     Ok(())
 }
 
-/// Maps used by middleware to look up controller identities at request time.
-pub type ControllerIndexes = (
-    HashMap<String, ControllerIdentity>,
-    HashMap<String, Vec<ControllerIdentity>>,
-);
+/// Indexes built at startup from the configured controller identities.
+#[derive(Debug)]
+pub struct ControllerIndexes {
+    /// Controller identities keyed by `id`.
+    pub by_id: HashMap<String, ControllerIdentity>,
+    /// Controller identities keyed by issuer URL for O(1) middleware lookup.
+    pub by_issuer: HashMap<String, Vec<ControllerIdentity>>,
+}
 
 /// Outcome of matching JWT claims against a set of controller identity
 /// candidates that share the token's issuer.
@@ -181,9 +184,9 @@ pub type ControllerIndexes = (
 pub enum ControllerMatch<'a> {
     /// Exactly one identity matched the token's claim constraints.
     Single(&'a ControllerIdentity),
-    /// No identity matched. The contained string explains the most recent
-    /// failure (for diagnostics / 401 detail).
-    None(String),
+    /// No identity matched. The contained string lists all per-identity
+    /// rejection reasons, joined by `"; "`, for diagnostics.
+    Unmatched(String),
     /// Two or more identities matched — configuration is ambiguous.
     Multiple(Vec<&'a ControllerIdentity>),
 }
@@ -220,18 +223,18 @@ fn audience_matches(claim: &serde_json::Value, expected: &str) -> bool {
 /// which accepts either a string or an array of strings per RFC 7519 §4.1.3.
 ///
 /// Returns `Single` when exactly one identity satisfies all constraints,
-/// `Multiple` when two or more do (ambiguous configuration), and `None` with
-/// the most recent failure detail when none match.
+/// `Multiple` when two or more do (ambiguous configuration), and `Unmatched`
+/// with all per-identity rejection reasons when none match.
 pub fn match_controller_identity<'a>(
     token_claims: &serde_json::Value,
     candidates: &'a [ControllerIdentity],
 ) -> ControllerMatch<'a> {
     let mut matched: Vec<&'a ControllerIdentity> = Vec::new();
-    let mut last_err: Option<String> = None;
+    let mut errors: Vec<String> = Vec::new();
 
     for ident in candidates {
         let Some(expected_aud) = ident.claims.get("aud") else {
-            last_err = Some(format!(
+            errors.push(format!(
                 "identity {:?}: missing required claims.aud constraint",
                 ident.id
             ));
@@ -239,7 +242,7 @@ pub fn match_controller_identity<'a>(
         };
         let aud_claim = token_claims.get("aud").unwrap_or(&serde_json::Value::Null);
         if !audience_matches(aud_claim, expected_aud) {
-            last_err = Some(format!(
+            errors.push(format!(
                 "identity {:?}: aud claim does not match expected audience {:?}",
                 ident.id, expected_aud
             ));
@@ -258,23 +261,27 @@ pub fn match_controller_identity<'a>(
         ) {
             Ok(()) => matched.push(ident),
             Err(e) => {
-                last_err = Some(format!("identity {:?}: {}", ident.id, e));
+                errors.push(format!("identity {:?}: {}", ident.id, e));
             }
         }
     }
 
     match matched.len() {
         1 => ControllerMatch::Single(matched.into_iter().next().unwrap()),
-        0 => ControllerMatch::None(last_err.unwrap_or_else(|| "no candidates".to_string())),
+        0 => ControllerMatch::Unmatched(if errors.is_empty() {
+            "no candidates".to_string()
+        } else {
+            errors.join("; ")
+        }),
         _ => ControllerMatch::Multiple(matched),
     }
 }
 
 /// Index a list of `ControllerIdentity` values by id and by issuer.
 ///
-/// Validates each id, rejects duplicate ids, and returns
-/// `(by_id, by_issuer)`. Multiple identities may share an issuer (they get
-/// disambiguated by claim constraints at request time).
+/// Validates each id, rejects duplicate ids, and returns a `ControllerIndexes`.
+/// Multiple identities may share an issuer (they get disambiguated by claim
+/// constraints at request time).
 pub fn build_controller_indexes(controllers: &[ControllerIdentity]) -> Result<ControllerIndexes> {
     let mut by_id: HashMap<String, ControllerIdentity> = HashMap::new();
     let mut by_issuer: HashMap<String, Vec<ControllerIdentity>> = HashMap::new();
@@ -300,7 +307,7 @@ pub fn build_controller_indexes(controllers: &[ControllerIdentity]) -> Result<Co
             .push(c.clone());
     }
 
-    Ok((by_id, by_issuer))
+    Ok(ControllerIndexes { by_id, by_issuer })
 }
 
 #[cfg(test)]
@@ -396,16 +403,16 @@ mod tests {
         let c2 = ident("b.example.com/x", "https://issuer.example.com");
         let c3 = ident("c.example.com", "https://other.example.com");
 
-        let (by_id, by_iss) = build_controller_indexes(&[c1, c2, c3]).unwrap();
+        let indexes = build_controller_indexes(&[c1, c2, c3]).unwrap();
 
-        assert_eq!(by_id.len(), 3);
-        assert!(by_id.contains_key("a.example.com"));
-        assert!(by_id.contains_key("b.example.com/x"));
-        assert!(by_id.contains_key("c.example.com"));
+        assert_eq!(indexes.by_id.len(), 3);
+        assert!(indexes.by_id.contains_key("a.example.com"));
+        assert!(indexes.by_id.contains_key("b.example.com/x"));
+        assert!(indexes.by_id.contains_key("c.example.com"));
 
-        assert_eq!(by_iss.len(), 2);
-        assert_eq!(by_iss["https://issuer.example.com"].len(), 2);
-        assert_eq!(by_iss["https://other.example.com"].len(), 1);
+        assert_eq!(indexes.by_issuer.len(), 2);
+        assert_eq!(indexes.by_issuer["https://issuer.example.com"].len(), 2);
+        assert_eq!(indexes.by_issuer["https://other.example.com"].len(), 1);
     }
 
     #[test]
@@ -519,7 +526,9 @@ mod tests {
         let claims = serde_json::json!({"sub": "anyone", "aud": "anything"});
         let m = match_controller_identity(&claims, &candidates);
         match m {
-            ControllerMatch::None(detail) => assert!(detail.contains("claims.aud"), "{detail}"),
+            ControllerMatch::Unmatched(detail) => {
+                assert!(detail.contains("claims.aud"), "{detail}")
+            }
             other => panic!("expected None, got {other:?}"),
         }
     }
@@ -556,7 +565,7 @@ mod tests {
         let claims = serde_json::json!({"sub": "x", "aud": ["other"]});
         let m = match_controller_identity(&claims, &candidates);
         match m {
-            ControllerMatch::None(detail) => {
+            ControllerMatch::Unmatched(detail) => {
                 assert!(detail.contains("aud claim does not match"), "got: {detail}")
             }
             other => panic!("expected None, got {other:?}"),
@@ -572,7 +581,9 @@ mod tests {
         let claims = serde_json::json!({"aud": "rise", "sub": "other-bot"});
         let m = match_controller_identity(&claims, &candidates);
         match m {
-            ControllerMatch::None(detail) => assert!(detail.contains("a.example.com"), "{detail}"),
+            ControllerMatch::Unmatched(detail) => {
+                assert!(detail.contains("a.example.com"), "{detail}")
+            }
             other => panic!("expected None, got {other:?}"),
         }
     }
@@ -585,7 +596,7 @@ mod tests {
         )];
         let claims = serde_json::json!({"aud": "rise", "sub": "x"});
         let m = match_controller_identity(&claims, &candidates);
-        assert!(matches!(m, ControllerMatch::None(_)), "got {m:?}");
+        assert!(matches!(m, ControllerMatch::Unmatched(_)), "got {m:?}");
     }
 
     #[test]
@@ -640,6 +651,6 @@ mod tests {
     #[test]
     fn test_match_empty_candidates() {
         let m = match_controller_identity(&serde_json::json!({}), &[]);
-        assert!(matches!(m, ControllerMatch::None(_)));
+        assert!(matches!(m, ControllerMatch::Unmatched(_)));
     }
 }

--- a/src/server/auth/controller.rs
+++ b/src/server/auth/controller.rs
@@ -25,7 +25,8 @@ use crate::server::state::AppState;
 /// Each entry binds a stable controller ID (the key used under
 /// `status.controllers`) to an OIDC issuer plus optional claim constraints
 /// (`audience`, `subject`, free-form `claims`). Wildcards in
-/// `subject`/`claims` follow `JwtValidator::validate_custom_claims` rules.
+/// `audience`/`subject`/`claims` follow `JwtValidator::validate_custom_claims`
+/// glob rules (`*` matches any sequence of characters).
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct ControllerIdentity {
     /// Stable controller ID written under `status.controllers`. Must be a
@@ -34,13 +35,16 @@ pub struct ControllerIdentity {
     pub id: String,
     /// OIDC issuer URL. Used for JWKS discovery and `iss` validation.
     pub issuer: String,
-    /// Expected `aud` claim. Exact match when set.
+    /// Expected `aud` claim. Per RFC 7519 the JWT `aud` may be either a
+    /// string or an array of strings — the match succeeds when the expected
+    /// value equals the string `aud`, or when it appears in the `aud` array.
+    /// Glob `*` supported.
     #[serde(default)]
     pub audience: Option<String>,
-    /// Expected `sub` claim. Wildcards supported.
+    /// Expected `sub` claim. Glob `*` supported.
     #[serde(default)]
     pub subject: Option<String>,
-    /// Additional claim constraints. Wildcards supported.
+    /// Additional string-valued claim constraints. Glob `*` supported.
     #[serde(default)]
     pub claims: HashMap<String, String>,
 }
@@ -83,29 +87,52 @@ impl FromRequestParts<AppState> for ControllerAuthContext {
     }
 }
 
-// DNS-1123 subdomain followed by an optional single `/name` suffix.
-// - Host: one or more lowercase DNS labels joined by `.`, at least one `.` (so
-//   single-word hosts like `localhost` are rejected — controller IDs must be
-//   fully-qualified to act as Kubernetes annotation key prefixes).
-// - Optional path segment after `/`: `[A-Za-z0-9_.-]+` (matches Kubernetes
-//   annotation key name format).
+// DNS-1123 subdomain followed by an optional `/name` suffix where `name`
+// follows Kubernetes annotation key name rules.
+//
+// Host portion: one or more lowercase DNS labels joined by `.`, at least one
+// `.` (so single-word hosts like `localhost` are rejected — controller IDs
+// must be fully-qualified to act as Kubernetes annotation key prefixes).
+//
+// Name portion: matches the rule from
+// <https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set>:
+// "must be 63 characters or less, beginning and ending with an alphanumeric
+// character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and
+// alphanumerics between". Length is enforced separately in
+// `validate_controller_id` so the regex stays readable.
 static CONTROLLER_ID_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
-        r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)+(/[A-Za-z0-9_.-]+)?$",
+        r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)+(/[A-Za-z0-9]([A-Za-z0-9_.-]*[A-Za-z0-9])?)?$",
     )
     .expect("controller id regex compiles")
 });
 
+/// Maximum length of the `/name` portion of a controller id, per Kubernetes
+/// annotation key name rules.
+const CONTROLLER_ID_NAME_MAX_LEN: usize = 63;
+
 /// Validate a controller `id` value.
 ///
 /// Format: DNS-1123 subdomain (at least one `.`) optionally followed by a
-/// single `/name` segment, max 253 chars total.
+/// single `/name` segment matching the Kubernetes annotation key name rules
+/// (alphanumeric start/end, `-`/`_`/`.` allowed in between, max 63 chars).
+/// Whole id is capped at 253 chars.
 pub fn validate_controller_id(id: &str) -> Result<()> {
     if id.is_empty() {
         bail!("controller id is empty");
     }
     if id.len() > 253 {
         bail!("controller id too long (>{} chars)", 253);
+    }
+    if let Some(slash_pos) = id.find('/') {
+        let name = &id[slash_pos + 1..];
+        if name.len() > CONTROLLER_ID_NAME_MAX_LEN {
+            bail!(
+                "controller id name portion too long ({} > {} chars)",
+                name.len(),
+                CONTROLLER_ID_NAME_MAX_LEN
+            );
+        }
     }
     if !CONTROLLER_ID_RE.is_match(id) {
         bail!(
@@ -121,6 +148,98 @@ pub type ControllerIndexes = (
     HashMap<String, ControllerIdentity>,
     HashMap<String, Vec<ControllerIdentity>>,
 );
+
+/// Outcome of matching JWT claims against a set of controller identity
+/// candidates that share the token's issuer.
+#[derive(Debug)]
+pub enum ControllerMatch<'a> {
+    /// Exactly one identity matched the token's claim constraints.
+    Single(&'a ControllerIdentity),
+    /// No identity matched. The contained string explains the most recent
+    /// failure (for diagnostics / 401 detail).
+    None(String),
+    /// Two or more identities matched — configuration is ambiguous.
+    Multiple(Vec<&'a ControllerIdentity>),
+}
+
+/// Check whether a JWT `aud` claim matches the expected audience.
+///
+/// `aud` may be a single string or an array of strings per RFC 7519 §4.1.3
+/// (`aud` is "a single case-sensitive string or a JSON array of case-sensitive
+/// strings"). When the expected audience contains a `*` it is matched as a
+/// glob pattern using the same rules as `JwtValidator::validate_custom_claims`.
+fn audience_matches(claim: &serde_json::Value, expected: &str) -> bool {
+    let check = |actual: &str| -> bool {
+        if expected.contains('*') {
+            crate::server::auth::jwt::JwtValidator::matches_wildcard_pattern(expected, actual)
+        } else {
+            actual == expected
+        }
+    };
+    match claim {
+        serde_json::Value::String(s) => check(s),
+        serde_json::Value::Array(arr) => arr.iter().filter_map(|v| v.as_str()).any(check),
+        _ => false,
+    }
+}
+
+/// Match a verified JWT's claims against a list of candidate identities.
+///
+/// Pure helper extracted from `auth_middleware` so it can be unit-tested
+/// without spinning up JWKS. Caller is responsible for verifying that the
+/// JWT signature and `iss` are correct before invoking.
+///
+/// Each identity's constraints are applied as follows:
+/// - `audience`: matched against the JWT `aud` claim, accepting either a
+///   string or an array of strings (RFC 7519 §4.1.3). Glob `*` allowed.
+/// - `subject`: matched against the JWT `sub` claim via
+///   `validate_custom_claims` (string with glob `*`).
+/// - `claims`: matched via `validate_custom_claims` (string-valued claims
+///   with glob `*`).
+///
+/// Returns `Single` when exactly one identity satisfies all constraints,
+/// `Multiple` when two or more do (ambiguous configuration), and `None` with
+/// the most recent failure detail when none match.
+pub fn match_controller_identity<'a>(
+    token_claims: &serde_json::Value,
+    candidates: &'a [ControllerIdentity],
+) -> ControllerMatch<'a> {
+    let mut matched: Vec<&'a ControllerIdentity> = Vec::new();
+    let mut last_err: Option<String> = None;
+
+    for ident in candidates {
+        if let Some(expected_aud) = &ident.audience {
+            let aud_claim = token_claims.get("aud").unwrap_or(&serde_json::Value::Null);
+            if !audience_matches(aud_claim, expected_aud) {
+                last_err = Some(format!(
+                    "identity {:?}: aud claim does not match expected audience {:?}",
+                    ident.id, expected_aud
+                ));
+                continue;
+            }
+        }
+
+        let mut expected_string_claims = ident.claims.clone();
+        if let Some(sub) = &ident.subject {
+            expected_string_claims.insert("sub".to_string(), sub.clone());
+        }
+        match crate::server::auth::jwt::JwtValidator::validate_custom_claims(
+            token_claims,
+            &expected_string_claims,
+        ) {
+            Ok(()) => matched.push(ident),
+            Err(e) => {
+                last_err = Some(format!("identity {:?}: {}", ident.id, e));
+            }
+        }
+    }
+
+    match matched.len() {
+        1 => ControllerMatch::Single(matched.into_iter().next().unwrap()),
+        0 => ControllerMatch::None(last_err.unwrap_or_else(|| "no candidates".to_string())),
+        _ => ControllerMatch::Multiple(matched),
+    }
+}
 
 /// Index a list of `ControllerIdentity` values by id and by issuer.
 ///
@@ -182,6 +301,12 @@ mod tests {
             "controller.example.com/a/b",        // nested path segments not allowed
             "controller.example.com//x",         // empty path segment
             "controller.example.com/with space", // invalid path char
+            "controller.example.com/-leading",   // leading hyphen in name
+            "controller.example.com/trailing-",  // trailing hyphen in name
+            "controller.example.com/.dot",       // leading dot in name
+            "controller.example.com/dot.",       // trailing dot in name
+            "controller.example.com/_under",     // leading underscore in name
+            "controller.example.com/under_",     // trailing underscore in name
         ] {
             assert!(
                 validate_controller_id(id).is_err(),
@@ -192,19 +317,34 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_controller_id_rejects_too_long() {
-        // Build a 254-char id: many short labels.
+    fn test_validate_controller_id_rejects_too_long_total() {
+        // Build a host >253 chars so the whole-id length check fires.
         let host = (0..50).map(|_| "ab").collect::<Vec<_>>().join(".");
-        // host is 50 labels of 2 chars + 49 dots = 100 + 49 = 149 chars
-        let mut id = host.clone();
+        let mut id = host;
         while id.len() <= 253 {
             id.push_str(".ab");
         }
         assert!(id.len() > 253);
-        // Strip until valid form check would matter; format may also fail format check
-        // but length check fires first.
         let err = validate_controller_id(&id).unwrap_err().to_string();
         assert!(err.contains("too long"), "got: {err}");
+    }
+
+    #[test]
+    fn test_validate_controller_id_rejects_name_over_63_chars() {
+        // 64-character name segment (alphanumeric so the format check would pass,
+        // forcing the length check to fire first).
+        let id = format!("controller.example.com/{}", "a".repeat(64));
+        let err = validate_controller_id(&id).unwrap_err().to_string();
+        assert!(
+            err.contains("name portion too long"),
+            "expected name length error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_controller_id_accepts_name_exactly_63_chars() {
+        let id = format!("controller.example.com/{}", "a".repeat(63));
+        validate_controller_id(&id).expect("63-char name should be accepted");
     }
 
     fn ident(id: &str, issuer: &str) -> ControllerIdentity {
@@ -256,5 +396,203 @@ mod tests {
         let c = ident("a.example.com", "");
         let err = build_controller_indexes(&[c]).unwrap_err().to_string();
         assert!(err.contains("empty issuer"), "got: {err}");
+    }
+
+    // --- audience_matches ---
+
+    #[test]
+    fn test_audience_matches_string_exact() {
+        assert!(audience_matches(&serde_json::json!("rise"), "rise"));
+        assert!(!audience_matches(&serde_json::json!("rise"), "other"));
+    }
+
+    #[test]
+    fn test_audience_matches_string_glob() {
+        assert!(audience_matches(&serde_json::json!("rise-prod"), "rise-*"));
+        assert!(audience_matches(&serde_json::json!("rise"), "*"));
+        assert!(!audience_matches(&serde_json::json!("other"), "rise-*"));
+    }
+
+    #[test]
+    fn test_audience_matches_array_contains_expected() {
+        let claim = serde_json::json!(["other-aud", "rise", "extra"]);
+        assert!(audience_matches(&claim, "rise"));
+    }
+
+    #[test]
+    fn test_audience_matches_array_no_match() {
+        let claim = serde_json::json!(["a", "b", "c"]);
+        assert!(!audience_matches(&claim, "rise"));
+    }
+
+    #[test]
+    fn test_audience_matches_array_glob() {
+        let claim = serde_json::json!(["api-prod", "web-dev"]);
+        assert!(audience_matches(&claim, "api-*"));
+        assert!(audience_matches(&claim, "*-dev"));
+        assert!(!audience_matches(&claim, "api-dev"));
+    }
+
+    #[test]
+    fn test_audience_matches_array_ignores_non_string_entries() {
+        let claim = serde_json::json!([42, true, "rise"]);
+        assert!(audience_matches(&claim, "rise"));
+    }
+
+    #[test]
+    fn test_audience_matches_missing_claim() {
+        assert!(!audience_matches(&serde_json::Value::Null, "rise"));
+        assert!(!audience_matches(&serde_json::json!(42), "rise"));
+    }
+
+    // --- match_controller_identity ---
+
+    fn ident_full(
+        id: &str,
+        audience: Option<&str>,
+        subject: Option<&str>,
+        claims: &[(&str, &str)],
+    ) -> ControllerIdentity {
+        ControllerIdentity {
+            id: id.to_string(),
+            issuer: "https://issuer.example.com".to_string(),
+            audience: audience.map(String::from),
+            subject: subject.map(String::from),
+            claims: claims
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn test_match_single_no_constraints() {
+        let candidates = [ident_full("a.example.com", None, None, &[])];
+        let claims = serde_json::json!({"sub": "anyone", "aud": "anything"});
+        let m = match_controller_identity(&claims, &candidates);
+        match m {
+            ControllerMatch::Single(i) => assert_eq!(i.id, "a.example.com"),
+            other => panic!("expected Single, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_match_single_with_constraints() {
+        let candidates = [ident_full(
+            "a.example.com",
+            Some("rise"),
+            Some("ctrl-*"),
+            &[("scope", "controller")],
+        )];
+        let claims = serde_json::json!({
+            "sub": "ctrl-abc",
+            "aud": "rise",
+            "scope": "controller",
+        });
+        let m = match_controller_identity(&claims, &candidates);
+        assert!(matches!(m, ControllerMatch::Single(_)), "got {m:?}");
+    }
+
+    #[test]
+    fn test_match_audience_array() {
+        let candidates = [ident_full("a.example.com", Some("rise"), None, &[])];
+        let claims = serde_json::json!({
+            "sub": "x",
+            "aud": ["other", "rise"],
+        });
+        let m = match_controller_identity(&claims, &candidates);
+        assert!(matches!(m, ControllerMatch::Single(_)), "got {m:?}");
+    }
+
+    #[test]
+    fn test_match_audience_array_no_match() {
+        let candidates = [ident_full("a.example.com", Some("rise"), None, &[])];
+        let claims = serde_json::json!({"sub": "x", "aud": ["other"]});
+        let m = match_controller_identity(&claims, &candidates);
+        match m {
+            ControllerMatch::None(detail) => {
+                assert!(detail.contains("aud claim does not match"), "got: {detail}")
+            }
+            other => panic!("expected None, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_match_none_when_subject_mismatches() {
+        let candidates = [ident_full("a.example.com", None, Some("ctrl-*"), &[])];
+        let claims = serde_json::json!({"sub": "other-bot"});
+        let m = match_controller_identity(&claims, &candidates);
+        match m {
+            ControllerMatch::None(detail) => assert!(detail.contains("a.example.com"), "{detail}"),
+            other => panic!("expected None, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_match_none_when_extra_claim_missing() {
+        let candidates = [ident_full(
+            "a.example.com",
+            None,
+            None,
+            &[("scope", "controller")],
+        )];
+        let claims = serde_json::json!({"sub": "x"});
+        let m = match_controller_identity(&claims, &candidates);
+        assert!(matches!(m, ControllerMatch::None(_)), "got {m:?}");
+    }
+
+    #[test]
+    fn test_match_multiple_when_constraints_ambiguous() {
+        // Two identities with no constraints both match any token.
+        let candidates = [
+            ident_full("a.example.com", None, None, &[]),
+            ident_full("b.example.com", None, None, &[]),
+        ];
+        let claims = serde_json::json!({"sub": "x"});
+        let m = match_controller_identity(&claims, &candidates);
+        match m {
+            ControllerMatch::Multiple(matches) => {
+                let ids: Vec<&str> = matches.iter().map(|i| i.id.as_str()).collect();
+                assert_eq!(ids.len(), 2);
+                assert!(ids.contains(&"a.example.com"));
+                assert!(ids.contains(&"b.example.com"));
+            }
+            other => panic!("expected Multiple, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_match_disambiguates_by_audience() {
+        // Same issuer, different audiences; only one should match.
+        let candidates = [
+            ident_full("a.example.com", Some("rise-a"), None, &[]),
+            ident_full("b.example.com", Some("rise-b"), None, &[]),
+        ];
+        let claims = serde_json::json!({"sub": "x", "aud": "rise-b"});
+        let m = match_controller_identity(&claims, &candidates);
+        match m {
+            ControllerMatch::Single(i) => assert_eq!(i.id, "b.example.com"),
+            other => panic!("expected Single, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_match_disambiguates_by_subject() {
+        let candidates = [
+            ident_full("a.example.com", None, Some("ctrl-a"), &[]),
+            ident_full("b.example.com", None, Some("ctrl-b"), &[]),
+        ];
+        let claims = serde_json::json!({"sub": "ctrl-b"});
+        let m = match_controller_identity(&claims, &candidates);
+        match m {
+            ControllerMatch::Single(i) => assert_eq!(i.id, "b.example.com"),
+            other => panic!("expected Single, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_match_empty_candidates() {
+        let m = match_controller_identity(&serde_json::json!({}), &[]);
+        assert!(matches!(m, ControllerMatch::None(_)));
     }
 }

--- a/src/server/auth/handlers.rs
+++ b/src/server/auth/handlers.rs
@@ -639,6 +639,7 @@ pub struct MeResponse {
     pub id: String,
     pub email: String,
     pub is_admin: bool,
+    pub is_operator: bool,
     pub can_create_teams: bool,
 }
 
@@ -652,11 +653,13 @@ pub async fn me(
     // User is injected by auth middleware
     tracing::debug!("GET /me: user_id={}, email={}", user.id, user.email);
     let is_admin = state.is_admin(&user.email);
+    let is_operator = state.is_operator(&user.email);
     let can_create_teams = is_admin || state.auth_settings.allow_team_creation;
     Ok(Json(MeResponse {
         id: user.id.to_string(),
         email: user.email.clone(),
         is_admin,
+        is_operator,
         can_create_teams,
     }))
 }

--- a/src/server/auth/jwt.rs
+++ b/src/server/auth/jwt.rs
@@ -286,7 +286,7 @@ impl JwtValidator {
     ///
     /// Note: Consecutive wildcards (e.g., `app**prod`) are treated as a single wildcard
     /// due to split() creating empty parts, which always match.
-    fn matches_wildcard_pattern(pattern: &str, text: &str) -> bool {
+    pub(crate) fn matches_wildcard_pattern(pattern: &str, text: &str) -> bool {
         // Split pattern by '*' to get literal parts
         let parts: Vec<&str> = pattern.split('*').collect();
 

--- a/src/server/auth/middleware.rs
+++ b/src/server/auth/middleware.rs
@@ -10,7 +10,6 @@ use serde::Deserialize;
 
 use crate::db::{service_accounts, users, User};
 use crate::server::auth::context::VerifiedExternalToken;
-use crate::server::auth::controller::VerifiedControllerToken;
 use crate::server::auth::cookie_helpers;
 use crate::server::state::AppState;
 
@@ -171,70 +170,6 @@ pub async fn auth_middleware(
 
         tracing::debug!("User authenticated: {} ({})", user.email, user.id);
         req.extensions_mut().insert(user);
-    } else if let Some(controller_candidates) = state.controllers_by_issuer.get(&issuer).cloned() {
-        // External issuer matches at least one configured controller identity.
-        // Controller identities take precedence over service-account issuers
-        // when the same `iss` is reused: we fail closed here rather than
-        // falling back to the SA path, so a misconfigured controller token
-        // can't be silently downgraded to an SA principal.
-        tracing::debug!(
-            "Auth middleware: external JWT from controller issuer '{}', {} candidate identity(ies)",
-            issuer,
-            controller_candidates.len()
-        );
-
-        let claims = state
-            .jwt_validator
-            .validate_token(&token, &issuer)
-            .await
-            .map_err(|e| {
-                tracing::warn!(
-                    "Auth middleware: controller JWT JWKS validation failed for issuer '{}': {:#}",
-                    issuer,
-                    e
-                );
-                (StatusCode::UNAUTHORIZED, format!("Invalid token: {}", e))
-            })?;
-
-        use crate::server::auth::controller::{match_controller_identity, ControllerMatch};
-        match match_controller_identity(&claims, &controller_candidates) {
-            ControllerMatch::Single(ident) => {
-                tracing::info!(
-                    "Controller authenticated: identity_id={}, issuer={}",
-                    ident.id,
-                    issuer
-                );
-                req.extensions_mut().insert(VerifiedControllerToken {
-                    identity_id: ident.id.clone(),
-                    issuer: issuer.clone(),
-                    claims,
-                });
-            }
-            ControllerMatch::None(detail) => {
-                tracing::warn!(
-                    "Controller JWT for issuer '{}' did not match any configured identity: {}",
-                    issuer,
-                    detail
-                );
-                return Err((
-                    StatusCode::UNAUTHORIZED,
-                    "Token did not match any configured controller identity".to_string(),
-                ));
-            }
-            ControllerMatch::Multiple(matched) => {
-                let ids: Vec<&str> = matched.iter().map(|i| i.id.as_str()).collect();
-                tracing::error!(
-                    "Multiple controller identities matched JWT from issuer '{}': {:?}",
-                    issuer,
-                    ids
-                );
-                return Err((
-                    StatusCode::CONFLICT,
-                    "Token matched multiple controller identities; configuration is ambiguous"
-                        .to_string(),
-                ));
-            }
-        }
     } else {
         // External issuer — phase 1: JWKS validation only
         tracing::debug!(
@@ -242,22 +177,31 @@ pub async fn auth_middleware(
             issuer
         );
 
-        // Lightweight guard: skip JWKS fetch if no SA uses this issuer
-        let exists = service_accounts::issuer_exists(&state.db_pool, &issuer)
-            .await
-            .map_err(|e| {
-                tracing::error!("Failed to check issuer existence: {:#}", e);
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "Database error".to_string(),
-                )
-            })?;
+        // Lightweight guard: skip JWKS fetch if no controller or SA uses this issuer.
+        let controller_issuer_exists = state.controllers_by_issuer.contains_key(&issuer);
+        let service_account_issuer_exists = if controller_issuer_exists {
+            false
+        } else {
+            service_accounts::issuer_exists(&state.db_pool, &issuer)
+                .await
+                .map_err(|e| {
+                    tracing::error!("Failed to check issuer existence: {:#}", e);
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "Database error".to_string(),
+                    )
+                })?
+        };
 
-        if !exists {
-            tracing::warn!("No service accounts configured for issuer: {}", issuer);
+        if !service_account_issuer_exists && !controller_issuer_exists {
+            tracing::warn!(
+                "No service accounts or controller identities configured for issuer: {}",
+                issuer
+            );
             return Err((
                 StatusCode::UNAUTHORIZED,
-                "No service accounts configured for this issuer".to_string(),
+                "No service accounts or controller identities configured for this issuer"
+                    .to_string(),
             ));
         }
 
@@ -280,7 +224,8 @@ pub async fn auth_middleware(
             issuer
         );
 
-        // Store the verified token for phase 2 (handler-level claim validation)
+        // Store the verified token for route-specific controller extraction or
+        // project-scoped service-account claim validation.
         req.extensions_mut().insert(VerifiedExternalToken {
             issuer: issuer.clone(),
             claims,
@@ -347,13 +292,6 @@ pub async fn platform_access_middleware(
     // Their access is validated per-project in phase 2.
     if req.extensions().get::<VerifiedExternalToken>().is_some() {
         tracing::debug!("Skipping platform access check for external token (service account)");
-        return Ok(next.run(req).await);
-    }
-
-    // Controller tokens bypass platform access checks; controller endpoints
-    // perform their own authorization based on `identity_id`.
-    if req.extensions().get::<VerifiedControllerToken>().is_some() {
-        tracing::debug!("Skipping platform access check for controller token");
         return Ok(next.run(req).await);
     }
 

--- a/src/server/auth/middleware.rs
+++ b/src/server/auth/middleware.rs
@@ -177,12 +177,12 @@ pub async fn auth_middleware(
             issuer
         );
 
-        // Lightweight guard: skip JWKS fetch if no controller or SA uses this issuer.
-        let controller_issuer_exists = state.controllers_by_issuer.contains_key(&issuer);
-        let service_account_issuer_exists = if controller_issuer_exists {
-            false
-        } else {
-            service_accounts::issuer_exists(&state.db_pool, &issuer)
+        // Lightweight guard: skip JWKS fetch if neither a controller nor any SA
+        // uses this issuer. Controller issuers are in static config (O(1));
+        // SA issuers require a DB round-trip and are only checked when the
+        // issuer isn't already a known controller issuer.
+        if !state.controllers_by_issuer.contains_key(&issuer) {
+            let sa_issuer_exists = service_accounts::issuer_exists(&state.db_pool, &issuer)
                 .await
                 .map_err(|e| {
                     tracing::error!("Failed to check issuer existence: {:#}", e);
@@ -190,19 +190,18 @@ pub async fn auth_middleware(
                         StatusCode::INTERNAL_SERVER_ERROR,
                         "Database error".to_string(),
                     )
-                })?
-        };
-
-        if !service_account_issuer_exists && !controller_issuer_exists {
-            tracing::warn!(
-                "No service accounts or controller identities configured for issuer: {}",
-                issuer
-            );
-            return Err((
-                StatusCode::UNAUTHORIZED,
-                "No service accounts or controller identities configured for this issuer"
-                    .to_string(),
-            ));
+                })?;
+            if !sa_issuer_exists {
+                tracing::warn!(
+                    "No service accounts or controller identities configured for issuer: {}",
+                    issuer
+                );
+                return Err((
+                    StatusCode::UNAUTHORIZED,
+                    "No service accounts or controller identities configured for this issuer"
+                        .to_string(),
+                ));
+            }
         }
 
         // Validate signature + expiry via JWKS (no custom claim validation)

--- a/src/server/auth/middleware.rs
+++ b/src/server/auth/middleware.rs
@@ -10,7 +10,9 @@ use serde::Deserialize;
 
 use crate::db::{service_accounts, users, User};
 use crate::server::auth::context::VerifiedExternalToken;
+use crate::server::auth::controller::VerifiedControllerToken;
 use crate::server::auth::cookie_helpers;
+use crate::server::auth::jwt::JwtValidator;
 use crate::server::state::AppState;
 
 /// Check if a JWT issuer is a Rise-issued JWT
@@ -170,6 +172,93 @@ pub async fn auth_middleware(
 
         tracing::debug!("User authenticated: {} ({})", user.email, user.id);
         req.extensions_mut().insert(user);
+    } else if let Some(controller_candidates) = state.controllers_by_issuer.get(&issuer).cloned() {
+        // External issuer matches at least one configured controller identity.
+        // Controller identities take precedence over service-account issuers
+        // when the same `iss` is reused: we fail closed here rather than
+        // falling back to the SA path, so a misconfigured controller token
+        // can't be silently downgraded to an SA principal.
+        tracing::debug!(
+            "Auth middleware: external JWT from controller issuer '{}', {} candidate identity(ies)",
+            issuer,
+            controller_candidates.len()
+        );
+
+        let claims = state
+            .jwt_validator
+            .validate_token(&token, &issuer)
+            .await
+            .map_err(|e| {
+                tracing::warn!(
+                    "Auth middleware: controller JWT JWKS validation failed for issuer '{}': {:#}",
+                    issuer,
+                    e
+                );
+                (StatusCode::UNAUTHORIZED, format!("Invalid token: {}", e))
+            })?;
+
+        let mut matched: Vec<&crate::server::auth::controller::ControllerIdentity> = Vec::new();
+        let mut last_err: Option<String> = None;
+        for ident in &controller_candidates {
+            let mut expected = ident.claims.clone();
+            if let Some(aud) = &ident.audience {
+                expected.insert("aud".to_string(), aud.clone());
+            }
+            if let Some(sub) = &ident.subject {
+                expected.insert("sub".to_string(), sub.clone());
+            }
+            match JwtValidator::validate_custom_claims(&claims, &expected) {
+                Ok(()) => matched.push(ident),
+                Err(e) => {
+                    tracing::debug!(
+                        "Controller identity {:?} did not match token claims: {}",
+                        ident.id,
+                        e
+                    );
+                    last_err = Some(e.to_string());
+                }
+            }
+        }
+
+        match matched.as_slice() {
+            [ident] => {
+                tracing::info!(
+                    "Controller authenticated: identity_id={}, issuer={}",
+                    ident.id,
+                    issuer
+                );
+                req.extensions_mut().insert(VerifiedControllerToken {
+                    identity_id: ident.id.clone(),
+                    issuer: issuer.clone(),
+                    claims,
+                });
+            }
+            [] => {
+                let detail = last_err.unwrap_or_else(|| "unknown".to_string());
+                tracing::warn!(
+                    "Controller JWT for issuer '{}' did not match any configured identity: {}",
+                    issuer,
+                    detail
+                );
+                return Err((
+                    StatusCode::UNAUTHORIZED,
+                    "Token did not match any configured controller identity".to_string(),
+                ));
+            }
+            _ => {
+                let ids: Vec<&str> = matched.iter().map(|i| i.id.as_str()).collect();
+                tracing::error!(
+                    "Multiple controller identities matched JWT from issuer '{}': {:?}",
+                    issuer,
+                    ids
+                );
+                return Err((
+                    StatusCode::CONFLICT,
+                    "Token matched multiple controller identities; configuration is ambiguous"
+                        .to_string(),
+                ));
+            }
+        }
     } else {
         // External issuer — phase 1: JWKS validation only
         tracing::debug!(
@@ -282,6 +371,13 @@ pub async fn platform_access_middleware(
     // Their access is validated per-project in phase 2.
     if req.extensions().get::<VerifiedExternalToken>().is_some() {
         tracing::debug!("Skipping platform access check for external token (service account)");
+        return Ok(next.run(req).await);
+    }
+
+    // Controller tokens bypass platform access checks; controller endpoints
+    // perform their own authorization based on `identity_id`.
+    if req.extensions().get::<VerifiedControllerToken>().is_some() {
+        tracing::debug!("Skipping platform access check for controller token");
         return Ok(next.run(req).await);
     }
 

--- a/src/server/auth/middleware.rs
+++ b/src/server/auth/middleware.rs
@@ -12,7 +12,6 @@ use crate::db::{service_accounts, users, User};
 use crate::server::auth::context::VerifiedExternalToken;
 use crate::server::auth::controller::VerifiedControllerToken;
 use crate::server::auth::cookie_helpers;
-use crate::server::auth::jwt::JwtValidator;
 use crate::server::state::AppState;
 
 /// Check if a JWT issuer is a Rise-issued JWT
@@ -197,31 +196,9 @@ pub async fn auth_middleware(
                 (StatusCode::UNAUTHORIZED, format!("Invalid token: {}", e))
             })?;
 
-        let mut matched: Vec<&crate::server::auth::controller::ControllerIdentity> = Vec::new();
-        let mut last_err: Option<String> = None;
-        for ident in &controller_candidates {
-            let mut expected = ident.claims.clone();
-            if let Some(aud) = &ident.audience {
-                expected.insert("aud".to_string(), aud.clone());
-            }
-            if let Some(sub) = &ident.subject {
-                expected.insert("sub".to_string(), sub.clone());
-            }
-            match JwtValidator::validate_custom_claims(&claims, &expected) {
-                Ok(()) => matched.push(ident),
-                Err(e) => {
-                    tracing::debug!(
-                        "Controller identity {:?} did not match token claims: {}",
-                        ident.id,
-                        e
-                    );
-                    last_err = Some(e.to_string());
-                }
-            }
-        }
-
-        match matched.as_slice() {
-            [ident] => {
+        use crate::server::auth::controller::{match_controller_identity, ControllerMatch};
+        match match_controller_identity(&claims, &controller_candidates) {
+            ControllerMatch::Single(ident) => {
                 tracing::info!(
                     "Controller authenticated: identity_id={}, issuer={}",
                     ident.id,
@@ -233,8 +210,7 @@ pub async fn auth_middleware(
                     claims,
                 });
             }
-            [] => {
-                let detail = last_err.unwrap_or_else(|| "unknown".to_string());
+            ControllerMatch::None(detail) => {
                 tracing::warn!(
                     "Controller JWT for issuer '{}' did not match any configured identity: {}",
                     issuer,
@@ -245,7 +221,7 @@ pub async fn auth_middleware(
                     "Token did not match any configured controller identity".to_string(),
                 ));
             }
-            _ => {
+            ControllerMatch::Multiple(matched) => {
                 let ids: Vec<&str> = matched.iter().map(|i| i.id.as_str()).collect();
                 tracing::error!(
                     "Multiple controller identities matched JWT from issuer '{}': {:?}",

--- a/src/server/auth/mod.rs
+++ b/src/server/auth/mod.rs
@@ -1,5 +1,6 @@
 pub mod admin;
 pub mod context;
+pub mod controller;
 pub mod cookie_helpers;
 pub mod entra_sync;
 pub mod group_sync;

--- a/src/server/deployment/handlers.rs
+++ b/src/server/deployment/handlers.rs
@@ -803,7 +803,11 @@ pub async fn create_deployment(
     // Only mask auth failures (401/403) as 404 to prevent project existence leakage;
     // preserve 409 (SA collision) and 5xx (misconfiguration) for diagnosability.
     let (user, is_sa) = auth
-        .resolve_for_project(&state.db_pool, &project)
+        .resolve_for_project(
+            &state.db_pool,
+            &project,
+            state.controllers_by_issuer.as_ref(),
+        )
         .await
         .map_err(|e| {
             if e.status == StatusCode::UNAUTHORIZED || e.status == StatusCode::FORBIDDEN {
@@ -1547,7 +1551,11 @@ pub async fn update_deployment_status_by_project(
 
     // Resolve auth for project scope
     let (user, is_sa) = auth
-        .resolve_for_project(&state.db_pool, &project)
+        .resolve_for_project(
+            &state.db_pool,
+            &project,
+            state.controllers_by_issuer.as_ref(),
+        )
         .await
         .map_err(|e| {
             if e.status == StatusCode::UNAUTHORIZED || e.status == StatusCode::FORBIDDEN {
@@ -1640,7 +1648,11 @@ pub async fn update_deployment_status(
 
     // Resolve auth for project scope
     let (user, is_sa) = auth
-        .resolve_for_project(&state.db_pool, &project)
+        .resolve_for_project(
+            &state.db_pool,
+            &project,
+            state.controllers_by_issuer.as_ref(),
+        )
         .await
         .map_err(|e| {
             if e.status == StatusCode::UNAUTHORIZED || e.status == StatusCode::FORBIDDEN {
@@ -1691,7 +1703,11 @@ pub async fn list_deployments(
 
     // Resolve auth for project scope
     let (user, is_sa) = auth
-        .resolve_for_project(&state.db_pool, &project)
+        .resolve_for_project(
+            &state.db_pool,
+            &project,
+            state.controllers_by_issuer.as_ref(),
+        )
         .await
         .map_err(|e| {
             if e.status == StatusCode::UNAUTHORIZED || e.status == StatusCode::FORBIDDEN {
@@ -1804,7 +1820,11 @@ pub async fn stop_deployments_by_group(
 
     // Resolve auth for project scope
     let (_user, is_sa) = auth
-        .resolve_for_project(&state.db_pool, &project)
+        .resolve_for_project(
+            &state.db_pool,
+            &project,
+            state.controllers_by_issuer.as_ref(),
+        )
         .await
         .map_err(|e| {
             if e.status == StatusCode::UNAUTHORIZED || e.status == StatusCode::FORBIDDEN {
@@ -1915,7 +1935,11 @@ pub async fn stop_deployment(
 
     // Resolve auth for project scope
     let (_user, is_sa) = auth
-        .resolve_for_project(&state.db_pool, &project)
+        .resolve_for_project(
+            &state.db_pool,
+            &project,
+            state.controllers_by_issuer.as_ref(),
+        )
         .await
         .map_err(|e| {
             if e.status == StatusCode::UNAUTHORIZED || e.status == StatusCode::FORBIDDEN {
@@ -2038,7 +2062,11 @@ pub async fn get_deployment_by_project(
 
     // Resolve auth for project scope
     let (_user, is_sa) = auth
-        .resolve_for_project(&state.db_pool, &project)
+        .resolve_for_project(
+            &state.db_pool,
+            &project,
+            state.controllers_by_issuer.as_ref(),
+        )
         .await
         .map_err(|e| {
             if e.status == StatusCode::UNAUTHORIZED || e.status == StatusCode::FORBIDDEN {
@@ -2122,7 +2150,11 @@ pub async fn list_deployment_groups(
 
     // Resolve auth for project scope
     let (_user, is_sa) = auth
-        .resolve_for_project(&state.db_pool, &project)
+        .resolve_for_project(
+            &state.db_pool,
+            &project,
+            state.controllers_by_issuer.as_ref(),
+        )
         .await
         .map_err(|e| {
             if e.status == StatusCode::UNAUTHORIZED || e.status == StatusCode::FORBIDDEN {
@@ -2179,7 +2211,11 @@ pub async fn stream_deployment_logs(
 
     // Resolve auth for project scope
     let (_user, is_sa) = auth
-        .resolve_for_project(&state.db_pool, &project)
+        .resolve_for_project(
+            &state.db_pool,
+            &project,
+            state.controllers_by_issuer.as_ref(),
+        )
         .await
         .map_err(|e| {
             if e.status == StatusCode::UNAUTHORIZED || e.status == StatusCode::FORBIDDEN {

--- a/src/server/registry/handlers.rs
+++ b/src/server/registry/handlers.rs
@@ -31,7 +31,11 @@ pub async fn get_deployment_registry_credentials(
 
     // Resolve auth for project scope
     let (user, is_sa) = auth
-        .resolve_for_project(&state.db_pool, &project)
+        .resolve_for_project(
+            &state.db_pool,
+            &project,
+            state.controllers_by_issuer.as_ref(),
+        )
         .await
         .map_err(|e| {
             if e.status == StatusCode::UNAUTHORIZED || e.status == StatusCode::FORBIDDEN {

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -234,7 +234,7 @@ pub struct AuthSettings {
     #[serde(default)]
     pub operator_users: Vec<String>,
     /// Trusted external controller identities. Each entry binds a stable
-    /// controller ID to an OIDC issuer plus optional claim constraints.
+    /// controller ID to an OIDC issuer plus required claim constraints.
     /// Used by generic-resource controller endpoints.
     #[serde(default)]
     pub controllers: Vec<crate::server::auth::controller::ControllerIdentity>,

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -223,9 +223,21 @@ pub struct AuthSettings {
     pub issuer: String,
     pub client_id: String,
     pub client_secret: String,
-    /// List of admin user emails (have full permissions)
+    /// List of admin user emails for the default organization. Admins do NOT
+    /// implicitly receive the Operator role — list the email in
+    /// `operator_users` separately if needed.
     #[serde(default)]
     pub admin_users: Vec<String>,
+    /// List of Operator user emails. Operators have full access to generic
+    /// resource storage and built-in resource management. This is a separate
+    /// role from `admin_users`.
+    #[serde(default)]
+    pub operator_users: Vec<String>,
+    /// Trusted external controller identities. Each entry binds a stable
+    /// controller ID to an OIDC issuer plus optional claim constraints.
+    /// Used by generic-resource controller endpoints.
+    #[serde(default)]
+    pub controllers: Vec<crate::server::auth::controller::ControllerIdentity>,
     /// Platform access control configuration
     #[serde(default)]
     pub platform_access: PlatformAccessConfig,

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -515,11 +515,11 @@ impl AppState {
         }
 
         // Validate and index configured controller identities
-        let (controllers_by_id, controllers_by_iss) =
+        let controller_indexes =
             crate::server::auth::controller::build_controller_indexes(&settings.auth.controllers)
                 .context("Failed to load controller identities from auth.controllers")?;
-        let controllers = Arc::new(controllers_by_id);
-        let controllers_by_issuer = Arc::new(controllers_by_iss);
+        let controllers = Arc::new(controller_indexes.by_id);
+        let controllers_by_issuer = Arc::new(controller_indexes.by_issuer);
         if !controllers.is_empty() {
             let ids: Vec<&str> = controllers.keys().map(String::as_str).collect();
             tracing::info!(

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -10,6 +10,7 @@ use crate::server::registry::{
     models::OciClientAuthConfig, providers::OciClientAuthProvider, RegistryProvider,
 };
 
+use crate::server::auth::controller::ControllerIdentity;
 #[cfg(feature = "backend")]
 use crate::server::registry::{
     models::{EcrConfig, GitLabRegistryConfig, JfrogConfig, JfrogTokenProvider},
@@ -21,6 +22,7 @@ use crate::server::settings::{
 use anyhow::{Context, Result};
 use sqlx::postgres::PgPoolOptions;
 use sqlx::PgPool;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -45,6 +47,14 @@ pub struct AppState {
     pub registry_provider: Arc<dyn RegistryProvider>,
     pub oci_client: Arc<crate::server::oci::OciClient>,
     pub admin_users: Arc<Vec<String>>,
+    /// Operator role allowlist (case-insensitive email match).
+    pub operator_users: Arc<Vec<String>>,
+    /// Controller identities keyed by `id`. Consumed by future generic
+    /// resource endpoints; unused in PR3.
+    #[allow(dead_code)]
+    pub controllers: Arc<HashMap<String, ControllerIdentity>>,
+    /// Controller identities indexed by issuer URL for middleware lookup.
+    pub controllers_by_issuer: Arc<HashMap<String, Vec<ControllerIdentity>>>,
     pub auth_settings: Arc<AuthSettings>,
     pub server_settings: Arc<ServerSettings>,
     pub token_store: Arc<dyn TokenStore>,
@@ -201,6 +211,14 @@ impl AppState {
     /// Check if a user is an admin (case-insensitive email match)
     pub fn is_admin(&self, user_email: &str) -> bool {
         crate::server::auth::admin::is_admin_user(&self.admin_users, user_email)
+    }
+
+    /// Check if a user has the Operator role (case-insensitive email match).
+    ///
+    /// Operators are a separate role from admins. Use this for access checks
+    /// on generic-resource APIs once they're wired up.
+    pub fn is_operator(&self, user_email: &str) -> bool {
+        crate::server::auth::admin::is_operator_user(&self.operator_users, user_email)
     }
 
     /// Run database migrations
@@ -488,6 +506,27 @@ impl AppState {
         let admin_users = Arc::new(settings.auth.admin_users.clone());
         if !admin_users.is_empty() {
             tracing::info!("Configured {} admin user(s)", admin_users.len());
+        }
+
+        // Store operator users list (separate role from admin)
+        let operator_users = Arc::new(settings.auth.operator_users.clone());
+        if !operator_users.is_empty() {
+            tracing::info!("Configured {} operator user(s)", operator_users.len());
+        }
+
+        // Validate and index configured controller identities
+        let (controllers_by_id, controllers_by_iss) =
+            crate::server::auth::controller::build_controller_indexes(&settings.auth.controllers)
+                .context("Failed to load controller identities from auth.controllers")?;
+        let controllers = Arc::new(controllers_by_id);
+        let controllers_by_issuer = Arc::new(controllers_by_iss);
+        if !controllers.is_empty() {
+            let ids: Vec<&str> = controllers.keys().map(String::as_str).collect();
+            tracing::info!(
+                "Configured {} controller identity(ies): {:?}",
+                controllers.len(),
+                ids
+            );
         }
 
         // Store auth settings for issuer comparison
@@ -990,6 +1029,9 @@ impl AppState {
             registry_provider,
             oci_client,
             admin_users,
+            operator_users,
+            controllers,
+            controllers_by_issuer,
             auth_settings,
             server_settings,
             token_store,


### PR DESCRIPTION
## Summary

This PR introduces support for external controller authentication via OIDC JWTs and adds a separate Operator role for generic resource management. Controllers can now authenticate to Rise using trusted OIDC issuers, with claim-based validation for fine-grained access control. The Operator role is a distinct authorization level from admin users, allowing separation of concerns between platform administration and resource operations.

## Key Changes

- **Controller Authentication** (`src/server/auth/controller.rs` - new file)
  - New `ControllerIdentity` configuration type for registering trusted external controllers
  - `VerifiedControllerToken` type injected into request extensions after JWKS validation
  - `ControllerAuthContext` Axum extractor for handler-level token access
  - Controller ID validation: DNS-1123 subdomain format with optional `/name` suffix
  - Comprehensive test coverage for ID validation and index building

- **Auth Middleware Enhancement** (`src/server/auth/middleware.rs`)
  - Controller token path runs before service-account fallback when issuer matches a configured controller
  - Claim validation using wildcard matching for `audience`, `subject`, and custom claims
  - Fail-closed behavior: misconfigured controller tokens don't silently downgrade to SA principals
  - Controller tokens bypass platform access checks (controller endpoints perform own authorization)

- **Operator Role** (`src/server/auth/admin.rs`)
  - New `is_operator_user()` function for case-insensitive email matching
  - Operators are a separate role from admins (no implicit inheritance)
  - Full test coverage for operator role checks

- **Configuration & State Management**
  - `AuthSettings` extended with `operator_users` and `controllers` fields
  - `AppState` now stores controller indexes (by ID and by issuer) for middleware lookup
  - `AppState::is_operator()` method for authorization checks
  - Controller identity validation and indexing at startup

- **API Response Updates** (`src/server/auth/handlers.rs`)
  - `/me` endpoint now includes `is_operator` field in response

- **Documentation**
  - Updated configuration docs with controller identity examples and role descriptions
  - Schema generation for `ControllerIdentity` in backend-settings.schema.json
  - Development config includes example operator user

## Implementation Details

- Controller identities are indexed by both ID and issuer URL for efficient middleware lookup
- Multiple controller identities can share an issuer; they're disambiguated by claim constraints at request time
- Duplicate controller IDs are rejected at startup with clear error messages
- Controller tokens are stored in request extensions alongside other auth context
- The extractor pattern allows future generic-resource endpoints to require controller auth with `ControllerAuthContext` handler argument
- All new code includes comprehensive unit tests with edge case coverage

## Notes

- Controller endpoints are not yet wired up (landing in a future PR with generic resource API)
- The `#[allow(dead_code)]` attributes on controller types are intentional—they'll be consumed by future PRs

https://claude.ai/code/session_01H8ACtHHCqkvX6ZCL3EYAEe