### PR TITLE
ci(docs-preview): add tracing to diagnose cleanup failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -546,8 +546,16 @@ jobs:
         # artifact from the default branch so prod content is always restored
         # even if the current live state was clobbered by a previous bug.
         run: |
-          set -euo pipefail
+          set -euxo pipefail
           repo="${GITHUB_REPOSITORY}"
+
+          echo "::group::Diagnostics"
+          gh --version || echo "gh not found"
+          gh auth status 2>&1 || true
+          echo "Repository: ${repo}"
+          echo "Workspace: ${GITHUB_WORKSPACE:-<unset>}"
+          echo "::endgroup::"
+
           mkdir -p docs-preview
 
           fetch_artifact() {
@@ -560,7 +568,11 @@ jobs:
             echo "Seeding docs-preview with ${label} artifact ${artifact_id}"
             local tmp
             tmp="$(mktemp -d)"
-            gh api "repos/${repo}/actions/artifacts/${artifact_id}/zip" > "${tmp}/artifact.zip"
+            if ! gh api "repos/${repo}/actions/artifacts/${artifact_id}/zip" > "${tmp}/artifact.zip"; then
+              echo "::error::Failed to download ${label} artifact ${artifact_id}"
+              rm -rf "${tmp}"
+              return 1
+            fi
             unzip -q "${tmp}/artifact.zip" -d "${tmp}"
             if [[ -f "${tmp}/artifact.tar" ]]; then
               tar -xf "${tmp}/artifact.tar" -C docs-preview
@@ -570,16 +582,23 @@ jobs:
             rm -rf "${tmp}"
           }
 
+          echo "Fetching default branch..."
           default_branch="$(gh api "repos/${repo}" --jq '.default_branch')"
-          artifacts_json="$(gh api "repos/${repo}/actions/artifacts?name=github-pages&per_page=100")"
+          echo "Default branch: ${default_branch}"
 
-          live_id="$(echo "${artifacts_json}" \
-            | jq -r '[.artifacts[] | select(.expired == false)] | first | .id // empty')"
+          echo "Listing github-pages artifacts..."
+          artifacts_json="$(gh api "repos/${repo}/actions/artifacts?name=github-pages&per_page=100")"
+          echo "Got artifacts JSON (${#artifacts_json} bytes)"
+
+          live_id="$(printf '%s' "${artifacts_json}" \
+            | jq -r '[.artifacts[] | select(.expired == false)] | .[0].id // empty')"
+          echo "Live artifact id: '${live_id}'"
           fetch_artifact "${live_id}" "live"
 
-          prod_id="$(echo "${artifacts_json}" \
+          prod_id="$(printf '%s' "${artifacts_json}" \
             | jq -r --arg branch "${default_branch}" \
-              '[.artifacts[] | select(.expired == false and .workflow_run.head_branch == $branch)] | first | .id // empty')"
+              '[.artifacts[] | select(.expired == false and .workflow_run.head_branch == $branch)] | .[0].id // empty')"
+          echo "Prod artifact id: '${prod_id}'"
           if [[ -n "${prod_id}" && "${prod_id}" != "${live_id}" ]]; then
             fetch_artifact "${prod_id}" "production"
           fi

--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -37,9 +37,18 @@ jobs:
         # previews) and overlay the latest production artifact from the
         # default branch so prod content survives even if live was clobbered.
         run: |
-          set -euo pipefail
+          set -euxo pipefail
           repo="${GITHUB_REPOSITORY}"
           pr_number="${{ github.event.pull_request.number }}"
+
+          echo "::group::Diagnostics"
+          gh --version || echo "gh not found"
+          gh auth status 2>&1 || true
+          echo "Repository: ${repo}"
+          echo "PR number: ${pr_number}"
+          echo "Workspace: ${GITHUB_WORKSPACE:-<unset>}"
+          echo "::endgroup::"
+
           mkdir -p docs-preview
 
           fetch_artifact() {
@@ -52,7 +61,11 @@ jobs:
             echo "Seeding docs-preview with ${label} artifact ${artifact_id}"
             local tmp
             tmp="$(mktemp -d)"
-            gh api "repos/${repo}/actions/artifacts/${artifact_id}/zip" > "${tmp}/artifact.zip"
+            if ! gh api "repos/${repo}/actions/artifacts/${artifact_id}/zip" > "${tmp}/artifact.zip"; then
+              echo "::error::Failed to download ${label} artifact ${artifact_id}"
+              rm -rf "${tmp}"
+              return 1
+            fi
             unzip -q "${tmp}/artifact.zip" -d "${tmp}"
             if [[ -f "${tmp}/artifact.tar" ]]; then
               tar -xf "${tmp}/artifact.tar" -C docs-preview
@@ -62,16 +75,23 @@ jobs:
             rm -rf "${tmp}"
           }
 
+          echo "Fetching default branch..."
           default_branch="$(gh api "repos/${repo}" --jq '.default_branch')"
-          artifacts_json="$(gh api "repos/${repo}/actions/artifacts?name=github-pages&per_page=100")"
+          echo "Default branch: ${default_branch}"
 
-          live_id="$(echo "${artifacts_json}" \
-            | jq -r '[.artifacts[] | select(.expired == false)] | first | .id // empty')"
+          echo "Listing github-pages artifacts..."
+          artifacts_json="$(gh api "repos/${repo}/actions/artifacts?name=github-pages&per_page=100")"
+          echo "Got artifacts JSON (${#artifacts_json} bytes)"
+
+          live_id="$(printf '%s' "${artifacts_json}" \
+            | jq -r '[.artifacts[] | select(.expired == false)] | .[0].id // empty')"
+          echo "Live artifact id: '${live_id}'"
           fetch_artifact "${live_id}" "live"
 
-          prod_id="$(echo "${artifacts_json}" \
+          prod_id="$(printf '%s' "${artifacts_json}" \
             | jq -r --arg branch "${default_branch}" \
-              '[.artifacts[] | select(.expired == false and .workflow_run.head_branch == $branch)] | first | .id // empty')"
+              '[.artifacts[] | select(.expired == false and .workflow_run.head_branch == $branch)] | .[0].id // empty')"
+          echo "Prod artifact id: '${prod_id}'"
           if [[ -n "${prod_id}" && "${prod_id}" != "${live_id}" ]]; then
             fetch_artifact "${prod_id}" "production"
           fi


### PR DESCRIPTION
The first run of the docs-preview-cleanup workflow (added in #318) failed at the seed step after 3 seconds with only `Process completed with exit code 1` visible — no usable trace. See the [failing run](https://github.com/rise-deploy/rise/actions/runs/26338661683/job/77536669949).

This PR adds diagnostics so the next run shows exactly which command exits non-zero.

## Changes

- `set -euxo pipefail` (added `-x` to trace every command)
- Diagnostics block at the start (`gh --version`, `gh auth status`, repo, workspace) wrapped in `::group::`
- Each `gh api` call is preceded by an `echo` so the trace makes the failure point obvious
- `fetch_artifact` now emits an `::error::` annotation if the artifact zip download itself fails (instead of silently failing under `set -e`)
- Switched the jq filter from `| first | .id // empty` to `| .[0].id // empty` — equivalent but more portable across jq builds

Same change applied to the seed step in `ci.yml`'s `docs-preview` job so future PR-opened runs surface the same diagnostics.

## Test plan

- [ ] Merge to develop
- [ ] Close any PR to trigger the cleanup workflow
- [ ] Inspect the trace output in the seed step's logs and follow up with the actual fix

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVU649pxc5osNqeBiGUWDo)_