### PR TITLE
Add platform capabilities endpoint

### DIFF
--- a/frontend/src/features/quickstart-templates.tsx
+++ b/frontend/src/features/quickstart-templates.tsx
@@ -36,11 +36,11 @@ export function useQuickstartTemplates() {
     return { templates, error };
 }
 
-// Read-only properties of the deployment platform. `capabilities` is an open,
-// namespaced map of boolean flags (e.g. `deployments:canRunAsRoot`).
+// Read-only properties of the deployment platform. Capability flags sit flat
+// at the top level under namespaced keys (e.g. `deployments:canRunAsRoot`).
 export interface PlatformCapabilities {
     runtime_arch: string | null;
-    capabilities: Record<string, boolean>;
+    'deployments:canRunAsRoot': boolean;
 }
 
 export function usePlatformCapabilities() {
@@ -115,7 +115,7 @@ export function QuickstartDeployModal({ template, onClose, onDeployed }: DeployM
     // capabilities mean a privileged port (< 1024) can't be bound and the app
     // will crash-loop. This is computed client-side from the platform
     // capability rather than baked into each template's `warning`.
-    const canRunAsRoot = caps?.capabilities['deployments:canRunAsRoot'] ?? true;
+    const canRunAsRoot = caps?.['deployments:canRunAsRoot'] ?? true;
     const privilegedPortRisk = !canRunAsRoot && template.http_port < 1024;
 
     const handleDeploy = async () => {

--- a/frontend/src/features/quickstart-templates.tsx
+++ b/frontend/src/features/quickstart-templates.tsx
@@ -36,6 +36,23 @@ export function useQuickstartTemplates() {
     return { templates, error };
 }
 
+// Read-only properties of the deployment platform. `capabilities` is an open,
+// namespaced map of boolean flags (e.g. `deployments:canRunAsRoot`).
+export interface PlatformCapabilities {
+    runtime_arch: string | null;
+    capabilities: Record<string, boolean>;
+}
+
+export function usePlatformCapabilities() {
+    const [caps, setCaps] = useState<PlatformCapabilities | null>(null);
+    useEffect(() => {
+        api.getPlatformCapabilities()
+            .then(c => setCaps(c as PlatformCapabilities))
+            .catch(() => { /* permissive default applied in api client */ });
+    }, []);
+    return caps;
+}
+
 export function QuickstartCard({ template, onSelect }: { template: QuickstartTemplate; onSelect: () => void }) {
     return (
         <button
@@ -79,6 +96,7 @@ export function QuickstartDeployModal({ template, onClose, onDeployed }: DeployM
     const [currentUser, setCurrentUser] = useState<any>(null);
     const [formData, setFormData] = useState<{ name: string; access_class: string; owner: string }>({ name: '', access_class: 'public', owner: 'self' });
     const [saving, setSaving] = useState(false);
+    const caps = usePlatformCapabilities();
 
     useEffect(() => {
         if (!template) return;
@@ -92,6 +110,13 @@ export function QuickstartDeployModal({ template, onClose, onDeployed }: DeployM
     }, []);
 
     if (!template) return null;
+
+    // Capability-derived hint: when the platform runs apps as non-root, dropped
+    // capabilities mean a privileged port (< 1024) can't be bound and the app
+    // will crash-loop. This is computed client-side from the platform
+    // capability rather than baked into each template's `warning`.
+    const canRunAsRoot = caps?.capabilities['deployments:canRunAsRoot'] ?? true;
+    const privilegedPortRisk = !canRunAsRoot && template.http_port < 1024;
 
     const handleDeploy = async () => {
         if (!formData.name) { showToast('Project name is required', 'error'); return; }
@@ -144,6 +169,13 @@ export function QuickstartDeployModal({ template, onClose, onDeployed }: DeployM
             {template.warning && (
                 <div style={{ marginBottom: 14 }}>
                     <Alert tone="warn" icon="info">{template.warning}</Alert>
+                </div>
+            )}
+            {privilegedPortRisk && (
+                <div style={{ marginBottom: 14 }}>
+                    <Alert tone="warn" icon="info">
+                        This platform runs apps as a non-root user, so binding port {template.http_port} (below 1024) may fail. Prefer an image that listens on a port ≥ 1024.
+                    </Alert>
                 </div>
             )}
             <div className="r-quickstart-meta">

--- a/frontend/src/features/quickstart-templates.tsx
+++ b/frontend/src/features/quickstart-templates.tsx
@@ -37,10 +37,10 @@ export function useQuickstartTemplates() {
 }
 
 // Read-only properties of the deployment platform. Capability flags sit flat
-// at the top level under namespaced keys (e.g. `deployments:canRunAsRoot`).
+// at the top level (e.g. `runtime_allows_root`).
 export interface PlatformCapabilities {
     runtime_arch: string | null;
-    'deployments:canRunAsRoot': boolean;
+    runtime_allows_root: boolean;
 }
 
 export function usePlatformCapabilities() {
@@ -115,8 +115,8 @@ export function QuickstartDeployModal({ template, onClose, onDeployed }: DeployM
     // capabilities mean a privileged port (< 1024) can't be bound and the app
     // will crash-loop. This is computed client-side from the platform
     // capability rather than baked into each template's `warning`.
-    const canRunAsRoot = caps?.['deployments:canRunAsRoot'] ?? true;
-    const privilegedPortRisk = !canRunAsRoot && template.http_port < 1024;
+    const allowsRoot = caps?.runtime_allows_root ?? true;
+    const privilegedPortRisk = !allowsRoot && template.http_port < 1024;
 
     const handleDeploy = async () => {
         if (!formData.name) { showToast('Project name is required', 'error'); return; }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -233,7 +233,7 @@ class RiseAPI {
     // getLogsCapabilities, we type-guard each field and fall back to a safe,
     // permissive default on any failure so a backend change can't break the UI.
     async getPlatformCapabilities() {
-        const safeDefault = { runtime_arch: null, capabilities: {} };
+        const safeDefault = { runtime_arch: null, 'deployments:canRunAsRoot': true };
         let payload;
         try {
             payload = await this.request('/platform/capabilities');
@@ -246,13 +246,10 @@ class RiseAPI {
             return safeDefault;
         }
         const runtime_arch = typeof payload.runtime_arch === 'string' ? payload.runtime_arch : null;
-        const capabilities = {};
-        if (payload.capabilities && typeof payload.capabilities === 'object') {
-            for (const [key, value] of Object.entries(payload.capabilities)) {
-                if (typeof value === 'boolean') capabilities[key] = value;
-            }
-        }
-        return { runtime_arch, capabilities };
+        const canRunAsRoot = typeof payload['deployments:canRunAsRoot'] === 'boolean'
+            ? payload['deployments:canRunAsRoot']
+            : true;
+        return { runtime_arch, 'deployments:canRunAsRoot': canRunAsRoot };
     }
 
     // Service account endpoints

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -227,6 +227,34 @@ class RiseAPI {
         return this.request('/quickstart-templates');
     }
 
+    // Read-only properties of the deployment platform (architecture, whether
+    // pods may run as root, …). Lets the UI derive consequences client-side
+    // (e.g. "this template binds a privileged port and may fail here"). Like
+    // getLogsCapabilities, we type-guard each field and fall back to a safe,
+    // permissive default on any failure so a backend change can't break the UI.
+    async getPlatformCapabilities() {
+        const safeDefault = { runtime_arch: null, capabilities: {} };
+        let payload;
+        try {
+            payload = await this.request('/platform/capabilities');
+        } catch (err) {
+            console.warn('getPlatformCapabilities request failed; using safe default:', err);
+            return safeDefault;
+        }
+        if (!payload || typeof payload !== 'object') {
+            console.warn('getPlatformCapabilities returned non-object payload; using safe default:', payload);
+            return safeDefault;
+        }
+        const runtime_arch = typeof payload.runtime_arch === 'string' ? payload.runtime_arch : null;
+        const capabilities = {};
+        if (payload.capabilities && typeof payload.capabilities === 'object') {
+            for (const [key, value] of Object.entries(payload.capabilities)) {
+                if (typeof value === 'boolean') capabilities[key] = value;
+            }
+        }
+        return { runtime_arch, capabilities };
+    }
+
     // Service account endpoints
     async getProjectServiceAccounts(projectName) {
         return this.request(`/projects/${projectName}/service-accounts`);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -233,7 +233,7 @@ class RiseAPI {
     // getLogsCapabilities, we type-guard each field and fall back to a safe,
     // permissive default on any failure so a backend change can't break the UI.
     async getPlatformCapabilities() {
-        const safeDefault = { runtime_arch: null, 'deployments:canRunAsRoot': true };
+        const safeDefault = { runtime_arch: null, runtime_allows_root: true };
         let payload;
         try {
             payload = await this.request('/platform/capabilities');
@@ -246,10 +246,10 @@ class RiseAPI {
             return safeDefault;
         }
         const runtime_arch = typeof payload.runtime_arch === 'string' ? payload.runtime_arch : null;
-        const canRunAsRoot = typeof payload['deployments:canRunAsRoot'] === 'boolean'
-            ? payload['deployments:canRunAsRoot']
+        const runtime_allows_root = typeof payload.runtime_allows_root === 'boolean'
+            ? payload.runtime_allows_root
             : true;
-        return { runtime_arch, 'deployments:canRunAsRoot': canRunAsRoot };
+        return { runtime_arch, runtime_allows_root };
     }
 
     // Service account endpoints

--- a/src/build/method.rs
+++ b/src/build/method.rs
@@ -135,16 +135,17 @@ impl BuildOptions {
     /// When `preloaded_config` is provided, its `.build` section is used instead
     /// of loading rise.toml from disk, avoiding duplicate file reads/warnings.
     ///
-    /// `backend_platform_hint` is the architecture advertised by the backend
-    /// (derived from the `runtime_arch` platform capability); it sits below
-    /// rise.toml in precedence but above the host-arch fallback.
+    /// `backend_platform_hint` is the build platform resolved from the backend
+    /// (an advertised `runtime_arch`, or the legacy default for a backend that
+    /// predates the capabilities endpoint); it sits below rise.toml in
+    /// precedence but above the host-arch fallback.
     pub(crate) fn from_build_args(
         config: &Config,
         image_tag: String,
         app_path: String,
         build_args: &BuildArgs,
         preloaded_config: Option<crate::build::config::ProjectBuildConfig>,
-        backend_platform_hint: Option<&str>,
+        backend_platform_hint: Option<crate::build::BackendPlatformHint>,
     ) -> Self {
         use tracing::warn;
 

--- a/src/build/method.rs
+++ b/src/build/method.rs
@@ -135,8 +135,8 @@ impl BuildOptions {
     /// When `preloaded_config` is provided, its `.build` section is used instead
     /// of loading rise.toml from disk, avoiding duplicate file reads/warnings.
     ///
-    /// `backend_platform_hint` is the `target_platform` advertised by the
-    /// backend (from the registry-credentials response); it sits below
+    /// `backend_platform_hint` is the architecture advertised by the backend
+    /// (derived from the `runtime_arch` platform capability); it sits below
     /// rise.toml in precedence but above the host-arch fallback.
     pub(crate) fn from_build_args(
         config: &Config,

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -47,8 +47,36 @@ pub enum PlatformSource {
     /// From the backend-advertised architecture (`runtime_arch` platform
     /// capability), mapped to a `linux/{arch}` platform string.
     BackendHint,
+    /// Legacy `linux/amd64` default, used when the backend predates the
+    /// platform capabilities endpoint (the endpoint returned 404). Kept
+    /// distinct from [`PlatformSource::BackendHint`] so logs don't claim the
+    /// cluster actually advertised this architecture.
+    LegacyBackendDefault,
     /// Fell through to `host_platform()` / `std::env::consts::ARCH`.
     HostFallback,
+}
+
+/// The build-platform hint resolved from the backend, distinguishing a real
+/// advertised architecture (from a supported capabilities endpoint) from the
+/// legacy default used when the backend predates the endpoint. This lets
+/// [`resolve_platform`] label the [`PlatformSource`] honestly instead of
+/// passing both off as [`PlatformSource::BackendHint`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BackendPlatformHint {
+    /// Architecture advertised by a supported capabilities endpoint.
+    Advertised(String),
+    /// Legacy default for a backend without the capabilities endpoint.
+    LegacyDefault(String),
+}
+
+impl BackendPlatformHint {
+    /// The platform string and the source label that should be reported for it.
+    fn into_resolved(self) -> (String, PlatformSource) {
+        match self {
+            BackendPlatformHint::Advertised(p) => (p, PlatformSource::BackendHint),
+            BackendPlatformHint::LegacyDefault(p) => (p, PlatformSource::LegacyBackendDefault),
+        }
+    }
 }
 
 /// Resolve the build platform from the standard precedence chain:
@@ -64,7 +92,7 @@ pub fn resolve_platform(
     cli: Option<&str>,
     env: Option<&str>,
     project: Option<&str>,
-    backend_hint: Option<&str>,
+    backend_hint: Option<BackendPlatformHint>,
 ) -> (String, PlatformSource) {
     if let Some(v) = cli {
         return (v.to_string(), PlatformSource::CliFlag);
@@ -75,8 +103,8 @@ pub fn resolve_platform(
     if let Some(v) = project {
         return (v.to_string(), PlatformSource::RiseToml);
     }
-    if let Some(v) = backend_hint {
-        return (v.to_string(), PlatformSource::BackendHint);
+    if let Some(hint) = backend_hint {
+        return hint.into_resolved();
     }
     (host_platform(), PlatformSource::HostFallback)
 }
@@ -441,7 +469,7 @@ mod tests {
             Some("linux/cli-wins"),
             Some("linux/env"),
             Some("linux/project"),
-            Some("linux/backend"),
+            Some(BackendPlatformHint::Advertised("linux/backend".to_string())),
         );
         assert_eq!(value, "linux/cli-wins");
         assert_eq!(source, PlatformSource::CliFlag);
@@ -456,7 +484,7 @@ mod tests {
             None,
             Some("linux/env-wins"),
             Some("linux/project"),
-            Some("linux/backend"),
+            Some(BackendPlatformHint::Advertised("linux/backend".to_string())),
         );
         assert_eq!(value, "linux/env-wins");
         assert_eq!(source, PlatformSource::EnvVar);
@@ -465,18 +493,62 @@ mod tests {
     #[test]
     fn test_resolve_platform_project_over_backend() {
         // With no CLI flag and no env, rise.toml outranks the backend hint.
-        let (value, source) =
-            resolve_platform(None, None, Some("linux/project"), Some("linux/backend"));
+        let (value, source) = resolve_platform(
+            None,
+            None,
+            Some("linux/project"),
+            Some(BackendPlatformHint::Advertised("linux/backend".to_string())),
+        );
         assert_eq!(value, "linux/project");
         assert_eq!(source, PlatformSource::RiseToml);
     }
 
     #[test]
     fn test_resolve_platform_backend_over_host() {
-        // With no user signal, the backend hint beats host arch fallback.
-        let (value, source) = resolve_platform(None, None, None, Some("linux/backend-arch"));
+        // With no user signal, an advertised backend hint beats host fallback
+        // and is labeled BackendHint.
+        let (value, source) = resolve_platform(
+            None,
+            None,
+            None,
+            Some(BackendPlatformHint::Advertised(
+                "linux/backend-arch".to_string(),
+            )),
+        );
         assert_eq!(value, "linux/backend-arch");
         assert_eq!(source, PlatformSource::BackendHint);
+    }
+
+    #[test]
+    fn test_resolve_platform_legacy_backend_default() {
+        // A legacy default (old backend without the capabilities endpoint) is
+        // used like a backend hint but labeled distinctly so logs don't claim
+        // the cluster advertised it.
+        let (value, source) = resolve_platform(
+            None,
+            None,
+            None,
+            Some(BackendPlatformHint::LegacyDefault(
+                "linux/amd64".to_string(),
+            )),
+        );
+        assert_eq!(value, "linux/amd64");
+        assert_eq!(source, PlatformSource::LegacyBackendDefault);
+    }
+
+    #[test]
+    fn test_resolve_platform_cli_wins_over_legacy_default() {
+        // An explicit user choice still wins over the legacy fallback.
+        let (value, source) = resolve_platform(
+            Some("linux/cli"),
+            None,
+            None,
+            Some(BackendPlatformHint::LegacyDefault(
+                "linux/amd64".to_string(),
+            )),
+        );
+        assert_eq!(value, "linux/cli");
+        assert_eq!(source, PlatformSource::CliFlag);
     }
 
     #[test]

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -18,7 +18,8 @@ mod ssl;
 /// Fallback target platform when nothing more specific (CLI flag, env var,
 /// rise.toml, backend hint) is provided. We default to the host architecture
 /// so local dev (e.g. ARM Mac + ARM minikube) just works; production deploys
-/// override via the backend's `target_platform` hint.
+/// override via the backend's advertised architecture (the `runtime_arch`
+/// platform capability).
 pub fn host_platform() -> String {
     let arch = match std::env::consts::ARCH {
         "x86_64" => "amd64",
@@ -43,7 +44,8 @@ pub enum PlatformSource {
     EnvVar,
     /// From `[build].platform` in rise.toml.
     RiseToml,
-    /// From the backend-advertised `target_platform` hint.
+    /// From the backend-advertised architecture (`runtime_arch` platform
+    /// capability), mapped to a `linux/{arch}` platform string.
     BackendHint,
     /// Fell through to `host_platform()` / `std::env::consts::ARCH`.
     HostFallback,

--- a/src/cli/deployment/core.rs
+++ b/src/cli/deployment/core.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use std::time::Duration;
 use tracing::{debug, info, warn};
 
-use crate::build::{self, BuildOptions, PlatformSource};
+use crate::build::{self, BackendPlatformHint, BuildOptions, PlatformSource};
 use crate::config::Config;
 
 // Re-export models from API module (always available)
@@ -450,13 +450,16 @@ fn log_platform_choice(platform: &str, source: PlatformSource, operation: &str) 
     match source {
         CliFlag | EnvVar | RiseToml => {} // explicit user choice, stay silent
         BackendHint => info!("{operation} for {platform} (target cluster architecture)"),
+        LegacyBackendDefault => info!(
+            "{operation} for {platform} (legacy default; this backend predates the platform capabilities endpoint)"
+        ),
         HostFallback => {
             // Reached only when a *supported* capabilities endpoint reported no
             // required architecture (a genuinely unconstrained cluster — e.g.
             // local dev). An *unsupported* endpoint (old backend → 404) does NOT
-            // land here: `fetch_backend_platform_hint` maps that to the legacy
-            // `linux/amd64` default, which resolves as `BackendHint` above. So
-            // we can state "unconstrained" here without conflating the two.
+            // land here: `fetch_backend_platform_hint` reports that as
+            // `LegacyBackendDefault` (linux/amd64). So we can state
+            // "unconstrained" here without conflating the two.
             info!(
                 "{operation} for {platform} (host architecture; target cluster is unconstrained — pass --platform to override)"
             )
@@ -515,17 +518,23 @@ async fn fetch_deployment_registry_credentials(
 const LEGACY_PLATFORM_FALLBACK: &str = "linux/amd64";
 
 /// Derive the container build platform the target cluster expects (e.g.
-/// "linux/amd64") from the platform capabilities endpoint. `None` when the
-/// cluster is unconstrained — the build then falls back to the host
-/// architecture.
+/// "linux/amd64") from the platform capabilities endpoint.
 ///
-/// For backward compatibility with backends that predate the endpoint, a 404 is
-/// treated as "use the legacy `linux/amd64` default" rather than a hard failure.
+/// Returns:
+/// - `Some(Advertised(..))` when the endpoint pins an architecture;
+/// - `Some(LegacyDefault(..))` when the endpoint is absent (404 — a backend
+///   that predates it), so the deploy keeps working with the legacy default
+///   rather than erroring;
+/// - `None` when a *supported* endpoint reports an unconstrained cluster — the
+///   build then falls back to the host architecture.
+///
+/// Any other non-success status is a hard error: without positive evidence of
+/// the target architecture we must not silently guess.
 async fn fetch_backend_platform_hint(
     http_client: &Client,
     backend_url: &str,
     token: &str,
-) -> Result<Option<String>> {
+) -> Result<Option<BackendPlatformHint>> {
     let url = format!("{}/api/v1/platform/capabilities", backend_url);
 
     let response = http_client
@@ -542,7 +551,9 @@ async fn fetch_backend_platform_hint(
             "Backend has no /platform/capabilities endpoint; falling back to legacy platform '{}'",
             LEGACY_PLATFORM_FALLBACK
         );
-        return Ok(Some(LEGACY_PLATFORM_FALLBACK.to_string()));
+        return Ok(Some(BackendPlatformHint::LegacyDefault(
+            LEGACY_PLATFORM_FALLBACK.to_string(),
+        )));
     }
 
     if !response.status().is_success() {
@@ -562,7 +573,9 @@ async fn fetch_backend_platform_hint(
         .json()
         .await
         .context("Failed to parse platform capabilities response")?;
-    Ok(caps.runtime_arch.map(|arch| format!("linux/{arch}")))
+    Ok(caps
+        .runtime_arch
+        .map(|arch| BackendPlatformHint::Advertised(format!("linux/{arch}"))))
 }
 
 /// A runtime environment variable override for a deployment
@@ -786,7 +799,7 @@ pub async fn create_deployment(
                 deploy_opts.build_args.platform.as_deref(),
                 env.as_deref(),
                 toml_platform,
-                backend_platform.as_deref(),
+                backend_platform,
             );
             log_platform_choice(&platform, source, "Pulling");
             if let Err(e) = build::docker_pull(&container_cli, source_image, &platform) {
@@ -900,7 +913,7 @@ pub async fn create_deployment(
             deploy_opts.path.to_string(),
             deploy_opts.build_args,
             deploy_opts.toml_config,
-            backend_platform.as_deref(),
+            backend_platform,
         );
         log_platform_choice(&options.platform, options.platform_source, "Building");
 
@@ -2147,5 +2160,76 @@ mod tests {
         assert_eq!(normalize_git_url(""), None);
         assert_eq!(normalize_git_url("not-a-url"), None);
         assert_eq!(normalize_git_url("/local/path/repo"), None);
+    }
+
+    /// Spawn a one-shot HTTP server that answers the first request with the
+    /// given status line (e.g. "404 Not Found") and JSON `body`, then closes.
+    /// Lets us drive `fetch_backend_platform_hint` end-to-end through reqwest
+    /// without a mock-server dependency. Returns the base URL.
+    async fn spawn_one_shot_response(status_line: &'static str, body: &'static str) -> String {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            // Drain the request first so the client has finished writing, then
+            // reply and close.
+            let mut buf = [0u8; 1024];
+            let _ = socket.read(&mut buf).await;
+            let response = format!(
+                "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            let _ = socket.write_all(response.as_bytes()).await;
+            let _ = socket.shutdown().await;
+        });
+        format!("http://{addr}")
+    }
+
+    #[tokio::test]
+    async fn platform_hint_404_maps_to_legacy_default() {
+        // An old backend without the endpoint returns 404; we must fall back to
+        // the legacy linux/amd64 default rather than erroring or treating the
+        // cluster as unconstrained.
+        let base = spawn_one_shot_response("404 Not Found", "").await;
+        let hint = super::fetch_backend_platform_hint(&super::Client::new(), &base, "test-token")
+            .await
+            .expect("404 must not be a hard error");
+        assert_eq!(
+            hint,
+            Some(super::BackendPlatformHint::LegacyDefault(
+                "linux/amd64".to_string()
+            ))
+        );
+    }
+
+    #[tokio::test]
+    async fn platform_hint_uses_advertised_arch() {
+        let base = spawn_one_shot_response(
+            "200 OK",
+            r#"{"runtime_arch":"arm64","runtime_allows_root":true}"#,
+        )
+        .await;
+        let hint = super::fetch_backend_platform_hint(&super::Client::new(), &base, "test-token")
+            .await
+            .unwrap();
+        assert_eq!(
+            hint,
+            Some(super::BackendPlatformHint::Advertised(
+                "linux/arm64".to_string()
+            ))
+        );
+    }
+
+    #[tokio::test]
+    async fn platform_hint_unconstrained_cluster_is_none() {
+        // Supported endpoint, but no architecture pinned → no hint, so the
+        // build falls back to the host architecture.
+        let base = spawn_one_shot_response("200 OK", r#"{"runtime_allows_root":true}"#).await;
+        let hint = super::fetch_backend_platform_hint(&super::Client::new(), &base, "test-token")
+            .await
+            .unwrap();
+        assert_eq!(hint, None);
     }
 }

--- a/src/cli/deployment/core.rs
+++ b/src/cli/deployment/core.rs
@@ -504,12 +504,27 @@ async fn fetch_deployment_registry_credentials(
     })
 }
 
-/// Fetch the deployment platform's capabilities (architecture, etc.).
-async fn fetch_platform_capabilities(
+/// Legacy default build platform, used when the backend predates the platform
+/// capabilities endpoint. Older backends advertised `linux/amd64` by default
+/// (their node selector pinned amd64), so a newer CLI talking to an older
+/// backend keeps that behavior instead of erroring.
+///
+/// TODO: remove this fallback once all backends expose
+/// `GET /api/v1/platform/capabilities`.
+const LEGACY_PLATFORM_FALLBACK: &str = "linux/amd64";
+
+/// Derive the container build platform the target cluster expects (e.g.
+/// "linux/amd64") from the platform capabilities endpoint. `None` when the
+/// cluster is unconstrained — the build then falls back to the host
+/// architecture.
+///
+/// For backward compatibility with backends that predate the endpoint, a 404 is
+/// treated as "use the legacy `linux/amd64` default" rather than a hard failure.
+async fn fetch_backend_platform_hint(
     http_client: &Client,
     backend_url: &str,
     token: &str,
-) -> Result<PlatformCapabilities> {
+) -> Result<Option<String>> {
     let url = format!("{}/api/v1/platform/capabilities", backend_url);
 
     let response = http_client
@@ -518,6 +533,16 @@ async fn fetch_platform_capabilities(
         .send()
         .await
         .context("Failed to fetch platform capabilities")?;
+
+    // Older backend without the endpoint: don't break the deploy, fall back to
+    // the platform older backends defaulted to.
+    if response.status().as_u16() == 404 {
+        debug!(
+            "Backend has no /platform/capabilities endpoint; falling back to legacy platform '{}'",
+            LEGACY_PLATFORM_FALLBACK
+        );
+        return Ok(Some(LEGACY_PLATFORM_FALLBACK.to_string()));
+    }
 
     if !response.status().is_success() {
         let status = response.status();
@@ -532,22 +557,10 @@ async fn fetch_platform_capabilities(
         );
     }
 
-    response
+    let caps: PlatformCapabilities = response
         .json()
         .await
-        .context("Failed to parse platform capabilities response")
-}
-
-/// Derive the container build platform the target cluster expects (e.g.
-/// "linux/amd64") from the platform capabilities endpoint. `None` when the
-/// cluster is unconstrained — the build then falls back to the host
-/// architecture.
-async fn fetch_backend_platform_hint(
-    http_client: &Client,
-    backend_url: &str,
-    token: &str,
-) -> Result<Option<String>> {
-    let caps = fetch_platform_capabilities(http_client, backend_url, token).await?;
+        .context("Failed to parse platform capabilities response")?;
     Ok(caps.runtime_arch.map(|arch| format!("linux/{arch}")))
 }
 

--- a/src/cli/deployment/core.rs
+++ b/src/cli/deployment/core.rs
@@ -432,8 +432,8 @@ struct GetRegistryCredsResponse {
 }
 
 /// Subset of the platform capabilities response the CLI cares about. The full
-/// response also carries a `capabilities` map (consumed by the frontend);
-/// unknown fields are ignored.
+/// response also carries other capability flags (e.g. `runtime_allows_root`)
+/// the CLI doesn't need; unknown fields are ignored.
 #[derive(serde::Deserialize)]
 struct PlatformCapabilities {
     /// Container architecture the target cluster accepts (e.g. "amd64"). Absent

--- a/src/cli/deployment/core.rs
+++ b/src/cli/deployment/core.rs
@@ -429,17 +429,22 @@ struct GetRegistryCredsResponse {
     credentials: RegistryCredentials,
     #[allow(dead_code)]
     repository: String,
-    /// Backend-advertised container platform for the target cluster (e.g.
-    /// "linux/amd64"). Absent when the backend doesn't pin a node arch — CLI
-    /// then falls back to the host architecture.
-    #[serde(default)]
-    target_platform: Option<String>,
 }
 
-/// Registry credentials plus the backend-advertised target platform.
+/// Subset of the platform capabilities response the CLI cares about. The full
+/// response also carries a `capabilities` map (consumed by the frontend);
+/// unknown fields are ignored.
+#[derive(serde::Deserialize)]
+struct PlatformCapabilities {
+    /// Container architecture the target cluster accepts (e.g. "amd64"). Absent
+    /// when the cluster is unconstrained.
+    #[serde(default)]
+    runtime_arch: Option<String>,
+}
+
+/// Registry credentials for a deployment.
 struct DeploymentRegistryInfo {
     credentials: RegistryCredentials,
-    target_platform: Option<String>,
 }
 
 /// Log the resolved build platform and the source it was inferred from, so the
@@ -496,8 +501,54 @@ async fn fetch_deployment_registry_credentials(
 
     Ok(DeploymentRegistryInfo {
         credentials: resp.credentials,
-        target_platform: resp.target_platform,
     })
+}
+
+/// Fetch the deployment platform's capabilities (architecture, etc.).
+async fn fetch_platform_capabilities(
+    http_client: &Client,
+    backend_url: &str,
+    token: &str,
+) -> Result<PlatformCapabilities> {
+    let url = format!("{}/api/v1/platform/capabilities", backend_url);
+
+    let response = http_client
+        .get(&url)
+        .bearer_auth(token)
+        .send()
+        .await
+        .context("Failed to fetch platform capabilities")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let error_text = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "Unknown error".to_string());
+        bail!(
+            "Failed to fetch platform capabilities ({}): {}",
+            status,
+            error_text
+        );
+    }
+
+    response
+        .json()
+        .await
+        .context("Failed to parse platform capabilities response")
+}
+
+/// Derive the container build platform the target cluster expects (e.g.
+/// "linux/amd64") from the platform capabilities endpoint. `None` when the
+/// cluster is unconstrained — the build then falls back to the host
+/// architecture.
+async fn fetch_backend_platform_hint(
+    http_client: &Client,
+    backend_url: &str,
+    token: &str,
+) -> Result<Option<String>> {
+    let caps = fetch_platform_capabilities(http_client, backend_url, token).await?;
+    Ok(caps.runtime_arch.map(|arch| format!("linux/{arch}")))
 }
 
 /// A runtime environment variable override for a deployment
@@ -710,6 +761,8 @@ pub async fn create_deployment(
             .await?;
 
             // Pull the source image for the configured platform.
+            let backend_platform =
+                fetch_backend_platform_hint(http_client, backend_url, &token).await?;
             let toml_platform = deploy_opts
                 .toml_config
                 .as_ref()
@@ -720,7 +773,7 @@ pub async fn create_deployment(
                 deploy_opts.build_args.platform.as_deref(),
                 env.as_deref(),
                 toml_platform,
-                registry_info.target_platform.as_deref(),
+                backend_platform.as_deref(),
             );
             log_platform_choice(&platform, source, "Pulling");
             if let Err(e) = build::docker_pull(&container_cli, source_image, &platform) {
@@ -815,8 +868,10 @@ pub async fn create_deployment(
     } else {
         // Build from source path: Execute build and push.
         //
-        // Fetch credentials first so the backend's target_platform hint can
-        // feed into BuildOptions' platform precedence.
+        // Fetch the backend's architecture hint first so it can feed into
+        // BuildOptions' platform precedence.
+        let backend_platform =
+            fetch_backend_platform_hint(http_client, backend_url, &token).await?;
         let registry_info = fetch_deployment_registry_credentials(
             http_client,
             backend_url,
@@ -832,7 +887,7 @@ pub async fn create_deployment(
             deploy_opts.path.to_string(),
             deploy_opts.build_args,
             deploy_opts.toml_config,
-            registry_info.target_platform.as_deref(),
+            backend_platform.as_deref(),
         );
         log_platform_choice(&options.platform, options.platform_source, "Building");
 

--- a/src/cli/deployment/core.rs
+++ b/src/cli/deployment/core.rs
@@ -437,14 +437,9 @@ struct GetRegistryCredsResponse {
 #[derive(serde::Deserialize)]
 struct PlatformCapabilities {
     /// Container architecture the target cluster accepts (e.g. "amd64"). Absent
-    /// when the cluster is unconstrained.
-    #[serde(default)]
+    /// when the cluster is unconstrained. (`Option` fields default to `None`
+    /// when the key is missing, so no `#[serde(default)]` is needed.)
     runtime_arch: Option<String>,
-}
-
-/// Registry credentials for a deployment.
-struct DeploymentRegistryInfo {
-    credentials: RegistryCredentials,
 }
 
 /// Log the resolved build platform and the source it was inferred from, so the
@@ -456,7 +451,15 @@ fn log_platform_choice(platform: &str, source: PlatformSource, operation: &str) 
         CliFlag | EnvVar | RiseToml => {} // explicit user choice, stay silent
         BackendHint => info!("{operation} for {platform} (target cluster architecture)"),
         HostFallback => {
-            info!("{operation} for {platform} (host architecture; pass --platform to override)")
+            // Reached only when a *supported* capabilities endpoint reported no
+            // required architecture (a genuinely unconstrained cluster — e.g.
+            // local dev). An *unsupported* endpoint (old backend → 404) does NOT
+            // land here: `fetch_backend_platform_hint` maps that to the legacy
+            // `linux/amd64` default, which resolves as `BackendHint` above. So
+            // we can state "unconstrained" here without conflating the two.
+            info!(
+                "{operation} for {platform} (host architecture; target cluster is unconstrained — pass --platform to override)"
+            )
         }
     }
 }
@@ -468,7 +471,7 @@ async fn fetch_deployment_registry_credentials(
     token: &str,
     project_name: &str,
     deployment_id: &str,
-) -> Result<DeploymentRegistryInfo> {
+) -> Result<RegistryCredentials> {
     let url = format!(
         "{}/api/v1/projects/{}/deployments/{}/registry-credentials",
         backend_url, project_name, deployment_id
@@ -499,9 +502,7 @@ async fn fetch_deployment_registry_credentials(
         .await
         .context("Failed to parse registry credentials response")?;
 
-    Ok(DeploymentRegistryInfo {
-        credentials: resp.credentials,
-    })
+    Ok(resp.credentials)
 }
 
 /// Legacy default build platform, used when the backend predates the platform
@@ -752,7 +753,7 @@ pub async fn create_deployment(
             };
 
             // Fetch deployment-scoped registry credentials
-            let registry_info = fetch_deployment_registry_credentials(
+            let credentials = fetch_deployment_registry_credentials(
                 http_client,
                 backend_url,
                 &token,
@@ -760,14 +761,13 @@ pub async fn create_deployment(
                 &deployment_info.deployment_id,
             )
             .await?;
-            let credentials = &registry_info.credentials;
 
             login_to_registry(
                 http_client,
                 backend_url,
                 &token,
                 &container_cli,
-                credentials,
+                &credentials,
                 deploy_opts.project_name,
                 &deployment_info.deployment_id,
             )
@@ -885,7 +885,7 @@ pub async fn create_deployment(
         // BuildOptions' platform precedence.
         let backend_platform =
             fetch_backend_platform_hint(http_client, backend_url, &token).await?;
-        let registry_info = fetch_deployment_registry_credentials(
+        let credentials = fetch_deployment_registry_credentials(
             http_client,
             backend_url,
             &token,
@@ -909,7 +909,7 @@ pub async fn create_deployment(
             backend_url,
             &token,
             options.container_cli.command(),
-            &registry_info.credentials,
+            &credentials,
             deploy_opts.project_name,
             &deployment_info.deployment_id,
         )

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -201,6 +201,10 @@ pub async fn run_server(settings: settings::Settings) -> Result<()> {
             "/schema/rise-toml/v1",
             axum::routing::get(rise_toml_schema_v1_redirect),
         )
+        // Platform capabilities are non-sensitive and must be reachable by
+        // project service accounts (which have no project context here), so the
+        // route is public.
+        .merge(platform::routes::routes())
         .merge(auth::routes::public_routes())
         .merge(workload_tokens::routes::routes());
 
@@ -227,8 +231,7 @@ pub async fn run_server(settings: settings::Settings) -> Result<()> {
         .merge(environments::routes::routes())
         .merge(extensions::routes::routes())
         .merge(encryption::routes::routes())
-        .merge(quickstart::routes::routes())
-        .merge(platform::routes::routes());
+        .merge(quickstart::routes::routes());
 
     #[cfg(feature = "backend")]
     let platform_routes = platform_routes.merge(resources::routes::routes());

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -13,6 +13,7 @@ pub mod extensions;
 pub mod frontend;
 pub mod middleware;
 pub mod oci;
+pub mod platform;
 pub mod project;
 pub mod quickstart;
 pub mod rate_limit;
@@ -226,7 +227,8 @@ pub async fn run_server(settings: settings::Settings) -> Result<()> {
         .merge(environments::routes::routes())
         .merge(extensions::routes::routes())
         .merge(encryption::routes::routes())
-        .merge(quickstart::routes::routes());
+        .merge(quickstart::routes::routes())
+        .merge(platform::routes::routes());
 
     #[cfg(feature = "backend")]
     let platform_routes = platform_routes.merge(resources::routes::routes());

--- a/src/server/platform/handlers.rs
+++ b/src/server/platform/handlers.rs
@@ -1,19 +1,16 @@
 use super::models::PlatformCapabilities;
-use crate::server::auth::context::AuthContext;
 use crate::server::state::AppState;
 use axum::{extract::State, Json};
 
 /// Describe the deployment platform's capabilities.
 ///
-/// Authenticated but not project-scoped: it intentionally accepts any
-/// `AuthContext` (interactive users *and* CI service accounts) so the CLI can
-/// resolve its build architecture the same way it reaches
-/// `registry-credentials`. We deliberately do **not** call `auth.user()`, which
-/// would reject service-account tokens.
-pub async fn platform_capabilities(
-    State(state): State<AppState>,
-    _auth: AuthContext,
-) -> Json<PlatformCapabilities> {
+/// Served as a public (unauthenticated) endpoint: it must be callable by
+/// project service accounts, but it has no project context to resolve a service
+/// account against, and the response carries no sensitive information (just the
+/// runtime architecture and whether pods may run as root). Keeping it public
+/// avoids the awkward middle ground of accepting any JWKS-valid token without
+/// the per-project claim validation that scoped endpoints perform.
+pub async fn platform_capabilities(State(state): State<AppState>) -> Json<PlatformCapabilities> {
     // When no Kubernetes controller is configured (local dev / non-K8s
     // runtimes) there is no resource builder, so we advertise an unconstrained
     // platform.

--- a/src/server/platform/handlers.rs
+++ b/src/server/platform/handlers.rs
@@ -1,0 +1,34 @@
+use super::models::PlatformCapabilities;
+use crate::server::auth::context::AuthContext;
+use crate::server::state::AppState;
+use axum::{extract::State, Json};
+
+/// Describe the deployment platform's capabilities.
+///
+/// Authenticated but not project-scoped: it intentionally accepts any
+/// `AuthContext` (interactive users *and* CI service accounts) so the CLI can
+/// resolve its build architecture the same way it reaches
+/// `registry-credentials`. We deliberately do **not** call `auth.user()`, which
+/// would reject service-account tokens.
+pub async fn platform_capabilities(
+    State(state): State<AppState>,
+    _auth: AuthContext,
+) -> Json<PlatformCapabilities> {
+    // When no Kubernetes controller is configured (local dev / non-K8s
+    // runtimes) there is no resource builder, so we advertise an unconstrained
+    // platform.
+    let runtime_arch = state
+        .resource_builder
+        .as_ref()
+        .and_then(|rb| rb.node_selector.get("kubernetes.io/arch"))
+        .cloned();
+    let pod_security_enabled = state
+        .resource_builder
+        .as_ref()
+        .map(|rb| rb.pod_security_enabled);
+
+    Json(PlatformCapabilities::new(
+        runtime_arch,
+        pod_security_enabled,
+    ))
+}

--- a/src/server/platform/mod.rs
+++ b/src/server/platform/mod.rs
@@ -1,0 +1,3 @@
+pub mod handlers;
+pub mod models;
+pub mod routes;

--- a/src/server/platform/models.rs
+++ b/src/server/platform/models.rs
@@ -19,10 +19,9 @@ pub struct PlatformCapabilities {
     pub runtime_arch: Option<String>,
     /// Whether deployed pods are allowed to run as the root user. Derived from
     /// the controller's `pod_security_enabled` setting: `false` when the
-    /// platform enforces a restricted security context. The `deployments:`
-    /// prefix namespaces the capability to the deployment surface.
-    #[serde(rename = "deployments:canRunAsRoot")]
-    pub deployments_can_run_as_root: bool,
+    /// platform enforces a restricted security context (which also means a
+    /// privileged port `< 1024` can't be bound).
+    pub runtime_allows_root: bool,
 }
 
 impl PlatformCapabilities {
@@ -30,14 +29,12 @@ impl PlatformCapabilities {
     ///
     /// `pod_security_enabled` is `None` when there is no Kubernetes controller
     /// configured (e.g. local dev / non-K8s runtimes), in which case nothing
-    /// restricts running as root, so `deployments:canRunAsRoot` defaults to
-    /// `true`.
+    /// restricts running as root, so `runtime_allows_root` defaults to `true`.
     pub fn new(runtime_arch: Option<String>, pod_security_enabled: Option<bool>) -> Self {
-        let deployments_can_run_as_root =
-            pod_security_enabled.map(|enabled| !enabled).unwrap_or(true);
+        let runtime_allows_root = pod_security_enabled.map(|enabled| !enabled).unwrap_or(true);
         Self {
             runtime_arch,
-            deployments_can_run_as_root,
+            runtime_allows_root,
         }
     }
 }
@@ -50,30 +47,30 @@ mod tests {
     fn enforced_pod_security_disallows_root() {
         let caps = PlatformCapabilities::new(Some("amd64".to_string()), Some(true));
         assert_eq!(caps.runtime_arch.as_deref(), Some("amd64"));
-        assert!(!caps.deployments_can_run_as_root);
+        assert!(!caps.runtime_allows_root);
     }
 
     #[test]
     fn disabled_pod_security_allows_root() {
         let caps = PlatformCapabilities::new(None, Some(false));
         assert!(caps.runtime_arch.is_none());
-        assert!(caps.deployments_can_run_as_root);
+        assert!(caps.runtime_allows_root);
     }
 
     #[test]
     fn no_controller_defaults_to_allowing_root() {
         let caps = PlatformCapabilities::new(None, None);
-        assert!(caps.deployments_can_run_as_root);
+        assert!(caps.runtime_allows_root);
     }
 
     #[test]
-    fn serializes_flat_with_namespaced_key() {
+    fn serializes_flat() {
         let caps = PlatformCapabilities::new(None, Some(true));
         let json = serde_json::to_value(&caps).unwrap();
         // `runtime_arch` is omitted when absent; the capability sits flat at the
-        // top level under its namespaced key (no redundant `capabilities` wrap).
+        // top level (no redundant `capabilities` wrap).
         assert!(json.get("runtime_arch").is_none());
         assert!(json.get("capabilities").is_none());
-        assert_eq!(json["deployments:canRunAsRoot"], serde_json::json!(false));
+        assert_eq!(json["runtime_allows_root"], serde_json::json!(false));
     }
 }

--- a/src/server/platform/models.rs
+++ b/src/server/platform/models.rs
@@ -1,19 +1,14 @@
 use serde::Serialize;
-use std::collections::BTreeMap;
 
-/// Capability key: whether deployed pods are allowed to run as the root user.
-/// Derived from the controller's `pod_security_enabled` setting. When the
-/// platform enforces a restricted security context this is `false`, and the
-/// frontend can derive consequences from it (e.g. binding a privileged port
-/// `< 1024` will fail without `CAP_NET_BIND_SERVICE` or root).
-pub const CAP_DEPLOYMENTS_CAN_RUN_AS_ROOT: &str = "deployments:canRunAsRoot";
-
-/// Read-only description of the deployment platform's properties, surfaced to
+/// Read-only description of the deployment platform's capabilities, surfaced to
 /// clients via `GET /api/v1/platform/capabilities`.
 ///
-/// The intent is to name the real cluster *capabilities* (architecture, whether
-/// pods may run as root) and let clients derive *consequences* themselves,
-/// rather than baking those consequences into per-resource config.
+/// The response body *is* the capability set — fields sit flat at the top
+/// level. The intent is to name the real cluster capabilities (architecture,
+/// whether pods may run as root) and let clients derive *consequences*
+/// themselves (e.g. "binding a privileged port `< 1024` will fail without
+/// `CAP_NET_BIND_SERVICE` or root"), rather than baking those consequences into
+/// per-resource config. New capabilities are added as additional fields.
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct PlatformCapabilities {
     /// Container architecture the target cluster accepts (e.g. `amd64`,
@@ -22,10 +17,12 @@ pub struct PlatformCapabilities {
     /// unconstrained — clients then fall back to the host architecture.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runtime_arch: Option<String>,
-    /// Namespaced boolean capability flags (e.g. `deployments:canRunAsRoot`).
-    /// Kept as an open map so new capabilities can be added without a wire
-    /// break.
-    pub capabilities: BTreeMap<String, bool>,
+    /// Whether deployed pods are allowed to run as the root user. Derived from
+    /// the controller's `pod_security_enabled` setting: `false` when the
+    /// platform enforces a restricted security context. The `deployments:`
+    /// prefix namespaces the capability to the deployment surface.
+    #[serde(rename = "deployments:canRunAsRoot")]
+    pub deployments_can_run_as_root: bool,
 }
 
 impl PlatformCapabilities {
@@ -36,12 +33,11 @@ impl PlatformCapabilities {
     /// restricts running as root, so `deployments:canRunAsRoot` defaults to
     /// `true`.
     pub fn new(runtime_arch: Option<String>, pod_security_enabled: Option<bool>) -> Self {
-        let can_run_as_root = pod_security_enabled.map(|enabled| !enabled).unwrap_or(true);
-        let mut capabilities = BTreeMap::new();
-        capabilities.insert(CAP_DEPLOYMENTS_CAN_RUN_AS_ROOT.to_string(), can_run_as_root);
+        let deployments_can_run_as_root =
+            pod_security_enabled.map(|enabled| !enabled).unwrap_or(true);
         Self {
             runtime_arch,
-            capabilities,
+            deployments_can_run_as_root,
         }
     }
 }
@@ -54,39 +50,30 @@ mod tests {
     fn enforced_pod_security_disallows_root() {
         let caps = PlatformCapabilities::new(Some("amd64".to_string()), Some(true));
         assert_eq!(caps.runtime_arch.as_deref(), Some("amd64"));
-        assert_eq!(
-            caps.capabilities.get(CAP_DEPLOYMENTS_CAN_RUN_AS_ROOT),
-            Some(&false)
-        );
+        assert!(!caps.deployments_can_run_as_root);
     }
 
     #[test]
     fn disabled_pod_security_allows_root() {
         let caps = PlatformCapabilities::new(None, Some(false));
         assert!(caps.runtime_arch.is_none());
-        assert_eq!(
-            caps.capabilities.get(CAP_DEPLOYMENTS_CAN_RUN_AS_ROOT),
-            Some(&true)
-        );
+        assert!(caps.deployments_can_run_as_root);
     }
 
     #[test]
     fn no_controller_defaults_to_allowing_root() {
         let caps = PlatformCapabilities::new(None, None);
-        assert_eq!(
-            caps.capabilities.get(CAP_DEPLOYMENTS_CAN_RUN_AS_ROOT),
-            Some(&true)
-        );
+        assert!(caps.deployments_can_run_as_root);
     }
 
     #[test]
-    fn runtime_arch_omitted_from_json_when_absent() {
+    fn serializes_flat_with_namespaced_key() {
         let caps = PlatformCapabilities::new(None, Some(true));
         let json = serde_json::to_value(&caps).unwrap();
+        // `runtime_arch` is omitted when absent; the capability sits flat at the
+        // top level under its namespaced key (no redundant `capabilities` wrap).
         assert!(json.get("runtime_arch").is_none());
-        assert_eq!(
-            json["capabilities"][CAP_DEPLOYMENTS_CAN_RUN_AS_ROOT],
-            serde_json::json!(false)
-        );
+        assert!(json.get("capabilities").is_none());
+        assert_eq!(json["deployments:canRunAsRoot"], serde_json::json!(false));
     }
 }

--- a/src/server/platform/models.rs
+++ b/src/server/platform/models.rs
@@ -1,0 +1,92 @@
+use serde::Serialize;
+use std::collections::BTreeMap;
+
+/// Capability key: whether deployed pods are allowed to run as the root user.
+/// Derived from the controller's `pod_security_enabled` setting. When the
+/// platform enforces a restricted security context this is `false`, and the
+/// frontend can derive consequences from it (e.g. binding a privileged port
+/// `< 1024` will fail without `CAP_NET_BIND_SERVICE` or root).
+pub const CAP_DEPLOYMENTS_CAN_RUN_AS_ROOT: &str = "deployments:canRunAsRoot";
+
+/// Read-only description of the deployment platform's properties, surfaced to
+/// clients via `GET /api/v1/platform/capabilities`.
+///
+/// The intent is to name the real cluster *capabilities* (architecture, whether
+/// pods may run as root) and let clients derive *consequences* themselves,
+/// rather than baking those consequences into per-resource config.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct PlatformCapabilities {
+    /// Container architecture the target cluster accepts (e.g. `amd64`,
+    /// `arm64`), taken from the controller's
+    /// `node_selector["kubernetes.io/arch"]`. Absent when the cluster is
+    /// unconstrained — clients then fall back to the host architecture.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_arch: Option<String>,
+    /// Namespaced boolean capability flags (e.g. `deployments:canRunAsRoot`).
+    /// Kept as an open map so new capabilities can be added without a wire
+    /// break.
+    pub capabilities: BTreeMap<String, bool>,
+}
+
+impl PlatformCapabilities {
+    /// Build the capability set from the platform's raw properties.
+    ///
+    /// `pod_security_enabled` is `None` when there is no Kubernetes controller
+    /// configured (e.g. local dev / non-K8s runtimes), in which case nothing
+    /// restricts running as root, so `deployments:canRunAsRoot` defaults to
+    /// `true`.
+    pub fn new(runtime_arch: Option<String>, pod_security_enabled: Option<bool>) -> Self {
+        let can_run_as_root = pod_security_enabled.map(|enabled| !enabled).unwrap_or(true);
+        let mut capabilities = BTreeMap::new();
+        capabilities.insert(CAP_DEPLOYMENTS_CAN_RUN_AS_ROOT.to_string(), can_run_as_root);
+        Self {
+            runtime_arch,
+            capabilities,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enforced_pod_security_disallows_root() {
+        let caps = PlatformCapabilities::new(Some("amd64".to_string()), Some(true));
+        assert_eq!(caps.runtime_arch.as_deref(), Some("amd64"));
+        assert_eq!(
+            caps.capabilities.get(CAP_DEPLOYMENTS_CAN_RUN_AS_ROOT),
+            Some(&false)
+        );
+    }
+
+    #[test]
+    fn disabled_pod_security_allows_root() {
+        let caps = PlatformCapabilities::new(None, Some(false));
+        assert!(caps.runtime_arch.is_none());
+        assert_eq!(
+            caps.capabilities.get(CAP_DEPLOYMENTS_CAN_RUN_AS_ROOT),
+            Some(&true)
+        );
+    }
+
+    #[test]
+    fn no_controller_defaults_to_allowing_root() {
+        let caps = PlatformCapabilities::new(None, None);
+        assert_eq!(
+            caps.capabilities.get(CAP_DEPLOYMENTS_CAN_RUN_AS_ROOT),
+            Some(&true)
+        );
+    }
+
+    #[test]
+    fn runtime_arch_omitted_from_json_when_absent() {
+        let caps = PlatformCapabilities::new(None, Some(true));
+        let json = serde_json::to_value(&caps).unwrap();
+        assert!(json.get("runtime_arch").is_none());
+        assert_eq!(
+            json["capabilities"][CAP_DEPLOYMENTS_CAN_RUN_AS_ROOT],
+            serde_json::json!(false)
+        );
+    }
+}

--- a/src/server/platform/routes.rs
+++ b/src/server/platform/routes.rs
@@ -1,0 +1,10 @@
+use super::handlers;
+use crate::server::state::AppState;
+use axum::{routing::get, Router};
+
+pub fn routes() -> Router<AppState> {
+    Router::new().route(
+        "/platform/capabilities",
+        get(handlers::platform_capabilities),
+    )
+}

--- a/src/server/registry/handlers.rs
+++ b/src/server/registry/handlers.rs
@@ -90,18 +90,11 @@ pub async fn get_deployment_registry_credentials(
                 .with_context("repository", &repository)
         })?;
 
-    // If the controller pins `kubernetes.io/arch`, surface it so the CLI can
-    // build a matching image. Unset means "no constraint" — CLI falls back to
-    // host architecture, which is the right default for local-dev clusters.
-    let target_platform = state
-        .resource_builder
-        .as_ref()
-        .and_then(|rb| rb.node_selector.get("kubernetes.io/arch"))
-        .map(|arch| format!("linux/{arch}"));
-
+    // The target architecture is advertised separately via the platform
+    // capabilities endpoint (`GET /api/v1/platform/capabilities`), which the
+    // CLI consults to choose its build platform.
     Ok(Json(GetRegistryCredsResponse {
         credentials,
         repository,
-        target_platform,
     }))
 }

--- a/src/server/registry/models.rs
+++ b/src/server/registry/models.rs
@@ -36,12 +36,6 @@ pub struct RegistryCredentials {
 pub struct GetRegistryCredsResponse {
     pub credentials: RegistryCredentials,
     pub repository: String,
-    /// Container platform the target cluster will accept (e.g. "linux/amd64").
-    /// Populated from the controller's `node_selector["kubernetes.io/arch"]`
-    /// when pinned; absent when the cluster is unconstrained, letting the CLI
-    /// fall back to host architecture.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub target_platform: Option<String>,
 }
 
 /// Configuration for AWS ECR registry


### PR DESCRIPTION
Introduce a read-only `GET /api/v1/platform/capabilities` endpoint that names
the deployment platform's real properties so clients can derive consequences
themselves (e.g. "this template binds a privileged port and may fail here")
rather than baking them into per-resource config.

Response shape (flat — the body *is* the capability set):

```json
{ "runtime_arch": "amd64", "runtime_allows_root": false }
```

- `runtime_arch`: container architecture the cluster accepts, from the
  controller's `node_selector["kubernetes.io/arch"]`. Omitted when the cluster
  is unconstrained.
- `runtime_allows_root`: whether deployed pods may run as root, derived from the
  controller's `pod_security_enabled` (`false` under a restricted security
  context, which also means a privileged port `< 1024` can't be bound).

New capabilities are added as additional flat fields.

### Backend
- New `server::platform` module (models/handlers/routes).
- Served as a **public** (unauthenticated) route: it must be callable by project
  service accounts but has no project context to validate a service account's
  per-project claims against, and the response is non-sensitive.
- **Breaking for the wire contract:** `target_platform` is removed from the
  registry-credentials response (`GET .../registry-credentials`). The
  architecture is now advertised solely via the capabilities endpoint.

### CLI
- Fetches the build-platform hint from the new endpoint instead of
  registry-credentials; precedence (`--platform` → `RISE_PLATFORM` → `rise.toml`
  → backend hint → host arch) and `PlatformSource::BackendHint` are unchanged.
- **Backward compatibility:** a newer CLI talking to an older backend without
  the endpoint receives a 404 and falls back to the legacy `linux/amd64`
  default (what older backends advertised in practice) instead of failing. This
  shim is marked with a TODO to be removed once all backends expose the
  endpoint.

### Frontend
- `api.getPlatformCapabilities()` with defensive parsing, plus a derived
  privileged-port hint in the quickstart deploy modal that layers alongside the
  free-form template `warning`.

https://claude.ai/code/session_01BYcrKW6Kd29rtiBsgJxaEe