### PR TITLE
Honor theme preferences on auth pages

### DIFF
--- a/src/server/frontend/mod.rs
+++ b/src/server/frontend/mod.rs
@@ -7,7 +7,7 @@ use tera::Tera;
 
 /// Names of shared Tera partials that should be registered alongside any
 /// auth-page template so `{% include %}` statements resolve.
-const AUTH_TEMPLATE_PARTIALS: &[&str] = &["_auth-tokens.css.tera"];
+const AUTH_TEMPLATE_PARTIALS: &[&str] = &["_auth-tokens.css.tera", "_auth-theme.js.tera"];
 
 /// Load a static file from the configured static_dir, with path traversal protection.
 pub async fn load_static_file(static_dir: &str, rel_path: &str) -> Option<Vec<u8>> {
@@ -26,8 +26,8 @@ pub async fn load_static_file(static_dir: &str, rel_path: &str) -> Option<Vec<u8
 /// shared partials in `AUTH_TEMPLATE_PARTIALS` — into a fresh `Tera` instance.
 ///
 /// This is the canonical way to render the auth-page templates: each template
-/// uses `{% include "_auth-tokens.css.tera" %}` to share its design tokens, so
-/// the partial must be registered alongside.
+/// uses shared `{% include %}` partials for auth-page styling and scripts, so
+/// those partials must be registered alongside.
 pub async fn load_auth_template(
     static_dir: &str,
     template_name: &str,

--- a/static/_auth-theme.js.tera
+++ b/static/_auth-theme.js.tera
@@ -1,0 +1,26 @@
+(function () {
+    var root = document.documentElement;
+    var prefs = {};
+    var palettes = ["mint", "indigo", "ember", "slate"];
+    var themes = ["system", "light", "dark"];
+
+    try {
+        var raw = window.localStorage && window.localStorage.getItem("rise.prefs.v1");
+        prefs = raw ? JSON.parse(raw) : {};
+    } catch (_) {
+        prefs = {};
+    }
+
+    var palette = palettes.indexOf(prefs.palette) >= 0 ? prefs.palette : "indigo";
+    var theme = themes.indexOf(prefs.theme) >= 0 ? prefs.theme : "system";
+    var resolvedTheme = theme;
+
+    if (theme === "system") {
+        resolvedTheme = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches
+            ? "dark"
+            : "light";
+    }
+
+    root.dataset.palette = palette;
+    root.classList.toggle("dark", resolvedTheme === "dark");
+})();

--- a/static/_auth-tokens.css.tera
+++ b/static/_auth-tokens.css.tera
@@ -1,18 +1,94 @@
 /* Shared design tokens for Tera-rendered auth pages.
-   Keep this in rough alignment with frontend/src/styles/rise.css (light mode).
-   Single source of truth for the palette on auth pages. */
+   Keep this in rough alignment with frontend/src/styles/rise.css. */
 :root {
-    --bg: oklch(0.985 0.009 270);
+    color-scheme: light;
+    --bg: oklch(0.985 0.004 80);
     --surface: #ffffff;
-    --surface-2: oklch(0.96 0.012 270);
-    --border-faint: oklch(0.94 0.006 270);
-    --border: oklch(0.91 0.008 270);
+    --surface-2: oklch(0.96 0.005 80);
+    --border-faint: oklch(0.88 0.005 80);
+    --border: oklch(0.84 0.005 80);
     --text: oklch(0.20 0.006 80);
     --muted: oklch(0.50 0.006 80);
     --soft: oklch(0.62 0.006 80);
     --accent: oklch(0.55 0.17 270);
+    --accent-fg: #ffffff;
+    --accent-soft: oklch(0.95 0.04 270);
     --ok: oklch(0.62 0.13 150);
     --ok-bg: oklch(0.96 0.04 150);
     --err: oklch(0.58 0.18 25);
     --err-bg: oklch(0.96 0.04 25);
+    --shadow-md: 0 4px 18px rgba(20, 20, 15, .05), 0 1px 2px rgba(20, 20, 15, .04);
+}
+
+:root.dark {
+    color-scheme: dark;
+    --bg: oklch(0.17 0.005 80);
+    --surface: oklch(0.20 0.005 80);
+    --surface-2: oklch(0.23 0.005 80);
+    --border-faint: oklch(0.23 0.005 80);
+    --border: oklch(0.27 0.005 80);
+    --text: oklch(0.96 0.004 80);
+    --muted: oklch(0.68 0.004 80);
+    --soft: oklch(0.55 0.004 80);
+    --accent: oklch(0.75 0.16 270);
+    --accent-fg: oklch(0.20 0.05 270);
+    --accent-soft: oklch(0.30 0.10 270);
+    --ok: oklch(0.78 0.13 150);
+    --ok-bg: oklch(0.28 0.06 150);
+    --err: oklch(0.72 0.16 25);
+    --err-bg: oklch(0.30 0.10 25);
+    --shadow-md: 0 4px 18px rgba(0, 0, 0, .4);
+}
+
+:root[data-palette="mint"]:not(.dark) {
+    --accent: oklch(0.55 0.10 165);
+    --accent-soft: oklch(0.95 0.04 165);
+    --bg: oklch(0.985 0.008 165);
+    --surface-2: oklch(0.96 0.011 165);
+    --border-faint: oklch(0.89 0.009 165);
+}
+:root[data-palette="mint"].dark {
+    --accent: oklch(0.78 0.13 165);
+    --accent-fg: oklch(0.20 0.04 165);
+    --accent-soft: oklch(0.30 0.08 165);
+}
+
+:root[data-palette="indigo"]:not(.dark) {
+    --accent: oklch(0.55 0.17 270);
+    --accent-soft: oklch(0.95 0.04 270);
+    --bg: oklch(0.985 0.009 270);
+    --surface-2: oklch(0.96 0.012 270);
+    --border-faint: oklch(0.89 0.01 270);
+}
+:root[data-palette="indigo"].dark {
+    --accent: oklch(0.78 0.14 270);
+    --accent-fg: oklch(0.20 0.05 270);
+    --accent-soft: oklch(0.30 0.10 270);
+}
+
+:root[data-palette="ember"]:not(.dark) {
+    --accent: oklch(0.62 0.16 40);
+    --accent-soft: oklch(0.95 0.05 40);
+    --bg: oklch(0.987 0.01 55);
+    --surface-2: oklch(0.965 0.013 55);
+    --border-faint: oklch(0.89 0.011 55);
+}
+:root[data-palette="ember"].dark {
+    --accent: oklch(0.78 0.15 40);
+    --accent-fg: oklch(0.22 0.06 40);
+    --accent-soft: oklch(0.32 0.10 40);
+}
+
+:root[data-palette="slate"]:not(.dark) {
+    --accent: oklch(0.32 0.012 250);
+    --accent-fg: #ffffff;
+    --accent-soft: oklch(0.92 0.006 250);
+    --bg: oklch(0.985 0.004 250);
+    --surface-2: oklch(0.96 0.005 250);
+    --border-faint: oklch(0.89 0.005 250);
+}
+:root[data-palette="slate"].dark {
+    --accent: oklch(0.88 0.005 250);
+    --accent-fg: oklch(0.18 0.005 250);
+    --accent-soft: oklch(0.30 0.06 250);
 }

--- a/static/auth-signin.html.tera
+++ b/static/auth-signin.html.tera
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/x-icon" href="/assets/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon-32x32.png">
+    <script>{% include "_auth-theme.js.tera" %}</script>
     <style>
         {% include "_auth-tokens.css.tera" %}
         * { box-sizing: border-box; }
@@ -23,7 +24,7 @@
             background: var(--surface);
             border: 1px solid var(--border-faint);
             border-radius: 14px;
-            box-shadow: 0 4px 18px rgba(20, 20, 15, .05), 0 1px 2px rgba(20, 20, 15, .04);
+            box-shadow: var(--shadow-md);
             padding: 36px 32px; text-align: center;
         }
         .logo {
@@ -49,7 +50,7 @@
         }
         .btn {
             display: block; width: 100%; text-align: center;
-            background: var(--accent); color: #fff;
+            background: var(--accent); color: var(--accent-fg);
             border: none; border-radius: 7px;
             padding: 10px 14px; margin-top: 22px;
             font-size: 13px; font-weight: 500; text-decoration: none;

--- a/static/auth-success.html.tera
+++ b/static/auth-success.html.tera
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/x-icon" href="/assets/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon-32x32.png">
+    <script>{% include "_auth-theme.js.tera" %}</script>
     <style>
         {% include "_auth-tokens.css.tera" %}
         * { box-sizing: border-box; }
@@ -23,7 +24,7 @@
             background: var(--surface);
             border: 1px solid var(--border-faint);
             border-radius: 14px;
-            box-shadow: 0 4px 18px rgba(20, 20, 15, .05), 0 1px 2px rgba(20, 20, 15, .04);
+            box-shadow: var(--shadow-md);
             padding: 36px 32px; text-align: center;
         }
         .logo {
@@ -55,7 +56,7 @@
         .progress > div { height: 100%; width: 0%; background: var(--accent); border-radius: 999px; transition: width 1000ms; }
         .btn {
             display: inline-block; text-align: center;
-            background: var(--accent); color: #fff;
+            background: var(--accent); color: var(--accent-fg);
             border: none; border-radius: 7px;
             padding: 10px 16px; margin-top: 20px;
             font-size: 13px; font-weight: 500; text-decoration: none;
@@ -63,7 +64,7 @@
         }
         .btn:hover { filter: brightness(1.06); }
         .errbox {
-            background: var(--err-bg); color: oklch(0.40 0.14 25);
+            background: var(--err-bg); color: var(--err);
             border: 1px solid color-mix(in oklch, var(--err) 30%, transparent);
             border-radius: 7px; padding: 10px 12px; font-size: 12.5px;
             margin: 14px 0 0; text-align: left;

--- a/static/auth-ui-success.html.tera
+++ b/static/auth-ui-success.html.tera
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/x-icon" href="/assets/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon-32x32.png">
+    <script>{% include "_auth-theme.js.tera" %}</script>
     <style>
         {% include "_auth-tokens.css.tera" %}
         * { box-sizing: border-box; }
@@ -23,7 +24,7 @@
             background: var(--surface);
             border: 1px solid var(--border-faint);
             border-radius: 14px;
-            box-shadow: 0 4px 18px rgba(20, 20, 15, .05), 0 1px 2px rgba(20, 20, 15, .04);
+            box-shadow: var(--shadow-md);
             padding: 36px 32px; text-align: center;
         }
         .logo {

--- a/static/cli-auth-success.html.tera
+++ b/static/cli-auth-success.html.tera
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/x-icon" href="/assets/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon-32x32.png">
+    <script>{% include "_auth-theme.js.tera" %}</script>
     <style>
         {% include "_auth-tokens.css.tera" %}
         * { box-sizing: border-box; }
@@ -23,7 +24,7 @@
             background: var(--surface);
             border: 1px solid var(--border-faint);
             border-radius: 14px;
-            box-shadow: 0 4px 18px rgba(20, 20, 15, .05), 0 1px 2px rgba(20, 20, 15, .04);
+            box-shadow: var(--shadow-md);
             padding: 36px 32px; text-align: center;
         }
         .logo {
@@ -56,7 +57,7 @@
         .steps ul { margin: 0; padding-left: 18px; }
         .steps li { margin: 4px 0; }
         .errbox {
-            background: var(--err-bg); color: oklch(0.40 0.14 25);
+            background: var(--err-bg); color: var(--err);
             border: 1px solid color-mix(in oklch, var(--err) 30%, transparent);
             border-radius: 7px; padding: 10px 12px; font-size: 12.5px;
             margin: 14px 0 0; text-align: left;


### PR DESCRIPTION
## Summary
- apply stored Rise theme preferences to Tera-rendered auth pages before paint
- add shared dark-mode and palette-aware auth tokens
- register the auth theme bootstrap partial with auth template loading

## Tests
- git diff --cached --check
- CARGO_BUILD_RUSTC_WRAPPER= cargo check