### PR TITLE
helm: default metacontroller controllerClass to empty for safe upgrades

### DIFF
--- a/helm/rise/values.yaml
+++ b/helm/rise/values.yaml
@@ -126,14 +126,23 @@ metacontroller:
   # Disable this if Metacontroller is already installed in the cluster.
   install: true
   # Controller-class identifier for this Kubernetes deployment controller.
-  # The generated CompositeController only matches RiseProject CRs whose
-  # `rise.dev/controller-class` label equals this value, so multiple Rise
+  # When non-empty, the generated CompositeController carries a
+  # `labelSelector` on `rise.dev/controller-class=<value>`, so multiple Rise
   # controllers (e.g. K8s + a future Lambda backend) can coexist without
-  # fighting over each other's CRs. Must match the backend's
-  # `deployment_controller.controller_class_name` config (same default).
-  # Set to an empty string to disable label-based filtering and match every
-  # RiseProject CR (the legacy single-controller behaviour).
-  controllerClass: "default"
+  # fighting over each other's CRs. The value must match the backend's
+  # `deployment_controller.controller_class_name` config.
+  #
+  # Defaults to empty (no labelSelector) so the CompositeController matches
+  # every RiseProject CR. This is the safe upgrade default: installs coming
+  # from pre-label releases have RiseProject CRs without the label, and a
+  # non-empty selector would cause Metacontroller to drop them from its
+  # watch during the upgrade — orphaning their child resources and (via the
+  # finalize hook) marking every active deployment as Stopped before the
+  # new backend can stamp the label.
+  #
+  # Multi-controller installs should set this explicitly to the same value
+  # as `deployment_controller.controller_class_name` (typically `default`).
+  controllerClass: ""
 
 # Runtime deployment logs.
 # The Rise API always enforces authorization and proxies log access; Loki is only


### PR DESCRIPTION
## Summary

- Change the default of `metacontroller.controllerClass` from `"default"` to `""` so the rendered `CompositeController` omits its `labelSelector`.
- Multi-controller installs still get the filter — they just have to set the value explicitly.

## Why

The 0.23.0-rc1 commit `de110ad` ("Stamp controller-class label on RiseProject CRs and select on it") added a `labelSelector` on `rise.dev/controller-class=default` to the `CompositeController` and a backfill pass that stamps that label on existing `RiseProject` CRs. The two operations don't compose safely across a `helm upgrade` from a pre-label release:

1. Helm applies the new `CompositeController` immediately — its labelSelector now excludes every existing `RiseProject` CR (none of them have the label yet).
2. Metacontroller drops those CRs from its watch and fires the `finalize` webhook for them.
3. `process_finalize` in `src/server/deployment/webhook.rs` marks every non-terminal deployment as `Stopped` and returns an empty children list — Metacontroller GCs the K8s resources.
4. The new backend pod finally rolls out and runs `backfill_rise_projects`, stamping the label so the selector matches again — but by then every deployment is `Stopped`, so `compute_desired_children` returns no infrastructure and nothing comes back automatically.

Result: every active deployment ends up `Stopped` after the upgrade. The user-visible recovery is to redeploy each project, which creates a new deployment that flows through the normal `Pending → ... → Healthy` path and re-provisions infrastructure.

The label-selector mechanism is still useful for true multi-controller installs, but turning it on by default makes single-controller upgrades break. Operators with multiple controllers can set `metacontroller.controllerClass` explicitly (it must match `deployment_controller.controller_class_name`). The backend keeps stamping the label unconditionally, so no behavior changes for that case.

## Test plan

- [x] `helm lint helm/rise` passes.
- [x] `helm template` with defaults: rendered `CompositeController` has no `labelSelector` (verified).
- [x] `helm template ... --set metacontroller.controllerClass=default`: rendered `CompositeController` carries the labelSelector (verified — opt-in still works).
- [ ] Verify on a clean 0.22.1 -> this-branch upgrade in a test cluster that deployments stay `Healthy` (was `Stopped` before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
