### PR TITLE
fix: frontend redeploy inherits source deployment's http_port

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -154,7 +154,6 @@ class RiseAPI {
                 from_deployment: sourceDeploymentId,
                 use_source_env_vars: useSourceEnvVars,
                 group: sourceDeployment.deployment_group || 'default',
-                http_port: sourceDeployment.controller_metadata?.http_port || 8080,
             })
         });
     }


### PR DESCRIPTION
## Summary

- Frontend's **Redeploy** / **Rollback** button was sending `http_port: 8080` on every request because it read `sourceDeployment.controller_metadata?.http_port` (which doesn't exist — `http_port` is a top-level field on the deployment response). The `|| 8080` fallback always fired.
- The server treats an explicit `payload.http_port` as user intent and skips the source-inheritance branch (`src/server/deployment/handlers.rs:1004-1008`), so any project not listening on 8080 came back up on the wrong port after a UI redeploy.
- Fix: drop the field from `createDeploymentFrom`. The server already inherits `source_deployment.http_port` when the request omits it — that's the same contract the CLI relies on.

## Test plan

- [ ] Deploy a project with `rise d c --http-port 3000 ...`, wait until Running.
- [ ] In the UI, click **Redeploy** on it. Confirm the new deployment's `http_port` stays at 3000 (deployment detail page) and the pod's `PORT` env var is 3000.
- [ ] Regression: `rise d c --from <id>` (no `--http-port`) still inherits the source port.
- [ ] Override still works: `rise d c --from <id> --http-port 4000` uses 4000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
