### PR TITLE
Stop docs deploys from wiping PR previews and serialize Pages jobs

### DIFF
--- a/.github/actions/seed-pages-site/action.yml
+++ b/.github/actions/seed-pages-site/action.yml
@@ -1,0 +1,83 @@
+name: Seed Pages site
+description: |
+  Populate a directory with the current live GitHub Pages contents.
+  GitHub Pages deployments are atomic full-site replacements, so any job
+  that only produces a subtree (PR preview, prod docs, single-PR cleanup)
+  must seed the rest of the site from the latest live state or it will
+  wipe sibling content (other previews, prod docs, etc.).
+
+  Pulls the latest non-expired github-pages artifact ("live") and overlays
+  the latest default-branch artifact ("prod"), so prod content is restored
+  even if the live state was clobbered by an earlier deploy.
+inputs:
+  output-dir:
+    description: Directory to seed (created if missing).
+    required: true
+  github-token:
+    description: Token with actions:read on this repository.
+    required: true
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        OUTPUT_DIR: ${{ inputs.output-dir }}
+      run: |
+        set -euxo pipefail
+        repo="${GITHUB_REPOSITORY}"
+        out="${OUTPUT_DIR}"
+
+        echo "::group::Diagnostics"
+        gh --version || echo "gh not found"
+        gh auth status 2>&1 || true
+        echo "Repository: ${repo}"
+        echo "Output dir: ${out}"
+        echo "::endgroup::"
+
+        mkdir -p "${out}"
+
+        fetch_artifact() {
+          local artifact_id="$1"
+          local label="$2"
+          if [[ -z "${artifact_id}" || "${artifact_id}" == "null" ]]; then
+            echo "No ${label} artifact found; skipping."
+            return 0
+          fi
+          echo "Seeding ${out} with ${label} artifact ${artifact_id}"
+          local tmp
+          tmp="$(mktemp -d)"
+          if ! gh api "repos/${repo}/actions/artifacts/${artifact_id}/zip" > "${tmp}/artifact.zip"; then
+            echo "::error::Failed to download ${label} artifact ${artifact_id}"
+            rm -rf "${tmp}"
+            return 1
+          fi
+          unzip -q "${tmp}/artifact.zip" -d "${tmp}"
+          if [[ -f "${tmp}/artifact.tar" ]]; then
+            tar -xf "${tmp}/artifact.tar" -C "${out}"
+          else
+            echo "::warning::${label} artifact ${artifact_id} did not contain artifact.tar"
+          fi
+          rm -rf "${tmp}"
+        }
+
+        echo "Fetching default branch..."
+        default_branch="$(gh api "repos/${repo}" --jq '.default_branch')"
+        echo "Default branch: ${default_branch}"
+
+        echo "Listing github-pages artifacts..."
+        artifacts_json="$(gh api "repos/${repo}/actions/artifacts?name=github-pages&per_page=100")"
+        echo "Got artifacts JSON (${#artifacts_json} bytes)"
+
+        live_id="$(printf '%s' "${artifacts_json}" \
+          | jq -r '[.artifacts[] | select(.expired == false)] | .[0].id // empty')"
+        echo "Live artifact id: '${live_id}'"
+        fetch_artifact "${live_id}" "live"
+
+        prod_id="$(printf '%s' "${artifacts_json}" \
+          | jq -r --arg branch "${default_branch}" \
+            '[.artifacts[] | select(.expired == false and .workflow_run.head_branch == $branch)] | .[0].id // empty')"
+        echo "Prod artifact id: '${prod_id}'"
+        if [[ -n "${prod_id}" && "${prod_id}" != "${live_id}" ]]; then
+          fetch_artifact "${prod_id}" "production"
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,9 +357,17 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     needs: prepare
+    # Pages deploys must be serialized across docs-deploy, docs-preview, and
+    # docs-preview-cleanup — concurrent deploys race the atomic site swap and
+    # whichever finishes last wipes the others' sibling subtrees (e.g. PR
+    # previews disappearing after a develop merge).
+    concurrency:
+      group: pages-deploy
+      cancel-in-progress: false
     environment:
       name: github-pages
     permissions:
+      actions: read
       contents: read
       id-token: write
       pages: write
@@ -396,11 +404,20 @@ jobs:
           RISE_DOCS_SWITCH_LABEL: User docs
         run: npm run build
 
+      - name: Seed Pages site with current live state
+        uses: ./.github/actions/seed-pages-site
+        with:
+          output-dir: docs-prod
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Stage docs
         shell: bash
         run: |
           set -euo pipefail
           repo_name="${{ github.event.repository.name }}"
+          # Replace only the prod-owned subtrees; anything else seeded in
+          # docs-prod/ (notably preview/pr-*) must survive this atomic deploy.
+          rm -rf docs-prod/user docs-prod/operator docs-prod/index.html
           mkdir -p docs-prod/user docs-prod/operator
           cp -a docs/user/dist/. docs-prod/user/
           cp -a docs/engineering/dist/. docs-prod/operator/
@@ -499,6 +516,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && needs.prepare.outputs.is_trusted_pr == 'true'
     needs: prepare
+    # Shared serialization queue with docs-deploy and docs-preview-cleanup; see
+    # the docs-deploy concurrency block for why.
+    concurrency:
+      group: pages-deploy
+      cancel-in-progress: false
     environment:
       name: github-pages
     permissions:
@@ -541,73 +563,11 @@ jobs:
           RISE_DOCS_SWITCH_LABEL: User docs
         run: npm run build
 
-      - name: Seed docs-preview with current live site
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # GitHub Pages deployments are atomic full-site replacements, so a
-        # preview-only artifact would wipe the production site and any other
-        # PRs' previews. Seed docs-preview/ with the latest live Pages artifact
-        # (preserving other PRs' previews), then overlay the latest production
-        # artifact from the default branch so prod content is always restored
-        # even if the current live state was clobbered by a previous bug.
-        run: |
-          set -euxo pipefail
-          repo="${GITHUB_REPOSITORY}"
-
-          echo "::group::Diagnostics"
-          gh --version || echo "gh not found"
-          gh auth status 2>&1 || true
-          echo "Repository: ${repo}"
-          echo "Workspace: ${GITHUB_WORKSPACE:-<unset>}"
-          echo "::endgroup::"
-
-          mkdir -p docs-preview
-
-          fetch_artifact() {
-            local artifact_id="$1"
-            local label="$2"
-            if [[ -z "${artifact_id}" || "${artifact_id}" == "null" ]]; then
-              echo "No ${label} artifact found; skipping."
-              return 0
-            fi
-            echo "Seeding docs-preview with ${label} artifact ${artifact_id}"
-            local tmp
-            tmp="$(mktemp -d)"
-            if ! gh api "repos/${repo}/actions/artifacts/${artifact_id}/zip" > "${tmp}/artifact.zip"; then
-              echo "::error::Failed to download ${label} artifact ${artifact_id}"
-              rm -rf "${tmp}"
-              return 1
-            fi
-            unzip -q "${tmp}/artifact.zip" -d "${tmp}"
-            if [[ -f "${tmp}/artifact.tar" ]]; then
-              tar -xf "${tmp}/artifact.tar" -C docs-preview
-            else
-              echo "::warning::${label} artifact ${artifact_id} did not contain artifact.tar"
-            fi
-            rm -rf "${tmp}"
-          }
-
-          echo "Fetching default branch..."
-          default_branch="$(gh api "repos/${repo}" --jq '.default_branch')"
-          echo "Default branch: ${default_branch}"
-
-          echo "Listing github-pages artifacts..."
-          artifacts_json="$(gh api "repos/${repo}/actions/artifacts?name=github-pages&per_page=100")"
-          echo "Got artifacts JSON (${#artifacts_json} bytes)"
-
-          live_id="$(printf '%s' "${artifacts_json}" \
-            | jq -r '[.artifacts[] | select(.expired == false)] | .[0].id // empty')"
-          echo "Live artifact id: '${live_id}'"
-          fetch_artifact "${live_id}" "live"
-
-          prod_id="$(printf '%s' "${artifacts_json}" \
-            | jq -r --arg branch "${default_branch}" \
-              '[.artifacts[] | select(.expired == false and .workflow_run.head_branch == $branch)] | .[0].id // empty')"
-          echo "Prod artifact id: '${prod_id}'"
-          if [[ -n "${prod_id}" && "${prod_id}" != "${live_id}" ]]; then
-            fetch_artifact "${prod_id}" "production"
-          fi
+      - name: Seed Pages site with current live state
+        uses: ./.github/actions/seed-pages-site
+        with:
+          output-dir: docs-preview
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Stage docs preview
         shell: bash

--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -9,8 +9,11 @@ on:
 permissions:
   contents: read
 
+# Pages deploys must be serialized across this workflow, ci.yml's docs-deploy
+# and ci.yml's docs-preview — concurrent deploys race the atomic site swap
+# and the loser's content wipes the others' sibling subtrees.
 concurrency:
-  group: docs-preview-cleanup-${{ github.event.pull_request.number }}
+  group: pages-deploy
   cancel-in-progress: false
 
 jobs:
@@ -26,76 +29,21 @@ jobs:
       pages: write
       pull-requests: write
     steps:
-      - name: Seed docs-preview with current live site and drop this PR's preview
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Seed Pages site with current live state
+        uses: ./.github/actions/seed-pages-site
+        with:
+          output-dir: docs-preview
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Drop this PR's preview
         id: seed
         shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # Pages deployments are atomic full-site replacements, so to drop one
-        # PR's preview we have to re-upload the full site without it. Seed
-        # docs-preview/ with the latest live artifact (preserves other PRs'
-        # previews) and overlay the latest production artifact from the
-        # default branch so prod content survives even if live was clobbered.
         run: |
-          set -euxo pipefail
-          repo="${GITHUB_REPOSITORY}"
+          set -euo pipefail
           pr_number="${{ github.event.pull_request.number }}"
-
-          echo "::group::Diagnostics"
-          gh --version || echo "gh not found"
-          gh auth status 2>&1 || true
-          echo "Repository: ${repo}"
-          echo "PR number: ${pr_number}"
-          echo "Workspace: ${GITHUB_WORKSPACE:-<unset>}"
-          echo "::endgroup::"
-
-          mkdir -p docs-preview
-
-          fetch_artifact() {
-            local artifact_id="$1"
-            local label="$2"
-            if [[ -z "${artifact_id}" || "${artifact_id}" == "null" ]]; then
-              echo "No ${label} artifact found; skipping."
-              return 0
-            fi
-            echo "Seeding docs-preview with ${label} artifact ${artifact_id}"
-            local tmp
-            tmp="$(mktemp -d)"
-            if ! gh api "repos/${repo}/actions/artifacts/${artifact_id}/zip" > "${tmp}/artifact.zip"; then
-              echo "::error::Failed to download ${label} artifact ${artifact_id}"
-              rm -rf "${tmp}"
-              return 1
-            fi
-            unzip -q "${tmp}/artifact.zip" -d "${tmp}"
-            if [[ -f "${tmp}/artifact.tar" ]]; then
-              tar -xf "${tmp}/artifact.tar" -C docs-preview
-            else
-              echo "::warning::${label} artifact ${artifact_id} did not contain artifact.tar"
-            fi
-            rm -rf "${tmp}"
-          }
-
-          echo "Fetching default branch..."
-          default_branch="$(gh api "repos/${repo}" --jq '.default_branch')"
-          echo "Default branch: ${default_branch}"
-
-          echo "Listing github-pages artifacts..."
-          artifacts_json="$(gh api "repos/${repo}/actions/artifacts?name=github-pages&per_page=100")"
-          echo "Got artifacts JSON (${#artifacts_json} bytes)"
-
-          live_id="$(printf '%s' "${artifacts_json}" \
-            | jq -r '[.artifacts[] | select(.expired == false)] | .[0].id // empty')"
-          echo "Live artifact id: '${live_id}'"
-          fetch_artifact "${live_id}" "live"
-
-          prod_id="$(printf '%s' "${artifacts_json}" \
-            | jq -r --arg branch "${default_branch}" \
-              '[.artifacts[] | select(.expired == false and .workflow_run.head_branch == $branch)] | .[0].id // empty')"
-          echo "Prod artifact id: '${prod_id}'"
-          if [[ -n "${prod_id}" && "${prod_id}" != "${live_id}" ]]; then
-            fetch_artifact "${prod_id}" "production"
-          fi
-
           if [[ -d "docs-preview/preview/pr-${pr_number}" ]]; then
             echo "Removing docs-preview/preview/pr-${pr_number}"
             rm -rf "docs-preview/preview/pr-${pr_number}"


### PR DESCRIPTION
## Summary

Fixes the bug that made PR 325 and PR 326 previews 404 after the most recent `develop` merge, and removes the race that caused it.

**Root cause**: GitHub Pages deployments are atomic full-site replacements. The `docs-preview` and `docs-preview-cleanup` jobs both seeded the live site into their output dir before uploading, so they could safely deploy a subtree without nuking siblings. The production `docs-deploy` job did not — every push to `develop` published only `docs-prod/{user,operator,index.html}` and atomically replaced the entire Pages site, silently erasing every open PR's `/preview/pr-*/` subtree.

Additionally, the three jobs (`docs-deploy`, `docs-preview`, `docs-preview-cleanup`) had no shared concurrency group, so two of them running simultaneously could race the upload/swap and the loser's content would wipe the winner's siblings even with the seed step in place.

## Changes

- **Extract** `.github/actions/seed-pages-site/` — composite action that downloads the latest non-expired `github-pages` artifact (preserves PR previews) and overlays the latest default-branch artifact (restores prod content if live was clobbered). Was ~50 lines duplicated across `ci.yml` and `docs-preview-cleanup.yml`; about to be a third copy.
- **`docs-deploy`**: seed Pages site into `docs-prod/` first, then surgically replace only `docs-prod/{user,operator,index.html}` before deploy. Any `docs-prod/preview/pr-*/` subtree from the seed survives. Removes stale prod files that `cp -a` alone would leave behind.
- **`docs-preview`** and **`docs-preview-cleanup`**: now both call the composite action.
- **Concurrency**: `docs-deploy`, `docs-preview`, and `docs-preview-cleanup` all opt into a shared `pages-deploy` group with `cancel-in-progress: false`. Pages deploys serialize through one queue regardless of which workflow triggered them. The cleanup workflow previously had per-PR concurrency only.

Net: -134 / +125 LOC after consolidation; 3 files touched, 1 added.

## Test plan

- [ ] CI passes (Helm lint, Rust quality checks, etc. are unaffected; docs-preview job for this PR should still produce a working `/preview/pr-N/`)
- [ ] Verify the docs-preview job for this PR successfully seeds and deploys — landing page at `https://rise-deploy.github.io/rise/preview/pr-N/` returns 200
- [ ] After merge, the next push to `develop` triggers `docs-deploy`; verify `/preview/pr-N/` survives the deploy (where N is any then-open PR)
- [ ] Open two PRs and trigger a develop push roughly simultaneously; confirm all three deploys serialize via the `pages-deploy` queue rather than racing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
