### PR TITLE
Display claim count in service account list

### DIFF
--- a/frontend/src/features/projects.tsx
+++ b/frontend/src/features/projects.tsx
@@ -353,20 +353,23 @@ export function AppUsersList({ projectName, project, accessClasses, currentUserE
                     : removeAction(() => setConfirmRemove({ kind: 'team', teamId: t.id, name: t.name })),
             };
         }),
-        ...serviceAccounts.map(sa => ({
-            key: `sa-${sa.id}`,
-            kind: 'sa',
-            icon: KIND_META.sa.icon,
-            name: <span style={{ fontWeight: 500 }}>{sa.email}</span>,
-            kindLabel: KIND_META.sa.label,
-            extra: null,
-            actions: (
-                <>
-                    <RButton size="sm" icon="edit" onClick={() => openEditSa(sa)}>Edit</RButton>
-                    {removeAction(() => setConfirmRemove({ kind: 'sa', sa, name: sa.email }))}
-                </>
-            ),
-        })),
+        ...serviceAccounts.map(sa => {
+            const claimCount = Object.keys(sa.claims || {}).length;
+            return {
+                key: `sa-${sa.id}`,
+                kind: 'sa',
+                icon: KIND_META.sa.icon,
+                name: <span style={{ fontWeight: 500 }}>{sa.email}</span>,
+                kindLabel: [KIND_META.sa.label, `${claimCount} ${claimCount === 1 ? 'claim' : 'claims'}`],
+                extra: null,
+                actions: (
+                    <>
+                        <RButton size="sm" icon="edit" onClick={() => openEditSa(sa)}>Edit</RButton>
+                        {removeAction(() => setConfirmRemove({ kind: 'sa', sa, name: sa.email }))}
+                    </>
+                ),
+            };
+        }),
     ];
 
     const filterMap = { all: null, users: 'user', teams: 'team', sas: 'sa' };


### PR DESCRIPTION
## Summary
Updated the service accounts list display to show the number of claims associated with each service account alongside the service account label.

## Changes
- Modified the service accounts mapping in `AppUsersList` to calculate and display claim counts
- Changed `kindLabel` from a simple string to an array containing both the label and claim count text
- The claim count displays as "1 claim" (singular) or "N claims" (plural) based on the actual count
- Refactored the map function to use an explicit return statement for better readability

## Implementation Details
- Extracts claim count from `sa.claims` object using `Object.keys().length`
- Maintains backward compatibility with existing service account UI structure
- No changes to functionality, purely a display enhancement

https://claude.ai/code/session_01Cri3cg6GZKbBxJRGWNbyZr