### PR TITLE
Add token claims debugging for CI/CD authentication troubleshooting

### DIFF
--- a/docs/engineering/src/content/docs/configuration.md
+++ b/docs/engineering/src/content/docs/configuration.md
@@ -463,6 +463,38 @@ Run with `RUST_LOG=debug` to see configuration loading details:
 RUST_LOG=debug cargo run --bin rise -- backend server
 ```
 
+## Debugging Authentication and Token Claims
+
+When a deploy or login is rejected with a permission or "claims do not match"
+error, raise the backend log level to see the issuer, claims, and validation
+decisions Rise makes for an incoming token. Keep general output at `info` and
+turn up only the auth and workload-token paths so the relevant lines aren't
+buried:
+
+```bash
+RUST_LOG=info,rise::server::auth=debug,rise::server::workload_tokens=debug \
+  rise backend server
+```
+
+This surfaces:
+
+- `rise::server::auth::handlers` — the OIDC ID-token claims during browser login
+  (`ID token claims: {...}`)
+- `rise::server::auth::middleware` — the issuer the backend peeked at and the
+  JWKS-validation outcome for an incoming token
+- `rise::server::auth::context` — per-service-account claim-mismatch reasons
+  (`SA <id> claim mismatch: ...`); these log at `info`, so they show even without
+  the `debug` targets above
+- `rise::server::workload_tokens::handlers` — `Issued workload identity token`
+  (project / environment / audience / ttl) when an app mints a token through the
+  token-exchange endpoint
+
+`RUST_LOG=rise=debug` works as a catch-all but is far noisier.
+
+To inspect claims from the *client* side — the token the `rise` CLI presents
+(`RISE_TOKEN`, a `RISE_TOKEN_COMMAND`, or GitHub Actions OIDC) — see
+**Inspecting Token Claims** in the user troubleshooting guide.
+
 ## Quickstart Templates
 
 Rise's web UI surfaces a curated catalog of stateless container images that

--- a/docs/user/src/content/docs/user-guide/configuration.mdx
+++ b/docs/user/src/content/docs/user-guide/configuration.mdx
@@ -147,4 +147,4 @@ This file is created automatically on first `rise login`.
 
 ## Backend Configuration Schema
 
-If you're operating a Rise deployment, a JSON Schema for backend configuration (`rise.yaml`) is available at [`backend-settings.schema.json`](/docs/schemas/backend-settings.schema.json). See the [Operator Configuration guide](/operator-docs/configuration/) for details.
+If you're operating a Rise deployment, a JSON Schema for backend configuration (`rise.yaml`) is available at [`backend-settings.schema.json`](/docs/schemas/backend-settings.schema.json). See the [Operator Configuration guide](https://rise-deploy.github.io/rise/operator/configuration/) for details.

--- a/docs/user/src/content/docs/user-guide/troubleshooting.md
+++ b/docs/user/src/content/docs/user-guide/troubleshooting.md
@@ -146,32 +146,15 @@ account configuration (`rise sa list -p <project>`). They must match exactly —
 `RUST_LOG=debug rise <command>` works too but is much noisier; the
 `rise::cli::login::token_utils=debug` target isolates just the token line.
 
-This same line is emitted regardless of token source, so it also surfaces the
-claims of tokens **minted through the token provider** — a `RISE_TOKEN_COMMAND`
-that prints a JWT, or a GitHub Actions OIDC token minted on demand.
+The line is emitted whether the token is static or **minted on demand through
+the token provider** (a `RISE_TOKEN_COMMAND` that prints a JWT, or a GitHub
+Actions OIDC token), so it always reflects the token actually sent.
 
-For the *server* side of the same exchange, raise the log level on the backend
-instead. Keep the general output at `info` and turn up only the auth and
-workload-token paths so the relevant lines aren't buried:
-
-```bash
-RUST_LOG=info,rise::server::auth=debug,rise::server::workload_tokens=debug \
-  rise backend server
-```
-
-This surfaces:
-
-- `rise::server::auth::handlers` — the OIDC ID-token claims during browser login
-  (`ID token claims: {...}`)
-- `rise::server::auth::middleware` — the issuer the backend peeked at and the
-  JWKS-validation outcome for an incoming token
-- `rise::server::auth::context` — per-service-account claim-mismatch reasons
-  (`SA <id> claim mismatch: ...`); these log at `info`, so they show even without
-  the `debug` targets above
-- `rise::server::workload_tokens::handlers` — `Issued workload identity token`
-  (project / environment / audience / ttl) when an app mints a token
-
-`RUST_LOG=rise=debug` works as a catch-all but is far noisier.
+The *server* side of the same exchange — the issuer the backend peeked at, JWKS
+validation outcomes, and per-service-account claim-mismatch reasons — is only
+visible to whoever operates your Rise backend. If you run it yourself, see
+[Debugging Authentication and Token Claims](https://rise-deploy.github.io/rise/operator/configuration/#debugging-authentication-and-token-claims)
+in the operator docs.
 
 See [Workload Identity Tokens](../workload-identity-tokens) for inspecting the
 Rise-signed tokens an app mints for downstream systems.

--- a/docs/user/src/content/docs/user-guide/troubleshooting.md
+++ b/docs/user/src/content/docs/user-guide/troubleshooting.md
@@ -117,6 +117,50 @@ Service accounts can only deploy, not manage projects. Use a regular user accoun
 
 See [Authentication](../authentication) for full service account setup.
 
+## Inspecting Token Claims
+
+When a deploy is rejected with a permission or "claims do not match" error — most
+often from CI, where the token comes from `RISE_TOKEN`, `RISE_TOKEN_COMMAND`, or
+auto-detected GitHub Actions OIDC rather than an interactive login — the quickest
+way to see *what identity the CLI is actually presenting* is to raise the log
+level on the token-resolution path. The CLI logs the resolved token's decoded
+header and claims at `debug` (the signature is never logged):
+
+```bash
+RUST_LOG=rise::cli::login::token_utils=debug rise deploy
+```
+
+```
+DEBUG rise::cli::login::token_utils: Using token from RISE_TOKEN environment variable
+DEBUG rise::cli::login::token_utils: Token header.claims is {"alg":"RS256","typ":"JWT","kid":"38826b17-..."}.{"iss":"https://token.actions.githubusercontent.com","aud":"https://rise.example.net","sub":"repo:my-org/my-service:environment:production","repository":"my-org/my-service","repository_owner":"my-org","environment":"production","ref":"refs/heads/main","ref_protected":"false","event_name":"push","workflow_ref":"my-org/my-service/.github/workflows/rise.yml@refs/heads/main","exp":1780386362,"iat":1780386062,...}
+```
+
+The source label names where the token came from — `RISE_TOKEN environment
+variable`, `RISE_TOKEN_COMMAND`, `GitHub Actions OIDC`, or `stored login token`.
+
+Compare the printed `iss`, `aud`, and the rest of the claims against your service
+account configuration (`rise sa list -p <project>`). They must match exactly — a mismatched
+`iss` (e.g. a trailing slash) or a missing claim is the usual cause of
+[`No service account matched the token claims`](#no-service-account-matched-the-token-claims).
+
+`RUST_LOG=debug rise <command>` works too but is much noisier; the
+`rise::cli::login::token_utils=debug` target isolates just the token line.
+
+This same line is emitted regardless of token source, so it also surfaces the
+claims of tokens **minted through the token provider** — a `RISE_TOKEN_COMMAND`
+that prints a JWT, or a GitHub Actions OIDC token minted on demand.
+
+For the *server* side of the same exchange (issuer the backend peeked at, JWKS
+validation outcome, and per-service-account claim-mismatch reasons), raise the
+backend log level instead:
+
+```bash
+RUST_LOG=rise=debug rise backend server
+```
+
+See [Workload Identity Tokens](../workload-identity-tokens) for inspecting the
+Rise-signed tokens an app mints for downstream systems.
+
 ## Getting Help
 
 - Check deployment logs: `rise deployment logs <project> <deployment-id>`

--- a/docs/user/src/content/docs/user-guide/troubleshooting.md
+++ b/docs/user/src/content/docs/user-guide/troubleshooting.md
@@ -150,13 +150,28 @@ This same line is emitted regardless of token source, so it also surfaces the
 claims of tokens **minted through the token provider** — a `RISE_TOKEN_COMMAND`
 that prints a JWT, or a GitHub Actions OIDC token minted on demand.
 
-For the *server* side of the same exchange (issuer the backend peeked at, JWKS
-validation outcome, and per-service-account claim-mismatch reasons), raise the
-backend log level instead:
+For the *server* side of the same exchange, raise the log level on the backend
+instead. Keep the general output at `info` and turn up only the auth and
+workload-token paths so the relevant lines aren't buried:
 
 ```bash
-RUST_LOG=rise=debug rise backend server
+RUST_LOG=info,rise::server::auth=debug,rise::server::workload_tokens=debug \
+  rise backend server
 ```
+
+This surfaces:
+
+- `rise::server::auth::handlers` — the OIDC ID-token claims during browser login
+  (`ID token claims: {...}`)
+- `rise::server::auth::middleware` — the issuer the backend peeked at and the
+  JWKS-validation outcome for an incoming token
+- `rise::server::auth::context` — per-service-account claim-mismatch reasons
+  (`SA <id> claim mismatch: ...`); these log at `info`, so they show even without
+  the `debug` targets above
+- `rise::server::workload_tokens::handlers` — `Issued workload identity token`
+  (project / environment / audience / ttl) when an app mints a token
+
+`RUST_LOG=rise=debug` works as a catch-all but is far noisier.
 
 See [Workload Identity Tokens](../workload-identity-tokens) for inspecting the
 Rise-signed tokens an app mints for downstream systems.

--- a/src/cli/token_source.rs
+++ b/src/cli/token_source.rs
@@ -20,7 +20,7 @@ use tokio::sync::Mutex;
 use tracing::warn;
 
 use crate::config::Config;
-use crate::login::token_utils::read_token_exp;
+use crate::login::token_utils::{log_token_debug, read_token_exp};
 
 /// Re-mint cached JWTs before two thirds of their observed lifetime has elapsed
 /// and once they are within this many seconds of expiry, so a request issued
@@ -115,7 +115,14 @@ const GHA_OIDC_MINT_TIMEOUT_DEFAULT_SECS: u64 = 10;
 pub async fn token_with_retry(provider: &TokenProvider) -> Result<String> {
     for attempt in 0..=TOKEN_RESOLUTION_RETRIES {
         match provider.token().await {
-            Ok(token) => return Ok(token),
+            Ok(token) => {
+                // Surface the resolved token's claims at debug so operators can
+                // confirm what identity a command (e.g. `rise deploy` from CI)
+                // is presenting — the OIDC token in RISE_TOKEN, a minted GitHub
+                // Actions OIDC token, etc. Signature is never logged.
+                log_token_debug(&token, provider.describe());
+                return Ok(token);
+            }
             Err(e) if is_non_retryable_token_error(&e) => return Err(e),
             Err(e) if attempt < TOKEN_RESOLUTION_RETRIES => {
                 let backoff = TOKEN_RETRY_BASE_BACKOFF * (attempt as u32 + 1);
@@ -192,14 +199,16 @@ impl CachedToken {
 }
 
 /// A fixed token (from `RISE_TOKEN` or the stored login config). Never expires
-/// from the CLI's perspective; `refresh` returns the same value.
+/// from the CLI's perspective; `refresh` returns the same value. `source` is a
+/// short label naming where the token came from, surfaced in debug logs.
 pub struct StaticToken {
     value: String,
+    source: &'static str,
 }
 
 impl StaticToken {
-    pub fn new(value: String) -> Self {
-        Self { value }
+    pub fn new(value: String, source: &'static str) -> Self {
+        Self { value, source }
     }
 }
 
@@ -209,7 +218,7 @@ impl TokenSource for StaticToken {
         Ok(self.value.clone())
     }
     fn describe(&self) -> &'static str {
-        "static token"
+        self.source
     }
 }
 
@@ -471,7 +480,10 @@ pub fn select_token_provider(
 ) -> Result<TokenProvider> {
     // 1. Explicit RISE_TOKEN wins (backward compatible).
     if let Some(token) = inputs.rise_token.filter(|t| !t.is_empty()) {
-        return Ok(Arc::new(StaticToken::new(token)));
+        return Ok(Arc::new(StaticToken::new(
+            token,
+            "RISE_TOKEN environment variable",
+        )));
     }
     // 2. Generic command escape hatch.
     if let Some(cmd) = inputs.rise_token_command.filter(|c| !c.is_empty()) {
@@ -502,7 +514,7 @@ pub fn select_token_provider(
     }
     // 4. Stored login token.
     if let Some(token) = inputs.stored_token.filter(|t| !t.is_empty()) {
-        return Ok(Arc::new(StaticToken::new(token)));
+        return Ok(Arc::new(StaticToken::new(token, "stored login token")));
     }
     // 5. Nothing.
     Err(TokenSourceError::NoSource("Not authenticated. Run 'rise login' first.".to_string()).into())
@@ -570,7 +582,7 @@ mod tests {
 
     #[tokio::test]
     async fn static_token_returns_value() {
-        let s = StaticToken::new("abc".to_string());
+        let s = StaticToken::new("abc".to_string(), "static token");
         assert_eq!(s.token().await.unwrap(), "abc");
     }
 
@@ -626,7 +638,7 @@ mod tests {
         i.audience = Some("aud".into());
         i.stored_token = Some("stored".into());
         let p = select_token_provider(&client(), i).unwrap();
-        assert_eq!(p.describe(), "static token");
+        assert_eq!(p.describe(), "RISE_TOKEN environment variable");
     }
 
     #[test]
@@ -670,7 +682,7 @@ mod tests {
         let mut i = base_inputs();
         i.stored_token = Some("stored".into());
         let p = select_token_provider(&client(), i).unwrap();
-        assert_eq!(p.describe(), "static token");
+        assert_eq!(p.describe(), "stored login token");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

This PR adds comprehensive debugging capabilities for token resolution in CI/CD environments, helping operators diagnose "claims do not match" errors by inspecting the actual identity being presented to the Rise backend.

## Key Changes

- **Documentation**: Added new "Inspecting Token Claims" troubleshooting section in `docs/user/src/content/docs/user-guide/troubleshooting.md` with:
  - Instructions for enabling debug logging via `RUST_LOG=rise::cli::login::token_utils=debug`
  - Example output showing decoded JWT header and claims
  - Guidance on comparing claims against service account configuration
  - References to server-side debugging and workload identity tokens

- **Token Source Labeling**: Enhanced `StaticToken` to track the source of tokens:
  - Added `source: &'static str` field to `StaticToken` struct
  - Updated constructor to accept source label parameter
  - Modified `describe()` method to return the actual source instead of generic "static token"
  - Sources now include: `"RISE_TOKEN environment variable"`, `"RISE_TOKEN_COMMAND"`, `"GitHub Actions OIDC"`, `"stored login token"`

- **Debug Logging**: Integrated token claims logging in `token_with_retry()`:
  - Calls new `log_token_debug()` function after successful token resolution
  - Passes provider's `describe()` output to surface token source in logs
  - Logs decoded JWT header and claims (signature never logged) at debug level

- **Test Updates**: Updated unit tests to reflect new `StaticToken` constructor signature and verify correct source labels are used

## Implementation Details

The changes enable operators to quickly diagnose authentication issues in CI/CD pipelines by:
1. Running a command with debug logging enabled
2. Observing the exact claims the CLI is presenting
3. Comparing against configured service account requirements
4. Identifying mismatches (e.g., trailing slashes in `iss`, missing claims)

This works across all token sources (environment variables, token commands, GitHub Actions OIDC, stored login tokens) and complements server-side debugging via `RUST_LOG=rise=debug rise backend server`.

https://claude.ai/code/session_012SW8NcHTwTwut1sT85kBLn