### PR TITLE
fix(ci): stop docs-preview from clobbering live Pages site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -496,6 +496,7 @@ jobs:
     environment:
       name: github-pages
     permissions:
+      actions: read
       contents: read
       id-token: write
       issues: write
@@ -533,6 +534,55 @@ jobs:
           RISE_DOCS_SWITCH_URL: /${{ github.event.repository.name }}/preview/pr-${{ github.event.pull_request.number }}/user/
           RISE_DOCS_SWITCH_LABEL: User docs
         run: npm run build
+
+      - name: Seed docs-preview with current live site
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # GitHub Pages deployments are atomic full-site replacements, so a
+        # preview-only artifact would wipe the production site and any other
+        # PRs' previews. Seed docs-preview/ with the latest live Pages artifact
+        # (preserving other PRs' previews), then overlay the latest production
+        # artifact from the default branch so prod content is always restored
+        # even if the current live state was clobbered by a previous bug.
+        run: |
+          set -euo pipefail
+          repo="${GITHUB_REPOSITORY}"
+          mkdir -p docs-preview
+
+          fetch_artifact() {
+            local artifact_id="$1"
+            local label="$2"
+            if [[ -z "${artifact_id}" || "${artifact_id}" == "null" ]]; then
+              echo "No ${label} artifact found; skipping."
+              return 0
+            fi
+            echo "Seeding docs-preview with ${label} artifact ${artifact_id}"
+            local tmp
+            tmp="$(mktemp -d)"
+            gh api "repos/${repo}/actions/artifacts/${artifact_id}/zip" > "${tmp}/artifact.zip"
+            unzip -q "${tmp}/artifact.zip" -d "${tmp}"
+            if [[ -f "${tmp}/artifact.tar" ]]; then
+              tar -xf "${tmp}/artifact.tar" -C docs-preview
+            else
+              echo "::warning::${label} artifact ${artifact_id} did not contain artifact.tar"
+            fi
+            rm -rf "${tmp}"
+          }
+
+          default_branch="$(gh api "repos/${repo}" --jq '.default_branch')"
+          artifacts_json="$(gh api "repos/${repo}/actions/artifacts?name=github-pages&per_page=100")"
+
+          live_id="$(echo "${artifacts_json}" \
+            | jq -r '[.artifacts[] | select(.expired == false)] | first | .id // empty')"
+          fetch_artifact "${live_id}" "live"
+
+          prod_id="$(echo "${artifacts_json}" \
+            | jq -r --arg branch "${default_branch}" \
+              '[.artifacts[] | select(.expired == false and .workflow_run.head_branch == $branch)] | first | .id // empty')"
+          if [[ -n "${prod_id}" && "${prod_id}" != "${live_id}" ]]; then
+            fetch_artifact "${prod_id}" "production"
+          fi
 
       - name: Stage docs preview
         shell: bash

--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -1,0 +1,133 @@
+name: Docs preview cleanup
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - develop
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-preview-cleanup-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Remove docs preview
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      pages: write
+      pull-requests: write
+    steps:
+      - name: Seed docs-preview with current live site and drop this PR's preview
+        id: seed
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Pages deployments are atomic full-site replacements, so to drop one
+        # PR's preview we have to re-upload the full site without it. Seed
+        # docs-preview/ with the latest live artifact (preserves other PRs'
+        # previews) and overlay the latest production artifact from the
+        # default branch so prod content survives even if live was clobbered.
+        run: |
+          set -euo pipefail
+          repo="${GITHUB_REPOSITORY}"
+          pr_number="${{ github.event.pull_request.number }}"
+          mkdir -p docs-preview
+
+          fetch_artifact() {
+            local artifact_id="$1"
+            local label="$2"
+            if [[ -z "${artifact_id}" || "${artifact_id}" == "null" ]]; then
+              echo "No ${label} artifact found; skipping."
+              return 0
+            fi
+            echo "Seeding docs-preview with ${label} artifact ${artifact_id}"
+            local tmp
+            tmp="$(mktemp -d)"
+            gh api "repos/${repo}/actions/artifacts/${artifact_id}/zip" > "${tmp}/artifact.zip"
+            unzip -q "${tmp}/artifact.zip" -d "${tmp}"
+            if [[ -f "${tmp}/artifact.tar" ]]; then
+              tar -xf "${tmp}/artifact.tar" -C docs-preview
+            else
+              echo "::warning::${label} artifact ${artifact_id} did not contain artifact.tar"
+            fi
+            rm -rf "${tmp}"
+          }
+
+          default_branch="$(gh api "repos/${repo}" --jq '.default_branch')"
+          artifacts_json="$(gh api "repos/${repo}/actions/artifacts?name=github-pages&per_page=100")"
+
+          live_id="$(echo "${artifacts_json}" \
+            | jq -r '[.artifacts[] | select(.expired == false)] | first | .id // empty')"
+          fetch_artifact "${live_id}" "live"
+
+          prod_id="$(echo "${artifacts_json}" \
+            | jq -r --arg branch "${default_branch}" \
+              '[.artifacts[] | select(.expired == false and .workflow_run.head_branch == $branch)] | first | .id // empty')"
+          if [[ -n "${prod_id}" && "${prod_id}" != "${live_id}" ]]; then
+            fetch_artifact "${prod_id}" "production"
+          fi
+
+          if [[ -d "docs-preview/preview/pr-${pr_number}" ]]; then
+            echo "Removing docs-preview/preview/pr-${pr_number}"
+            rm -rf "docs-preview/preview/pr-${pr_number}"
+            echo "removed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No preview folder for PR ${pr_number}; nothing to redeploy."
+            echo "removed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure GitHub Pages
+        if: steps.seed.outputs.removed == 'true'
+        uses: actions/configure-pages@v5
+
+      - name: Upload docs artifact
+        if: steps.seed.outputs.removed == 'true'
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: docs-preview
+
+      - name: Deploy docs to GitHub Pages
+        if: steps.seed.outputs.removed == 'true'
+        uses: actions/deploy-pages@v4
+
+      - name: Update PR comment
+        if: steps.seed.outputs.removed == 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const marker = '<!-- rise-docs-preview -->';
+            const body = [
+              marker,
+              'Docs preview removed (PR closed).',
+            ].join('\n');
+
+            const issue_number = context.payload.pull_request.number;
+            const { owner, repo } = context.repo;
+            try {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number,
+                per_page: 100,
+              });
+              const existing = comments.find((comment) => comment.body?.includes(marker));
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              }
+            } catch (error) {
+              core.warning(`Unable to update docs preview comment: ${error.message}`);
+            }


### PR DESCRIPTION
GitHub Pages deployments are atomic full-site replacements, so the
docs-preview job was uploading only `preview/pr-N/...` and wiping the
production site (and any other PRs' previews) on every trusted PR build.

Seed docs-preview/ with the latest live Pages artifact (preserves other
PRs' previews), then overlay the latest production artifact from the
default branch so prod content is always restored even if the current
live state was previously clobbered. The PR's preview is then staged on
top as before.