### PR TITLE
add cross-platform dev-setup script (macOS + Linux)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,9 +140,6 @@ jobs:
       - name: Run cargo audit
         run: cargo audit
 
-      - name: Verify SQLX offline query data
-        run: mise run sqlx:check
-
   unit-tests-linux:
     name: Linux tests
     runs-on: ubuntu-latest
@@ -186,6 +183,15 @@ jobs:
         run: |
           sqlx database create
           sqlx migrate run
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/rise_test
+
+      - name: Verify SQLX offline query data is in sync with schema
+        # Runs here (not in rust-quality) because sqlx-cli 0.9+ requires a
+        # live DB for `prepare --check` to detect schema drift. Coverage
+        # drift (missing cache entry for a new query!() macro) is still
+        # caught by the SQLX_OFFLINE=true clippy step in rust-quality.
+        run: mise run sqlx:check
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/rise_test
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Note that this does not include server code unless you use `--features cli,serve
 
 ### Prerequisites
 
-- Docker and Docker Compose
+- Docker (or Docker Desktop on macOS) and Docker Compose
 - Rust 1.91+
 - [mise](https://mise.jdx.dev/) (recommended for development)
 
@@ -54,19 +54,20 @@ direnv allow
 # Install development tools
 mise install
 
-# One-time host setup (requires sudo)
-mise setup:hosts
-mise setup:docker
+# One-stop dev environment setup (cross-platform: Linux + macOS).
+# Configures /etc/hosts (sudo), Docker insecure registries, and brings up
+# a local cluster (minikube by default; k3s on Linux). Run interactively
+# so the sudo prompt works.
+mise setup
 
-# Terminal (1): Start Minikube
-mise minikube:up
-
-# Terminal (2): Start the frontend
+# Terminal (1): Start the frontend
 mise frontend:dev
 
-# Terminal (3) Start the backend (will also start required containers with docker compose)
+# Terminal (2): Start the backend (will also start required containers with docker compose)
 mise backend:run
 ```
+
+`mise setup` invokes `./scripts/dev-setup.sh`. You can also run individual steps directly: `./scripts/dev-setup.sh hosts`, `docker`, `minikube`, `k3s`, or `preflight` (hosts + docker only).
 
 Services will be available at:
 - **Rise server**: http://localhost:3000

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -91,7 +91,7 @@ deployment_controller:
   auth_signin_url: "http://rise.local:3000" # Domain for user-facing OAuth redirects, must be resolvable by users' browsers
   ingress_annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
-  ingress_port: 8080 # `mise minikube:up` port-forwards ingress to this port
+  ingress_port: 8080 # `mise setup minikube` (or `mise setup pf`) port-forwards ingress to this port
   ingress_schema: "http" # Use http for local development
   host_aliases:
     rise.local: "${RISE_K8S_HOST_IP:-192.168.49.1}" # Host IP reachable from Kubernetes pods

--- a/docs/engineering/src/content/docs/development.md
+++ b/docs/engineering/src/content/docs/development.md
@@ -77,13 +77,25 @@ mise frontend:dev  # Vite dev server only
 | Task | Purpose |
 |------|---------|
 | `setup` | One-stop dev setup: hosts + docker + cluster (interactive) |
-| `minikube:up` | Bring up Minikube with registry access and ingress port-forwarding (**preferred**) |
-| `minikube:down` | Stop and delete Minikube |
-| `k3s:up` / `k3s:down` | Alternative: K3s (Linux only — use when Minikube doesn't work, or in ephemeral/dedicated Rise dev environments) |
+| `down` | Undo what `setup` did (kills port-forward, deletes cluster, strips .env block + daemon.json registries + /etc/hosts block) |
 
-All three tasks delegate to `./scripts/dev-setup.sh`. The script can also be invoked directly with subcommands `hosts`, `docker`, `minikube`, `k3s`, or `preflight` (hosts + docker only).
+Everything is driven by `./scripts/dev-setup.sh`. `mise setup` and `mise down` are convenience wrappers; positional args pass through, so any script subcommand works as `mise setup <subcmd>`:
 
-**Minikube vs K3s**: `minikube:up` is preferred on most developer machines — it runs a single-node Kubernetes cluster inside a Docker container, starts quickly, and integrates well with the local Docker network so pods can reach `rise-registry:5000`. Use `k3s:up` (Linux only) when Minikube doesn't work on your machine (e.g., nested virtualization issues) or when setting up an ephemeral or dedicated environment solely for Rise development where the slight extra K3s overhead doesn't matter.
+| Invocation | What it does |
+|------------|--------------|
+| `mise setup hosts` | Rewrite the managed `/etc/hosts` block (base hosts + `*.rise.local` ingress hosts enumerated from the current cluster) |
+| `mise setup hosts-clear` | Remove the managed `/etc/hosts` block |
+| `mise setup docker` | Configure Docker insecure-registries (asks to restart Docker Desktop on macOS) |
+| `mise setup docker-clear` | Remove rise registries from `daemon.json` |
+| `mise setup minikube` | Bring up Minikube + ingress port-forward + Helm install (**preferred** on most dev machines) |
+| `mise setup minikube-down` | `minikube delete` |
+| `mise setup k3s` | Bring up k3s (Linux only — use when Minikube doesn't work, or in ephemeral/dedicated Rise dev environments) |
+| `mise setup k3s-down` | Uninstall k3s |
+| `mise setup pf` | Start the ingress port-forward (`localhost:8080` + `:8443`) in the background |
+| `mise setup pf-down` | Stop the ingress port-forward |
+| `mise setup preflight` | hosts + docker only, no cluster |
+
+**Minikube vs K3s**: Minikube is preferred on most developer machines — it runs a single-node Kubernetes cluster inside a Docker container, starts quickly, and integrates well with the local Docker network so pods can reach `rise-registry:5000`. Use k3s (Linux only) when Minikube doesn't work on your machine (e.g., nested virtualization issues) or when setting up an ephemeral or dedicated environment solely for Rise development where the slight extra k3s overhead doesn't matter.
 
 ### Development
 
@@ -194,7 +206,7 @@ Host Machine (127.0.0.1)
 minikube ssh -- curl http://rise-registry:5000/v2/
 # Should return: {}
 ```
-If it fails, re-run `mise minikube:up`.
+If it fails, re-run `mise setup minikube`.
 
 **Reset everything:**
 ```bash

--- a/docs/engineering/src/content/docs/development.md
+++ b/docs/engineering/src/content/docs/development.md
@@ -38,7 +38,7 @@ mise dev
 
 This single command:
 
-1. **Checks prerequisites** — verifies `/etc/hosts` entries, Docker daemon, and Kubernetes connectivity. If anything is missing it tells you exactly what to run.
+1. **Checks prerequisites** — verifies `/etc/hosts` entries, Docker daemon, and Kubernetes connectivity. If anything is missing it lists the issues and asks whether to continue anyway.
 2. **Starts Docker Compose services** — PostgreSQL, Dex (OIDC), container registry.
 3. **Runs database migrations.**
 4. **Starts the Vite frontend dev server** (background).
@@ -63,14 +63,6 @@ mise frontend:dev  # Vite dev server only
 ```
 
 ## Mise Tasks Reference
-
-### Checks (run automatically by `mise dev`)
-
-| Task | Purpose |
-|------|---------|
-| `check:hosts` | Verify `/etc/hosts` has `rise-registry` and `rise.local` |
-| `check:docker` | Verify Docker is running and insecure registries are configured |
-| `check:k8s` | Verify a Kubernetes cluster is reachable via `kubectl` |
 
 ### Setup (one-time, idempotent)
 
@@ -101,7 +93,7 @@ Everything is driven by `./scripts/dev-setup.sh`. `mise setup` and `mise down` a
 
 | Task | Purpose |
 |------|---------|
-| `dev` | Full dev stack (checks + services + frontend + backend) |
+| `dev` | Full dev stack (preflight prompt + services + frontend + backend) |
 | `backend:run` | Backend only (starts deps + migrates) |
 | `frontend:dev` | Vite frontend dev server |
 | `db:migrate` | Run database migrations |

--- a/docs/engineering/src/content/docs/development.md
+++ b/docs/engineering/src/content/docs/development.md
@@ -15,18 +15,20 @@ title: "Local Development"
 # Install mise-managed tools (minikube, helm, kubectl, etc.)
 mise install
 
-# Configure /etc/hosts and Docker daemon (idempotent, requires sudo).
-# On WSL with Docker Desktop, setup:docker skips cleanly if /etc/docker is not present.
-mise setup:hosts
-mise setup:docker
-
-# Start a local Kubernetes cluster
-mise minikube:up   # preferred on most developer machines (see below)
+# One-stop dev environment setup. Cross-platform (Linux + macOS), idempotent,
+# and interactive. Configures /etc/hosts (sudo), Docker insecure registries,
+# and brings up a local cluster (minikube by default; offers k3s on Linux).
+mise setup
 ```
 
-The cluster setup task writes pod-reachable host URLs to `.env`. If you use
-direnv, run `direnv allow` once and `.envrc` will load those values
-automatically.
+`mise setup` is a thin wrapper around `./scripts/dev-setup.sh`. Run individual
+steps with `./scripts/dev-setup.sh <hosts|docker|minikube|k3s|preflight>` if
+you only need one part. The script writes pod-reachable host URLs to `.env`;
+if you use direnv, run `direnv allow` once and `.envrc` will load them.
+
+On macOS, Docker Desktop's daemon config lives at `~/.docker/daemon.json` and
+the script updates it there. The script offers to restart Docker Desktop for
+you so the new insecure-registries take effect.
 
 ## Day-to-Day
 
@@ -74,13 +76,14 @@ mise frontend:dev  # Vite dev server only
 
 | Task | Purpose |
 |------|---------|
-| `setup:hosts` | Add `rise-registry` and `rise.local` to `/etc/hosts` |
-| `setup:docker` | Configure Docker daemon insecure registries |
-| `minikube:up` | Start Minikube with registry access and ingress port-forwarding (**preferred**) |
+| `setup` | One-stop dev setup: hosts + docker + cluster (interactive) |
+| `minikube:up` | Bring up Minikube with registry access and ingress port-forwarding (**preferred**) |
 | `minikube:down` | Stop and delete Minikube |
-| `k3s:up` / `k3s:down` | Alternative: K3s (use when Minikube doesn't work, or in ephemeral/dedicated Rise dev environments) |
+| `k3s:up` / `k3s:down` | Alternative: K3s (Linux only — use when Minikube doesn't work, or in ephemeral/dedicated Rise dev environments) |
 
-**Minikube vs K3s**: `minikube:up` is preferred on most developer machines — it runs a single-node Kubernetes cluster inside a Docker container, starts quickly, and integrates well with the local Docker network so pods can reach `rise-registry:5000`. Use `k3s:up` when Minikube doesn't work on your machine (e.g., nested virtualization issues) or when setting up an ephemeral or dedicated environment solely for Rise development where the slight extra K3s overhead doesn't matter.
+All three tasks delegate to `./scripts/dev-setup.sh`. The script can also be invoked directly with subcommands `hosts`, `docker`, `minikube`, `k3s`, or `preflight` (hosts + docker only).
+
+**Minikube vs K3s**: `minikube:up` is preferred on most developer machines — it runs a single-node Kubernetes cluster inside a Docker container, starts quickly, and integrates well with the local Docker network so pods can reach `rise-registry:5000`. Use `k3s:up` (Linux only) when Minikube doesn't work on your machine (e.g., nested virtualization issues) or when setting up an ephemeral or dedicated environment solely for Rise development where the slight extra K3s overhead doesn't matter.
 
 ### Development
 
@@ -180,7 +183,7 @@ Host Machine (127.0.0.1)
 
 ## Troubleshooting
 
-**`http: server gave HTTP response to HTTPS client`** — insecure registries not configured. Run `mise setup:docker`.
+**`http: server gave HTTP response to HTTPS client`** — insecure registries not configured. Run `./scripts/dev-setup.sh docker`.
 
 **BuildKit can't push to registry** — verify `RISE_MANAGED_BUILDKIT_NETWORK_NAME=rise_default` is set in your environment (should be in `.envrc`).
 

--- a/mise.toml
+++ b/mise.toml
@@ -23,60 +23,30 @@ run = "./scripts/dev-setup.sh"
 description = "Tear down what 'mise setup' brought up (cluster, .env block, daemon.json registries, /etc/hosts block). Interactive."
 run = "./scripts/dev-setup.sh down"
 
-[tasks."check:hosts"]
-description = "Verify /etc/hosts has the required rise-registry, rise-jfrog and rise.local entries."
+[tasks.dev]
 run = """
-ok=true
+issues=""
 for h in rise-registry rise-jfrog rise.local; do
-  if ! awk -v h="$h" '{for (i = 1; i <= NF; i++) if ($i == h) {found = 1; exit}} END {exit !found}' /etc/hosts; then
-    echo "MISSING: /etc/hosts entry for '$h'"
-    ok=false
+  if ! awk -v h="$h" '{for(i=1;i<=NF;i++) if($i==h){found=1;exit}} END{exit !found}' /etc/hosts 2>/dev/null; then
+    issues="${issues}\n  - /etc/hosts missing '$h'  →  mise setup hosts"
   fi
 done
-if [ "$ok" = false ]; then
-  echo ""
-  echo "Run './scripts/dev-setup.sh hosts' to fix this."
-  exit 1
-fi
-echo "OK: /etc/hosts is configured."
-"""
-
-[tasks."check:docker"]
-description = "Verify Docker is running and has insecure-registries configured."
-run = """
 if ! docker info > /dev/null 2>&1; then
-  echo "FAIL: Docker daemon is not running."
-  echo "Start Docker (Docker Desktop on macOS) and try again."
-  exit 1
+  issues="${issues}\n  - Docker is not running"
 fi
-case "$(uname -s)" in
-  Darwin) daemon_json="$HOME/.docker/daemon.json" ;;
-  *)      daemon_json="/etc/docker/daemon.json" ;;
-esac
-if [ -f "$daemon_json" ] && ! grep -q 'rise-registry:5000' "$daemon_json"; then
-  echo "MISSING: 'rise-registry:5000' not in $daemon_json insecure-registries."
-  echo ""
-  echo "Run './scripts/dev-setup.sh docker' to fix this."
-  exit 1
-fi
-echo "OK: Docker is running and configured."
-"""
-
-[tasks."check:k8s"]
-description = "Verify a Kubernetes cluster (minikube or k3s) is reachable."
-run = """
 if ! kubectl cluster-info > /dev/null 2>&1; then
-  echo "FAIL: No Kubernetes cluster reachable via kubectl."
-  echo ""
-  echo "Run './scripts/dev-setup.sh minikube' (or 'k3s' on Linux) to set one up."
-  exit 1
+  issues="${issues}\n  - No Kubernetes cluster reachable  →  mise setup minikube"
 fi
-echo "OK: Kubernetes cluster is reachable."
-"""
+if [ -n "$issues" ]; then
+  printf "Preflight issues:\n%b\n\n" "$issues"
+  printf "Continue anyway? [y/N] "
+  read -r answer
+  case "$answer" in
+    [yY]*) ;;
+    *) exit 1 ;;
+  esac
+fi
 
-[tasks.dev]
-depends = ["check:hosts", "check:docker", "check:k8s"]
-run = """
 docker compose up -d
 mise run db:migrate
 mise run frontend:dev &

--- a/mise.toml
+++ b/mise.toml
@@ -15,28 +15,26 @@ kubectl = "latest"
 k9s = "latest"
 vault = "latest"
 
+[tasks.setup]
+description = "One-stop dev environment setup (hosts, docker, cluster). Cross-platform (Linux + macOS). Run interactively."
+run = "./scripts/dev-setup.sh"
+
 [tasks."check:hosts"]
 description = "Verify /etc/hosts has the required rise-registry, rise-jfrog and rise.local entries."
 run = """
 ok=true
-if ! grep -q '\\brise-registry\\b' /etc/hosts; then
-  echo "MISSING: /etc/hosts entry for 'rise-registry'"
-  ok=false
-fi
-if ! grep -q '\\brise-jfrog\\b' /etc/hosts; then
-  echo "MISSING: /etc/hosts entry for 'rise-jfrog'"
-  ok=false
-fi
-if ! grep -q '\\brise\\.local\\b' /etc/hosts; then
-  echo "MISSING: /etc/hosts entry for 'rise.local'"
-  ok=false
-fi
+for h in rise-registry rise-jfrog rise.local; do
+  if ! grep -qE "\\<${h//./\\.}\\>" /etc/hosts; then
+    echo "MISSING: /etc/hosts entry for '$h'"
+    ok=false
+  fi
+done
 if [ "$ok" = false ]; then
   echo ""
-  echo "Run 'mise setup:hosts' to fix this."
+  echo "Run './scripts/dev-setup.sh hosts' to fix this."
   exit 1
 fi
-echo "OK: /etc/hosts has rise-registry, rise-jfrog and rise.local entries."
+echo "OK: /etc/hosts is configured."
 """
 
 [tasks."check:docker"]
@@ -44,13 +42,17 @@ description = "Verify Docker is running and has insecure-registries configured."
 run = """
 if ! docker info > /dev/null 2>&1; then
   echo "FAIL: Docker daemon is not running."
-  echo "Start Docker and try again."
+  echo "Start Docker (Docker Desktop on macOS) and try again."
   exit 1
 fi
-if [ -f /etc/docker/daemon.json ] && ! grep -q 'rise-registry:5000' /etc/docker/daemon.json; then
-  echo "MISSING: 'rise-registry:5000' not in /etc/docker/daemon.json insecure-registries."
+case "$(uname -s)" in
+  Darwin) daemon_json="$HOME/.docker/daemon.json" ;;
+  *)      daemon_json="/etc/docker/daemon.json" ;;
+esac
+if [ -f "$daemon_json" ] && ! grep -q 'rise-registry:5000' "$daemon_json"; then
+  echo "MISSING: 'rise-registry:5000' not in $daemon_json insecure-registries."
   echo ""
-  echo "Run 'mise setup:docker' to fix this."
+  echo "Run './scripts/dev-setup.sh docker' to fix this."
   exit 1
 fi
 echo "OK: Docker is running and configured."
@@ -62,7 +64,7 @@ run = """
 if ! kubectl cluster-info > /dev/null 2>&1; then
   echo "FAIL: No Kubernetes cluster reachable via kubectl."
   echo ""
-  echo "Run 'mise minikube:up' or 'mise k3s:up' to set one up."
+  echo "Run './scripts/dev-setup.sh minikube' (or 'k3s' on Linux) to set one up."
   exit 1
 fi
 echo "OK: Kubernetes cluster is reachable."
@@ -237,177 +239,31 @@ cargo install cargo-dist --locked
 cargo dist build --target x86_64-unknown-linux-gnu --target x86_64-apple-darwin --target aarch64-apple-darwin
 """
 
-[tasks."setup:hosts"]
-description = "Ensure /etc/hosts has rise-registry, rise-jfrog and rise.local entries (idempotent)."
-run = """
-set -x
-# Remove any existing entries and re-add to ensure correctness
-sudo sed -i '/\\brise-registry\\b/d; /\\brise-jfrog\\b/d; /\\brise\\.local\\b/d' /etc/hosts
-echo '127.0.0.1 rise-registry' | sudo tee -a /etc/hosts
-echo '127.0.0.1 rise-jfrog' | sudo tee -a /etc/hosts
-echo '127.0.0.1 rise.local' | sudo tee -a /etc/hosts
-"""
-
-[tasks."setup:docker"]
-description = "Ensure Docker daemon has insecure-registries configured for the local registry (idempotent)."
-run = """
-set -x
-DAEMON_JSON="/etc/docker/daemon.json"
-DAEMON_DIR=$(dirname "$DAEMON_JSON")
-REQUIRED_REGISTRIES='["rise-registry:5000","localhost:5000","127.0.0.1:5000","rise-jfrog:8082","localhost:3082"]'
-if [ ! -d "$DAEMON_DIR" ]; then
-  echo "Skipping Docker daemon config because $DAEMON_DIR does not exist."
-  exit 0
-fi
-if [ ! -f "$DAEMON_JSON" ]; then
-  echo "Creating $DAEMON_JSON with insecure-registries..."
-  echo "{\"insecure-registries\": $REQUIRED_REGISTRIES}" | sudo tee "$DAEMON_JSON"
-  sudo systemctl restart docker || true
-elif ! grep -q 'rise-registry:5000' "$DAEMON_JSON"; then
-  echo "Adding insecure-registries to existing $DAEMON_JSON..."
-  UPDATED=$(jq --argjson regs "$REQUIRED_REGISTRIES" '.["insecure-registries"] = ((.["insecure-registries"] // []) + $regs | unique)' "$DAEMON_JSON")
-  echo "$UPDATED" | sudo tee "$DAEMON_JSON" > /dev/null
-  echo "Restarting Docker..."
-  sudo systemctl restart docker || true
-else
-  echo "Docker daemon already configured."
-fi
-"""
-
 [tasks."minikube:up"]
 description = "Start Minikube with local Docker registry access and ingress port-forwarding."
-depends = ["setup:hosts", "setup:docker"]
-run = """
-set -x
-
-docker compose up -d registry
-NETWORK_NAME=rise_default
-REGISTRY_NAME=rise-registry
-REGISTRY_DIR="/etc/containerd/certs.d/localhost:5000"
-JFROG_REGISTRY_DIR="/etc/containerd/certs.d/rise-jfrog:8082"
-
-minikube delete
-minikube start --driver=docker --insecure-registry="${REGISTRY_NAME}:5000" --insecure-registry="rise-jfrog:8082" --memory=4096mb --cpus=2 --cni=calico
-minikube addons enable ingress
-
-for node in $(minikube node list | awk '{print $1}'); do
-  docker exec "${node}" mkdir -p "${REGISTRY_DIR}"
-  cat <<EOF | docker exec -i "${node}" cp /dev/stdin "${REGISTRY_DIR}/hosts.toml"
-[host."http://${REGISTRY_NAME}:5000"]
-EOF
-  docker exec "${node}" mkdir -p "${JFROG_REGISTRY_DIR}"
-  cat <<EOF | docker exec -i "${node}" cp /dev/stdin "${JFROG_REGISTRY_DIR}/hosts.toml"
-[host."http://rise-jfrog:8082"]
-EOF
-done
-
-docker network connect "${NETWORK_NAME}" minikube || true
-
-echo
-echo "Minikube started. Port-forwarding ingress-nginx-controller to localhost:8080 (HTTP) and localhost:8443 (HTTPS)..."
-echo
-
-kubectl port-forward --namespace ingress-nginx svc/ingress-nginx-controller 8080:80 8443:443 &
-echo "Port-forward running in background (PID: $!)"
-
-# Install Metacontroller + Rise CRDs for development
-HOST_IP=$(ip -4 route get 1.1.1.1 | awk '{for (i = 1; i <= NF; i++) if ($i == "src") {print $(i + 1); exit}}')
-if [ -f .env ]; then
-  sed -i '/^# BEGIN RISE K8S DEV$/,/^# END RISE K8S DEV$/d' .env
-fi
-cat >> .env <<EOF
-# BEGIN RISE K8S DEV
-export RISE_K8S_HOST_IP="${HOST_IP}"
-export RISE_AUTH_BACKEND_URL="http://${HOST_IP}:3000"
-export RISE_METACONTROLLER_WEBHOOK_BASE_URL="http://${HOST_IP}:3001"
-# END RISE K8S DEV
-EOF
-helm dependency build helm/rise
-helm upgrade --install rise-dev ./helm/rise \
-  -f helm/rise/values-dev.yaml \
-  --set "metacontroller.webhookBaseUrl=${RISE_METACONTROLLER_WEBHOOK_BASE_URL:-http://${HOST_IP}:3001}" \
-  --namespace rise \
-  --create-namespace
-"""
+run = "./scripts/dev-setup.sh minikube"
 
 [tasks."minikube:down"]
 description = "Stop and delete Minikube."
 run = "minikube delete"
 
 [tasks."k3s:up"]
-depends = ["setup:hosts", "setup:docker"]
+description = "Install and configure k3s (Linux only)."
+run = "./scripts/dev-setup.sh k3s"
+
+[tasks."k3s:down"]
+description = "Uninstall k3s (Linux only)."
 run = """
-set -x
-
-# Configure K3s registries for insecure access to rise-registry:5000
-sudo mkdir -p /etc/rancher/k3s
-sudo tee /etc/rancher/k3s/registries.yaml > /dev/null <<EOF
-mirrors:
-  "rise-registry:5000":
-    endpoint:
-      - "http://rise-registry:5000"
-  "rise-jfrog:8082":
-    endpoint:
-      - "http://localhost:3082"
-EOF
-
-# Ensure the local Docker registry is running
-docker compose up -d registry
-
-# Install K3s
-curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--flannel-backend=none --cluster-cidr=192.168.0.0/16 --disable-network-policy --disable=traefik" sh -
-sleep 10
-mkdir -p ~/.kube
-sudo cat /etc/rancher/k3s/k3s.yaml > ~/.kube/config
-kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.31.4/manifests/operator-crds.yaml --server-side --force-conflicts
-kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.31.4/manifests/tigera-operator.yaml --server-side --force-conflicts
-kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.31.4/manifests/custom-resources.yaml --server-side --force-conflicts
-helm upgrade --install ingress-nginx ingress-nginx \
-  --repo https://kubernetes.github.io/ingress-nginx \
-  --namespace ingress-nginx --create-namespace \
-  --set controller.hostPort.enabled=true \
-  --set controller.hostPort.ports.http=8080 \
-  --set controller.hostPort.ports.https=8443 \
-  --set controller.service.type=ClusterIP
-
-# Install Metacontroller + Rise CRDs for development
-HOST_IP=$(kubectl get node $(hostname) -o jsonpath='{.metadata.annotations.k3s\\.io/internal-ip}')
-if [ -f .env ]; then
-  sed -i '/^# BEGIN RISE K8S DEV$/,/^# END RISE K8S DEV$/d' .env
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "k3s is Linux only."
+  exit 1
 fi
-cat >> .env <<EOF
-# BEGIN RISE K8S DEV
-export RISE_K8S_HOST_IP="${HOST_IP}"
-export RISE_AUTH_BACKEND_URL="http://${HOST_IP}:3000"
-export RISE_METACONTROLLER_WEBHOOK_BASE_URL="http://${HOST_IP}:3001"
-# END RISE K8S DEV
-EOF
-helm dependency build helm/rise
-kubectl apply --server-side --force-conflicts -f helm/rise/crds/
-helm upgrade --install rise-dev ./helm/rise \
-  -f helm/rise/values-dev.yaml \
-  --set "metacontroller.webhookBaseUrl=${RISE_METACONTROLLER_WEBHOOK_BASE_URL:-http://${HOST_IP}:3001}" \
-  --skip-crds \
-  --namespace rise \
-  --create-namespace
-
-set +x
-echo
-echo
-echo "Note: Wrote Kubernetes host reachability settings to .env."
-echo "If you use direnv, run 'direnv reload' or restart 'mise backend:run' so Rise picks them up."
-echo
-echo "K3s internal IP: $(kubectl get node $(hostname) -o jsonpath='{.metadata.annotations.k3s\\.io/internal-ip}')"
+sudo /usr/local/bin/k3s-uninstall.sh
 """
 
 [tasks."test:e2e-build"]
 description = "Run end-to-end build backend tests (all or specific backends)."
 run = "bash tests/e2e-build/run.sh"
-
-[tasks."k3s:down"]
-run = """
-sudo /usr/local/bin/k3s-uninstall.sh
-"""
 
 [tasks."dev:oidc-issuer"]
 run = """

--- a/mise.toml
+++ b/mise.toml
@@ -24,7 +24,7 @@ description = "Verify /etc/hosts has the required rise-registry, rise-jfrog and 
 run = """
 ok=true
 for h in rise-registry rise-jfrog rise.local; do
-  if ! grep -qE "\\<${h//./\\.}\\>" /etc/hosts; then
+  if ! awk -v h="$h" '{for (i = 1; i <= NF; i++) if ($i == h) {found = 1; exit}} END {exit !found}' /etc/hosts; then
     echo "MISSING: /etc/hosts entry for '$h'"
     ok=false
   fi

--- a/mise.toml
+++ b/mise.toml
@@ -243,28 +243,6 @@ cargo install cargo-dist --locked
 cargo dist build --target x86_64-unknown-linux-gnu --target x86_64-apple-darwin --target aarch64-apple-darwin
 """
 
-[tasks."minikube:up"]
-description = "Start Minikube with local Docker registry access and ingress port-forwarding."
-run = "./scripts/dev-setup.sh minikube"
-
-[tasks."minikube:down"]
-description = "Stop and delete Minikube."
-run = "minikube delete"
-
-[tasks."k3s:up"]
-description = "Install and configure k3s (Linux only)."
-run = "./scripts/dev-setup.sh k3s"
-
-[tasks."k3s:down"]
-description = "Uninstall k3s (Linux only)."
-run = """
-if [ "$(uname -s)" != "Linux" ]; then
-  echo "k3s is Linux only."
-  exit 1
-fi
-sudo /usr/local/bin/k3s-uninstall.sh
-"""
-
 [tasks."test:e2e-build"]
 description = "Run end-to-end build backend tests (all or specific backends)."
 run = "bash tests/e2e-build/run.sh"

--- a/mise.toml
+++ b/mise.toml
@@ -19,6 +19,10 @@ vault = "latest"
 description = "One-stop dev environment setup (hosts, docker, cluster). Cross-platform (Linux + macOS). Run interactively."
 run = "./scripts/dev-setup.sh"
 
+[tasks.down]
+description = "Tear down what 'mise setup' brought up (cluster, .env block, daemon.json registries, /etc/hosts block). Interactive."
+run = "./scripts/dev-setup.sh down"
+
 [tasks."check:hosts"]
 description = "Verify /etc/hosts has the required rise-registry, rise-jfrog and rise.local entries."
 run = """

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -1,0 +1,416 @@
+#!/usr/bin/env bash
+# One-stop dev environment setup for Rise. Cross-platform (Linux + macOS).
+#
+# Usage:
+#   ./scripts/dev-setup.sh             # interactive: do everything
+#   ./scripts/dev-setup.sh hosts       # only /etc/hosts entries
+#   ./scripts/dev-setup.sh docker      # only Docker insecure-registries
+#   ./scripts/dev-setup.sh minikube    # bring up local minikube + helm install
+#   ./scripts/dev-setup.sh k3s         # bring up local k3s (Linux only)
+#   ./scripts/dev-setup.sh preflight   # hosts + docker, no cluster
+#
+# Run this script directly (not via a `mise` task dependency chain) so that
+# sudo can prompt on a real TTY when needed.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+OS=$(uname -s)
+
+REQUIRED_HOSTS=(rise-registry rise-jfrog rise.local)
+REQUIRED_REGISTRIES='["rise-registry:5000","localhost:5000","127.0.0.1:5000","rise-jfrog:8082","localhost:3082"]'
+
+log()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+ok()   { printf '\033[1;32m OK\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m  !\033[0m %s\n' "$*" >&2; }
+err()  { printf '\033[1;31m  x\033[0m %s\n' "$*" >&2; }
+ask()  { local p=$1 d=${2:-} a; read -r -p "$p${d:+ [$d]}: " a; echo "${a:-$d}"; }
+
+require_cmd() {
+  local missing=()
+  for c in "$@"; do command -v "$c" >/dev/null 2>&1 || missing+=("$c"); done
+  if (( ${#missing[@]} > 0 )); then
+    err "Missing required tools: ${missing[*]}"
+    err "Install them first (most are managed by 'mise install')."
+    exit 1
+  fi
+}
+
+ensure_sudo() {
+  # Cache sudo credentials up front so later commands run non-interactively
+  # without surprising the user mid-script.
+  if ! sudo -v; then
+    err "sudo authentication failed"
+    exit 1
+  fi
+  # Keep sudo alive while the script runs.
+  ( while true; do sudo -n true; sleep 50; kill -0 "$$" 2>/dev/null || exit; done ) 2>/dev/null &
+}
+
+# ---- /etc/hosts ------------------------------------------------------------
+
+setup_hosts() {
+  log "Configuring /etc/hosts entries: ${REQUIRED_HOSTS[*]}"
+  local tmp
+  tmp=$(mktemp)
+  # Drop any existing lines that mention our hosts (the older `sed -i` was
+  # GNU-only; awk is portable across Linux and BSD/macOS).
+  awk -v pat='\\<(rise-registry|rise-jfrog|rise\\.local)\\>' '$0 !~ pat' /etc/hosts > "$tmp"
+  {
+    echo '127.0.0.1 rise-registry'
+    echo '127.0.0.1 rise-jfrog'
+    echo '127.0.0.1 rise.local'
+  } >> "$tmp"
+  if ! cmp -s "$tmp" /etc/hosts; then
+    sudo cp "$tmp" /etc/hosts
+    ok "/etc/hosts updated"
+  else
+    ok "/etc/hosts already configured"
+  fi
+  rm -f "$tmp"
+}
+
+check_hosts() {
+  local missing=()
+  for h in "${REQUIRED_HOSTS[@]}"; do
+    grep -qE "\\<${h//./\\.}\\>" /etc/hosts || missing+=("$h")
+  done
+  (( ${#missing[@]} == 0 ))
+}
+
+# ---- Docker insecure-registries -------------------------------------------
+
+daemon_json_path() {
+  if [[ "$OS" == "Darwin" ]]; then
+    echo "$HOME/.docker/daemon.json"
+  else
+    echo "/etc/docker/daemon.json"
+  fi
+}
+
+write_daemon_json() {
+  # $1 = target path, $2 = "sudo" or "" for the writer
+  local target=$1 writer=$2 merged
+  if [[ -f "$target" ]]; then
+    merged=$(jq --argjson regs "$REQUIRED_REGISTRIES" \
+      '.["insecure-registries"] = (((.["insecure-registries"] // []) + $regs) | unique)' "$target")
+  else
+    merged=$(jq -n --argjson regs "$REQUIRED_REGISTRIES" '{"insecure-registries": $regs}')
+  fi
+  if [[ -n "$writer" ]]; then
+    printf '%s\n' "$merged" | $writer tee "$target" >/dev/null
+  else
+    mkdir -p "$(dirname "$target")"
+    printf '%s\n' "$merged" > "$target"
+  fi
+}
+
+wait_for_docker() {
+  local timeout=${1:-180}
+  log "Waiting up to ${timeout}s for the Docker daemon to come back up..."
+  local i=0
+  until docker info >/dev/null 2>&1; do
+    if (( i >= timeout )); then
+      err "Docker did not become ready within ${timeout}s"
+      return 1
+    fi
+    sleep 2
+    i=$(( i + 2 ))
+  done
+  ok "Docker daemon is responsive"
+}
+
+restart_docker_desktop_mac() {
+  # Prefer the built-in CLI; it cleanly stops the GUI + engine and starts them
+  # back up, and it blocks until the engine is reachable. Available since
+  # Docker Desktop 4.37 (Jan 2025).
+  if docker desktop --help >/dev/null 2>&1; then
+    log "Restarting Docker Desktop via 'docker desktop restart'"
+    if docker desktop restart; then
+      wait_for_docker 180 || return 1
+      return 0
+    fi
+    warn "'docker desktop restart' failed; falling back to manual quit + open"
+  fi
+
+  log "Quitting Docker Desktop"
+  # The bundle id is com.docker.docker regardless of whether the app is named
+  # "Docker" or "Docker Desktop", so target it by id.
+  osascript -e 'tell application id "com.docker.docker" to quit' >/dev/null 2>&1 || true
+  # Wait for the helper processes to actually exit before relaunching.
+  local i=0
+  while pgrep -fq 'Docker Desktop|/Applications/Docker.app/Contents/MacOS/Docker'; do
+    if (( i >= 30 )); then
+      warn "Docker processes still running after 30s; force-killing"
+      pkill -f 'Docker Desktop|/Applications/Docker.app/Contents/MacOS/Docker' || true
+      sleep 2
+      break
+    fi
+    sleep 1
+    i=$(( i + 1 ))
+  done
+
+  log "Launching Docker Desktop"
+  if ! open -b com.docker.docker; then
+    err "Could not launch Docker Desktop (bundle id com.docker.docker)"
+    return 1
+  fi
+  wait_for_docker 180
+}
+
+setup_docker() {
+  require_cmd jq docker
+  local target writer
+  target=$(daemon_json_path)
+
+  if ! docker info >/dev/null 2>&1; then
+    err "Docker daemon is not reachable. Start Docker (Docker Desktop on macOS) and re-run."
+    exit 1
+  fi
+
+  if [[ "$OS" == "Darwin" ]]; then
+    writer=""
+    log "Updating Docker Desktop daemon config at $target"
+    write_daemon_json "$target" "$writer"
+    warn "Docker Desktop must be restarted for insecure-registries to apply."
+    if [[ "${RISE_DEV_RESTART_DOCKER:-}" != "0" ]]; then
+      local ans
+      ans=$(ask "Restart Docker Desktop now? (y/N)" "N")
+      if [[ "$ans" =~ ^[Yy]$ ]]; then
+        restart_docker_desktop_mac || warn "Automatic restart failed; restart Docker Desktop manually."
+      else
+        warn "Restart Docker Desktop manually before bringing up the cluster."
+      fi
+    fi
+  else
+    if [[ ! -d /etc/docker ]]; then
+      warn "/etc/docker missing — is Docker installed natively? Skipping daemon.json update."
+      warn "If you use Docker Desktop on Linux, set insecure-registries via its UI."
+      return 0
+    fi
+    writer="sudo"
+    log "Updating $target (requires sudo)"
+    ensure_sudo
+    write_daemon_json "$target" "$writer"
+    if command -v systemctl >/dev/null 2>&1; then
+      log "Restarting docker.service"
+      sudo systemctl restart docker || warn "systemctl restart docker failed; restart manually."
+    else
+      warn "No systemctl found; restart the Docker daemon manually."
+    fi
+  fi
+  ok "Docker insecure-registries configured"
+}
+
+check_docker() {
+  local target
+  target=$(daemon_json_path)
+  if [[ ! -f "$target" ]]; then return 1; fi
+  grep -q 'rise-registry:5000' "$target"
+}
+
+# ---- Host IP detection (cross-platform) -----------------------------------
+
+get_host_ip() {
+  case "$OS" in
+    Linux)
+      ip -4 route get 1.1.1.1 2>/dev/null \
+        | awk '{for (i = 1; i <= NF; i++) if ($i == "src") {print $(i + 1); exit}}'
+      ;;
+    Darwin)
+      local iface
+      iface=$(route -n get 1.1.1.1 2>/dev/null | awk '/interface:/ {print $2}')
+      [[ -n "$iface" ]] && ipconfig getifaddr "$iface"
+      ;;
+  esac
+}
+
+# ---- .env management ------------------------------------------------------
+
+write_dev_env_block() {
+  local host_ip=$1
+  local f="$REPO_ROOT/.env"
+  if [[ -f "$f" ]]; then
+    awk '
+      /^# BEGIN RISE K8S DEV$/ { skip = 1; next }
+      /^# END RISE K8S DEV$/   { skip = 0; next }
+      !skip
+    ' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+  fi
+  cat >> "$f" <<EOF
+# BEGIN RISE K8S DEV
+export RISE_K8S_HOST_IP="${host_ip}"
+export RISE_AUTH_BACKEND_URL="http://${host_ip}:3000"
+export RISE_METACONTROLLER_WEBHOOK_BASE_URL="http://${host_ip}:3001"
+# END RISE K8S DEV
+EOF
+  ok "Wrote .env block (RISE_K8S_HOST_IP=$host_ip)"
+}
+
+helm_install_rise_dev() {
+  local host_ip=$1 skip_crds=${2:-}
+  cd "$REPO_ROOT"
+  helm dependency build helm/rise
+  local args=(
+    upgrade --install rise-dev ./helm/rise
+    -f helm/rise/values-dev.yaml
+    --set "metacontroller.webhookBaseUrl=http://${host_ip}:3001"
+    --namespace rise --create-namespace
+  )
+  [[ -n "$skip_crds" ]] && args+=(--skip-crds)
+  helm "${args[@]}"
+}
+
+# ---- Minikube --------------------------------------------------------------
+
+setup_minikube() {
+  require_cmd docker minikube kubectl helm
+  cd "$REPO_ROOT"
+  log "Starting local registry via docker compose"
+  docker compose up -d registry
+
+  local network=rise_default
+  local reg_name=rise-registry
+  local reg_dir="/etc/containerd/certs.d/localhost:5000"
+  local jfrog_dir="/etc/containerd/certs.d/rise-jfrog:8082"
+
+  log "Recreating minikube cluster"
+  minikube delete || true
+  minikube start --driver=docker \
+    --insecure-registry="${reg_name}:5000" \
+    --insecure-registry="rise-jfrog:8082" \
+    --memory=4096mb --cpus=2 --cni=calico
+  minikube addons enable ingress
+
+  log "Wiring containerd registry mirrors inside minikube"
+  for node in $(minikube node list | awk '{print $1}'); do
+    docker exec "${node}" mkdir -p "${reg_dir}"
+    cat <<EOF | docker exec -i "${node}" cp /dev/stdin "${reg_dir}/hosts.toml"
+[host."http://${reg_name}:5000"]
+EOF
+    docker exec "${node}" mkdir -p "${jfrog_dir}"
+    cat <<EOF | docker exec -i "${node}" cp /dev/stdin "${jfrog_dir}/hosts.toml"
+[host."http://rise-jfrog:8082"]
+EOF
+  done
+
+  docker network connect "${network}" minikube 2>/dev/null || true
+
+  log "Port-forwarding ingress-nginx-controller to localhost:8080 (HTTP) and 8443 (HTTPS)"
+  kubectl port-forward --namespace ingress-nginx svc/ingress-nginx-controller 8080:80 8443:443 \
+    >/dev/null 2>&1 &
+  ok "Port-forward running in background (PID: $!)"
+
+  local host_ip
+  host_ip=$(get_host_ip)
+  if [[ -z "$host_ip" ]]; then
+    err "Could not determine host IP. Inspect 'route -n get 1.1.1.1' (Darwin) or 'ip route get 1.1.1.1' (Linux)."
+    return 1
+  fi
+  write_dev_env_block "$host_ip"
+  helm_install_rise_dev "$host_ip" ""
+  ok "minikube ready. If you use direnv: run 'direnv reload'."
+}
+
+# ---- K3s (Linux only) -----------------------------------------------------
+
+setup_k3s() {
+  if [[ "$OS" != "Linux" ]]; then
+    err "k3s is Linux-only. On macOS, use the 'minikube' command instead."
+    exit 1
+  fi
+  require_cmd docker kubectl helm curl
+  ensure_sudo
+  cd "$REPO_ROOT"
+
+  log "Writing /etc/rancher/k3s/registries.yaml"
+  sudo mkdir -p /etc/rancher/k3s
+  sudo tee /etc/rancher/k3s/registries.yaml > /dev/null <<EOF
+mirrors:
+  "rise-registry:5000":
+    endpoint:
+      - "http://rise-registry:5000"
+  "rise-jfrog:8082":
+    endpoint:
+      - "http://localhost:3082"
+EOF
+
+  log "Starting local registry via docker compose"
+  docker compose up -d registry
+
+  log "Installing k3s"
+  curl -sfL https://get.k3s.io \
+    | INSTALL_K3S_EXEC="--flannel-backend=none --cluster-cidr=192.168.0.0/16 --disable-network-policy --disable=traefik" sh -
+  sleep 10
+  mkdir -p ~/.kube
+  sudo cat /etc/rancher/k3s/k3s.yaml > ~/.kube/config
+
+  log "Installing Calico + ingress-nginx"
+  kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.31.4/manifests/operator-crds.yaml --server-side --force-conflicts
+  kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.31.4/manifests/tigera-operator.yaml --server-side --force-conflicts
+  kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.31.4/manifests/custom-resources.yaml --server-side --force-conflicts
+  helm upgrade --install ingress-nginx ingress-nginx \
+    --repo https://kubernetes.github.io/ingress-nginx \
+    --namespace ingress-nginx --create-namespace \
+    --set controller.hostPort.enabled=true \
+    --set controller.hostPort.ports.http=8080 \
+    --set controller.hostPort.ports.https=8443 \
+    --set controller.service.type=ClusterIP
+
+  local host_ip
+  host_ip=$(kubectl get node "$(hostname)" -o jsonpath='{.metadata.annotations.k3s\.io/internal-ip}')
+  if [[ -z "$host_ip" ]]; then
+    err "Could not determine k3s internal IP"
+    return 1
+  fi
+  write_dev_env_block "$host_ip"
+  kubectl apply --server-side --force-conflicts -f helm/rise/crds/
+  helm_install_rise_dev "$host_ip" "--skip-crds"
+  ok "k3s ready. K3s internal IP: $host_ip. If you use direnv: run 'direnv reload'."
+}
+
+# ---- Top-level commands ---------------------------------------------------
+
+cmd_preflight() {
+  setup_hosts
+  setup_docker
+}
+
+cmd_all() {
+  setup_hosts
+  setup_docker
+  local cluster default=minikube
+  if [[ "$OS" == "Linux" ]]; then
+    cluster=$(ask "Bring up which cluster? [minikube/k3s/skip]" "$default")
+  else
+    cluster=$(ask "Bring up minikube now? [minikube/skip]" "$default")
+  fi
+  case "$cluster" in
+    minikube) setup_minikube ;;
+    k3s)      setup_k3s ;;
+    skip|"")  log "Skipping cluster bring-up" ;;
+    *)        err "Unknown cluster: $cluster"; exit 1 ;;
+  esac
+}
+
+usage() {
+  sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+main() {
+  local cmd=${1:-all}
+  case "$cmd" in
+    -h|--help|help) usage 0 ;;
+    hosts)     setup_hosts ;;
+    docker)    setup_docker ;;
+    minikube)  setup_minikube ;;
+    k3s)       setup_k3s ;;
+    preflight) cmd_preflight ;;
+    all)       cmd_all ;;
+    *)         err "Unknown command: $cmd"; usage 1 ;;
+  esac
+}
+
+main "$@"

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -54,9 +54,23 @@ setup_hosts() {
   log "Configuring /etc/hosts entries: ${REQUIRED_HOSTS[*]}"
   local tmp
   tmp=$(mktemp)
-  # Drop any existing lines that mention our hosts (the older `sed -i` was
-  # GNU-only; awk is portable across Linux and BSD/macOS).
-  awk -v pat='\\<(rise-registry|rise-jfrog|rise\\.local)\\>' '$0 !~ pat' /etc/hosts > "$tmp"
+  # Drop any existing lines that contain one of our hostnames as a
+  # whitespace-separated token. We avoid \< / \> word boundaries because BSD
+  # awk on macOS doesn't honor them — that bug caused this dedup to silently
+  # match nothing and entries to accumulate across runs. Field-based exact
+  # comparison is portable.
+  awk '
+    {
+      keep = 1
+      for (i = 1; i <= NF; i++) {
+        if ($i == "rise-registry" || $i == "rise-jfrog" || $i == "rise.local") {
+          keep = 0
+          break
+        }
+      }
+      if (keep) print
+    }
+  ' /etc/hosts > "$tmp"
   {
     echo '127.0.0.1 rise-registry'
     echo '127.0.0.1 rise-jfrog'
@@ -74,7 +88,12 @@ setup_hosts() {
 check_hosts() {
   local missing=()
   for h in "${REQUIRED_HOSTS[@]}"; do
-    grep -qE "\\<${h//./\\.}\\>" /etc/hosts || missing+=("$h")
+    awk -v h="$h" '
+      {
+        for (i = 1; i <= NF; i++) if ($i == h) { found = 1; exit }
+      }
+      END { exit !found }
+    ' /etc/hosts || missing+=("$h")
   done
   (( ${#missing[@]} == 0 ))
 }

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -421,17 +421,41 @@ cmd_preflight() {
 cmd_all() {
   setup_hosts
   setup_docker
-  local cluster default=minikube
-  if [[ "$OS" == "Linux" ]]; then
-    cluster=$(ask "Bring up which cluster? [minikube/k3s/skip]" "$default")
+
+  local action
+  if kubectl --context=minikube get nodes >/dev/null 2>&1; then
+    if [[ "$OS" == "Linux" ]]; then
+      action=$(ask "minikube already running. Action? [keep/recreate/k3s/skip]" "keep")
+    else
+      action=$(ask "minikube already running. Action? [keep/recreate/skip]" "keep")
+    fi
   else
-    cluster=$(ask "Bring up minikube now? [minikube/skip]" "$default")
+    if [[ "$OS" == "Linux" ]]; then
+      action=$(ask "Bring up which cluster? [minikube/k3s/skip]" "minikube")
+    else
+      action=$(ask "Bring up minikube now? [minikube/skip]" "minikube")
+    fi
   fi
-  case "$cluster" in
-    minikube) setup_minikube ;;
-    k3s)      setup_k3s ;;
-    skip|"")  log "Skipping cluster bring-up" ;;
-    *)        err "Unknown cluster: $cluster"; exit 1 ;;
+
+  case "$action" in
+    keep|minikube)
+      setup_minikube
+      ;;
+    recreate)
+      log "Deleting existing minikube cluster before recreate"
+      minikube delete >/dev/null || warn "minikube delete reported an error; continuing"
+      setup_minikube
+      ;;
+    k3s)
+      setup_k3s
+      ;;
+    skip|"")
+      log "Skipping cluster bring-up"
+      ;;
+    *)
+      err "Unknown action: $action"
+      exit 1
+      ;;
   esac
 }
 

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -89,9 +89,13 @@ setup_hosts() {
     echo "127.0.0.1 rise-registry"
     echo "127.0.0.1 rise-jfrog"
     echo "127.0.0.1 rise.local"
-    for h in "${ingress_hosts[@]}"; do
-      echo "127.0.0.1 $h"
-    done
+    # Guard the expansion because bash 3.2 (the system bash on macOS) errors
+    # on "${arr[@]}" under set -u when arr is empty.
+    if (( ${#ingress_hosts[@]} > 0 )); then
+      for h in "${ingress_hosts[@]}"; do
+        echo "127.0.0.1 $h"
+      done
+    fi
     echo "$HOSTS_END_MARKER"
   } >> "$tmp"
 

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -172,6 +172,13 @@ setup_docker() {
     exit 1
   fi
 
+  # Idempotency: if the required registries are already present, skip the
+  # rewrite (and the needless Docker Desktop restart prompt on macOS).
+  if check_docker; then
+    ok "Docker insecure-registries already configured ($target)"
+    return 0
+  fi
+
   if [[ "$OS" == "Darwin" ]]; then
     writer=""
     log "Updating Docker Desktop daemon config at $target"
@@ -290,12 +297,27 @@ setup_minikube() {
   local reg_dir="/etc/containerd/certs.d/localhost:5000"
   local jfrog_dir="/etc/containerd/certs.d/rise-jfrog:8082"
 
-  log "Recreating minikube cluster"
-  minikube delete || true
-  minikube start --driver=docker \
-    --insecure-registry="${reg_name}:5000" \
-    --insecure-registry="rise-jfrog:8082" \
-    --memory=4096mb --cpus=2 --cni=calico
+  # Start minikube only if it's not already reachable. Recreating wastes
+  # 30-60s and nukes state the developer may want to keep — `minikube delete`
+  # explicitly when a fresh cluster is wanted.
+  #
+  # `minikube status` parses container IPs and breaks when minikube has more
+  # than one network attached (which our setup intentionally does). Use
+  # kubectl reachability against the minikube context as the source of truth.
+  if kubectl --context=minikube get nodes >/dev/null 2>&1; then
+    ok "minikube cluster already reachable; skipping 'minikube start'"
+  else
+    log "Starting minikube"
+    minikube start --driver=docker \
+      --insecure-registry="${reg_name}:5000" \
+      --insecure-registry="rise-jfrog:8082" \
+      --memory=4096mb --cpus=2 --cni=calico
+  fi
+
+  log "Setting kubectl context to 'minikube'"
+  kubectl config use-context minikube >/dev/null
+
+  log "Ensuring ingress addon is enabled"
   minikube addons enable ingress
 
   log "Wiring containerd registry mirrors inside minikube"
@@ -312,10 +334,14 @@ EOF
 
   docker network connect "${network}" minikube 2>/dev/null || true
 
-  log "Port-forwarding ingress-nginx-controller to localhost:8080 (HTTP) and 8443 (HTTPS)"
-  kubectl port-forward --namespace ingress-nginx svc/ingress-nginx-controller 8080:80 8443:443 \
-    >/dev/null 2>&1 &
-  ok "Port-forward running in background (PID: $!)"
+  if lsof -iTCP:8080 -sTCP:LISTEN >/dev/null 2>&1; then
+    ok "Port 8080 already in use; assuming ingress port-forward is running"
+  else
+    log "Port-forwarding ingress-nginx-controller to localhost:8080 (HTTP) and 8443 (HTTPS)"
+    kubectl port-forward --namespace ingress-nginx svc/ingress-nginx-controller 8080:80 8443:443 \
+      >/dev/null 2>&1 &
+    ok "Port-forward running in background (PID: $!)"
+  fi
 
   local host_ip
   host_ip=$(get_host_ip)

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -2,15 +2,20 @@
 # One-stop dev environment setup for Rise. Cross-platform (Linux + macOS).
 #
 # Usage:
-#   ./scripts/dev-setup.sh              # interactive: do everything
-#   ./scripts/dev-setup.sh hosts        # write the managed /etc/hosts block
-#                                         (base + *.rise.local ingress hosts
-#                                          enumerated from the current cluster)
-#   ./scripts/dev-setup.sh hosts-clear  # remove the managed /etc/hosts block
-#   ./scripts/dev-setup.sh docker       # only Docker insecure-registries
-#   ./scripts/dev-setup.sh minikube     # bring up local minikube + helm install
-#   ./scripts/dev-setup.sh k3s          # bring up local k3s (Linux only)
-#   ./scripts/dev-setup.sh preflight    # hosts + docker, no cluster
+#   ./scripts/dev-setup.sh               # interactive: do everything
+#   ./scripts/dev-setup.sh down          # interactive: undo everything
+#
+#   ./scripts/dev-setup.sh hosts         # write the managed /etc/hosts block
+#                                          (base + *.rise.local ingress hosts
+#                                           enumerated from the current cluster)
+#   ./scripts/dev-setup.sh hosts-clear   # remove the managed /etc/hosts block
+#   ./scripts/dev-setup.sh docker        # only Docker insecure-registries
+#   ./scripts/dev-setup.sh docker-clear  # remove rise registries from daemon.json
+#   ./scripts/dev-setup.sh minikube      # bring up local minikube + helm install
+#   ./scripts/dev-setup.sh minikube-down # 'minikube delete'
+#   ./scripts/dev-setup.sh k3s           # bring up local k3s (Linux only)
+#   ./scripts/dev-setup.sh k3s-down      # uninstall k3s (Linux only)
+#   ./scripts/dev-setup.sh preflight     # hosts + docker, no cluster
 #
 # Run this script directly (not via a `mise` task dependency chain) so that
 # sudo can prompt on a real TTY when needed.
@@ -511,6 +516,139 @@ EOF
   ok "k3s ready. K3s internal IP: $host_ip. If you use direnv: run 'direnv reload'."
 }
 
+# ---- Teardown -------------------------------------------------------------
+
+# Kill any kubectl port-forward this script (or a previous run of it) started
+# for ingress-nginx. We match by command line because the process is detached
+# and we don't track PIDs across runs.
+kill_ingress_port_forward() {
+  local pids
+  pids=$(pgrep -f 'kubectl port-forward.*ingress-nginx.*8080:80' 2>/dev/null || true)
+  if [[ -n "$pids" ]]; then
+    log "Killing ingress port-forward processes: $pids"
+    kill $pids 2>/dev/null || true
+    ok "Port-forward processes terminated"
+  else
+    ok "No ingress port-forward processes running"
+  fi
+}
+
+down_minikube() {
+  command -v minikube >/dev/null 2>&1 || { ok "minikube not installed; nothing to delete"; return 0; }
+  if minikube profile list 2>/dev/null | awk '{print $2}' | grep -qx 'minikube'; then
+    log "Deleting minikube cluster"
+    minikube delete >/dev/null 2>&1 || warn "minikube delete reported an error"
+    ok "minikube cluster deleted"
+  else
+    ok "No minikube cluster to delete"
+  fi
+}
+
+down_k3s() {
+  if [[ "$OS" != "Linux" ]]; then
+    ok "k3s is Linux-only; nothing to uninstall on $OS"
+    return 0
+  fi
+  if [[ -x /usr/local/bin/k3s-uninstall.sh ]]; then
+    log "Uninstalling k3s"
+    sudo /usr/local/bin/k3s-uninstall.sh
+    ok "k3s uninstalled"
+  else
+    ok "No k3s installation found"
+  fi
+}
+
+clear_dev_env_block() {
+  local f="$REPO_ROOT/.env"
+  if [[ ! -f "$f" ]]; then
+    ok "No .env file; nothing to strip"
+    return 0
+  fi
+  if ! grep -q '^# BEGIN RISE K8S DEV$' "$f" 2>/dev/null; then
+    ok ".env has no rise-managed block"
+    return 0
+  fi
+  log "Stripping rise-managed block from $f"
+  awk '
+    /^# BEGIN RISE K8S DEV$/ { skip = 1; next }
+    /^# END RISE K8S DEV$/   { skip = 0; next }
+    !skip
+  ' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+  ok ".env cleaned"
+}
+
+clear_docker() {
+  require_cmd jq
+  local target
+  target=$(daemon_json_path)
+  if [[ ! -f "$target" ]]; then
+    ok "No $target; nothing to clean"
+    return 0
+  fi
+  if ! grep -q 'rise-registry:5000' "$target" 2>/dev/null; then
+    ok "Docker daemon.json has no rise registries to remove"
+    return 0
+  fi
+  log "Removing rise insecure-registries from $target"
+  local cleaned
+  cleaned=$(jq --argjson drop "$REQUIRED_REGISTRIES" '
+    if has("insecure-registries") then
+      .["insecure-registries"] = (.["insecure-registries"] - $drop)
+      | if (.["insecure-registries"] | length) == 0
+        then del(.["insecure-registries"]) else . end
+    else . end
+  ' "$target")
+
+  if [[ "$OS" == "Darwin" ]]; then
+    printf '%s\n' "$cleaned" > "$target"
+    ok "Removed rise registries from $target"
+    warn "Docker Desktop must be restarted for the change to take effect."
+    if [[ "${RISE_DEV_RESTART_DOCKER:-}" != "0" ]]; then
+      local ans
+      ans=$(ask "Restart Docker Desktop now? (y/N)" "N")
+      if [[ "$ans" =~ ^[Yy]$ ]]; then
+        restart_docker_desktop_mac || warn "Automatic restart failed; restart Docker Desktop manually."
+      fi
+    fi
+  else
+    ensure_sudo
+    printf '%s\n' "$cleaned" | sudo tee "$target" >/dev/null
+    ok "Removed rise registries from $target"
+    if command -v systemctl >/dev/null 2>&1; then
+      log "Restarting docker.service"
+      sudo systemctl restart docker || warn "systemctl restart docker failed; restart manually."
+    fi
+  fi
+}
+
+cmd_down() {
+  log "This will undo what 'mise setup' did:"
+  echo "    - terminate any 'kubectl port-forward' for ingress-nginx (8080/8443)"
+  echo "    - delete the minikube cluster (if present)"
+  [[ "$OS" == "Linux" ]] && echo "    - uninstall k3s (if installed)"
+  echo "    - strip the rise-managed block from .env"
+  echo "    - remove rise insecure-registries from $(daemon_json_path)"
+  echo "      (you will be asked to restart Docker)"
+  echo "    - remove the rise-managed block from /etc/hosts (sudo)"
+  echo
+  local ans
+  ans=$(ask "Proceed? (y/N)" "N")
+  if [[ ! "$ans" =~ ^[Yy]$ ]]; then
+    log "Aborted; nothing changed."
+    return 0
+  fi
+
+  # Reverse order of setup, so we don't pull /etc/hosts entries out from
+  # under a still-running cluster.
+  kill_ingress_port_forward
+  down_minikube
+  down_k3s
+  clear_dev_env_block
+  clear_docker
+  clear_hosts
+  ok "Teardown complete."
+}
+
 # ---- Top-level commands ---------------------------------------------------
 
 cmd_preflight() {
@@ -568,14 +706,18 @@ main() {
   local cmd=${1:-all}
   case "$cmd" in
     -h|--help|help) usage 0 ;;
-    hosts)        setup_hosts ;;
-    hosts-clear)  clear_hosts ;;
-    docker)       setup_docker ;;
-    minikube)     setup_minikube ;;
-    k3s)          setup_k3s ;;
-    preflight)    cmd_preflight ;;
-    all)          cmd_all ;;
-    *)            err "Unknown command: $cmd"; usage 1 ;;
+    hosts)         setup_hosts ;;
+    hosts-clear)   clear_hosts ;;
+    docker)        setup_docker ;;
+    docker-clear)  clear_docker ;;
+    minikube)      setup_minikube ;;
+    minikube-down) down_minikube ;;
+    k3s)           setup_k3s ;;
+    k3s-down)      down_k3s ;;
+    preflight)     cmd_preflight ;;
+    all)           cmd_all ;;
+    down)          cmd_down ;;
+    *)             err "Unknown command: $cmd"; usage 1 ;;
   esac
 }
 

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -122,23 +122,20 @@ wait_for_docker() {
 }
 
 restart_docker_desktop_mac() {
-  # Prefer the built-in CLI; it cleanly stops the GUI + engine and starts them
-  # back up, and it blocks until the engine is reachable. Available since
-  # Docker Desktop 4.37 (Jan 2025).
+  # `docker desktop restart` has been observed to return successfully while
+  # leaving the engine dead, so we drive the restart explicitly: stop -> wait
+  # for processes to exit -> relaunch via Launch Services (which reliably
+  # brings the GUI + engine up) -> poll for the daemon.
+  log "Stopping Docker Desktop"
   if docker desktop --help >/dev/null 2>&1; then
-    log "Restarting Docker Desktop via 'docker desktop restart'"
-    if docker desktop restart; then
-      wait_for_docker 180 || return 1
-      return 0
-    fi
-    warn "'docker desktop restart' failed; falling back to manual quit + open"
+    docker desktop stop >/dev/null 2>&1 || true
+  else
+    # The bundle id is com.docker.docker regardless of whether the app is
+    # named "Docker" or "Docker Desktop"; target it by id.
+    osascript -e 'tell application id "com.docker.docker" to quit' >/dev/null 2>&1 || true
   fi
 
-  log "Quitting Docker Desktop"
-  # The bundle id is com.docker.docker regardless of whether the app is named
-  # "Docker" or "Docker Desktop", so target it by id.
-  osascript -e 'tell application id "com.docker.docker" to quit' >/dev/null 2>&1 || true
-  # Wait for the helper processes to actually exit before relaunching.
+  # Wait for the GUI/engine processes to actually exit before relaunching.
   local i=0
   while pgrep -fq 'Docker Desktop|/Applications/Docker.app/Contents/MacOS/Docker'; do
     if (( i >= 30 )); then
@@ -153,10 +150,16 @@ restart_docker_desktop_mac() {
 
   log "Launching Docker Desktop"
   if ! open -b com.docker.docker; then
-    err "Could not launch Docker Desktop (bundle id com.docker.docker)"
+    err "Could not launch Docker Desktop via bundle id com.docker.docker."
+    err "Start it manually from Spotlight or /Applications/Docker.app and re-run."
     return 1
   fi
-  wait_for_docker 180
+
+  if ! wait_for_docker 180; then
+    err "Docker daemon did not come up. Try launching Docker Desktop manually"
+    err "(Spotlight -> Docker) and then re-run './scripts/dev-setup.sh minikube'."
+    return 1
+  fi
 }
 
 setup_docker() {
@@ -213,17 +216,29 @@ check_docker() {
 # ---- Host IP detection (cross-platform) -----------------------------------
 
 get_host_ip() {
+  # Print the host's outbound IPv4 to stdout, or nothing if it can't be
+  # determined. MUST always return 0 — callers do their own empty-check, and
+  # we don't want `set -e` to kill the script silently from inside a $().
+  local ip=""
   case "$OS" in
     Linux)
-      ip -4 route get 1.1.1.1 2>/dev/null \
-        | awk '{for (i = 1; i <= NF; i++) if ($i == "src") {print $(i + 1); exit}}'
+      ip=$(ip -4 route get 1.1.1.1 2>/dev/null \
+        | awk '{for (i = 1; i <= NF; i++) if ($i == "src") {print $(i + 1); exit}}') || true
       ;;
     Darwin)
       local iface
-      iface=$(route -n get 1.1.1.1 2>/dev/null | awk '/interface:/ {print $2}')
-      [[ -n "$iface" ]] && ipconfig getifaddr "$iface"
+      iface=$(route -n get 1.1.1.1 2>/dev/null | awk '/interface:/ {print $2}') || true
+      if [[ -n "$iface" ]]; then
+        # `ifconfig` is more reliable than `ipconfig getifaddr`, which returns
+        # empty (with rc=1) for cellular/tether/utun interfaces even when an
+        # inet address is configured.
+        ip=$(ifconfig "$iface" 2>/dev/null \
+          | awk '/^[[:space:]]+inet / {print $2; exit}') || true
+      fi
       ;;
   esac
+  [[ -n "$ip" ]] && printf '%s\n' "$ip"
+  return 0
 }
 
 # ---- .env management ------------------------------------------------------

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -2,12 +2,15 @@
 # One-stop dev environment setup for Rise. Cross-platform (Linux + macOS).
 #
 # Usage:
-#   ./scripts/dev-setup.sh             # interactive: do everything
-#   ./scripts/dev-setup.sh hosts       # only /etc/hosts entries
-#   ./scripts/dev-setup.sh docker      # only Docker insecure-registries
-#   ./scripts/dev-setup.sh minikube    # bring up local minikube + helm install
-#   ./scripts/dev-setup.sh k3s         # bring up local k3s (Linux only)
-#   ./scripts/dev-setup.sh preflight   # hosts + docker, no cluster
+#   ./scripts/dev-setup.sh              # interactive: do everything
+#   ./scripts/dev-setup.sh hosts        # write the managed /etc/hosts block
+#                                         (base + *.rise.local ingress hosts
+#                                          enumerated from the current cluster)
+#   ./scripts/dev-setup.sh hosts-clear  # remove the managed /etc/hosts block
+#   ./scripts/dev-setup.sh docker       # only Docker insecure-registries
+#   ./scripts/dev-setup.sh minikube     # bring up local minikube + helm install
+#   ./scripts/dev-setup.sh k3s          # bring up local k3s (Linux only)
+#   ./scripts/dev-setup.sh preflight    # hosts + docker, no cluster
 #
 # Run this script directly (not via a `mise` task dependency chain) so that
 # sudo can prompt on a real TTY when needed.
@@ -20,6 +23,11 @@ OS=$(uname -s)
 
 REQUIRED_HOSTS=(rise-registry rise-jfrog rise.local)
 REQUIRED_REGISTRIES='["rise-registry:5000","localhost:5000","127.0.0.1:5000","rise-jfrog:8082","localhost:3082"]'
+
+# Marker lines bracketing the section of /etc/hosts this script owns. Anything
+# between them is rewritten on each `hosts` run and removed on `hosts-clear`.
+HOSTS_BEGIN_MARKER='# >>> rise dev hosts (managed by scripts/dev-setup.sh) >>>'
+HOSTS_END_MARKER='# <<< rise dev hosts <<<'
 
 log()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
 ok()   { printf '\033[1;32m OK\033[0m %s\n' "$*"; }
@@ -51,38 +59,111 @@ ensure_sudo() {
 # ---- /etc/hosts ------------------------------------------------------------
 
 setup_hosts() {
-  log "Configuring /etc/hosts entries: ${REQUIRED_HOSTS[*]}"
+  log "Configuring /etc/hosts (managed block + ingress enumeration)"
   local tmp
   tmp=$(mktemp)
-  # Drop any existing lines that contain one of our hostnames as a
-  # whitespace-separated token. We avoid \< / \> word boundaries because BSD
-  # awk on macOS doesn't honor them — that bug caused this dedup to silently
-  # match nothing and entries to accumulate across runs. Field-based exact
-  # comparison is portable.
-  awk '
-    {
-      keep = 1
-      for (i = 1; i <= NF; i++) {
-        if ($i == "rise-registry" || $i == "rise-jfrog" || $i == "rise.local") {
-          keep = 0
-          break
-        }
-      }
-      if (keep) print
-    }
-  ' /etc/hosts > "$tmp"
+
+  # 1) Strip the managed block (if any) AND any legacy unmanaged lines for
+  #    rise-registry / rise-jfrog / rise.local that pre-date the marker block
+  #    (so re-running cleans up duplicates accumulated by older script
+  #    versions).
+  strip_managed_block_and_legacy /etc/hosts > "$tmp"
+
+  # 2) Enumerate ingress hostnames ending in .rise.local from the current
+  #    cluster context, if reachable. The .rise.local filter is the safety
+  #    guarantee — we never hijack arbitrary hostnames, so this is safe even
+  #    if the user is on a non-dev kubectl context.
+  local ingress_hosts=() h
+  while IFS= read -r h; do
+    [[ -n "$h" ]] && ingress_hosts+=("$h")
+  done < <(collect_ingress_rise_hosts)
+
+  # 3) Re-emit the managed block.
   {
-    echo '127.0.0.1 rise-registry'
-    echo '127.0.0.1 rise-jfrog'
-    echo '127.0.0.1 rise.local'
+    echo "$HOSTS_BEGIN_MARKER"
+    echo "127.0.0.1 rise-registry"
+    echo "127.0.0.1 rise-jfrog"
+    echo "127.0.0.1 rise.local"
+    for h in "${ingress_hosts[@]}"; do
+      echo "127.0.0.1 $h"
+    done
+    echo "$HOSTS_END_MARKER"
   } >> "$tmp"
+
   if ! cmp -s "$tmp" /etc/hosts; then
     sudo cp "$tmp" /etc/hosts
-    ok "/etc/hosts updated"
+    if (( ${#ingress_hosts[@]} > 0 )); then
+      ok "/etc/hosts updated (base + ${#ingress_hosts[@]} ingress host(s): ${ingress_hosts[*]})"
+    else
+      ok "/etc/hosts updated (base hosts only; no cluster reachable or no *.rise.local ingresses)"
+    fi
   else
-    ok "/etc/hosts already configured"
+    ok "/etc/hosts already up to date"
   fi
   rm -f "$tmp"
+}
+
+clear_hosts() {
+  log "Removing the rise-managed block from /etc/hosts"
+  local tmp
+  tmp=$(mktemp)
+  strip_managed_block_only /etc/hosts > "$tmp"
+  if ! cmp -s "$tmp" /etc/hosts; then
+    sudo cp "$tmp" /etc/hosts
+    ok "rise-managed block removed from /etc/hosts"
+  else
+    ok "No rise-managed block found in /etc/hosts"
+  fi
+  rm -f "$tmp"
+}
+
+# Emit /etc/hosts with the managed block (BEGIN..END markers, inclusive)
+# stripped. Used by `hosts-clear`.
+strip_managed_block_only() {
+  awk -v begin="$HOSTS_BEGIN_MARKER" -v end="$HOSTS_END_MARKER" '
+    {
+      if (in_block) {
+        if ($0 == end) in_block = 0
+        next
+      }
+      if ($0 == begin) { in_block = 1; next }
+      print
+    }
+  ' "$1"
+}
+
+# Like strip_managed_block_only, but additionally drops legacy lines that
+# contain one of our base hostnames as a whitespace-separated token outside
+# the managed block. This is the one-time migration path for /etc/hosts
+# files written before we sectioned off entries.
+strip_managed_block_and_legacy() {
+  awk -v begin="$HOSTS_BEGIN_MARKER" -v end="$HOSTS_END_MARKER" '
+    {
+      if (in_block) {
+        if ($0 == end) in_block = 0
+        next
+      }
+      if ($0 == begin) { in_block = 1; next }
+      for (i = 1; i <= NF; i++) {
+        if ($i == "rise-registry" || $i == "rise-jfrog" || $i == "rise.local") next
+      }
+      print
+    }
+  ' "$1"
+}
+
+# Print *.rise.local ingress hostnames from the current kubectl context, one
+# per line. Always returns 0 — an unreachable cluster, missing kubectl, or
+# zero matches all produce an empty list.
+collect_ingress_rise_hosts() {
+  command -v kubectl >/dev/null 2>&1 || return 0
+  kubectl --request-timeout=3s get --raw /healthz >/dev/null 2>&1 || return 0
+  kubectl get ingress --all-namespaces \
+    -o jsonpath='{range .items[*]}{range .spec.rules[*]}{.host}{"\n"}{end}{end}' \
+    2>/dev/null \
+    | awk '/\.rise\.local$/' \
+    | sort -u
+  return 0
 }
 
 check_hosts() {
@@ -487,13 +568,14 @@ main() {
   local cmd=${1:-all}
   case "$cmd" in
     -h|--help|help) usage 0 ;;
-    hosts)     setup_hosts ;;
-    docker)    setup_docker ;;
-    minikube)  setup_minikube ;;
-    k3s)       setup_k3s ;;
-    preflight) cmd_preflight ;;
-    all)       cmd_all ;;
-    *)         err "Unknown command: $cmd"; usage 1 ;;
+    hosts)        setup_hosts ;;
+    hosts-clear)  clear_hosts ;;
+    docker)       setup_docker ;;
+    minikube)     setup_minikube ;;
+    k3s)          setup_k3s ;;
+    preflight)    cmd_preflight ;;
+    all)          cmd_all ;;
+    *)            err "Unknown command: $cmd"; usage 1 ;;
   esac
 }
 

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -15,6 +15,9 @@
 #   ./scripts/dev-setup.sh minikube-down # 'minikube delete'
 #   ./scripts/dev-setup.sh k3s           # bring up local k3s (Linux only)
 #   ./scripts/dev-setup.sh k3s-down      # uninstall k3s (Linux only)
+#   ./scripts/dev-setup.sh pf            # background ingress port-forward
+#                                          (localhost:8080 + :8443)
+#   ./scripts/dev-setup.sh pf-down       # stop the ingress port-forward
 #   ./scripts/dev-setup.sh preflight     # hosts + docker, no cluster
 #
 # Run this script directly (not via a `mise` task dependency chain) so that
@@ -443,14 +446,7 @@ EOF
 
   docker network connect "${network}" minikube 2>/dev/null || true
 
-  if lsof -iTCP:8080 -sTCP:LISTEN >/dev/null 2>&1; then
-    ok "Port 8080 already in use; assuming ingress port-forward is running"
-  else
-    log "Port-forwarding ingress-nginx-controller to localhost:8080 (HTTP) and 8443 (HTTPS)"
-    kubectl port-forward --namespace ingress-nginx svc/ingress-nginx-controller 8080:80 8443:443 \
-      >/dev/null 2>&1 &
-    ok "Port-forward running in background (PID: $!)"
-  fi
+  start_ingress_port_forward
 
   local host_ip
   host_ip=$(get_host_ip)
@@ -461,6 +457,43 @@ EOF
   write_dev_env_block "$host_ip"
   helm_install_rise_dev "$host_ip" ""
   ok "minikube ready. If you use direnv: run 'direnv reload'."
+}
+
+# ---- Ingress port-forward -------------------------------------------------
+
+# Background a `kubectl port-forward` for the ingress controller, exposing
+# the cluster ingresses at localhost:8080 (HTTP) and localhost:8443 (HTTPS).
+# Idempotent: a port already in use is treated as "already running".
+start_ingress_port_forward() {
+  require_cmd kubectl
+  if lsof -iTCP:8080 -sTCP:LISTEN >/dev/null 2>&1; then
+    ok "Port 8080 already in use; ingress port-forward is already running"
+    return 0
+  fi
+  if ! kubectl get svc -n ingress-nginx ingress-nginx-controller >/dev/null 2>&1; then
+    err "Service ingress-nginx/ingress-nginx-controller not found."
+    err "Bring up a cluster first (e.g. ./scripts/dev-setup.sh minikube)."
+    return 1
+  fi
+  log "Port-forwarding ingress-nginx-controller to localhost:8080 (HTTP) and 8443 (HTTPS)"
+  kubectl port-forward --namespace ingress-nginx svc/ingress-nginx-controller 8080:80 8443:443 \
+    >/dev/null 2>&1 &
+  ok "Port-forward running in background (PID: $!)"
+}
+
+# Kill any kubectl port-forward this script (or a previous run) started for
+# ingress-nginx. Matched by command line because we don't track PIDs across
+# invocations.
+stop_ingress_port_forward() {
+  local pids
+  pids=$(pgrep -f 'kubectl port-forward.*ingress-nginx.*8080:80' 2>/dev/null || true)
+  if [[ -n "$pids" ]]; then
+    log "Killing ingress port-forward processes: $pids"
+    kill $pids 2>/dev/null || true
+    ok "Port-forward processes terminated"
+  else
+    ok "No ingress port-forward processes running"
+  fi
 }
 
 # ---- K3s (Linux only) -----------------------------------------------------
@@ -521,21 +554,6 @@ EOF
 }
 
 # ---- Teardown -------------------------------------------------------------
-
-# Kill any kubectl port-forward this script (or a previous run of it) started
-# for ingress-nginx. We match by command line because the process is detached
-# and we don't track PIDs across runs.
-kill_ingress_port_forward() {
-  local pids
-  pids=$(pgrep -f 'kubectl port-forward.*ingress-nginx.*8080:80' 2>/dev/null || true)
-  if [[ -n "$pids" ]]; then
-    log "Killing ingress port-forward processes: $pids"
-    kill $pids 2>/dev/null || true
-    ok "Port-forward processes terminated"
-  else
-    ok "No ingress port-forward processes running"
-  fi
-}
 
 down_minikube() {
   command -v minikube >/dev/null 2>&1 || { ok "minikube not installed; nothing to delete"; return 0; }
@@ -644,7 +662,7 @@ cmd_down() {
 
   # Reverse order of setup, so we don't pull /etc/hosts entries out from
   # under a still-running cluster.
-  kill_ingress_port_forward
+  stop_ingress_port_forward
   down_minikube
   down_k3s
   clear_dev_env_block
@@ -718,6 +736,8 @@ main() {
     minikube-down) down_minikube ;;
     k3s)           setup_k3s ;;
     k3s-down)      down_k3s ;;
+    pf)            start_ingress_port_forward ;;
+    pf-down)       stop_ingress_port_forward ;;
     preflight)     cmd_preflight ;;
     all)           cmd_all ;;
     down)          cmd_down ;;


### PR DESCRIPTION
## Summary

- Consolidates dev environment bootstrap into a single `./scripts/dev-setup.sh` that works on macOS as well as Linux. Drops the previous `mise setup:hosts` / `mise setup:docker` tasks and the inline shell in `minikube:up` / `k3s:up` -- replaced by `mise setup` (script wrapper). No more `depends` chains that swallowed sudo's TTY.
- macOS portability: writes to `~/.docker/daemon.json` (Docker Desktop) instead of the missing `/etc/docker/daemon.json`; uses portable field-based `awk` for `/etc/hosts` / `.env` edits (BSD `awk` silently ignored the previous word-boundary syntax); host IP via `route -n get` + `ifconfig | awk` (more reliable than `ipconfig getifaddr`, which returns empty for cellular/tether/utun interfaces); explicit Docker Desktop restart (`stop` then wait for processes then `open -b com.docker.docker` then poll up to 180s), since `docker desktop restart` was observed to report success while leaving the engine dead.
- Idempotency: `setup_docker` short-circuits when `daemon.json` already has rise registries. `setup_minikube` reuses an existing cluster (kubectl-context probe -- `minikube status` breaks on multi-network setups), always points `kubectl current-context` at `minikube`, skips the ingress port-forward when :8080 is already in use, and prompts `[keep/recreate/skip]` when a cluster is already running.
- `/etc/hosts` is now a managed block bracketed by marker lines -- re-runs cleanly replace the block (no accumulating entries) and `hosts-clear` fully undoes it. The block opportunistically enumerates `*.rise.local` ingress hostnames from the current cluster.
- Symmetric teardown: `./scripts/dev-setup.sh down` (or `mise down`) walks setup in reverse with one confirmation -- kill port-forward, cluster delete, strip `.env` block, remove rise registries from `daemon.json`, strip `/etc/hosts` block.
- Standalone ingress port-forward control via `mise setup pf` / `mise setup pf-down` (idempotent background start/stop).
- `mise dev` preflight checks (hosts, Docker, k8s) are inlined into the task and prompt `Continue anyway? [y/N]` on failure rather than hard-exiting -- removing the now-redundant `check:hosts`, `check:docker`, `check:k8s` tasks.
- `sqlx:check` moved from `rust-quality` CI job (no DB) to `unit-tests-linux` (has Postgres), fixing the `sqlx-cli 0.9` breakage where `prepare --check` now always needs a live database.

## Test plan

- [x] On macOS: `mise setup` succeeds end-to-end (hosts, daemon.json, optional Docker Desktop restart, minikube cluster, ingress port-forward, `.env` written).
- [x] Re-running `mise setup` is idempotent: no duplicate `/etc/hosts` lines, no duplicate `daemon.json` entries, no needless Docker Desktop restart prompt, existing minikube cluster kept and prompted as `[keep/recreate/skip]`.
- [x] `./scripts/dev-setup.sh pf` after `minikube` brings up port-forward; `pf-down` kills it; `lsof -i :8080` reflects state correctly.
- [x] `./scripts/dev-setup.sh hosts` after deploying a project picks up the new `*.rise.local` ingress hostname.
- [ ] `mise down` cleanly undoes everything (port-forward, cluster, .env block, daemon.json registries, /etc/hosts block) with one prompt.
- [ ] `./scripts/dev-setup.sh preflight` runs only hosts + docker and exits.
- [ ] `./scripts/dev-setup.sh k3s` on macOS errors out cleanly; `k3s-down` does the same.
- [ ] On Linux: `mise setup` configures `/etc/hosts`, `/etc/docker/daemon.json`, restarts docker via systemctl, brings up the chosen cluster.
- [ ] `mise dev` with a missing preflight condition lists issues and prompts to continue; answering `y` proceeds, anything else exits.

Generated with [Claude Code](https://claude.com/claude-code)