### PR TITLE
Gate fixed-cadence leader loops on a global schedule

### DIFF
--- a/.sqlx/query-258e0d919ebd4241359acf92ecabd6025cb17299f9ac8c97c8bb431fb58c395f.json
+++ b/.sqlx/query-258e0d919ebd4241359acf92ecabd6025cb17299f9ac8c97c8bb431fb58c395f.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO leader_schedules (name, last_run_at)\n             VALUES ($1, NOW())\n             ON CONFLICT (name) DO UPDATE\n               SET last_run_at = NOW()\n               WHERE leader_schedules.last_run_at + ($2 * INTERVAL '1 second') <= NOW()\n             RETURNING name",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Float8"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "258e0d919ebd4241359acf92ecabd6025cb17299f9ac8c97c8bb431fb58c395f"
+}

--- a/migrations/20260524000001_leader_schedules.sql
+++ b/migrations/20260524000001_leader_schedules.sql
@@ -1,0 +1,20 @@
+-- Leader schedules: globally-coordinated cadence for interval-based work.
+--
+-- Lease (`leader_leases`) guarantees mutual exclusion — only one replica is
+-- leader at a time. But each replica runs its own `tokio::time::interval`,
+-- anchored to that replica's start time. When leadership transitions, the
+-- new leader's first tick can fire much sooner (or later) than the old
+-- leader's next-scheduled work would have, producing a transient burst.
+--
+-- This table records the last globally-observed run timestamp per schedule
+-- name. Workers gate their work on `last_run_at + interval <= NOW()` via an
+-- atomic UPSERT in `GlobalSchedule::try_claim`, ensuring the new leader's
+-- first run waits the full interval since the previous leader's last run.
+--
+-- Independent from leases: one controller may hold one lease but run several
+-- schedules (e.g. ECR's provision/cleanup/drift loops share a lease but have
+-- different cadences).
+CREATE TABLE leader_schedules (
+    name        VARCHAR(128) PRIMARY KEY,
+    last_run_at TIMESTAMPTZ  NOT NULL
+);

--- a/src/db/leader_schedules.rs
+++ b/src/db/leader_schedules.rs
@@ -16,13 +16,20 @@
 //!
 //! Decoupled from `LeaderElection` on purpose: a single controller may hold
 //! one lease but run several schedules at different cadences (e.g. ECR's
-//! provision/cleanup/drift loops). Callers compose the two:
+//! provision/cleanup/drift loops). Callers compose the two via
+//! [`GlobalSchedule::try_claim_or_skip_as_leader`], which verifies
+//! leadership against the DB (fast-path: cached lease horizon) immediately
+//! before the schedule UPSERT — closing the TOCTOU window where a
+//! stale-cached `is_leader()` could let a non-leader advance `last_run_at`
+//! and stall the true leader for a full interval:
 //!
 //! ```ignore
 //! loop {
 //!     ticker.tick().await;
 //!     if !election.is_leader() { continue; }
-//!     if !schedule.try_claim().await? { continue; }
+//!     if !schedule.try_claim_or_skip_as_leader("my work", &election).await {
+//!         continue;
+//!     }
 //!     do_work().await;
 //! }
 //! ```
@@ -30,6 +37,8 @@
 use std::time::Duration;
 
 use sqlx::PgPool;
+
+use crate::db::leader_leases::{LeaderElection, LeaderStatus, LeaseError};
 
 /// Per-task globally-coordinated cadence gate. Cheap to clone (`PgPool` is
 /// reference-counted, `name` is owned). Construct one per loop.
@@ -90,6 +99,12 @@ impl GlobalSchedule {
     /// work now, `false` if it should skip this tick. Used by interval
     /// loops where the response is uniform across all three branches
     /// (claimed / not-yet-due / DB error → skip with appropriate log).
+    ///
+    /// Does not check leadership. Prefer
+    /// [`Self::try_claim_or_skip_as_leader`] in loops gated by a
+    /// `LeaderElection` — it closes the TOCTOU window where a stale-cached
+    /// `is_leader()` could let a non-leader advance `last_run_at` and stall
+    /// the true leader for a full interval.
     pub async fn try_claim_or_skip(&self, context: &str) -> bool {
         match self.try_claim().await {
             Ok(true) => true,
@@ -109,6 +124,55 @@ impl GlobalSchedule {
                 false
             }
         }
+    }
+
+    /// Like [`Self::try_claim_or_skip`], but first verifies leadership
+    /// against the DB via [`LeaderElection::ensure_leader_for`] with a zero
+    /// validity window. On the steady-state fast path (cached lease horizon
+    /// still in the future) this costs no DB round-trip — only when the
+    /// horizon has decayed does it fall back to a `verify_leader` query.
+    ///
+    /// Required when composing with `LeaderElection`: gating only on
+    /// `is_leader()` (atomic flag, can be briefly stale during a leadership
+    /// handover) lets a non-leader's claim succeed, advancing
+    /// `last_run_at` and delaying the true leader's next run by up to one
+    /// full interval. `ensure_leader_for` reads the horizon published only
+    /// after a DB-confirmed acquire/renew, so it cannot return `Leader`
+    /// for a holder that has actually lost the lease.
+    pub async fn try_claim_or_skip_as_leader(
+        &self,
+        context: &str,
+        election: &LeaderElection,
+    ) -> bool {
+        match election.ensure_leader_for(Duration::ZERO).await {
+            Ok(LeaderStatus::Leader) => {}
+            Ok(LeaderStatus::NotLeader) => {
+                tracing::debug!(
+                    schedule = %self.name,
+                    "{context} leadership lost before claim; skipping tick"
+                );
+                return false;
+            }
+            Err(LeaseError::Db(e)) => {
+                tracing::warn!(
+                    schedule = %self.name,
+                    error = ?e,
+                    "{context} leadership verification failed; skipping tick"
+                );
+                return false;
+            }
+            Err(e @ LeaseError::InvalidMinValidity { .. }) => {
+                // Unreachable: Duration::ZERO is always within the half-lease
+                // bound. Treat as programmer error and skip defensively.
+                tracing::error!(
+                    schedule = %self.name,
+                    error = ?e,
+                    "{context} ensure_leader_for misconfigured; skipping tick"
+                );
+                return false;
+            }
+        }
+        self.try_claim_or_skip(context).await
     }
 }
 
@@ -159,6 +223,74 @@ mod tests {
         );
         assert!(!a.try_claim().await?);
         assert!(!b.try_claim().await?);
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn as_leader_claims_when_holder(pool: PgPool) -> sqlx::Result<()> {
+        use uuid::Uuid;
+
+        let holder = LeaderElection::spawn(
+            pool.clone(),
+            "rise-test-as-leader-claim",
+            Uuid::new_v4(),
+            Duration::from_millis(1500),
+        );
+        // Wait for the background task to win the election.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while !holder.is_leader() && tokio::time::Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        assert!(holder.is_leader(), "holder should win election");
+
+        let s = GlobalSchedule::new(pool, "test-as-leader-claim", Duration::from_secs(60));
+        assert!(
+            s.try_claim_or_skip_as_leader("test", &holder).await,
+            "leader's first claim must succeed"
+        );
+        assert!(
+            !s.try_claim_or_skip_as_leader("test", &holder).await,
+            "second claim inside the interval must be denied"
+        );
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn as_leader_skips_when_not_holder_and_leaves_schedule_untouched(
+        pool: PgPool,
+    ) -> sqlx::Result<()> {
+        use uuid::Uuid;
+
+        let holder = LeaderElection::spawn(
+            pool.clone(),
+            "rise-test-as-leader-skip",
+            Uuid::new_v4(),
+            Duration::from_millis(1500),
+        );
+        let non_holder = LeaderElection::spawn(
+            pool.clone(),
+            "rise-test-as-leader-skip",
+            Uuid::new_v4(),
+            Duration::from_millis(1500),
+        );
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while !holder.is_leader() && tokio::time::Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        assert!(holder.is_leader(), "holder should win election");
+        assert!(!non_holder.is_leader(), "non-holder should not be leader");
+
+        let s = GlobalSchedule::new(pool, "test-as-leader-skip", Duration::from_secs(60));
+        assert!(
+            !s.try_claim_or_skip_as_leader("test", &non_holder).await,
+            "non-holder must not claim"
+        );
+        // Critical: the non-holder's failed attempt must not have written the
+        // schedule row. The true holder's next claim should still succeed.
+        assert!(
+            s.try_claim_or_skip_as_leader("test", &holder).await,
+            "holder's claim must succeed after non-holder was skipped"
+        );
         Ok(())
     }
 

--- a/src/db/leader_schedules.rs
+++ b/src/db/leader_schedules.rs
@@ -68,10 +68,11 @@ impl GlobalSchedule {
     /// Returns `Ok(false)` if the interval has not yet elapsed. The caller
     /// should skip this tick and try again on the next one.
     ///
-    /// This method does not check leadership — callers must already be the
-    /// leader for the corresponding `LeaderElection` before invoking it.
-    /// Composing the two gates (`is_leader()` + `try_claim()`) is the
-    /// expected pattern.
+    /// This method does not check leadership. When composing with a
+    /// `LeaderElection`, prefer [`Self::try_claim_or_skip_as_leader`] over
+    /// gating on `is_leader()` alone — the atomic flag can be briefly stale
+    /// during a leadership handover, letting a non-leader's claim succeed,
+    /// advance `last_run_at`, and stall the true leader for a full interval.
     pub async fn try_claim(&self) -> Result<bool, sqlx::Error> {
         let interval_secs = self.interval.as_secs_f64();
         // First run for an unseen schedule name inserts a row with
@@ -79,16 +80,16 @@ impl GlobalSchedule {
         // through `ON CONFLICT DO UPDATE`, gated by the `WHERE` clause: if
         // the interval has not elapsed, no row is updated and `RETURNING`
         // yields nothing.
-        let row: Option<(String,)> = sqlx::query_as(
+        let row = sqlx::query_scalar!(
             "INSERT INTO leader_schedules (name, last_run_at)
              VALUES ($1, NOW())
              ON CONFLICT (name) DO UPDATE
                SET last_run_at = NOW()
                WHERE leader_schedules.last_run_at + ($2 * INTERVAL '1 second') <= NOW()
              RETURNING name",
+            &self.name,
+            interval_secs,
         )
-        .bind(&self.name)
-        .bind(interval_secs)
         .fetch_optional(&self.pool)
         .await?;
         Ok(row.is_some())

--- a/src/db/leader_schedules.rs
+++ b/src/db/leader_schedules.rs
@@ -164,14 +164,31 @@ mod tests {
 
     #[sqlx::test]
     async fn concurrent_callers_only_one_wins(pool: PgPool) -> sqlx::Result<()> {
-        // Simulates a split-brain transient where two replicas both try to
-        // claim the slot simultaneously. The atomic UPSERT must serialize
-        // so exactly one wins.
-        let s1 = GlobalSchedule::new(pool.clone(), "test-race", Duration::from_secs(60));
-        let s2 = GlobalSchedule::new(pool, "test-race", Duration::from_secs(60));
+        // Simulates a split-brain transient where N replicas all try to
+        // claim the slot simultaneously. Each claimer runs on its own task
+        // and waits on a barrier so they all hit the DB at ~the same instant;
+        // the atomic UPSERT must serialize so exactly one wins.
+        use std::sync::Arc;
+        use tokio::sync::Barrier;
 
-        let (a, b) = tokio::join!(s1.try_claim(), s2.try_claim());
-        let wins = [a?, b?].iter().filter(|w| **w).count();
+        const N: usize = 8;
+        let barrier = Arc::new(Barrier::new(N));
+        let mut handles = Vec::with_capacity(N);
+        for _ in 0..N {
+            let s = GlobalSchedule::new(pool.clone(), "test-race", Duration::from_secs(60));
+            let barrier = barrier.clone();
+            handles.push(tokio::spawn(async move {
+                barrier.wait().await;
+                s.try_claim().await
+            }));
+        }
+
+        let mut wins = 0;
+        for h in handles {
+            if h.await.expect("task panicked")? {
+                wins += 1;
+            }
+        }
         assert_eq!(wins, 1, "exactly one concurrent claimer must win");
         Ok(())
     }

--- a/src/db/leader_schedules.rs
+++ b/src/db/leader_schedules.rs
@@ -1,0 +1,178 @@
+//! Globally-coordinated cadence for interval-based work running under a
+//! leader lease.
+//!
+//! `LeaderElection` guarantees mutual exclusion (only one replica is leader
+//! at a time), but each replica still runs its own `tokio::time::interval`
+//! anchored to its own start time. At a leadership transition the new
+//! leader's ticker can fire far sooner than the previous leader's next
+//! scheduled run, producing a transient burst — e.g. old leader sweeps at
+//! t=70 and dies; new leader's ticker fires at t=73, so two sweeps happen
+//! 3s apart when the configured interval is 10s.
+//!
+//! `GlobalSchedule::try_claim` closes that gap with a single atomic UPSERT
+//! against `leader_schedules` keyed by schedule name. The next slot is
+//! granted only when `last_run_at + interval <= NOW()`, so the new leader's
+//! first run waits the full interval since the previous leader's last run.
+//!
+//! Decoupled from `LeaderElection` on purpose: a single controller may hold
+//! one lease but run several schedules at different cadences (e.g. ECR's
+//! provision/cleanup/drift loops). Callers compose the two:
+//!
+//! ```ignore
+//! loop {
+//!     ticker.tick().await;
+//!     if !election.is_leader() { continue; }
+//!     if !schedule.try_claim().await? { continue; }
+//!     do_work().await;
+//! }
+//! ```
+
+use std::time::Duration;
+
+use sqlx::PgPool;
+
+/// Per-task globally-coordinated cadence gate. Cheap to clone (`PgPool` is
+/// reference-counted, `name` is owned). Construct one per loop.
+#[derive(Clone, Debug)]
+pub struct GlobalSchedule {
+    pool: PgPool,
+    name: String,
+    interval: Duration,
+}
+
+impl GlobalSchedule {
+    pub fn new(pool: PgPool, name: impl Into<String>, interval: Duration) -> Self {
+        Self {
+            pool,
+            name: name.into(),
+            interval,
+        }
+    }
+
+    /// Try to claim the next run slot.
+    ///
+    /// Returns `Ok(true)` if at least `interval` has elapsed since the last
+    /// globally-recorded run for this schedule name — `last_run_at` is
+    /// updated to `NOW()` in the same statement, fencing other callers
+    /// (across replicas) from claiming the same slot.
+    ///
+    /// Returns `Ok(false)` if the interval has not yet elapsed. The caller
+    /// should skip this tick and try again on the next one.
+    ///
+    /// This method does not check leadership — callers must already be the
+    /// leader for the corresponding `LeaderElection` before invoking it.
+    /// Composing the two gates (`is_leader()` + `try_claim()`) is the
+    /// expected pattern.
+    pub async fn try_claim(&self) -> Result<bool, sqlx::Error> {
+        let interval_secs = self.interval.as_secs_f64();
+        // First run for an unseen schedule name inserts a row with
+        // `last_run_at = NOW()` and the slot is granted. Subsequent runs go
+        // through `ON CONFLICT DO UPDATE`, gated by the `WHERE` clause: if
+        // the interval has not elapsed, no row is updated and `RETURNING`
+        // yields nothing.
+        let row: Option<(String,)> = sqlx::query_as(
+            "INSERT INTO leader_schedules (name, last_run_at)
+             VALUES ($1, NOW())
+             ON CONFLICT (name) DO UPDATE
+               SET last_run_at = NOW()
+               WHERE leader_schedules.last_run_at + ($2 * INTERVAL '1 second') <= NOW()
+             RETURNING name",
+        )
+        .bind(&self.name)
+        .bind(interval_secs)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.is_some())
+    }
+
+    /// Convenience wrapper around [`Self::try_claim`] that logs the outcome
+    /// and returns `bool` directly — `true` if the caller should run the
+    /// work now, `false` if it should skip this tick. Used by interval
+    /// loops where the response is uniform across all three branches
+    /// (claimed / not-yet-due / DB error → skip with appropriate log).
+    pub async fn try_claim_or_skip(&self, context: &str) -> bool {
+        match self.try_claim().await {
+            Ok(true) => true,
+            Ok(false) => {
+                tracing::debug!(
+                    schedule = %self.name,
+                    "{context} slot not yet due globally; skipping tick"
+                );
+                false
+            }
+            Err(e) => {
+                tracing::warn!(
+                    schedule = %self.name,
+                    error = ?e,
+                    "{context} schedule claim failed; skipping tick"
+                );
+                false
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[sqlx::test]
+    async fn first_call_claims_slot(pool: PgPool) -> sqlx::Result<()> {
+        let s = GlobalSchedule::new(pool, "test-first", Duration::from_secs(10));
+        assert!(s.try_claim().await?, "first call must claim the slot");
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn second_call_within_interval_is_denied(pool: PgPool) -> sqlx::Result<()> {
+        let s = GlobalSchedule::new(pool, "test-deny", Duration::from_secs(60));
+        assert!(s.try_claim().await?);
+        assert!(
+            !s.try_claim().await?,
+            "second call inside the interval must be denied"
+        );
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn call_after_interval_elapses_is_granted(pool: PgPool) -> sqlx::Result<()> {
+        // Shortest interval that's still robust under CI clock jitter: 1s.
+        let s = GlobalSchedule::new(pool, "test-elapse", Duration::from_secs(1));
+        assert!(s.try_claim().await?);
+        assert!(!s.try_claim().await?, "still inside the interval");
+        tokio::time::sleep(Duration::from_millis(1100)).await;
+        assert!(
+            s.try_claim().await?,
+            "call after interval elapses must be granted"
+        );
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn different_names_are_independent(pool: PgPool) -> sqlx::Result<()> {
+        let a = GlobalSchedule::new(pool.clone(), "test-a", Duration::from_secs(60));
+        let b = GlobalSchedule::new(pool, "test-b", Duration::from_secs(60));
+        assert!(a.try_claim().await?);
+        assert!(
+            b.try_claim().await?,
+            "claiming one schedule must not affect another"
+        );
+        assert!(!a.try_claim().await?);
+        assert!(!b.try_claim().await?);
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn concurrent_callers_only_one_wins(pool: PgPool) -> sqlx::Result<()> {
+        // Simulates a split-brain transient where two replicas both try to
+        // claim the slot simultaneously. The atomic UPSERT must serialize
+        // so exactly one wins.
+        let s1 = GlobalSchedule::new(pool.clone(), "test-race", Duration::from_secs(60));
+        let s2 = GlobalSchedule::new(pool, "test-race", Duration::from_secs(60));
+
+        let (a, b) = tokio::join!(s1.try_claim(), s2.try_claim());
+        let wins = [a?, b?].iter().filter(|w| **w).count();
+        assert_eq!(wins, 1, "exactly one concurrent claimer must win");
+        Ok(())
+    }
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -4,6 +4,7 @@ pub mod env_vars;
 pub mod environments;
 pub mod extensions;
 pub mod leader_leases;
+pub mod leader_schedules;
 pub mod models;
 pub mod oauth_transient_state;
 pub mod postgres_admin;

--- a/src/server/auth/entra_sync.rs
+++ b/src/server/auth/entra_sync.rs
@@ -618,7 +618,13 @@ pub async fn run_entra_sync_loop(
         // Global cadence gate: see `GlobalSchedule` docs. Long sync intervals
         // (often 1h+) make leader-transition bursts much more visible than
         // for short-cadence workers, so this matters especially here.
-        if !schedule.try_claim_or_skip("Entra sync").await {
+        // `_as_leader` re-verifies leadership against the DB before the
+        // schedule UPSERT, so a stale-cached non-leader cannot poison
+        // `last_run_at` and delay the true leader by the full interval.
+        if !schedule
+            .try_claim_or_skip_as_leader("Entra sync", &election)
+            .await
+        {
             continue;
         }
 

--- a/src/server/auth/entra_sync.rs
+++ b/src/server/auth/entra_sync.rs
@@ -27,6 +27,7 @@ use std::time::Duration;
 use uuid::Uuid;
 
 use crate::db::leader_leases::LeaderElection;
+use crate::db::leader_schedules::GlobalSchedule;
 use crate::db::{models::TeamRole, teams, users};
 
 // ============================================================================
@@ -594,6 +595,11 @@ pub async fn run_entra_sync_loop(
         Uuid::new_v4(),
         Duration::from_secs(interval_secs + 30),
     );
+    let schedule = GlobalSchedule::new(
+        pool.clone(),
+        "rise-entra-sync",
+        Duration::from_secs(interval_secs),
+    );
 
     loop {
         tokio::select! {
@@ -606,6 +612,13 @@ pub async fn run_entra_sync_loop(
 
         if !election.is_leader() {
             tracing::debug!("Skipping Entra sync cycle — another replica is the leader");
+            continue;
+        }
+
+        // Global cadence gate: see `GlobalSchedule` docs. Long sync intervals
+        // (often 1h+) make leader-transition bursts much more visible than
+        // for short-cadence workers, so this matters especially here.
+        if !schedule.try_claim_or_skip("Entra sync").await {
             continue;
         }
 

--- a/src/server/auth/entra_sync.rs
+++ b/src/server/auth/entra_sync.rs
@@ -597,7 +597,7 @@ pub async fn run_entra_sync_loop(
     );
     let schedule = GlobalSchedule::new(
         pool.clone(),
-        "rise-entra-sync",
+        "rise-entra-sync-cycle",
         Duration::from_secs(interval_secs),
     );
 

--- a/src/server/ecr/controller.rs
+++ b/src/server/ecr/controller.rs
@@ -109,7 +109,7 @@ impl EcrController {
 
             if !self
                 .provision_schedule
-                .try_claim_or_skip("ECR provision")
+                .try_claim_or_skip_as_leader("ECR provision", &self.election)
                 .await
             {
                 continue;
@@ -182,7 +182,11 @@ impl EcrController {
                 continue;
             }
 
-            if !self.cleanup_schedule.try_claim_or_skip("ECR cleanup").await {
+            if !self
+                .cleanup_schedule
+                .try_claim_or_skip_as_leader("ECR cleanup", &self.election)
+                .await
+            {
                 continue;
             }
 
@@ -281,7 +285,11 @@ impl EcrController {
                 continue;
             }
 
-            if !self.drift_schedule.try_claim_or_skip("ECR drift").await {
+            if !self
+                .drift_schedule
+                .try_claim_or_skip_as_leader("ECR drift", &self.election)
+                .await
+            {
                 continue;
             }
 

--- a/src/server/ecr/controller.rs
+++ b/src/server/ecr/controller.rs
@@ -5,6 +5,7 @@ use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use crate::db::leader_leases::LeaderElection;
+use crate::db::leader_schedules::GlobalSchedule;
 use crate::db::projects as db_projects;
 use crate::server::ecr::{EcrRepoManager, ECR_FINALIZER};
 use crate::server::state::ControllerState;
@@ -28,24 +29,46 @@ pub struct EcrController {
     provision_interval: Duration,
     cleanup_interval: Duration,
     drift_interval: Duration,
+    provision_schedule: GlobalSchedule,
+    cleanup_schedule: GlobalSchedule,
+    drift_schedule: GlobalSchedule,
 }
 
 impl EcrController {
     /// Create a new ECR controller
     pub fn new(state: Arc<ControllerState>, manager: Arc<EcrRepoManager>) -> Self {
+        let provision_interval = Duration::from_secs(10);
+        let cleanup_interval = Duration::from_secs(5);
+        let drift_interval = Duration::from_secs(60);
         let election = LeaderElection::spawn(
             state.db_pool.clone(),
             "rise-ecr-controller",
             Uuid::new_v4(),
             Duration::from_secs(60),
         );
+        // One schedule per loop: the three loops share a lease but have
+        // independent cadences. The 60s drift schedule is the most
+        // bursting-sensitive — short cadences (5s/10s) make transition
+        // bursts harder to notice but the gate is still cheap.
+        let provision_schedule = GlobalSchedule::new(
+            state.db_pool.clone(),
+            "rise-ecr-provision",
+            provision_interval,
+        );
+        let cleanup_schedule =
+            GlobalSchedule::new(state.db_pool.clone(), "rise-ecr-cleanup", cleanup_interval);
+        let drift_schedule =
+            GlobalSchedule::new(state.db_pool.clone(), "rise-ecr-drift", drift_interval);
         Self {
             state,
             manager,
             election,
-            provision_interval: Duration::from_secs(10),
-            cleanup_interval: Duration::from_secs(5),
-            drift_interval: Duration::from_secs(60),
+            provision_interval,
+            cleanup_interval,
+            drift_interval,
+            provision_schedule,
+            cleanup_schedule,
+            drift_schedule,
         }
     }
 
@@ -81,6 +104,14 @@ impl EcrController {
             ticker.tick().await;
 
             if !self.election.is_leader() {
+                continue;
+            }
+
+            if !self
+                .provision_schedule
+                .try_claim_or_skip("ECR provision")
+                .await
+            {
                 continue;
             }
 
@@ -148,6 +179,10 @@ impl EcrController {
             ticker.tick().await;
 
             if !self.election.is_leader() {
+                continue;
+            }
+
+            if !self.cleanup_schedule.try_claim_or_skip("ECR cleanup").await {
                 continue;
             }
 
@@ -243,6 +278,10 @@ impl EcrController {
             ticker.tick().await;
 
             if !self.election.is_leader() {
+                continue;
+            }
+
+            if !self.drift_schedule.try_claim_or_skip("ECR drift").await {
                 continue;
             }
 

--- a/src/server/project/controller.rs
+++ b/src/server/project/controller.rs
@@ -77,10 +77,12 @@ impl ProjectController {
 
             // Global cadence gate: ensures the new leader's first deletion
             // pass after a transition waits the full interval since the
-            // previous leader's last pass. See `GlobalSchedule` docs.
+            // previous leader's last pass. `_as_leader` re-verifies
+            // leadership against the DB (fast-path on the cached lease
+            // horizon) before the schedule UPSERT — see `GlobalSchedule` docs.
             if !self
                 .deletion_schedule
-                .try_claim_or_skip("project deletion")
+                .try_claim_or_skip_as_leader("project deletion", &self.election)
                 .await
             {
                 continue;

--- a/src/server/project/controller.rs
+++ b/src/server/project/controller.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 use crate::db::models::DeploymentStatus;
 use crate::db::{
     deployments as db_deployments, extensions as db_extensions, leader_leases::LeaderElection,
-    projects as db_projects,
+    leader_schedules::GlobalSchedule, projects as db_projects,
 };
 use crate::server::deployment::state_machine;
 use crate::server::state::ControllerState;
@@ -22,22 +22,30 @@ pub struct ProjectController {
     deletion_interval: Duration,
     cleanup_tick: AtomicU64,
     election: LeaderElection,
+    deletion_schedule: GlobalSchedule,
 }
 
 impl ProjectController {
     /// Create a new project controller
     pub fn new(state: Arc<ControllerState>) -> Self {
+        let deletion_interval = Duration::from_secs(5);
         let election = LeaderElection::spawn(
             state.db_pool.clone(),
             "rise-project-controller",
             Uuid::new_v4(),
             Duration::from_secs(60),
         );
+        let deletion_schedule = GlobalSchedule::new(
+            state.db_pool.clone(),
+            "rise-project-deletion",
+            deletion_interval,
+        );
         Self {
             state,
-            deletion_interval: Duration::from_secs(5),
+            deletion_interval,
             cleanup_tick: AtomicU64::new(1),
             election,
+            deletion_schedule,
         }
     }
 
@@ -64,6 +72,17 @@ impl ProjectController {
             ticker.tick().await;
 
             if !self.election.is_leader() {
+                continue;
+            }
+
+            // Global cadence gate: ensures the new leader's first deletion
+            // pass after a transition waits the full interval since the
+            // previous leader's last pass. See `GlobalSchedule` docs.
+            if !self
+                .deletion_schedule
+                .try_claim_or_skip("project deletion")
+                .await
+            {
                 continue;
             }
 

--- a/src/server/resources/gc.rs
+++ b/src/server/resources/gc.rs
@@ -155,8 +155,15 @@ impl ResourceGcController {
             }
             // Global cadence gate: prevents leader-transition bursts where
             // the new leader's first tick fires sooner than the old leader's
-            // next-scheduled sweep would have.
-            if !self.schedule.try_claim_or_skip("resource GC").await {
+            // next-scheduled sweep would have. `_as_leader` re-verifies
+            // leadership against the DB (fast-path on the cached lease
+            // horizon) before the schedule UPSERT, so a stale-cached
+            // non-leader cannot poison `last_run_at`.
+            if !self
+                .schedule
+                .try_claim_or_skip_as_leader("resource GC", &self.election)
+                .await
+            {
                 continue;
             }
             match self.sweep().await {

--- a/src/server/resources/gc.rs
+++ b/src/server/resources/gc.rs
@@ -53,6 +53,7 @@ use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use crate::db::leader_leases::{LeaderElection, LeaderStatus, LeaseError, LEASE_DURATION};
+use crate::db::leader_schedules::GlobalSchedule;
 use crate::server::settings::ResourceGcSettings;
 
 const ACTOR: &str = "system:resource-gc";
@@ -69,15 +70,23 @@ const PER_ROW_MIN_VALIDITY: Duration = Duration::from_secs(5);
 pub struct ResourceGcController {
     store: Arc<dyn ResourceStore>,
     election: LeaderElection,
+    schedule: GlobalSchedule,
     settings: ResourceGcSettings,
 }
 
 impl ResourceGcController {
     pub fn new(pool: PgPool, store: Arc<dyn ResourceStore>, settings: ResourceGcSettings) -> Self {
-        let election = LeaderElection::spawn(pool, LEASE_NAME, Uuid::new_v4(), LEASE_DURATION);
+        let election =
+            LeaderElection::spawn(pool.clone(), LEASE_NAME, Uuid::new_v4(), LEASE_DURATION);
+        let schedule = GlobalSchedule::new(
+            pool,
+            LEASE_NAME,
+            Duration::from_secs(settings.interval_secs),
+        );
         Self {
             store,
             election,
+            schedule,
             settings,
         }
     }
@@ -141,6 +150,12 @@ impl ResourceGcController {
         loop {
             ticker.tick().await;
             if !self.election.is_leader() {
+                continue;
+            }
+            // Global cadence gate: prevents leader-transition bursts where
+            // the new leader's first tick fires sooner than the old leader's
+            // next-scheduled sweep would have.
+            if !self.schedule.try_claim_or_skip("resource GC").await {
                 continue;
             }
             match self.sweep().await {

--- a/src/server/resources/gc.rs
+++ b/src/server/resources/gc.rs
@@ -58,6 +58,7 @@ use crate::server::settings::ResourceGcSettings;
 
 const ACTOR: &str = "system:resource-gc";
 const LEASE_NAME: &str = "rise-resource-gc";
+const SCHEDULE_NAME: &str = "rise-resource-gc-sweep";
 /// Minimum lease validity required before each destructive `try_collect` call.
 /// Comfortably above the p99 cost of one `try_collect` round-trip with headroom;
 /// well below the `LEASE_DURATION / 2` ceiling enforced by `ensure_leader_for`,
@@ -80,7 +81,7 @@ impl ResourceGcController {
             LeaderElection::spawn(pool.clone(), LEASE_NAME, Uuid::new_v4(), LEASE_DURATION);
         let schedule = GlobalSchedule::new(
             pool,
-            LEASE_NAME,
+            SCHEDULE_NAME,
             Duration::from_secs(settings.interval_secs),
         );
         Self {


### PR DESCRIPTION
## Summary

Follow-up to #317. Each replica's tokio interval ticker is anchored to its own start time, so when leadership transitions the new leader's first tick can fire much sooner than the previous leader's next scheduled run would have. The lease prevents simultaneous execution, but the configured interval still gets effectively bursted across handovers — e.g. old leader sweeps at t=70 and dies; new leader's ticker fires at t=73, two sweeps 3s apart for a 10s configured interval.

This PR adds a `leader_schedules(name PK, last_run_at)` table and a `GlobalSchedule` helper. Its `try_claim` is a single atomic UPSERT that only grants the next slot when `last_run_at + interval <= NOW()`, so the new leader waits the full interval since the previous leader's last run.

### Design

Concerns stay separated:
- `LeaderElection` — mutual exclusion (only one replica acts)
- `GlobalSchedule` — global cadence (work doesn't run sooner than its interval)

Controllers with one lease but several loops at different cadences (ECR's provision/cleanup/drift) get one schedule per loop.

### Sites wired

All six fixed-cadence leader-gated loops:
- `src/server/resources/gc.rs` — resource GC
- `src/server/auth/entra_sync.rs` — Entra active sync (long intervals make bursts especially visible here)
- `src/server/project/controller.rs` — project deletion loop
- `src/server/ecr/controller.rs` — provision, cleanup, drift detection (3 loops, 3 schedules)

### Intentionally left alone

Adaptive provisioner loops (`snowflake-oauth`, `aws-rds`, `aws-s3`, generic `oauth`) sleep 2s when reconciling and 10s when idle — their cadence is work-driven, not interval-driven. Global gating would delay active reconciliation without buying anything.

### Cost

One extra DB round-trip per tick per loop. At default cadences across all six wired loops: ~0.6 QPS per replica. Negligible.

## Test plan

- [x] 5 new sqlx tests on `GlobalSchedule` (first-call grants, second-within-interval denies, post-interval grants, independent names, concurrent callers serialize)
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo test --all-features --bin rise` — 468 passed (5 new + 463 existing)
- [x] Manual smoke: verify migration applies cleanly on existing dev DB (already done locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
