### PR TITLE
auto-detect build platform from backend or host arch

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -93,6 +93,13 @@ deployment_controller:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
   ingress_port: 8080 # `mise setup minikube` (or `mise setup pf`) port-forwards ingress to this port
   ingress_schema: "http" # Use http for local development
+  # Empty selector: pods schedule on whatever node arch the local cluster has
+  # (minikube typically has one node, matching the host). With no
+  # `kubernetes.io/arch` pin, the backend omits the platform hint to the CLI,
+  # which then falls back to host architecture. Net effect: `rise deploy` from
+  # an ARM Mac builds linux/arm64, from Intel builds linux/amd64 — no per-machine
+  # config tweak needed.
+  node_selector: {}
   host_aliases:
     rise.local: "${RISE_K8S_HOST_IP:-192.168.49.1}" # Host IP reachable from Kubernetes pods
   # Extra projected service account tokens mounted in every app pod at

--- a/docs/user/src/content/docs/user-guide/builds.md
+++ b/docs/user/src/content/docs/user-guide/builds.md
@@ -88,28 +88,33 @@ no_cache = true
 
 ## Target Platform
 
-Rise builds for `linux/amd64` by default because the backend Kubernetes cluster runs linux/amd64 containers. This is the correct setting for deployments and you typically don't need to change it.
+Rise normally picks the right build platform for you:
 
-On ARM Macs or other non-amd64 machines, builds will cross-compile by default. To build a native image for local use instead:
+- **`rise deploy`**: the backend tells the CLI what architecture its cluster expects (read from the controller's `node_selector["kubernetes.io/arch"]`). A production backend pinning amd64 will produce amd64 images even when you deploy from an ARM Mac.
+- **`rise build` / `rise run` / no backend hint**: the CLI builds for your host architecture (so an ARM Mac builds `linux/arm64`, an Intel machine builds `linux/amd64`).
+
+You only need to specify a platform explicitly to override the inference — for example, building an amd64 image on an ARM Mac for sharing with a colleague:
 
 ```bash
-rise build myapp:latest --platform linux/arm64
+rise build myapp:latest --platform linux/amd64
 ```
 
 Or in `rise.toml`:
 
 ```toml
 [build]
-platform = "linux/arm64"
+platform = "linux/amd64"
 ```
 
 Or via environment variable:
 
 ```bash
-RISE_PLATFORM=linux/arm64 rise build myapp:latest
+RISE_PLATFORM=linux/amd64 rise build myapp:latest
 ```
 
-Precedence: `--platform` flag > `RISE_PLATFORM` env var > `rise.toml` > default (`linux/amd64`).
+Precedence (highest to lowest): `--platform` flag → `RISE_PLATFORM` env var → `rise.toml` → backend-advertised target → host architecture.
+
+When the platform is inferred rather than explicitly set, the CLI prints a one-line notice so the choice isn't silent.
 
 ## SSL and Proxy
 

--- a/src/build/method.rs
+++ b/src/build/method.rs
@@ -80,7 +80,8 @@ pub struct BuildArgs {
     pub no_cache: bool,
 
     /// Target platform for the container image build (e.g., linux/amd64, linux/arm64).
-    /// Defaults to linux/amd64 for Rise server compatibility.
+    /// When unset, falls back to the backend-advertised cluster arch (during
+    /// `rise deploy`) or the host architecture.
     #[arg(long)]
     pub platform: Option<String>,
 }
@@ -116,6 +117,9 @@ pub(crate) struct BuildOptions {
     pub no_cache: bool,
     /// Target platform (e.g., "linux/amd64")
     pub platform: String,
+    /// Where `platform` was sourced from (CLI / env / rise.toml / backend / host).
+    /// Lets callers report or react to the precedence level that won.
+    pub platform_source: crate::build::PlatformSource,
 }
 
 impl BuildOptions {
@@ -130,12 +134,17 @@ impl BuildOptions {
     ///
     /// When `preloaded_config` is provided, its `.build` section is used instead
     /// of loading rise.toml from disk, avoiding duplicate file reads/warnings.
+    ///
+    /// `backend_platform_hint` is the `target_platform` advertised by the
+    /// backend (from the registry-credentials response); it sits below
+    /// rise.toml in precedence but above the host-arch fallback.
     pub(crate) fn from_build_args(
         config: &Config,
         image_tag: String,
         app_path: String,
         build_args: &BuildArgs,
         preloaded_config: Option<crate::build::config::ProjectBuildConfig>,
+        backend_platform_hint: Option<&str>,
     ) -> Self {
         use tracing::warn;
 
@@ -154,6 +163,17 @@ impl BuildOptions {
                 }
             }
         };
+
+        // Read RISE_PLATFORM exactly once here (instead of inside
+        // resolve_platform) and pass it explicitly. Keeps resolve_platform
+        // pure / unit-testable without touching process-global env.
+        let env_platform = crate::build::env_var_non_empty("RISE_PLATFORM");
+        let (platform, platform_source) = crate::build::resolve_platform(
+            build_args.platform.as_deref(),
+            env_platform.as_deref(),
+            project_config.as_ref().and_then(|c| c.platform.as_deref()),
+            backend_platform_hint,
+        );
 
         // Merge: CLI > Project > Environment (via Config) > Global (via Config) > Defaults
         Self {
@@ -252,12 +272,8 @@ impl BuildOptions {
                     .and_then(|c| c.no_cache)
                     .unwrap_or(false),
 
-            platform: build_args
-                .platform
-                .clone()
-                .or_else(|| crate::build::env_var_non_empty("RISE_PLATFORM"))
-                .or_else(|| project_config.as_ref().and_then(|c| c.platform.clone()))
-                .unwrap_or_else(|| crate::build::DEFAULT_PLATFORM.to_string()),
+            platform,
+            platform_source,
 
             push: false,
         }

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -15,10 +15,69 @@ mod railpack;
 mod registry;
 mod ssl;
 
-/// Default target platform for container image builds.
-/// Rise server nodes run linux/amd64, so this is the default for compatibility.
-/// Users can override with `--platform`, `RISE_PLATFORM`, or `[build] platform` in rise.toml.
-pub const DEFAULT_PLATFORM: &str = "linux/amd64";
+/// Fallback target platform when nothing more specific (CLI flag, env var,
+/// rise.toml, backend hint) is provided. We default to the host architecture
+/// so local dev (e.g. ARM Mac + ARM minikube) just works; production deploys
+/// override via the backend's `target_platform` hint.
+pub fn host_platform() -> String {
+    let arch = match std::env::consts::ARCH {
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        // Pass through other arches verbatim (e.g. "s390x", "riscv64") —
+        // OCI platform strings happen to match Rust's arch names for these.
+        other => other,
+    };
+    format!("linux/{arch}")
+}
+
+/// Where the resolved build platform value originated from.
+///
+/// Returned alongside the platform string by [`resolve_platform`] so callers
+/// can report or react to the precedence level that was selected (e.g. log
+/// "using host arch" vs. "using backend hint").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlatformSource {
+    /// From the `--platform` CLI flag.
+    CliFlag,
+    /// From the `RISE_PLATFORM` environment variable.
+    EnvVar,
+    /// From `[build].platform` in rise.toml.
+    RiseToml,
+    /// From the backend-advertised `target_platform` hint.
+    BackendHint,
+    /// Fell through to `host_platform()` / `std::env::consts::ARCH`.
+    HostFallback,
+}
+
+/// Resolve the build platform from the standard precedence chain:
+/// CLI flag → `RISE_PLATFORM` → rise.toml `[build].platform` →
+/// backend-advertised hint → host architecture.
+///
+/// All inputs are passed in explicitly — this function never reads process
+/// state (env, files) of its own. That keeps it pure and trivially testable
+/// without `std::env::set_var` racing against parallel tests. Callers are
+/// responsible for reading `RISE_PLATFORM` (typically via
+/// [`env_var_non_empty`]) and passing it as `env`.
+pub fn resolve_platform(
+    cli: Option<&str>,
+    env: Option<&str>,
+    project: Option<&str>,
+    backend_hint: Option<&str>,
+) -> (String, PlatformSource) {
+    if let Some(v) = cli {
+        return (v.to_string(), PlatformSource::CliFlag);
+    }
+    if let Some(v) = env {
+        return (v.to_string(), PlatformSource::EnvVar);
+    }
+    if let Some(v) = project {
+        return (v.to_string(), PlatformSource::RiseToml);
+    }
+    if let Some(v) = backend_hint {
+        return (v.to_string(), PlatformSource::BackendHint);
+    }
+    (host_platform(), PlatformSource::HostFallback)
+}
 
 pub use method::BuildArgs;
 pub(crate) use method::{BuildMethod, BuildOptions};
@@ -361,5 +420,68 @@ mod tests {
             Some("   ".to_string())
         );
         std::env::remove_var("TEST_WHITESPACE_VAR");
+    }
+
+    #[test]
+    fn test_host_platform_format() {
+        // Whatever the host arch, we always produce a "linux/<arch>" string.
+        let p = host_platform();
+        assert!(
+            p.starts_with("linux/") && p.len() > "linux/".len(),
+            "host_platform produced unexpected value: {p:?}"
+        );
+    }
+
+    #[test]
+    fn test_resolve_platform_cli_wins() {
+        // CLI flag wins over env, project, and backend hint.
+        let (value, source) = resolve_platform(
+            Some("linux/cli-wins"),
+            Some("linux/env"),
+            Some("linux/project"),
+            Some("linux/backend"),
+        );
+        assert_eq!(value, "linux/cli-wins");
+        assert_eq!(source, PlatformSource::CliFlag);
+    }
+
+    #[test]
+    fn test_resolve_platform_env_over_project_and_backend() {
+        // With no CLI flag, RISE_PLATFORM (passed in as `env`) outranks
+        // rise.toml and the backend hint. Previously hidden behind a
+        // process-global env mutation; now exercised purely via params.
+        let (value, source) = resolve_platform(
+            None,
+            Some("linux/env-wins"),
+            Some("linux/project"),
+            Some("linux/backend"),
+        );
+        assert_eq!(value, "linux/env-wins");
+        assert_eq!(source, PlatformSource::EnvVar);
+    }
+
+    #[test]
+    fn test_resolve_platform_project_over_backend() {
+        // With no CLI flag and no env, rise.toml outranks the backend hint.
+        let (value, source) =
+            resolve_platform(None, None, Some("linux/project"), Some("linux/backend"));
+        assert_eq!(value, "linux/project");
+        assert_eq!(source, PlatformSource::RiseToml);
+    }
+
+    #[test]
+    fn test_resolve_platform_backend_over_host() {
+        // With no user signal, the backend hint beats host arch fallback.
+        let (value, source) = resolve_platform(None, None, None, Some("linux/backend-arch"));
+        assert_eq!(value, "linux/backend-arch");
+        assert_eq!(source, PlatformSource::BackendHint);
+    }
+
+    #[test]
+    fn test_resolve_platform_host_fallback() {
+        // All inputs None → host architecture, marked as HostFallback.
+        let (value, source) = resolve_platform(None, None, None, None);
+        assert_eq!(value, host_platform());
+        assert_eq!(source, PlatformSource::HostFallback);
     }
 }

--- a/src/cli/deployment/core.rs
+++ b/src/cli/deployment/core.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use std::time::Duration;
 use tracing::{debug, info, warn};
 
-use crate::build::{self, BuildOptions};
+use crate::build::{self, BuildOptions, PlatformSource};
 use crate::config::Config;
 
 // Re-export models from API module (always available)
@@ -429,6 +429,31 @@ struct GetRegistryCredsResponse {
     credentials: RegistryCredentials,
     #[allow(dead_code)]
     repository: String,
+    /// Backend-advertised container platform for the target cluster (e.g.
+    /// "linux/amd64"). Absent when the backend doesn't pin a node arch — CLI
+    /// then falls back to the host architecture.
+    #[serde(default)]
+    target_platform: Option<String>,
+}
+
+/// Registry credentials plus the backend-advertised target platform.
+struct DeploymentRegistryInfo {
+    credentials: RegistryCredentials,
+    target_platform: Option<String>,
+}
+
+/// Log the resolved build platform and the source it was inferred from, so the
+/// choice isn't silent when Rise infers it. Explicit user choices (CLI flag,
+/// env var, rise.toml) stay quiet — the user already knows what they asked for.
+fn log_platform_choice(platform: &str, source: PlatformSource, operation: &str) {
+    use crate::build::PlatformSource::*;
+    match source {
+        CliFlag | EnvVar | RiseToml => {} // explicit user choice, stay silent
+        BackendHint => info!("{operation} for {platform} (target cluster architecture)"),
+        HostFallback => {
+            info!("{operation} for {platform} (host architecture; pass --platform to override)")
+        }
+    }
 }
 
 /// Fetch registry push credentials scoped to a specific deployment.
@@ -438,7 +463,7 @@ async fn fetch_deployment_registry_credentials(
     token: &str,
     project_name: &str,
     deployment_id: &str,
-) -> Result<RegistryCredentials> {
+) -> Result<DeploymentRegistryInfo> {
     let url = format!(
         "{}/api/v1/projects/{}/deployments/{}/registry-credentials",
         backend_url, project_name, deployment_id
@@ -469,7 +494,10 @@ async fn fetch_deployment_registry_credentials(
         .await
         .context("Failed to parse registry credentials response")?;
 
-    Ok(resp.credentials)
+    Ok(DeploymentRegistryInfo {
+        credentials: resp.credentials,
+        target_platform: resp.target_platform,
+    })
 }
 
 /// A runtime environment variable override for a deployment
@@ -660,7 +688,7 @@ pub async fn create_deployment(
             };
 
             // Fetch deployment-scoped registry credentials
-            let credentials = fetch_deployment_registry_credentials(
+            let registry_info = fetch_deployment_registry_credentials(
                 http_client,
                 backend_url,
                 &token,
@@ -668,25 +696,34 @@ pub async fn create_deployment(
                 &deployment_info.deployment_id,
             )
             .await?;
+            let credentials = &registry_info.credentials;
 
             login_to_registry(
                 http_client,
                 backend_url,
                 &token,
                 &container_cli,
-                &credentials,
+                credentials,
                 deploy_opts.project_name,
                 &deployment_info.deployment_id,
             )
             .await?;
 
-            // Pull the source image for the configured platform
-            let platform = deploy_opts
-                .build_args
-                .platform
-                .as_deref()
-                .unwrap_or(build::DEFAULT_PLATFORM);
-            if let Err(e) = build::docker_pull(&container_cli, source_image, platform) {
+            // Pull the source image for the configured platform.
+            let toml_platform = deploy_opts
+                .toml_config
+                .as_ref()
+                .and_then(|c| c.build.as_ref())
+                .and_then(|b| b.platform.as_deref());
+            let env = build::env_var_non_empty("RISE_PLATFORM");
+            let (platform, source) = build::resolve_platform(
+                deploy_opts.build_args.platform.as_deref(),
+                env.as_deref(),
+                toml_platform,
+                registry_info.target_platform.as_deref(),
+            );
+            log_platform_choice(&platform, source, "Pulling");
+            if let Err(e) = build::docker_pull(&container_cli, source_image, &platform) {
                 update_deployment_status(
                     http_client,
                     backend_url,
@@ -776,17 +813,11 @@ pub async fn create_deployment(
             }
         );
     } else {
-        // Build from source path: Execute build and push
-        let options = BuildOptions::from_build_args(
-            config,
-            deployment_info.image_tag.clone(),
-            deploy_opts.path.to_string(),
-            deploy_opts.build_args,
-            deploy_opts.toml_config,
-        );
-
-        // Step 2: Fetch deployment-scoped registry credentials and login
-        let credentials = fetch_deployment_registry_credentials(
+        // Build from source path: Execute build and push.
+        //
+        // Fetch credentials first so the backend's target_platform hint can
+        // feed into BuildOptions' platform precedence.
+        let registry_info = fetch_deployment_registry_credentials(
             http_client,
             backend_url,
             &token,
@@ -795,12 +826,22 @@ pub async fn create_deployment(
         )
         .await?;
 
+        let options = BuildOptions::from_build_args(
+            config,
+            deployment_info.image_tag.clone(),
+            deploy_opts.path.to_string(),
+            deploy_opts.build_args,
+            deploy_opts.toml_config,
+            registry_info.target_platform.as_deref(),
+        );
+        log_platform_choice(&options.platform, options.platform_source, "Building");
+
         login_to_registry(
             http_client,
             backend_url,
             &token,
             options.container_cli.command(),
-            &credentials,
+            &registry_info.credentials,
             deploy_opts.project_name,
             &deployment_info.deployment_id,
         )

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -47,6 +47,7 @@ pub async fn run_locally(
         options.path.to_string(),
         options.build_args,
         None,
+        None,
     )
     .with_push(false); // Never push local dev images
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1825,6 +1825,7 @@ async fn main() -> Result<()> {
                 path.clone(),
                 build_args,
                 None,
+                None,
             )
             .with_push(*push);
 

--- a/src/server/registry/handlers.rs
+++ b/src/server/registry/handlers.rs
@@ -90,8 +90,18 @@ pub async fn get_deployment_registry_credentials(
                 .with_context("repository", &repository)
         })?;
 
+    // If the controller pins `kubernetes.io/arch`, surface it so the CLI can
+    // build a matching image. Unset means "no constraint" — CLI falls back to
+    // host architecture, which is the right default for local-dev clusters.
+    let target_platform = state
+        .resource_builder
+        .as_ref()
+        .and_then(|rb| rb.node_selector.get("kubernetes.io/arch"))
+        .map(|arch| format!("linux/{arch}"));
+
     Ok(Json(GetRegistryCredsResponse {
         credentials,
         repository,
+        target_platform,
     }))
 }

--- a/src/server/registry/models.rs
+++ b/src/server/registry/models.rs
@@ -36,6 +36,12 @@ pub struct RegistryCredentials {
 pub struct GetRegistryCredsResponse {
     pub credentials: RegistryCredentials,
     pub repository: String,
+    /// Container platform the target cluster will accept (e.g. "linux/amd64").
+    /// Populated from the controller's `node_selector["kubernetes.io/arch"]`
+    /// when pinned; absent when the cluster is unconstrained, letting the CLI
+    /// fall back to host architecture.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_platform: Option<String>,
 }
 
 /// Configuration for AWS ECR registry


### PR DESCRIPTION
## Summary

- **CLI default → host architecture**: replaces the hardcoded `linux/amd64` with a `host_platform()` fallback (`aarch64` → `linux/arm64`, `x86_64` → `linux/amd64`). ARM-Mac devs no longer need to remember `--platform`.
- **Backend hint via registry-creds**: the existing `GET /api/v1/projects/{p}/deployments/{id}/registry-credentials` response now includes an optional `target_platform: Option<String>`, populated from the deployment controller's `node_selector["kubernetes.io/arch"]`. Production deploys still build amd64 because the prod controller pins it.
- **`config/development.yaml` ships with `node_selector: {}`**: local backend advertises no platform → CLI falls back to host arch → "just works" out of the box on both Intel and ARM Macs.

Precedence: `--platform` → `RISE_PLATFORM` → `rise.toml [build].platform` → backend hint → host arch. Old CLI/backend pairs stay compatible (`#[serde(default)]` on the new field; old CLI keeps its `linux/amd64` default).

When the platform is inferred (no user override), the CLI prints a one-line notice so the choice isn't silent.

## Test plan

- [x] `cargo test --all-features` (446 + 5 new tests, all pass)
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `mise run config:schema:check`
- [ ] End-to-end on ARM Mac: clean clone → `mise setup minikube` → `rise deploy` builds `linux/arm64` with no flags, pod runs
- [ ] End-to-end on Intel Mac: same flow, builds `linux/amd64`
- [ ] Verify prod-style backend with pinned `node_selector` still drives CLI to amd64 from an ARM Mac
- [ ] Verify explicit `--platform linux/amd64` override is silent and wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)
