### PR TITLE
Gradual RiseProject CRD backfill with version-label upgrade trigger

### DIFF
--- a/docs/engineering/public/schemas/backend-settings.schema.json
+++ b/docs/engineering/public/schemas/backend-settings.schema.json
@@ -317,6 +317,13 @@
               "description": "Stable identifier for this deployment controller, written to the\ndefault Organization's `spec.deploymentControllerClass` at startup.\nThe Kubernetes controller only reconciles projects whose\nOrganization's `spec.deploymentControllerClass` matches this value.\nStamped as a value of the `rise.dev/controller-class` label on\neach `RiseProject` CR, so it must be a valid Kubernetes label\nvalue (alphanumeric / `-` / `_` / `.`, no `/`). Defaults to\n`default`.",
               "type": "string"
             },
+            "crd_upsert_interval_ms": {
+              "default": 1000,
+              "description": "Interval in milliseconds between consecutive RiseProject CRD upserts\nduring the startup backfill. The backfill runs as a background task,\ntouching every active project's CRD at this rate so that version-label\nchanges (introduced by an upgrade) are propagated to Metacontroller\ngradually rather than all at once. Defaults to 1000 (1 per second).",
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
             "custom_domain_ingress_annotations": {
               "additionalProperties": {
                 "type": "string"

--- a/src/server/deployment/crd.rs
+++ b/src/server/deployment/crd.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::HashMap;
 
 use kube::api::{Api, ListParams, Patch, PatchParams};
 use kube::Client;
@@ -51,7 +51,20 @@ const TRIGGER_ANNOTATION: &str = "rise.dev/trigger";
 /// `enforce_controller_class`; the label is the forward-compatible carrier.
 pub const CONTROLLER_CLASS_LABEL: &str = "rise.dev/controller-class";
 
+/// Label key recording the Rise server version that last upserted this CRD.
+/// When the label value changes after an upgrade, the SSA patch bumps
+/// `resourceVersion`, which Metacontroller detects as a parent-resource update
+/// and immediately triggers a sync webhook call — no explicit annotation nudge
+/// required.
+pub const RISE_VERSION_LABEL: &str = "rise.dev/version";
+
 /// Create or update a `RiseProject` CRD for the given project.
+///
+/// Always stamps the current `CARGO_PKG_VERSION` as the `rise.dev/version`
+/// label. When the label value changes (i.e. after an upgrade), the SSA patch
+/// updates `resourceVersion`, which Metacontroller detects as a parent-resource
+/// change and triggers an immediate sync webhook call — no separate annotation
+/// nudge required.
 ///
 /// `controller_class` is stamped as the `rise.dev/controller-class` label
 /// when present. `None` means "no Kubernetes deployment controller is
@@ -64,12 +77,16 @@ pub async fn ensure_rise_project(
     let api: Api<RiseProject> = Api::all(client.clone());
 
     let mut rise_project = RiseProject::new(project_name, RiseProjectSpec {});
+    let labels = rise_project
+        .metadata
+        .labels
+        .get_or_insert_with(std::collections::BTreeMap::new);
+    labels.insert(
+        RISE_VERSION_LABEL.to_string(),
+        env!("CARGO_PKG_VERSION").to_string(),
+    );
     if let Some(class) = controller_class {
-        rise_project
-            .metadata
-            .labels
-            .get_or_insert_with(std::collections::BTreeMap::new)
-            .insert(CONTROLLER_CLASS_LABEL.to_string(), class.to_string());
+        labels.insert(CONTROLLER_CLASS_LABEL.to_string(), class.to_string());
     }
 
     api.patch(
@@ -150,41 +167,70 @@ pub async fn trigger_resync(client: &Client, project_name: &str) -> anyhow::Resu
 /// Reconcile `RiseProject` CRDs for every active project in the database.
 ///
 /// Handles three scenarios in one pass:
-/// 1. **Upgrade**: When migrating to Metacontroller, no RiseProject CRDs exist yet — they're created.
+/// 1. **Upgrade**: Existing CRDs whose `rise.dev/version` label differs
+///    from the running version are patched — the label change bumps
+///    `resourceVersion`, which Metacontroller sees as a parent-resource update
+///    and immediately calls the sync webhook. No explicit `trigger_resync` call
+///    is needed.
 /// 2. **Recovery**: An accidentally deleted CRD is recreated.
-/// 3. **Relabel**: An existing CRD missing the `rise.dev/controller-class`
-///    label (created before that label existed) is patched with it.
+/// 3. **New project**: A CRD that was never created (e.g. missed during a
+///    failed earlier startup) is created now.
 ///
-/// Calls `ensure_rise_project` unconditionally for every active project;
-/// server-side apply is a no-op when the resulting object would not change,
-/// so re-applying on every startup is safe.
-///
-/// Runs once at server startup. Per-project failures are logged as warnings
-/// and do not block startup or other projects.
+/// Projects are processed sequentially with `interval` between each upsert to
+/// spread the load across the Kubernetes API server and Metacontroller rather
+/// than flooding them all at once. Runs as a background task so startup is not
+/// blocked. Per-project failures are logged as warnings and do not affect other
+/// projects.
 pub async fn backfill_rise_projects(
     client: &Client,
     db_pool: &PgPool,
     controller_class: Option<&str>,
+    interval: std::time::Duration,
 ) -> anyhow::Result<()> {
+    let current_version = env!("CARGO_PKG_VERSION");
     let api: Api<RiseProject> = Api::all(client.clone());
     let existing_crds = api.list(&ListParams::default()).await?;
-    let existing_names: HashSet<String> =
-        existing_crds.items.iter().map(|r| r.name_any()).collect();
+
+    // Build a name→version-label map so we can log how many projects are
+    // getting an upgrade-triggered resync vs. a plain no-op reconcile.
+    let existing_version_by_name: HashMap<String, Option<String>> = existing_crds
+        .items
+        .iter()
+        .map(|r| {
+            let version = r
+                .metadata
+                .labels
+                .as_ref()
+                .and_then(|l| l.get(RISE_VERSION_LABEL))
+                .cloned();
+            (r.name_any(), version)
+        })
+        .collect();
 
     let active_projects = crate::db::projects::list_active(db_pool).await?;
 
+    let total = active_projects.len();
+    info!(
+        "RiseProject backfill: {} active projects, {} pre-existing CRDs, interval={}ms",
+        total,
+        existing_version_by_name.len(),
+        interval.as_millis(),
+    );
+
     let mut created = 0u32;
+    let mut upgraded = 0u32;
     let mut reconciled = 0u32;
     let mut failed = 0u32;
-    for project in &active_projects {
+    for (i, project) in active_projects.iter().enumerate() {
+        if i > 0 {
+            tokio::time::sleep(interval).await;
+        }
         match ensure_rise_project(client, &project.name, controller_class).await {
-            Ok(()) => {
-                if existing_names.contains(&project.name) {
-                    reconciled += 1;
-                } else {
-                    created += 1;
-                }
-            }
+            Ok(()) => match existing_version_by_name.get(&project.name) {
+                None => created += 1,
+                Some(v) if v.as_deref() != Some(current_version) => upgraded += 1,
+                _ => reconciled += 1,
+            },
             Err(e) => {
                 warn!(
                     project = %project.name,
@@ -195,22 +241,10 @@ pub async fn backfill_rise_projects(
         }
     }
 
-    if created > 0 || failed > 0 {
-        info!(
-            "RiseProject backfill: {} created, {} reconciled, {} failed \
-             ({} active projects, {} pre-existing CRDs)",
-            created,
-            reconciled,
-            failed,
-            active_projects.len(),
-            existing_names.len()
-        );
-    } else {
-        debug!(
-            "RiseProject backfill: {} reconciled, no creates/failures",
-            reconciled
-        );
-    }
+    info!(
+        "RiseProject backfill complete: {} created, {} upgraded, {} reconciled, {} failed",
+        created, upgraded, reconciled, failed,
+    );
 
     Ok(())
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -111,20 +111,35 @@ pub async fn run_server(settings: settings::Settings) -> Result<()> {
         encryption_provider: state.encryption_provider.clone(),
     };
 
-    // Reconcile RiseProject CRDs (upgrade migration, recovery, and label
-    // backfill — see `backfill_rise_projects` doc for the full set of
-    // scenarios).
+    // Reconcile RiseProject CRDs as a background task — see
+    // `backfill_rise_projects` for the full set of scenarios. The task is
+    // non-blocking so the HTTP server starts immediately; projects are upserted
+    // at a steady rate to avoid flooding the Kubernetes API and Metacontroller.
     #[cfg(feature = "backend")]
     if let Some(ref kube_client) = state.kube_client {
-        if let Err(e) = deployment::crd::backfill_rise_projects(
-            kube_client,
-            &state.db_pool,
-            state.deployment_controller_class_name.as_deref(),
-        )
-        .await
-        {
-            tracing::warn!("Failed to backfill RiseProject CRDs: {:?}", e);
-        }
+        use settings::DeploymentControllerSettings;
+        let interval_ms = match &settings.deployment_controller {
+            Some(DeploymentControllerSettings::Kubernetes {
+                crd_upsert_interval_ms,
+                ..
+            }) => *crd_upsert_interval_ms,
+            _ => 1000,
+        };
+        let kube_client = kube_client.clone();
+        let db_pool = state.db_pool.clone();
+        let controller_class = state.deployment_controller_class_name.clone();
+        tokio::spawn(async move {
+            if let Err(e) = deployment::crd::backfill_rise_projects(
+                &kube_client,
+                &db_pool,
+                controller_class.as_deref(),
+                std::time::Duration::from_millis(interval_ms),
+            )
+            .await
+            {
+                tracing::warn!("Failed to backfill RiseProject CRDs: {:?}", e);
+            }
+        });
     }
 
     // Spawn enabled controllers as background tasks

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -583,6 +583,10 @@ fn default_metacontroller_webhook_port() -> u16 {
     3001
 }
 
+fn default_crd_upsert_interval_ms() -> u64 {
+    1000
+}
+
 fn default_custom_domain_tls_mode() -> CustomDomainTlsMode {
     CustomDomainTlsMode::PerDomain
 }
@@ -1007,6 +1011,14 @@ pub enum DeploymentControllerSettings {
         /// Defaults to "app.kubernetes.io/name=metacontroller-operator".
         #[serde(default)]
         metacontroller_pod_label_selector: Option<String>,
+
+        /// Interval in milliseconds between consecutive RiseProject CRD upserts
+        /// during the startup backfill. The backfill runs as a background task,
+        /// touching every active project's CRD at this rate so that version-label
+        /// changes (introduced by an upgrade) are propagated to Metacontroller
+        /// gradually rather than all at once. Defaults to 1000 (1 per second).
+        #[serde(default = "default_crd_upsert_interval_ms")]
+        crd_upsert_interval_ms: u64,
     },
 }
 


### PR DESCRIPTION
## Summary

- Stamps `rise.dev/version` on every `RiseProject` CRD via `ensure_rise_project`. On upgrade, the changed label bumps `resourceVersion`, which Metacontroller detects as a parent-resource update and immediately calls the sync webhook — no separate `trigger_resync` needed, and no dependency on `resyncPeriodSeconds` actually firing.
- Backfill now runs as a `tokio::spawn` background task so the HTTP server starts immediately rather than blocking on Kubernetes API calls.
- Projects are processed sequentially at a configurable rate (new `crd_upsert_interval_ms` setting, default 1000 ms) to avoid bursting the Kubernetes API and Metacontroller on large installs.

## Test plan

- [ ] On upgrade, observe `RiseProject backfill: N upgraded` in logs and confirm Metacontroller calls the sync webhook for each project within N seconds
- [ ] On a same-version restart, observe all projects logged as `reconciled` (label unchanged → SSA no-op → no resync)
- [ ] Confirm HTTP server starts and accepts requests immediately (backfill log appears asynchronously)
- [ ] Set `crd_upsert_interval_ms: 100` and verify faster rollout in a dev cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)