### PR TITLE
fix: correct Combobox dropdown positioning inside modals

### DIFF
--- a/frontend/src/components/r-ui.tsx
+++ b/frontend/src/components/r-ui.tsx
@@ -543,11 +543,13 @@ export function Combobox(props: ComboboxProps) {
     const [query, setQuery] = useState('');
     const [activeIndex, setActiveIndex] = useState(0);
     const [popRect, setPopRect] = useState<{ top: number; left: number; width: number } | null>(null);
-    // When the combobox lives inside a Modal, portaling the listbox to
-    // document.body would put it outside the modal's focus-trap root — Tab
-    // from the search input/options would escape into the modal's first
-    // focusable. Render inline in that case so the trap sees the popover.
+    // When inside a Modal, portal to the .r-modal element (position: static) so:
+    //   • the modal's focus-trap (which queries within .r-modal) sees the popover
+    //   • the popup uses position:absolute whose containing block becomes .r-modal-mask
+    //     (the nearest positioned ancestor), avoiding backdrop-filter containing-block issues
+    //   • .r-modal's overflow:hidden does NOT clip it (containing block is above .r-modal)
     const [inModal, setInModal] = useState(false);
+    const [portalEl, setPortalEl] = useState<Element | null>(null);
     const wrapRef = useRef<HTMLDivElement>(null);
     const triggerRef = useRef<HTMLDivElement>(null);
     const popRef = useRef<HTMLDivElement>(null);
@@ -594,8 +596,10 @@ export function Combobox(props: ComboboxProps) {
     }, [open]);
 
     useEffect(() => {
-        if (!open) { setPopRect(null); setQuery(''); return; }
-        setInModal(Boolean(wrapRef.current?.closest('.r-modal')));
+        if (!open) { setPopRect(null); setQuery(''); setPortalEl(null); return; }
+        const modal = wrapRef.current?.closest<Element>('.r-modal') ?? null;
+        setInModal(Boolean(modal));
+        setPortalEl(modal ?? document.body);
         const update = () => {
             const el = triggerRef.current;
             if (!el) return;
@@ -737,7 +741,7 @@ export function Combobox(props: ComboboxProps) {
                 )}
                 <Icon name="chevd" size={14} className="chev" />
             </div>
-            {open && popRect && (() => {
+            {open && popRect && portalEl && (() => {
                 const popover = (
                     <div
                         ref={popRef}
@@ -745,7 +749,7 @@ export function Combobox(props: ComboboxProps) {
                         className="r-cbox-pop"
                         role="listbox"
                         aria-multiselectable={isMulti || undefined}
-                        style={{ position: 'fixed', top: popRect.top, left: popRect.left, width: popRect.width }}
+                        style={{ position: inModal ? 'absolute' : 'fixed', top: popRect.top, left: popRect.left, width: popRect.width }}
                     >
                         <div className="r-cbox-search">
                             <Icon name="search" size={13} />
@@ -802,10 +806,7 @@ export function Combobox(props: ComboboxProps) {
                         </div>
                     </div>
                 );
-                // Render inline (no portal) when inside a Modal so the modal's
-                // focus trap can see the popover; otherwise portal to body to
-                // escape any surrounding overflow clipping.
-                return inModal ? popover : createPortal(popover, document.body);
+                return createPortal(popover, portalEl);
             })()}
         </div>
     );

--- a/frontend/src/components/r-ui.tsx
+++ b/frontend/src/components/r-ui.tsx
@@ -543,13 +543,6 @@ export function Combobox(props: ComboboxProps) {
     const [query, setQuery] = useState('');
     const [activeIndex, setActiveIndex] = useState(0);
     const [popRect, setPopRect] = useState<{ top: number; left: number; width: number } | null>(null);
-    // When inside a Modal, portal to the .r-modal element (position: static) so:
-    //   • the modal's focus-trap (which queries within .r-modal) sees the popover
-    //   • the popup uses position:absolute whose containing block becomes .r-modal-mask
-    //     (the nearest positioned ancestor), avoiding backdrop-filter containing-block issues
-    //   • .r-modal's overflow:hidden does NOT clip it (containing block is above .r-modal)
-    const [inModal, setInModal] = useState(false);
-    const [portalEl, setPortalEl] = useState<Element | null>(null);
     const wrapRef = useRef<HTMLDivElement>(null);
     const triggerRef = useRef<HTMLDivElement>(null);
     const popRef = useRef<HTMLDivElement>(null);
@@ -596,10 +589,7 @@ export function Combobox(props: ComboboxProps) {
     }, [open]);
 
     useEffect(() => {
-        if (!open) { setPopRect(null); setQuery(''); setPortalEl(null); return; }
-        const modal = wrapRef.current?.closest<Element>('.r-modal') ?? null;
-        setInModal(Boolean(modal));
-        setPortalEl(modal ?? document.body);
+        if (!open) { setPopRect(null); setQuery(''); return; }
         const update = () => {
             const el = triggerRef.current;
             if (!el) return;
@@ -695,13 +685,15 @@ export function Combobox(props: ComboboxProps) {
 
     // Close when focus leaves both the wrapper and the portaled popover. The
     // existing mousedown click-away handles clicks; this covers keyboard Tab.
+    // Returning focus to the trigger ensures Tab stays within a modal's focus trap.
     const handleSearchBlur = () => {
         window.setTimeout(() => {
             const active = document.activeElement as Node | null;
-            if (!active) { setOpen(false); return; }
+            if (!active) { setOpen(false); triggerRef.current?.focus(); return; }
             if (wrapRef.current?.contains(active)) return;
             if (popRef.current?.contains(active)) return;
             setOpen(false);
+            triggerRef.current?.focus();
         }, 0);
     };
 
@@ -741,7 +733,7 @@ export function Combobox(props: ComboboxProps) {
                 )}
                 <Icon name="chevd" size={14} className="chev" />
             </div>
-            {open && popRect && portalEl && (() => {
+            {open && popRect && (() => {
                 const popover = (
                     <div
                         ref={popRef}
@@ -749,7 +741,7 @@ export function Combobox(props: ComboboxProps) {
                         className="r-cbox-pop"
                         role="listbox"
                         aria-multiselectable={isMulti || undefined}
-                        style={{ position: inModal ? 'absolute' : 'fixed', top: popRect.top, left: popRect.left, width: popRect.width }}
+                        style={{ position: 'fixed', top: popRect.top, left: popRect.left, width: popRect.width }}
                     >
                         <div className="r-cbox-search">
                             <Icon name="search" size={13} />
@@ -806,7 +798,7 @@ export function Combobox(props: ComboboxProps) {
                         </div>
                     </div>
                 );
-                return createPortal(popover, portalEl);
+                return createPortal(popover, document.body);
             })()}
         </div>
     );


### PR DESCRIPTION
## Summary

- The dropdown was rendered inline (no portal) when inside a modal to preserve focus-trap behaviour, but the modal mask's backdrop-filter creates a new CSS containing block for position:fixed descendants — causing the popup to appear far from its trigger
- Simplification: always portal to document.body; portaling outside the mask means position:fixed + getBoundingClientRect() coordinates work correctly everywhere with no context detection
- Focus-trap concern solved by returning focus to the trigger in handleSearchBlur — Tab-to-close lands back inside the modal and the trap handles it from there

## Test plan

- [ ] Open the Deploy template dialog and click the Owner combobox — dropdown should appear directly below the field
- [ ] Verify the Access class combobox in the same dialog also positions correctly
- [ ] Comboboxes outside modals (project/team pages) still position correctly
- [ ] Tab from the search input closes the dropdown and keeps focus inside the modal

Generated with Claude Code