### PR TITLE
Reserve the `RISE_` env-var prefix to prevent pod env collisions

### DIFF
--- a/docs/user/src/content/docs/user-guide/environment-variables.md
+++ b/docs/user/src/content/docs/user-guide/environment-variables.md
@@ -123,6 +123,10 @@ Rise automatically injects these variables into every deployment:
 
 Callers prepend their own protocol — e.g. `redis://${RISE_CONTAINER_HOST__REDIS}` or `http://${RISE_CONTAINER_HOST__API}`.
 
+:::caution[The `RISE_` prefix is reserved]
+The `RISE_` prefix is reserved for the auto-injected variables above. Setting your own variable whose name starts with `RISE_` — whether via `rise env set`, deploy-time overrides, or `[containers.<name>.env]` in `rise.toml` — is rejected. This prevents an injected value from silently shadowing your variable (or vice-versa).
+:::
+
 ## Deploy-Time Environment Overrides
 
 You can pass runtime environment variables directly when deploying:

--- a/src/server/deployment/handlers.rs
+++ b/src/server/deployment/handlers.rs
@@ -544,6 +544,14 @@ fn validate_env_override(env_override: &models::EnvOverride) -> Result<bool, Ser
         ));
     }
 
+    if models::is_reserved_env_var_key(&env_override.key) {
+        return Err(ServerError::bad_request(format!(
+            "Env override '{}' uses the reserved '{}' prefix, which is reserved for Rise-injected variables.",
+            env_override.key,
+            models::RESERVED_ENV_VAR_PREFIX,
+        )));
+    }
+
     let is_protected = normalize_env_override_is_protected(env_override);
     if is_protected && !env_override.is_secret {
         return Err(ServerError::bad_request(format!(
@@ -3255,6 +3263,22 @@ mod tests {
             err.message,
             "PORT cannot be set via env overrides. Use http_port/--http-port instead."
         );
+    }
+
+    #[test]
+    fn env_override_validation_rejects_reserved_rise_prefix() {
+        let err = validate_env_override(&EnvOverride {
+            key: "RISE_APP_URL".to_string(),
+            value: "value".to_string(),
+            is_secret: false,
+            is_protected: None,
+            source: None,
+            for_environment: None,
+        })
+        .unwrap_err();
+
+        assert_eq!(err.status, StatusCode::BAD_REQUEST);
+        assert!(err.message.contains("reserved"));
     }
 
     #[test]

--- a/src/server/deployment/models.rs
+++ b/src/server/deployment/models.rs
@@ -145,6 +145,20 @@ fn default_memory() -> String {
 pub use rise_backend_core::group::{normalize_deployment_group, DEFAULT_DEPLOYMENT_GROUP};
 pub use rise_backend_core::system_env::rise_system_env_vars;
 
+/// Prefix reserved for Rise-injected pod env vars (see `rise_system_env_vars`).
+///
+/// User-supplied env-var keys in this namespace are rejected so they cannot
+/// silently collide with / shadow a Rise-injected value (injected vars are set
+/// as explicit pod `env`, which Kubernetes resolves *after* `envFrom`).
+pub const RESERVED_ENV_VAR_PREFIX: &str = "RISE_";
+
+/// True if `key` falls in the reserved `RISE_*` namespace and must be rejected
+/// for user-supplied env vars. Case-sensitive: K8s env names are case-sensitive
+/// and the injected vars are uppercase.
+pub fn is_reserved_env_var_key(key: &str) -> bool {
+    key.starts_with(RESERVED_ENV_VAR_PREFIX)
+}
+
 /// Validate the wire-level multi-container spec (containers + routes) from a
 /// `CreateDeploymentRequest`. Returns `Ok(())` for legacy single-container
 /// requests (`containers` is `None`).

--- a/src/server/env_vars/handlers.rs
+++ b/src/server/env_vars/handlers.rs
@@ -896,8 +896,9 @@ mod tests {
             let err =
                 validate_env_var_key(key).expect_err(&format!("expected {key:?} to be rejected"));
             assert!(
-                err.to_string().contains("reserved"),
-                "unexpected error for {key:?}: {err}"
+                err.message.contains("reserved"),
+                "unexpected error for {key:?}: {}",
+                err.message
             );
         }
     }

--- a/src/server/env_vars/handlers.rs
+++ b/src/server/env_vars/handlers.rs
@@ -22,10 +22,10 @@ use std::collections::HashMap;
 /// silently normalised — if the key contains whitespace the caller likely made
 /// a mistake and should fix the request.
 ///
-// TODO(#344): reserve the `RISE_` prefix here so a user-supplied env var can't
-// collide with the Rise-injected `RISE_*` pod env (e.g. `RISE_APP_URL`,
-// `RISE_DEPLOYMENT_GROUP`, `RISE_CONTAINER_HOST__<NAME>`), which as explicit
-// pod env would silently shadow a same-named secret.
+/// The `RISE_` prefix is reserved for Rise-injected pod env vars (e.g.
+/// `RISE_APP_URL`, `RISE_DEPLOYMENT_GROUP`, `RISE_CONTAINER_HOST__<NAME>`).
+/// Those are set as explicit pod `env` and would silently shadow a same-named
+/// secret, so user-supplied keys in that namespace are rejected outright.
 fn validate_env_var_key(key: &str) -> Result<(), ServerError> {
     if key != key.trim() {
         return Err(ServerError::bad_request(format!(
@@ -41,6 +41,13 @@ fn validate_env_var_key(key: &str) -> Result<(), ServerError> {
         return Err(ServerError::bad_request(format!(
             "Invalid environment variable key {:?}: must consist of alphanumeric characters, '-', '_', or '.'",
             key
+        )));
+    }
+    if deployment_models::is_reserved_env_var_key(key) {
+        return Err(ServerError::bad_request(format!(
+            "Invalid environment variable key {:?}: the '{}' prefix is reserved for Rise-injected variables",
+            key,
+            deployment_models::RESERVED_ENV_VAR_PREFIX,
         )));
     }
     Ok(())
@@ -862,4 +869,45 @@ pub async fn preview_deployment_env_vars(
     env_vars.sort_by(|a, b| a.key.cmp(&b.key));
 
     Ok(Json(EnvVarsResponse { env_vars }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_env_var_key;
+
+    #[test]
+    fn accepts_valid_keys() {
+        for key in ["FOO", "MY_VAR", "foo.bar", "a-b_c.1", "rise_foo"] {
+            assert!(
+                validate_env_var_key(key).is_ok(),
+                "expected {key:?} to be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_reserved_rise_prefix() {
+        for key in [
+            "RISE_FOO",
+            "RISE_",
+            "RISE_APP_URL",
+            "RISE_CONTAINER_HOST__API",
+        ] {
+            let err =
+                validate_env_var_key(key).expect_err(&format!("expected {key:?} to be rejected"));
+            assert!(
+                err.to_string().contains("reserved"),
+                "unexpected error for {key:?}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_charset_and_whitespace() {
+        assert!(validate_env_var_key("").is_err());
+        assert!(validate_env_var_key(" FOO").is_err());
+        assert!(validate_env_var_key("FOO ").is_err());
+        assert!(validate_env_var_key("foo bar").is_err());
+        assert!(validate_env_var_key("foo$bar").is_err());
+    }
 }


### PR DESCRIPTION
Rise injects a family of `RISE_*` env vars into every deployed pod
(RISE_ISSUER, RISE_APP_URL, RISE_DEPLOYMENT_GROUP,
RISE_CONTAINER_HOST__<NAME>, ...). These are set as explicit pod `env`,
which Kubernetes resolves after `envFrom`/`secretRef`, so a Rise value
silently shadows a same-named user secret (and vice-versa) with no error.

Reserve the namespace by rejecting user-supplied keys starting with
`RISE_` at both validation boundaries:

- `validate_env_var_key` (project env vars set via the API)
- `validate_env_override` (deploy-time overrides, covering both
  top-level and per-container `[containers.X.env]` keys)

Add a shared `RESERVED_ENV_VAR_PREFIX` constant and
`is_reserved_env_var_key` helper next to `rise_system_env_vars`, the
source of truth for the injected namespace. Includes unit tests and a
docs note. Closes #344.