### PR TITLE
throttle snowflake-oauth reconciler and stop warehouse wake-ups

### DIFF
--- a/docs/engineering/public/schemas/backend-settings.schema.json
+++ b/docs/engineering/public/schemas/backend-settings.schema.json
@@ -831,6 +831,13 @@
               "description": "Snowflake user with CREATE INTEGRATION privilege",
               "type": "string"
             },
+            "verify_interval_seconds": {
+              "default": 3600,
+              "description": "How often (in seconds) to re-verify that the SECURITY INTEGRATION still\nexists in Snowflake once the extension is `Available`. The provisioner\nruns an inner 5s tick for transitional states, but `Available`\nextensions are only re-verified after this interval elapses. Default:\n3600 (1 hour). The metadata query used for the check (`SHOW\nINTEGRATIONS`) does not activate the configured warehouse, so a\nhealthy steady state lets Snowflake auto-suspend the warehouse.",
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
             "warehouse": {
               "default": null,
               "description": "Snowflake warehouse to use for queries\nRequired for executing SQL statements",

--- a/src/server/extensions/providers/snowflake_oauth.rs
+++ b/src/server/extensions/providers/snowflake_oauth.rs
@@ -1220,8 +1220,12 @@ impl SnowflakeOAuthProvisioner {
                 // against Snowflake every `verify_interval_seconds`. Otherwise
                 // the inner 5s tick would issue `SHOW INTEGRATIONS` constantly
                 // and (via the warehouse session) prevent auto-suspend.
+                //
+                // Compare elapsed in seconds (u64) to avoid any cast/overflow
+                // when building a `chrono::Duration` from the configured value.
                 let due = status.last_verified_at.is_none_or(|last| {
-                    Utc::now() - last >= Duration::seconds(self.verify_interval_seconds as i64)
+                    let elapsed_secs = (Utc::now() - last).num_seconds();
+                    elapsed_secs >= 0 && (elapsed_secs as u64) >= self.verify_interval_seconds
                 });
                 if !due {
                     return Ok(false);

--- a/src/server/extensions/providers/snowflake_oauth.rs
+++ b/src/server/extensions/providers/snowflake_oauth.rs
@@ -16,7 +16,6 @@ use tokio::time::sleep;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
-#[cfg(feature = "backend")]
 use snowflake_connector_rs::{SnowflakeAuthMethod, SnowflakeClient, SnowflakeClientConfig};
 
 /// User-facing extension spec - minimal configuration
@@ -65,6 +64,12 @@ pub struct SnowflakeOAuthProvisionerStatus {
     /// Timestamp when the integration was created
     #[serde(skip_serializing_if = "Option::is_none")]
     pub created_at: Option<DateTime<Utc>>,
+
+    /// Last time the Snowflake integration was successfully re-verified while
+    /// `Available`. Used to throttle the drift check to
+    /// `verify_interval_seconds` so the reconciler does not hammer Snowflake.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_verified_at: Option<DateTime<Utc>>,
 }
 
 /// State machine for Snowflake OAuth provisioning lifecycle
@@ -108,6 +113,7 @@ pub struct SnowflakeOAuthProvisionerConfig {
     pub default_blocked_roles: Vec<String>,
     pub default_scopes: Vec<String>,
     pub refresh_token_validity_seconds: i64,
+    pub verify_interval_seconds: u64,
 }
 
 /// Main Snowflake OAuth provisioner implementation
@@ -128,6 +134,7 @@ pub struct SnowflakeOAuthProvisioner {
     default_blocked_roles: Vec<String>,
     default_scopes: Vec<String>,
     refresh_token_validity_seconds: i64,
+    verify_interval_seconds: u64,
 }
 
 impl Clone for SnowflakeOAuthProvisioner {
@@ -147,6 +154,7 @@ impl Clone for SnowflakeOAuthProvisioner {
             default_blocked_roles: self.default_blocked_roles.clone(),
             default_scopes: self.default_scopes.clone(),
             refresh_token_validity_seconds: self.refresh_token_validity_seconds,
+            verify_interval_seconds: self.verify_interval_seconds,
         }
     }
 }
@@ -192,6 +200,7 @@ impl SnowflakeOAuthProvisioner {
             default_blocked_roles: config.default_blocked_roles,
             default_scopes: config.default_scopes,
             refresh_token_validity_seconds: config.refresh_token_validity_seconds,
+            verify_interval_seconds: config.verify_interval_seconds,
         }
     }
 
@@ -308,7 +317,6 @@ impl SnowflakeOAuthProvisioner {
     }
 
     /// Create Snowflake client using configured credentials
-    #[cfg(feature = "backend")]
     fn create_snowflake_client(&self) -> Result<SnowflakeClient> {
         let auth_method = match &self.auth {
             SnowflakeAuth::Password { password } => SnowflakeAuthMethod::Password(password.clone()),
@@ -424,29 +432,42 @@ impl SnowflakeOAuthProvisioner {
         Ok(client)
     }
 
-    /// Execute SQL statement on Snowflake
-    #[cfg(feature = "backend")]
+    /// Execute SQL statement on Snowflake using the configured warehouse.
     async fn execute_sql(&self, sql: &str) -> Result<Vec<Value>> {
+        self.execute_sql_inner(sql, true).await
+    }
+
+    /// Execute a metadata-only SQL statement on Snowflake without activating a
+    /// warehouse. Use for `SHOW`/`DESCRIBE`-style queries that the Snowflake
+    /// query engine can answer from metadata alone — avoids waking the
+    /// warehouse on the steady-state drift check.
+    async fn execute_metadata_sql(&self, sql: &str) -> Result<Vec<Value>> {
+        self.execute_sql_inner(sql, false).await
+    }
+
+    async fn execute_sql_inner(&self, sql: &str, use_warehouse: bool) -> Result<Vec<Value>> {
         let client = self.create_snowflake_client()?;
         let session = client
             .create_session()
             .await
             .context("Failed to create Snowflake session")?;
 
-        // Explicitly set warehouse if configured
-        // The warehouse field in SnowflakeClientConfig might not automatically apply to sessions
-        if let Some(ref warehouse) = self.warehouse {
-            debug!("Setting warehouse for session: {}", warehouse);
-            let use_warehouse_sql =
-                format!("USE WAREHOUSE {}", Self::escape_identifier(warehouse)?);
-            debug!("Executing: {}", use_warehouse_sql);
-            session
-                .query(use_warehouse_sql.as_str())
-                .await
-                .context("Failed to set warehouse for session")?;
-            debug!("Warehouse set successfully");
-        } else {
-            debug!("No warehouse configured - session will have no active warehouse");
+        // Only attach a warehouse when the caller's query actually needs one.
+        // Metadata-only queries skip this to let the warehouse auto-suspend.
+        if use_warehouse {
+            if let Some(ref warehouse) = self.warehouse {
+                debug!("Setting warehouse for session: {}", warehouse);
+                let use_warehouse_sql =
+                    format!("USE WAREHOUSE {}", Self::escape_identifier(warehouse)?);
+                debug!("Executing: {}", use_warehouse_sql);
+                session
+                    .query(use_warehouse_sql.as_str())
+                    .await
+                    .context("Failed to set warehouse for session")?;
+                debug!("Warehouse set successfully");
+            } else {
+                debug!("No warehouse configured - session will have no active warehouse");
+            }
         }
 
         let rows = session
@@ -508,14 +529,6 @@ impl SnowflakeOAuthProvisioner {
             .collect();
 
         Ok(json_rows)
-    }
-
-    /// Stub for when snowflake feature is not enabled
-    #[cfg(not(feature = "backend"))]
-    async fn execute_sql(&self, _sql: &str) -> Result<Vec<Value>> {
-        Err(anyhow!(
-            "Snowflake feature not enabled. Rebuild with --features snowflake"
-        ))
     }
 
     /// Handle Pending state: generate names and add finalizer
@@ -814,6 +827,7 @@ impl SnowflakeOAuthProvisioner {
                     oauth_extension_name
                 );
                 status.state = SnowflakeOAuthState::Available;
+                status.last_verified_at = Some(Utc::now());
                 return Ok(());
             } else {
                 // Extension exists but is marked for deletion
@@ -901,6 +915,7 @@ impl SnowflakeOAuthProvisioner {
 
         status.state = SnowflakeOAuthState::Available;
         status.error = None;
+        status.last_verified_at = Some(Utc::now());
 
         Ok(())
     }
@@ -919,11 +934,13 @@ impl SnowflakeOAuthProvisioner {
             .as_ref()
             .ok_or_else(|| anyhow!("Integration name not set"))?;
 
-        // Check if integration still exists with proper escaping
+        // Check if integration still exists with proper escaping.
+        // SHOW INTEGRATIONS is metadata-only, so we use the no-warehouse path
+        // — keeps the warehouse suspended during steady-state drift checks.
         let integration_name_escaped = Self::escape_string_literal(integration_name);
         let sql = format!("SHOW INTEGRATIONS LIKE '{}'", integration_name_escaped);
 
-        match self.execute_sql(&sql).await {
+        match self.execute_metadata_sql(&sql).await {
             Ok(rows) => {
                 if rows.is_empty() {
                     warn!(
@@ -1199,6 +1216,17 @@ impl SnowflakeOAuthProvisioner {
                 .await?;
             }
             SnowflakeOAuthState::Available => {
+                // Throttle the drift check: once Available, we only re-verify
+                // against Snowflake every `verify_interval_seconds`. Otherwise
+                // the inner 5s tick would issue `SHOW INTEGRATIONS` constantly
+                // and (via the warehouse session) prevent auto-suspend.
+                let due = status.last_verified_at.is_none_or(|last| {
+                    Utc::now() - last >= Duration::seconds(self.verify_interval_seconds as i64)
+                });
+                if !due {
+                    return Ok(false);
+                }
+
                 self.verify_integration_available(
                     &mut status,
                     project.id,
@@ -1207,6 +1235,11 @@ impl SnowflakeOAuthProvisioner {
                     &spec,
                 )
                 .await?;
+
+                // Stamp regardless of the inner result: transient Snowflake
+                // errors are intentionally swallowed inside the helper, and we
+                // don't want a flaky `SHOW INTEGRATIONS` to defeat the throttle.
+                status.last_verified_at = Some(Utc::now());
             }
             SnowflakeOAuthState::Failed => {
                 // Stay in Failed state - don't retry automatically

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -1847,6 +1847,15 @@ pub enum ExtensionProviderConfig {
         /// Refresh token validity in seconds (default: 7776000 = 90 days)
         #[serde(default = "default_refresh_token_validity_seconds")]
         refresh_token_validity_seconds: i64,
+        /// How often (in seconds) to re-verify that the SECURITY INTEGRATION still
+        /// exists in Snowflake once the extension is `Available`. The provisioner
+        /// runs an inner 5s tick for transitional states, but `Available`
+        /// extensions are only re-verified after this interval elapses. Default:
+        /// 3600 (1 hour). The metadata query used for the check (`SHOW
+        /// INTEGRATIONS`) does not activate the configured warehouse, so a
+        /// healthy steady state lets Snowflake auto-suspend the warehouse.
+        #[serde(default = "default_snowflake_verify_interval_seconds")]
+        verify_interval_seconds: u64,
     },
 }
 
@@ -1902,6 +1911,11 @@ fn default_scopes() -> Vec<String> {
 #[allow(dead_code)]
 fn default_refresh_token_validity_seconds() -> i64 {
     7776000 // 90 days
+}
+
+#[allow(dead_code)]
+fn default_snowflake_verify_interval_seconds() -> u64 {
+    3600 // 1 hour
 }
 
 /// Platform access control configuration

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -940,6 +940,7 @@ impl AppState {
                     default_blocked_roles,
                     default_scopes,
                     refresh_token_validity_seconds,
+                    verify_interval_seconds,
                 } = provider_config
                 {
                     tracing::info!("Initializing Snowflake OAuth provisioner");
@@ -962,6 +963,7 @@ impl AppState {
                                 default_blocked_roles: default_blocked_roles.clone(),
                                 default_scopes: default_scopes.clone(),
                                 refresh_token_validity_seconds: *refresh_token_validity_seconds,
+                                verify_interval_seconds: *verify_interval_seconds,
                             },
                         );
 


### PR DESCRIPTION
## Summary

- The Snowflake OAuth provisioner re-verified every `Available` extension on a 5-second tick, and every Snowflake session unconditionally issued `USE WAREHOUSE`. The warehouse stayed active forever — auto-suspend never engaged.
- Added an `execute_metadata_sql` path that skips `USE WAREHOUSE`, and switched the steady-state `SHOW INTEGRATIONS` drift check to it. The check is metadata-only and doesn't need a warehouse.
- Added a `last_verified_at` timestamp in extension status and a new operator setting `verify_interval_seconds` (default 1h) — the inner 5s tick still drives transitional states (Pending → Available), but `Available` extensions only re-hit Snowflake once per interval.
- Cleaned up redundant in-file `cfg(feature = "backend")` gates; the whole `snowflake_oauth` module is already feature-gated at `providers/mod.rs`.

Net effect: in steady state a single Snowflake extension touches Snowflake at most once per hour, and that touch is a metadata `SHOW INTEGRATIONS` with no warehouse session — so Snowflake's auto-suspend kicks in.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo check --no-default-features --features cli` (CLI-only build still compiles after removing the feature gates)
- [x] `mise run config:schema:generate` (committed regenerated schema)
- [ ] Manual: configure a Snowflake extension, let it reach `Available`, confirm in backend logs that `Setting warehouse for session` no longer appears on the steady-state ticks and that `SHOW INTEGRATIONS` runs ~hourly instead of every 5s
- [ ] Manual: check Snowflake `QUERY_HISTORY` — `WAREHOUSE_NAME` should be NULL for the steady-state `SHOW INTEGRATIONS` rows, and the warehouse should auto-suspend between verifications
- [ ] Drift behavior: manually `DROP INTEGRATION …` in Snowflake and confirm the extension transitions to `Failed` within ≤1 hour