### PR TITLE
Fix multi-container PORT env var to match declared port

### DIFF
--- a/docs/user/src/content/docs/user-guide/deployments.md
+++ b/docs/user/src/content/docs/user-guide/deployments.md
@@ -273,6 +273,7 @@ Notes:
 - Routes are matched longest-prefix-first by the ingress, so `/api` shadows `/` correctly. If `[routes]` is omitted and exactly one container has a `port`, Rise synthesises `/` → that container.
 - Platform and environment **replica limits apply to the deployment's total** replicas summed across all containers, not per container — e.g. with a cap of 10, `frontend = 4` + `backend = 3` + `worker = 4` (sum 11) is rejected. CPU and memory limits, by contrast, are enforced per container.
 - Every container receives a `RISE_CONTAINER` env var set to its own name (e.g. `"frontend"`, `"api"`).
+- Each container's `PORT` env var is set to **that container's own `port`** (e.g. `frontend` gets `PORT=8080`, `backend` gets `PORT=9090`) — not a single deployment-wide value. Containers without a `port` (workers) get no injected `PORT`.
 - When a deployment has two or more containers, each is also given a `RISE_CONTAINER_HOST__<NAME>` env var for every sibling that exposes a `port` (including a port-having container that isn't routed, such as a database) — pointing at that sibling's in-cluster Service. See [Environment Variables](../environment-variables#auto-injected-variables).
 
 ## CI/CD Deployments

--- a/docs/user/src/content/docs/user-guide/deployments.md
+++ b/docs/user/src/content/docs/user-guide/deployments.md
@@ -273,7 +273,7 @@ Notes:
 - Routes are matched longest-prefix-first by the ingress, so `/api` shadows `/` correctly. If `[routes]` is omitted and exactly one container has a `port`, Rise synthesises `/` → that container.
 - Platform and environment **replica limits apply to the deployment's total** replicas summed across all containers, not per container — e.g. with a cap of 10, `frontend = 4` + `backend = 3` + `worker = 4` (sum 11) is rejected. CPU and memory limits, by contrast, are enforced per container.
 - Every container receives a `RISE_CONTAINER` env var set to its own name (e.g. `"frontend"`, `"api"`).
-- Each container's `PORT` env var is set to **that container's own `port`** (e.g. `frontend` gets `PORT=8080`, `backend` gets `PORT=9090`) — not a single deployment-wide value. Containers without a `port` (workers) get no injected `PORT`.
+- Each container's `PORT` env var is set to **that container's own `port`** (e.g. `frontend` gets `PORT=8080`, `backend` gets `PORT=9090`) — not a single deployment-wide value. Containers without a `port` (workers) keep whatever deployment-wide `PORT` was set, if any.
 - When a deployment has two or more containers, each is also given a `RISE_CONTAINER_HOST__<NAME>` env var for every sibling that exposes a `port` (including a port-having container that isn't routed, such as a database) — pointing at that sibling's in-cluster Service. See [Environment Variables](../environment-variables#auto-injected-variables).
 
 ## CI/CD Deployments

--- a/src/server/deployment/webhook.rs
+++ b/src/server/deployment/webhook.rs
@@ -1577,6 +1577,10 @@ async fn compute_desired_children(
                 }
             }
 
+            // Pin `PORT` to this container's declared port (see
+            // `apply_container_port_env`).
+            apply_container_port_env(&mut per_container_env, spec.port);
+
             let health_check = spec.health_check.clone();
 
             let runtime = crate::server::deployment::resource_builder::ContainerRuntime {
@@ -1783,6 +1787,35 @@ fn any_container_deployment_observed(
         let key = format!("{}/{}-{}", namespace, base_name, spec.name);
         observed.deployments.contains_key(&key)
     })
+}
+
+/// Force the `PORT` env var to match a container's declared port.
+///
+/// Each container listens on its own declared port — the same port used for the
+/// K8s `containerPort`, the Service, the health probes, and the
+/// `RISE_CONTAINER_HOST__*` discovery vars. The `PORT` env var must therefore
+/// reflect *this* container's port, not the deployment-wide `http_port` carried
+/// by the global env vars. Without this, a multi-container app (e.g. a frontend
+/// on 3000 next to a service on 8000) would hand every process the same global
+/// `PORT` (8080 by default), so each app binds the wrong port.
+///
+/// `PORT` can't be set via per-container `env_overrides` (rejected at request
+/// time), so the declared port is the single source of truth. Containers with no
+/// declared port (workers) keep whatever global `PORT` was set, if any.
+fn apply_container_port_env(env: &mut Vec<EnvVar>, container_port: Option<u16>) {
+    let Some(container_port) = container_port else {
+        return;
+    };
+    let port_value = container_port.to_string();
+    if let Some(existing) = env.iter_mut().find(|v| v.name == "PORT") {
+        existing.value = Some(port_value);
+    } else {
+        env.push(EnvVar {
+            name: "PORT".to_string(),
+            value: Some(port_value),
+            ..Default::default()
+        });
+    }
 }
 
 /// Resolve the container + route list the reconciler should emit for a
@@ -3122,6 +3155,70 @@ mod tests {
         assert_eq!(routes.len(), 1);
         assert_eq!(routes[0].path, "/");
         assert_eq!(routes[0].container, "app");
+    }
+
+    #[test]
+    fn apply_container_port_env_overrides_global_port() {
+        // The global env vars carry the deployment-wide PORT (here the 8080
+        // default). A container declaring its own port (3000) must have PORT
+        // rewritten to 3000 so the app binds the same port the Service/probes
+        // target — not the inherited 8080.
+        let mut env = vec![
+            EnvVar {
+                name: "PORT".to_string(),
+                value: Some("8080".to_string()),
+                ..Default::default()
+            },
+            EnvVar {
+                name: "FOO".to_string(),
+                value: Some("bar".to_string()),
+                ..Default::default()
+            },
+        ];
+
+        apply_container_port_env(&mut env, Some(3000));
+
+        let port = env.iter().find(|v| v.name == "PORT").unwrap();
+        assert_eq!(port.value.as_deref(), Some("3000"));
+        // Unrelated vars are untouched and PORT isn't duplicated.
+        assert_eq!(env.iter().filter(|v| v.name == "PORT").count(), 1);
+        assert_eq!(
+            env.iter()
+                .find(|v| v.name == "FOO")
+                .unwrap()
+                .value
+                .as_deref(),
+            Some("bar")
+        );
+    }
+
+    #[test]
+    fn apply_container_port_env_inserts_when_absent() {
+        // If no global PORT was set, a container with a declared port still gets
+        // one.
+        let mut env = Vec::new();
+        apply_container_port_env(&mut env, Some(9000));
+        assert_eq!(env.len(), 1);
+        assert_eq!(env[0].name, "PORT");
+        assert_eq!(env[0].value.as_deref(), Some("9000"));
+    }
+
+    #[test]
+    fn apply_container_port_env_leaves_workers_untouched() {
+        // A worker (no declared port) keeps whatever global PORT was set, if any.
+        let mut env = vec![EnvVar {
+            name: "PORT".to_string(),
+            value: Some("8080".to_string()),
+            ..Default::default()
+        }];
+        apply_container_port_env(&mut env, None);
+        assert_eq!(env.len(), 1);
+        assert_eq!(env[0].value.as_deref(), Some("8080"));
+
+        // ...and a portless worker with no global PORT gets none injected.
+        let mut empty = Vec::new();
+        apply_container_port_env(&mut empty, None);
+        assert!(empty.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a bug in multi-container deployments where all containers were receiving the same global `PORT` environment variable, causing apps to bind the wrong port. Each container now gets a `PORT` env var matching its declared port.

## Problem

In multi-container deployments (e.g., a frontend on port 3000 and a backend on port 8000), all containers were inheriting the deployment-wide `PORT` env var (8080 by default). This caused each app to attempt binding the wrong port, since:
- The Kubernetes Service, health probes, and `RISE_CONTAINER_HOST__*` discovery vars all target each container's declared port
- But the global `PORT` env var didn't match, creating a mismatch

## Solution

Added `apply_container_port_env()` function that:
- Overrides the global `PORT` env var with each container's declared port
- Inserts a `PORT` env var if one doesn't exist
- Leaves workers (containers with no declared port) untouched, preserving any global `PORT`
- Is called during deployment reconciliation for each container

## Key Changes

- **`compute_desired_children()`**: Added call to `apply_container_port_env()` after building per-container env vars
- **`apply_container_port_env()`**: New function that ensures `PORT` matches the container's declared port
- **Tests**: Added three comprehensive tests covering override, insertion, and worker scenarios
- **Documentation**: Updated `deployments.md` to clarify that each container's `PORT` reflects its declared port

## Implementation Details

The `PORT` env var cannot be set via per-container `env_overrides` (rejected at request validation time), so the declared port is the single source of truth. This ensures consistency between what the container listens on and what the platform targets.

https://claude.ai/code/session_01KgfsCaMeHiBMXdUZ6v94aw