### PR TITLE
Make project name optional with rise.toml path resolution

### DIFF
--- a/docs/user/src/content/docs/user-guide/cli-reference.md
+++ b/docs/user/src/content/docs/user-guide/cli-reference.md
@@ -28,7 +28,15 @@ The Rise CLI (`rise`) provides commands for managing projects, deployments, team
 
 ## Project Name Resolution
 
-Most commands accept `-p <project>` to specify the project name. If omitted, Rise reads the project name from `rise.toml` or `.rise.toml` in the current directory (or the path specified by `--path`).
+Commands that operate on a project accept the project name as a positional argument (e.g. `rise project show my-app`), and deployment and environment commands also accept it via `-p <project>`. If omitted, Rise reads the project name from the `[project]` section of `rise.toml` or `.rise.toml` in the directory given by `--path` (defaults to the current directory).
+
+This means `rise project show`, `update`, and `delete` can be run with no project name when a `rise.toml` is present:
+
+```bash
+# Equivalent when rise.toml has [project] name = "my-app"
+rise project show my-app
+rise project show
+```
 
 ## Environment Variables
 

--- a/docs/user/src/content/docs/user-guide/configuration.mdx
+++ b/docs/user/src/content/docs/user-guide/configuration.mdx
@@ -112,6 +112,16 @@ rise project create
 
 If a `rise.toml` already exists, it is never overwritten — the project is created on the backend using the name from the file.
 
+## Managing a Project
+
+`rise project show`, `update`, and `delete` take an optional project name. When omitted, the name is read from the `[project]` section of `rise.toml` (or `.rise.toml`) in the directory given by `--path` (defaults to the current directory):
+
+```bash
+# Both work when rise.toml has [project] name = "my-app"
+rise project show my-app
+rise project show
+```
+
 ## Configuration Precedence
 
 Settings are resolved in this order (highest to lowest priority):

--- a/src/main.rs
+++ b/src/main.rs
@@ -289,15 +289,18 @@ enum ProjectCommands {
     /// Show project details
     #[command(visible_alias = "s")]
     Show {
-        /// Project name
-        project: String,
+        /// Project name (optional if rise.toml contains [project] section)
+        project: Option<String>,
+        /// Path to rise.toml (defaults to current directory)
+        #[arg(long, default_value = ".")]
+        path: String,
     },
     /// Update project
     #[command(visible_alias = "u")]
     #[command(visible_alias = "edit")]
     Update {
-        /// Project name
-        project: String,
+        /// Project name (optional if rise.toml contains [project] section)
+        project: Option<String>,
         /// New project name
         #[arg(long)]
         name: Option<String>,
@@ -310,13 +313,19 @@ enum ProjectCommands {
         /// URL to where the project code lives (e.g. a GitHub/GitLab repository). Use empty string to clear.
         #[arg(long)]
         source_url: Option<String>,
+        /// Path to rise.toml (defaults to current directory)
+        #[arg(long, default_value = ".")]
+        path: String,
     },
     /// Delete a project
     #[command(visible_alias = "del")]
     #[command(visible_alias = "rm")]
     Delete {
-        /// Project name
-        project: String,
+        /// Project name (optional if rise.toml contains [project] section)
+        project: Option<String>,
+        /// Path to rise.toml (defaults to current directory)
+        #[arg(long, default_value = ".")]
+        path: String,
     },
     /// Manage app users/teams (view-only access to deployed apps)
     #[command(subcommand)]
@@ -999,8 +1008,9 @@ async fn main() -> Result<()> {
             ProjectCommands::List {} => {
                 project::list_projects(&http_client, &backend_url, &config).await?;
             }
-            ProjectCommands::Show { project } => {
-                project::show_project(&http_client, &backend_url, &config, project).await?;
+            ProjectCommands::Show { project, path } => {
+                let project_name = resolve_project_name(project.clone(), path)?;
+                project::show_project(&http_client, &backend_url, &config, &project_name).await?;
             }
             ProjectCommands::Update {
                 project,
@@ -1008,7 +1018,9 @@ async fn main() -> Result<()> {
                 access_class,
                 owner,
                 source_url,
+                path,
             } => {
+                let project_name = resolve_project_name(project.clone(), path)?;
                 // Convert "--source-url ''" (empty string) to Some(None) to clear
                 let source_url_opt: Option<Option<String>> =
                     source_url
@@ -1018,7 +1030,7 @@ async fn main() -> Result<()> {
                     &http_client,
                     &backend_url,
                     &config,
-                    project,
+                    &project_name,
                     name.clone(),
                     access_class.clone(),
                     owner.clone(),
@@ -1026,8 +1038,9 @@ async fn main() -> Result<()> {
                 )
                 .await?;
             }
-            ProjectCommands::Delete { project } => {
-                project::delete_project(&http_client, &backend_url, &config, project).await?;
+            ProjectCommands::Delete { project, path } => {
+                let project_name = resolve_project_name(project.clone(), path)?;
+                project::delete_project(&http_client, &backend_url, &config, &project_name).await?;
             }
             ProjectCommands::AppUser(app_user_cmd) => {
                 let token = config.get_token().ok_or_else(|| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -291,7 +291,7 @@ enum ProjectCommands {
     Show {
         /// Project name (optional if rise.toml contains [project] section)
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
     },
@@ -313,7 +313,7 @@ enum ProjectCommands {
         /// URL to where the project code lives (e.g. a GitHub/GitLab repository). Use empty string to clear.
         #[arg(long)]
         source_url: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
     },
@@ -323,7 +323,7 @@ enum ProjectCommands {
     Delete {
         /// Project name (optional if rise.toml contains [project] section)
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
     },
@@ -341,7 +341,7 @@ enum AppUserCommands {
         project: Option<String>,
         /// User or team identifier (format: "user:email" or "team:name")
         identifier: String,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
     },
@@ -353,7 +353,7 @@ enum AppUserCommands {
         project: Option<String>,
         /// User or team identifier (format: "user:email" or "team:name")
         identifier: String,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
     },
@@ -363,7 +363,7 @@ enum AppUserCommands {
     List {
         /// Project name (optional if rise.toml contains [project] section)
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
     },
@@ -442,7 +442,7 @@ enum DeploymentCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
         /// Filter by deployment group
@@ -458,7 +458,7 @@ enum DeploymentCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
         /// Deployment ID
@@ -475,7 +475,7 @@ enum DeploymentCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
         /// Deployment group to stop
@@ -487,7 +487,7 @@ enum DeploymentCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
         /// Deployment ID (YYYYMMDD-HHMMSS format)
@@ -516,7 +516,7 @@ enum ServiceAccountCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
         /// OIDC issuer URL (e.g., https://gitlab.com)
@@ -533,7 +533,7 @@ enum ServiceAccountCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
     },
@@ -544,7 +544,7 @@ enum ServiceAccountCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
         /// Service account ID
@@ -557,7 +557,7 @@ enum ServiceAccountCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
         /// Service account ID
@@ -573,7 +573,7 @@ enum EnvCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
         /// Variable name (e.g., DATABASE_URL)
@@ -597,7 +597,7 @@ enum EnvCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
         /// Filter by environment (shows global + environment-scoped vars merged)
@@ -610,7 +610,7 @@ enum EnvCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
         /// Variable name
@@ -627,7 +627,7 @@ enum EnvCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
         /// Variable name
@@ -642,7 +642,7 @@ enum EnvCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
         /// Path to file containing environment variables
@@ -659,7 +659,7 @@ enum EnvCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
         /// Target environment (e.g., 'staging'). Resolved from rise.toml if not specified.
@@ -671,7 +671,7 @@ enum EnvCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
         /// Deployment ID
@@ -690,7 +690,7 @@ enum EnvironmentCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
         /// Primary deployment group for this environment
@@ -710,7 +710,7 @@ enum EnvironmentCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
     },
@@ -722,7 +722,7 @@ enum EnvironmentCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
     },
@@ -735,7 +735,7 @@ enum EnvironmentCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
         /// New environment name
@@ -760,7 +760,7 @@ enum EnvironmentCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
     },
@@ -774,7 +774,7 @@ enum DomainCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
         /// Domain name (e.g., example.com)
@@ -787,7 +787,7 @@ enum DomainCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
     },
@@ -798,7 +798,7 @@ enum DomainCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
         /// Domain name
@@ -815,7 +815,7 @@ enum ExtensionCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
         /// Extension name
@@ -833,7 +833,7 @@ enum ExtensionCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
         /// Extension name
@@ -848,7 +848,7 @@ enum ExtensionCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
         /// Extension name
@@ -864,7 +864,7 @@ enum ExtensionCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
     },
@@ -874,7 +874,7 @@ enum ExtensionCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
         /// Extension name
@@ -887,7 +887,7 @@ enum ExtensionCommands {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
         project: Option<String>,
-        /// Path to rise.toml (defaults to current directory)
+        /// Directory containing rise.toml (defaults to current directory)
         #[arg(long, default_value = ".")]
         path: String,
         /// Extension name


### PR DESCRIPTION
## Summary
Make the project name argument optional for `project show`, `project update`, and `project delete` commands. When not provided, the project name is resolved from the `[project]` section in a `rise.toml` file, with support for specifying a custom path via the `--path` flag.

## Key Changes
- **Show command**: Changed `project` argument from required `String` to optional `Option<String>`, added `--path` flag (defaults to current directory)
- **Update command**: Changed `project` argument from required `String` to optional `Option<String>`, added `--path` flag
- **Delete command**: Changed `project` argument from required `String` to optional `Option<String>`, added `--path` flag
- **Command handlers**: Added calls to `resolve_project_name()` helper function to resolve the project name from `rise.toml` when not explicitly provided
- **Documentation**: Updated command help text to indicate project name is optional when `rise.toml` contains a `[project]` section

## Implementation Details
- The `resolve_project_name()` function handles the logic of reading the project name from `rise.toml` when the argument is `None`
- The `--path` flag allows users to specify a custom location for `rise.toml` (e.g., `--path ./config/`)
- All three commands now support the same pattern: explicit project name takes precedence, falls back to `rise.toml` if available
- This improves the user experience by allowing commands like `rise project show` to work directly from a project directory without repeating the project name

https://claude.ai/code/session_01NoWgtmwgjUDCvfpPkbwcbD