### PR TITLE
Support per-field inheritance for build and deploy config

### DIFF
--- a/docs/user/public/schemas/rise-toml-v1.schema.json
+++ b/docs/user/public/schemas/rise-toml-v1.schema.json
@@ -111,12 +111,17 @@
           ],
           "description": "Build configuration to produce this container's image. Exclusive with `image`."
         },
-        "cpu": {
-          "description": "CPU allocation (e.g. \"500m\", \"1\") — sets both request and limit.",
-          "type": [
-            "string",
-            "null"
-          ]
+        "deploy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DeployConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Deployment resource configuration (replicas, cpu, memory, health_check).\nMirrors the top-level `[deploy]` table; unset fields inherit the\ntop-level `[deploy]` defaults."
         },
         "env": {
           "additionalProperties": {
@@ -126,26 +131,8 @@
           "description": "Plain-text environment variables scoped to this container. Merged on top\nof any project-level env vars; container-scoped values win on conflict.",
           "type": "object"
         },
-        "health_check": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/HealthCheckSetting"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "Health check configuration. HTTP liveness+readiness probes are disabled\nby default — they must be explicitly configured here. Set a config block\nto enable probes with a custom path/timing, or `health_check = false` to\nexplicitly mark them disabled. Requires `port` to be set."
-        },
         "image": {
           "description": "Pre-built image reference. Exclusive with `build`.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "memory": {
-          "description": "Memory allocation (e.g. \"256Mi\", \"1Gi\") — sets both request and limit.",
           "type": [
             "string",
             "null"
@@ -160,31 +147,33 @@
             "integer",
             "null"
           ]
-        },
-        "replicas": {
-          "description": "Number of replicas.",
-          "format": "uint32",
-          "minimum": 0,
-          "type": [
-            "integer",
-            "null"
-          ]
         }
       },
       "type": "object"
     },
     "DeployConfig": {
-      "description": "Deployment resource configuration",
+      "description": "Deployment resource configuration.\n\nShared by the top-level `[deploy]`, per-environment `[environments.<name>.deploy]`,\nand per-container `[containers.<name>.deploy]` tables. Top-level values act as\ndefaults that each container inherits per field.",
       "properties": {
         "cpu": {
-          "description": "CPU allocation (e.g., \"500m\", \"1\") — sets both K8s request and limit",
+          "description": "CPU allocation. Either a fixed value that sets both the K8s request and\nlimit (e.g. `\"500m\"`, `\"1\"`), or a `request-limit` range (e.g. `\"128m-1\"`\n→ request `128m`, limit `1`). The request may not exceed the limit, and\nthe limit is validated against the environment/platform allowed range.",
           "type": [
             "string",
             "null"
           ]
         },
+        "health_check": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HealthCheckSetting"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Health check configuration. HTTP liveness+readiness probes are disabled\nby default — they must be explicitly configured here. Set a config block\nto enable probes with a custom path/timing, or `health_check = false` to\nexplicitly mark them disabled. At the container level this requires the\ncontainer to have a `port`."
+        },
         "memory": {
-          "description": "Memory allocation (e.g., \"256Mi\", \"1Gi\") — sets both K8s request and limit",
+          "description": "Memory allocation. Either a fixed value that sets both the K8s request\nand limit (e.g. `\"256Mi\"`, `\"1Gi\"`), or a `request-limit` range (e.g.\n`\"64Mi-256Mi\"`). Same request/limit and range rules as `cpu`.",
           "type": [
             "string",
             "null"
@@ -373,7 +362,7 @@
       "additionalProperties": {
         "$ref": "#/$defs/ContainerConfig"
       },
-      "description": "Multi-container configuration. When non-empty, top-level `[build]` and\n`[deploy]` must not be set. Each container becomes a separate K8s\nDeployment so replica counts scale independently.",
+      "description": "Multi-container configuration. When non-empty, the top-level `[build]`\nand `[deploy]` tables act as defaults that each container inherits per\nfield (see `ContainerConfig`). Each container becomes a separate K8s\nDeployment so replica counts scale independently.",
       "type": "object"
     },
     "deploy": {

--- a/docs/user/src/content/docs/user-guide/deployments.md
+++ b/docs/user/src/content/docs/user-guide/deployments.md
@@ -232,31 +232,42 @@ A single Rise deployment can run multiple containers — for example a frontend,
 [project]
 name = "my-app"
 
+# Top-level [build] and [deploy] act as defaults that every container inherits.
+# [build] merges field-by-field (set the backend once, override only the
+# Dockerfile per container); [deploy] fields fall back individually.
+[build]
+backend = "docker"
+
+[deploy]
+replicas = 1
+cpu = "128m-500m"   # request 128m, cap the limit at 500m (see "CPU & memory" below)
+
 # Each container declares exactly one of `image` (pre-built reference) or
 # a `[containers.<name>.build]` block (the CLI builds and pushes for you).
 
-[containers.frontend.build]
-backend = "docker"
-dockerfile = "frontend/Dockerfile"
 [containers.frontend]
 port = 8080
-replicas = 2
+[containers.frontend.build]
+dockerfile = "frontend/Dockerfile"     # inherits backend = "docker"
+[containers.frontend.deploy]
+replicas = 2                           # override just the replica count
 
-[containers.backend.build]
-backend = "docker"
-dockerfile = "backend/Dockerfile"
 [containers.backend]
 port = 9090
-replicas = 3
-health_check = { path = "/health", initial_delay_seconds = 5 }
 # Per-container env vars. Project-level env vars also apply.
 env = { LOG_LEVEL = "info" }
+[containers.backend.build]
+dockerfile = "backend/Dockerfile"
+[containers.backend.deploy]
+replicas = 3
+health_check = { path = "/health", initial_delay_seconds = 5 }
 
 [containers.worker]
-# Pre-built image — the CLI won't try to build or push this one.
+# Pre-built image — the CLI won't try to build or push this one, and it ignores
+# the top-level [build] default. Workers have no port → no Service, no probes.
 image = "registry.example.com/my-app/worker:1.2.3"
+[containers.worker.deploy]
 replicas = 4
-# Workers have no port → no Service, no HTTP probes.
 
 [routes]
 "/api" = { container = "backend" }
@@ -267,14 +278,26 @@ When you run `rise deploy`, the backend allocates a deployment ID and returns on
 
 Notes:
 
-- `[containers]` is mutually exclusive with the top-level `[build]` and `[deploy]` sections. A single-container project uses the simple top-level `[build]`/`[deploy]` form — internally that's just one container named `app`.
+- The top-level `[build]` and `[deploy]` tables are **per-field defaults** for every container. `[build]` merges field-by-field under each container's own `[build]` (so a container with `image` ignores it); each `[deploy]` field (`replicas`, `cpu`, `memory`, `health_check`) falls back to the top-level value when the container omits it. A single-container project — top-level `[build]`/`[deploy]` with no `[containers]` — is internally just one container named `app`.
+- A container's resource settings live in `[containers.<name>.deploy]`, mirroring the top-level `[deploy]` table exactly (same fields, same syntax).
 - Containers without `port` get no `Service` and no HTTP probes — exactly what you want for workers / batch jobs.
-- HTTP probes are **disabled by default**. Set a `health_check` block to enable them (with a path and optional timing), or `health_check = false` to explicitly mark them disabled. Containers with a `port` but no `health_check` get a `Service` but no probe.
+- HTTP probes are **disabled by default**. Set a `[containers.<name>.deploy].health_check` block to enable them (with a path and optional timing), or `health_check = false` to explicitly mark them disabled. A `health_check` default set at the top level only applies to containers that have a `port`; port-less workers never get a probe. Containers with a `port` but no `health_check` get a `Service` but no probe.
 - Routes are matched longest-prefix-first by the ingress, so `/api` shadows `/` correctly. If `[routes]` is omitted and exactly one container has a `port`, Rise synthesises `/` → that container.
 - Platform and environment **replica limits apply to the deployment's total** replicas summed across all containers, not per container — e.g. with a cap of 10, `frontend = 4` + `backend = 3` + `worker = 4` (sum 11) is rejected. CPU and memory limits, by contrast, are enforced per container.
 - Every container receives a `RISE_CONTAINER` env var set to its own name (e.g. `"frontend"`, `"api"`).
 - Each container's `PORT` env var is set to **that container's own `port`** (e.g. `frontend` gets `PORT=8080`, `backend` gets `PORT=9090`) — not a single deployment-wide value. Containers without a `port` (workers) keep whatever deployment-wide `PORT` was set, if any.
 - When a deployment has two or more containers, each is also given a `RISE_CONTAINER_HOST__<NAME>` env var for every sibling that exposes a `port` (including a port-having container that isn't routed, such as a database) — pointing at that sibling's in-cluster Service. See [Environment Variables](../environment-variables#auto-injected-variables).
+
+## CPU & Memory
+
+The `cpu` and `memory` fields in any `[deploy]` table (top-level or per-container) accept two forms:
+
+| Form | Example | Effect |
+|---|---|---|
+| Fixed | `cpu = "256m"`, `memory = "512Mi"` | Sets the Kubernetes request **and** limit to the same value. |
+| Range | `cpu = "128m-1"`, `memory = "256Mi-1Gi"` | `request-limit` — the first value is the request, the second the limit. |
+
+CPU is expressed in cores (`1`, `2.5`) or millicores (`500m`); memory in bytes or binary-suffixed units (`512Mi`, `1Gi`). The request may not exceed the limit, and both are validated against the allowed range for the target environment/platform: `min ≤ request ≤ limit ≤ max`. A limit above the platform/environment maximum, or a request below its minimum, is rejected at deploy time with a clear message. Ranges let you reserve a small guaranteed amount (the request) while allowing bursts up to the limit.
 
 ## CI/CD Deployments
 

--- a/example/multi-container/README.md
+++ b/example/multi-container/README.md
@@ -82,9 +82,11 @@ curl https://multi-container.rise.dev/api/jobs
 
 ## Notes
 
-- `[containers]` is mutually exclusive with top-level `[build]` / `[deploy]`.
-  Existing single-container projects keep working — their top-level
-  `[build]` is treated as an implicit `app` container.
+- The top-level `[build]` / `[deploy]` tables act as per-field defaults that
+  every container inherits — `[build]` merges field-by-field (the example sets
+  `backend = "docker"` once), and each `[containers.<name>.deploy]` field falls
+  back to the top-level `[deploy]`. Single-container projects (no `[containers]`)
+  keep working — their top-level `[build]` is the implicit `app` container.
 - Redis here has no persistent volume, so pending jobs are lost on Redis
   pod restart. Fine for a demo; a real app would attach a PVC or use
   managed Redis.

--- a/example/multi-container/rise.toml
+++ b/example/multi-container/rise.toml
@@ -6,13 +6,24 @@ name = "multi-container"
 
 [project.env]
 
+# Top-level [build] defaults. Every container that builds from source inherits
+# these field-by-field and overrides only what it needs (here: the Dockerfile
+# and context). A container with `image` ignores [build] entirely.
+[build]
+backend = "docker"
+
+# Top-level [deploy] defaults. Each [containers.<name>.deploy] inherits these
+# per field, so a container only declares the values it wants to change.
+# `cpu = "128m-500m"` requests 128m and caps the limit at 500m.
+[deploy]
+replicas = 1
+cpu = "128m-500m"
+
 # Static frontend. Submits to `/api/jobs` and polls `/api/jobs` for status.
+# Inherits backend = "docker" and the default deploy (1 replica, 128m-500m CPU).
 [containers.frontend]
 port = 8080
-replicas = 1
-
 [containers.frontend.build]
-backend = "docker"
 dockerfile = "frontend/Dockerfile"
 build_context = "frontend"
 
@@ -20,26 +31,25 @@ build_context = "frontend"
 # Reads `RISE_CONTAINER_HOST__REDIS` (auto-injected by the controller).
 [containers.api]
 port = 8080
-replicas = 2
-health_check = { path = "/api/health" }
-
 [containers.api.build]
-backend = "docker"
 dockerfile = "api/Dockerfile"
 build_context = "api"
+[containers.api.deploy]
+replicas = 2                              # override the default replica count
+health_check = { path = "/api/health" }
 
 # Background worker. BRPOPs jobs from Redis, runs text analysis, writes the
 # result back. No `port` → no Service, no ingress route, no HTTP probes.
 [containers.worker]
-replicas = 1
 env = { WORK_MS = "2000" }
-
 [containers.worker.build]
-backend = "docker"
 dockerfile = "worker/Dockerfile"
 build_context = "worker"
+[containers.worker.deploy]
+cpu = "256m"                              # fixed: request == limit == 256m
 
-# Redis as the shared job queue. Upstream image — no [build] block.
+# Redis as the shared job queue. Upstream image — no [build] block, so it
+# ignores the top-level [build] default. Inherits the default [deploy].
 # `port` need not be HTTP — the K8s Service routes TCP fine, and Redis is not
 # in [routes], so it gets a Service (for discovery) but no HTTP probes by default.
 [containers.redis]

--- a/frontend/src/features/deployments.tsx
+++ b/frontend/src/features/deployments.tsx
@@ -41,11 +41,26 @@ function getStatusTone(status) {
 // ── CPU / memory parsing helpers for the multi-container resource breakdown ──
 // CPU is stored as the same string K8s accepts (`"500m"`, `"1"`, `"1.5"`).
 // Memory is the same — IEC suffixes (Ki/Mi/Gi/...) plus the SI suffixes K/M/G.
+// A value may also be a `request-limit` range (`"128m-1"`, `"256Mi-1Gi"`),
+// mirroring the backend's `split_request_limit` in
+// `src/server/deployment/quantity.rs`: a bare value means request == limit, a
+// `req-lim` value carries both sides.
 // Aggregation goes through (millicores, bytes), then re-formats for display so
 // "500m × 2 replicas + 1 × 3 replicas" prints as "4" (not "4000m") and "256Mi
 // × 4 + 1Gi" prints as a single readable value.
 
-function parseCpuToMillicores(s) {
+// Split a fixed-or-range value into its `[request, limit]` sides. A bare value
+// yields request == limit; a single `-` separates the two. Like the Rust
+// `split_request_limit`, real CPU/memory quantities never contain a `-`, so
+// splitting on it is safe (an exotic `"1e-3"` would split into unparseable
+// halves and fall through to 0, which is acceptable for a display total).
+function splitRequestLimit(s: string): [string, string] {
+    const parts = s.split('-');
+    if (parts.length === 2) return [parts[0].trim(), parts[1].trim()];
+    return [s, s];
+}
+
+function parseCpuToMillicores(s: string | null | undefined): number {
     if (s == null) return 0;
     const t = String(s).trim();
     if (!t) return 0;
@@ -57,7 +72,7 @@ function parseCpuToMillicores(s) {
     return Number.isFinite(v) ? v * 1000 : 0;
 }
 
-function formatMillicoresAsCpu(milli) {
+function formatMillicoresAsCpu(milli: number): string {
     if (!Number.isFinite(milli) || milli <= 0) return '0';
     if (milli % 1000 === 0) return String(milli / 1000);
     return `${Math.round(milli)}m`;
@@ -78,7 +93,7 @@ const MEM_UNIT_FACTORS = {
     E: 1e18,
 };
 
-function parseMemoryToBytes(s) {
+function parseMemoryToBytes(s: string | null | undefined): number {
     if (s == null) return 0;
     const t = String(s).trim();
     if (!t) return 0;
@@ -90,7 +105,7 @@ function parseMemoryToBytes(s) {
     return v * factor;
 }
 
-function formatBytesAsMemory(bytes) {
+function formatBytesAsMemory(bytes: number): string {
     if (!Number.isFinite(bytes) || bytes <= 0) return '0';
     // Render in the largest IEC unit that divides the total exactly, so the
     // breakdown stays precise (no rounding) regardless of mixed inputs. Memory
@@ -106,16 +121,28 @@ function formatBytesAsMemory(bytes) {
     return `${bytes}`;
 }
 
-/** Sum (replicas × per-container cpu/memory) across the deployment's containers. */
-function aggregateContainerResources(containers) {
+/**
+ * Sum (replicas × per-container cpu/memory) across the deployment's containers.
+ *
+ * Per-container `cpu`/`memory` may be a `request-limit` range. The "Resources"
+ * panel and breakdown header render this as the deployment's resource footprint
+ * (heading is just "CPU" / "Memory"), so we aggregate the *limit* side — the
+ * ceiling the deployment can consume. A fixed value has request == limit, so
+ * this is unchanged for the common case.
+ */
+function aggregateContainerResources(
+    containers: Array<{ replicas?: number | string | null; cpu?: string | null; memory?: string | null }>,
+): { replicas: number; cpu: string; memory: string } {
     let replicas = 0;
     let cpuMilli = 0;
     let memBytes = 0;
     for (const c of containers) {
         const r = Number(c.replicas) || 0;
         replicas += r;
-        cpuMilli += parseCpuToMillicores(c.cpu) * r;
-        memBytes += parseMemoryToBytes(c.memory) * r;
+        const [, cpuLimit] = splitRequestLimit(String(c.cpu ?? ''));
+        const [, memLimit] = splitRequestLimit(String(c.memory ?? ''));
+        cpuMilli += parseCpuToMillicores(cpuLimit) * r;
+        memBytes += parseMemoryToBytes(memLimit) * r;
     }
     return {
         replicas,

--- a/src/build/config.rs
+++ b/src/build/config.rs
@@ -89,11 +89,17 @@ pub fn load_full_project_config(app_path: &str) -> Result<Option<ProjectBuildCon
 /// Cross-field validation for `[containers]` and `[routes]`.
 ///
 /// Rules:
-/// - `[containers]` and top-level `[build]`/`[deploy]` are mutually exclusive.
+/// - The top-level `[build]`/`[deploy]` tables act as per-field defaults that
+///   each container inherits (build merges field-by-field; deploy fields fall
+///   back individually).
 /// - Container names must match `^[a-z][a-z0-9-]{0,14}$` (max 15 chars to keep
 ///   `<project>-<deployment_id(15)>-<container>` under the 63-char K8s limit).
-/// - Each container must have exactly one of `image` / `build`.
-/// - Each container declaring a `health_check` block must also set `port`.
+/// - Each container must resolve to exactly one of `image` / `build`. A
+///   container may not set both `image` and its own `[build]`, and a container
+///   with no `image` must resolve to a build (its own `[build]` and/or the
+///   inherited top-level `[build]`).
+/// - Each container with an explicit `[deploy].health_check` must also set
+///   `port` (an inherited default probe only applies to containers with a port).
 /// - Each route's `container` must exist and must have `port` set.
 /// - Each route's `path` must start with `/`, must not use the reserved
 ///   `/.rise` platform prefix, and must match a conservative URL-path charset.
@@ -105,12 +111,7 @@ fn validate_containers_and_routes(config: &ProjectBuildConfig) -> Result<()> {
         return Ok(());
     }
 
-    if config.build.is_some() || config.deploy.is_some() {
-        anyhow::bail!(
-            "Top-level [build]/[deploy] cannot be combined with [containers.<name>]. \
-             Move the top-level [build]/[deploy] settings into a [containers.app] entry."
-        );
-    }
+    let top_build_present = config.build.is_some();
 
     for (name, container) in &config.containers {
         if !is_valid_container_name(name) {
@@ -124,14 +125,20 @@ fn validate_containers_and_routes(config: &ProjectBuildConfig) -> Result<()> {
                 "[containers.{}] cannot set both 'image' and [build]; pick one",
                 name
             ),
-            (None, None) => {
-                anyhow::bail!("[containers.{}] must set either 'image' or [build]", name)
-            }
+            (None, None) if !top_build_present => anyhow::bail!(
+                "[containers.{}] must set either 'image' or [build] \
+                 (or inherit a top-level [build])",
+                name
+            ),
             _ => {}
         }
-        if container.health_check.is_some() && container.port.is_none() {
+        let container_health_check = container
+            .deploy
+            .as_ref()
+            .and_then(|d| d.health_check.as_ref());
+        if container_health_check.is_some() && container.port.is_none() {
             anyhow::bail!(
-                "[containers.{}] has health_check but no port; \
+                "[containers.{}] has a [deploy].health_check but no port; \
                  set port or remove health_check",
                 name
             );
@@ -494,11 +501,13 @@ name = "my-app"
 [containers.frontend]
 image = "registry.example.com/myapp/frontend:latest"
 port = 8080
+[containers.frontend.deploy]
 replicas = 2
 
 [containers.backend]
 image = "registry.example.com/myapp/backend:latest"
 port = 9090
+[containers.backend.deploy]
 replicas = 3
 health_check = { path = "/health" }
 
@@ -523,20 +532,55 @@ image = "registry.example.com/myapp/worker:latest"
     }
 
     #[test]
-    fn test_multi_container_rejects_top_level_build() {
+    fn test_multi_container_top_level_build_deploy_as_defaults() {
+        // Top-level [build]/[deploy] now coexist with [containers] and act as
+        // per-field defaults that each container inherits.
         let dir = write_toml(
             r#"
 [build]
 backend = "docker"
 
-[containers.app]
-image = "foo:bar"
+[deploy]
+replicas = 2
+cpu = "250m"
+
+[containers.web]
 port = 8080
+[containers.web.build]
+dockerfile = "web/Dockerfile"
+
+[containers.worker]
+[containers.worker.deploy]
+cpu = "500m"
 "#,
         );
-        let err = load_full_project_config(dir.path().to_str().unwrap())
-            .expect_err("expected mutual-exclusion error");
-        assert!(err.to_string().contains("Top-level [build]"), "got: {err}");
+        let config = load_full_project_config(dir.path().to_str().unwrap())
+            .unwrap()
+            .unwrap();
+        let resolved = config.resolve_deploy().unwrap();
+
+        let web = resolved
+            .containers
+            .iter()
+            .find(|c| c.name == "web")
+            .unwrap();
+        let web_build = web.build.as_ref().expect("web inherits a build");
+        assert_eq!(web_build.backend.as_deref(), Some("docker")); // inherited
+        assert_eq!(web_build.dockerfile.as_deref(), Some("web/Dockerfile")); // own
+        assert_eq!(web.replicas, Some(2)); // inherited deploy
+        assert_eq!(web.cpu.as_deref(), Some("250m")); // inherited deploy
+
+        let worker = resolved
+            .containers
+            .iter()
+            .find(|c| c.name == "worker")
+            .unwrap();
+        assert_eq!(
+            worker.build.as_ref().and_then(|b| b.backend.as_deref()),
+            Some("docker") // worker has no own build → inherits the whole top-level build
+        );
+        assert_eq!(worker.cpu.as_deref(), Some("500m")); // own override
+        assert_eq!(worker.replicas, Some(2)); // inherited deploy
     }
 
     #[test]
@@ -583,6 +627,7 @@ image = "foo:bar"
 [containers.api]
 image = "foo:bar"
 port = 8080
+[containers.api.deploy]
 health_check = false
 "#,
         );
@@ -591,7 +636,7 @@ health_check = false
             .unwrap();
         let api = config.containers.get("api").unwrap();
         assert!(matches!(
-            api.health_check,
+            api.deploy.as_ref().and_then(|d| d.health_check.as_ref()),
             Some(crate::rise_toml::HealthCheckSetting::Disabled(_))
         ));
     }
@@ -603,6 +648,7 @@ health_check = false
 [containers.api]
 image = "foo:bar"
 port = 8080
+[containers.api.deploy]
 health_check = true
 "#,
         );
@@ -728,6 +774,7 @@ port = 8080
             r#"
 [containers.app]
 image = "foo:bar"
+[containers.app.deploy]
 health_check = { path = "/health" }
 "#,
         );

--- a/src/cli/deployment/core.rs
+++ b/src/cli/deployment/core.rs
@@ -36,6 +36,20 @@ fn build_multi_container_payload(
     let resolved = cfg.resolve_deploy().map_err(|e| anyhow::anyhow!(e))?;
     if resolved.containers.is_empty() {
         // Single-container project; let the existing image flow handle it.
+        // A top-level `[deploy].health_check` has no effect here — health checks
+        // for a single app are configured by declaring `[containers.<name>]`
+        // (which inherits the top-level `[build]`/`[deploy]` defaults).
+        if cfg
+            .deploy
+            .as_ref()
+            .and_then(|d| d.health_check.as_ref())
+            .is_some()
+        {
+            warn!(
+                "[deploy].health_check is ignored for a single-container project; \
+                 declare [containers.<name>] (with a port) to configure health checks"
+            );
+        }
         return Ok((None, Vec::new()));
     }
 

--- a/src/rise_toml.rs
+++ b/src/rise_toml.rs
@@ -210,12 +210,16 @@ impl ProjectBuildConfig {
             return Ok(ResolvedDeploy::default());
         }
 
+        // Hoisted top-level defaults: these are identical for every container,
+        // so compute the clones once instead of per-iteration inside `.map()`.
+        let top_deploy = self.deploy.clone().unwrap_or_default();
+        let top_build = self.build.clone();
+
         let containers: Vec<ResolvedContainer> = self
             .containers
             .iter()
             .map(|(name, c)| {
                 let c_deploy = c.deploy.clone().unwrap_or_default();
-                let top_deploy = self.deploy.clone().unwrap_or_default();
 
                 // Build: field-level merge of the container's `[build]` over the
                 // top-level `[build]` defaults. A container with `image` takes no
@@ -223,7 +227,7 @@ impl ProjectBuildConfig {
                 let build = if c.image.is_some() {
                     None
                 } else {
-                    match (self.build.clone(), c.build.clone()) {
+                    match (top_build.clone(), c.build.clone()) {
                         (Some(top), Some(own)) => Some(own.merge_over(&top)),
                         (Some(top), None) => Some(top),
                         (None, own) => own,

--- a/src/rise_toml.rs
+++ b/src/rise_toml.rs
@@ -33,8 +33,9 @@ pub struct ProjectBuildConfig {
     #[serde(default)]
     pub environments: BTreeMap<String, EnvironmentConfig>,
 
-    /// Multi-container configuration. When non-empty, top-level `[build]` and
-    /// `[deploy]` must not be set. Each container becomes a separate K8s
+    /// Multi-container configuration. When non-empty, the top-level `[build]`
+    /// and `[deploy]` tables act as defaults that each container inherits per
+    /// field (see `ContainerConfig`). Each container becomes a separate K8s
     /// Deployment so replica counts scale independently.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub containers: BTreeMap<String, ContainerConfig>,
@@ -62,25 +63,16 @@ pub struct ContainerConfig {
     /// is plain TCP. Omit for workers.
     pub port: Option<u16>,
 
-    /// Number of replicas.
-    pub replicas: Option<u32>,
-
-    /// CPU allocation (e.g. "500m", "1") — sets both request and limit.
-    pub cpu: Option<String>,
-
-    /// Memory allocation (e.g. "256Mi", "1Gi") — sets both request and limit.
-    pub memory: Option<String>,
-
     /// Plain-text environment variables scoped to this container. Merged on top
     /// of any project-level env vars; container-scoped values win on conflict.
     #[serde(default)]
     pub env: BTreeMap<String, String>,
 
-    /// Health check configuration. HTTP liveness+readiness probes are disabled
-    /// by default — they must be explicitly configured here. Set a config block
-    /// to enable probes with a custom path/timing, or `health_check = false` to
-    /// explicitly mark them disabled. Requires `port` to be set.
-    pub health_check: Option<HealthCheckSetting>,
+    /// Deployment resource configuration (replicas, cpu, memory, health_check).
+    /// Mirrors the top-level `[deploy]` table; unset fields inherit the
+    /// top-level `[deploy]` defaults.
+    #[serde(default)]
+    pub deploy: Option<DeployConfig>,
 }
 
 /// `health_check` may either be `false` (probes disabled) or a config block.
@@ -221,16 +213,48 @@ impl ProjectBuildConfig {
         let containers: Vec<ResolvedContainer> = self
             .containers
             .iter()
-            .map(|(name, c)| ResolvedContainer {
-                name: name.clone(),
-                image: c.image.clone(),
-                build: c.build.clone(),
-                port: c.port,
-                replicas: c.replicas,
-                cpu: c.cpu.clone(),
-                memory: c.memory.clone(),
-                env: c.env.clone(),
-                health_check: c.health_check.clone(),
+            .map(|(name, c)| {
+                let c_deploy = c.deploy.clone().unwrap_or_default();
+                let top_deploy = self.deploy.clone().unwrap_or_default();
+
+                // Build: field-level merge of the container's `[build]` over the
+                // top-level `[build]` defaults. A container with `image` takes no
+                // build at all.
+                let build = if c.image.is_some() {
+                    None
+                } else {
+                    match (self.build.clone(), c.build.clone()) {
+                        (Some(top), Some(own)) => Some(own.merge_over(&top)),
+                        (Some(top), None) => Some(top),
+                        (None, own) => own,
+                    }
+                };
+
+                // Deploy: each field falls back to the top-level default.
+                // `health_check` only inherits when the container has a port —
+                // a port-less worker silently skips an inherited default probe.
+                let health_check = c_deploy.health_check.clone().or_else(|| {
+                    if c.port.is_some() {
+                        top_deploy.health_check.clone()
+                    } else {
+                        None
+                    }
+                });
+
+                ResolvedContainer {
+                    name: name.clone(),
+                    image: c.image.clone(),
+                    build,
+                    port: c.port,
+                    replicas: c_deploy.replicas.or(top_deploy.replicas),
+                    cpu: c_deploy.cpu.clone().or_else(|| top_deploy.cpu.clone()),
+                    memory: c_deploy
+                        .memory
+                        .clone()
+                        .or_else(|| top_deploy.memory.clone()),
+                    env: c.env.clone(),
+                    health_check,
+                }
             })
             .collect();
 
@@ -309,6 +333,162 @@ mod tests {
             "got: {err}"
         );
     }
+
+    fn resolved_named<'a>(rd: &'a ResolvedDeploy, name: &str) -> &'a ResolvedContainer {
+        rd.containers
+            .iter()
+            .find(|c| c.name == name)
+            .unwrap_or_else(|| panic!("container '{name}' not resolved"))
+    }
+
+    /// Build a `ProjectBuildConfig` from top-level build/deploy defaults and a
+    /// set of named containers (struct-literal init to satisfy clippy).
+    fn config_with(
+        build: Option<BuildConfig>,
+        deploy: Option<DeployConfig>,
+        containers: Vec<(&str, ContainerConfig)>,
+    ) -> ProjectBuildConfig {
+        ProjectBuildConfig {
+            build,
+            deploy,
+            containers: containers
+                .into_iter()
+                .map(|(n, c)| (n.to_string(), c))
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn resolve_deploy_inherits_top_level_deploy_per_field() {
+        // `api` overrides only cpu; everything else inherits the top-level deploy.
+        let config = config_with(
+            None,
+            Some(DeployConfig {
+                replicas: Some(3),
+                cpu: Some("250m".to_string()),
+                memory: Some("256Mi".to_string()),
+                health_check: None,
+            }),
+            vec![(
+                "api",
+                ContainerConfig {
+                    image: Some("nginx:latest".to_string()),
+                    port: Some(8080),
+                    deploy: Some(DeployConfig {
+                        cpu: Some("500m".to_string()),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+            )],
+        );
+
+        let rd = config.resolve_deploy().expect("resolve");
+        let api = resolved_named(&rd, "api");
+        assert_eq!(api.cpu.as_deref(), Some("500m")); // override wins
+        assert_eq!(api.memory.as_deref(), Some("256Mi")); // inherited
+        assert_eq!(api.replicas, Some(3)); // inherited
+    }
+
+    #[test]
+    fn resolve_deploy_merges_build_field_by_field() {
+        let config = config_with(
+            Some(BuildConfig {
+                backend: Some("docker".to_string()),
+                ..Default::default()
+            }),
+            None,
+            vec![
+                // Container with its own [build] overriding only the Dockerfile.
+                (
+                    "web",
+                    ContainerConfig {
+                        port: Some(8080),
+                        build: Some(BuildConfig {
+                            dockerfile: Some("web/Dockerfile".to_string()),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    },
+                ),
+                // Container that builds but declares no [build]: inherits all.
+                ("worker", ContainerConfig::default()),
+            ],
+        );
+
+        let rd = config.resolve_deploy().expect("resolve");
+        let web = resolved_named(&rd, "web").build.as_ref().expect("build");
+        assert_eq!(web.backend.as_deref(), Some("docker")); // inherited
+        assert_eq!(web.dockerfile.as_deref(), Some("web/Dockerfile")); // override
+        let worker = resolved_named(&rd, "worker").build.as_ref().expect("build");
+        assert_eq!(worker.backend.as_deref(), Some("docker")); // inherited whole
+    }
+
+    #[test]
+    fn resolve_deploy_image_container_takes_no_build() {
+        let config = config_with(
+            Some(BuildConfig {
+                backend: Some("docker".to_string()),
+                ..Default::default()
+            }),
+            None,
+            vec![(
+                "redis",
+                ContainerConfig {
+                    image: Some("redis:7".to_string()),
+                    port: Some(6379),
+                    ..Default::default()
+                },
+            )],
+        );
+
+        let rd = config.resolve_deploy().expect("resolve");
+        let redis = resolved_named(&rd, "redis");
+        assert!(redis.build.is_none(), "image container must take no build");
+        assert_eq!(redis.image.as_deref(), Some("redis:7"));
+    }
+
+    #[test]
+    fn resolve_deploy_inherits_health_check_only_with_port() {
+        let config = config_with(
+            None,
+            Some(DeployConfig {
+                health_check: Some(HealthCheckSetting::Config(HealthCheckConfig {
+                    path: Some("/healthz".to_string()),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            }),
+            vec![
+                (
+                    "web",
+                    ContainerConfig {
+                        image: Some("nginx".to_string()),
+                        port: Some(8080),
+                        ..Default::default()
+                    },
+                ),
+                (
+                    "worker",
+                    ContainerConfig {
+                        image: Some("busybox".to_string()),
+                        ..Default::default()
+                    },
+                ),
+            ],
+        );
+
+        let rd = config.resolve_deploy().expect("resolve");
+        assert!(
+            resolved_named(&rd, "web").health_check.is_some(),
+            "port-having container inherits the default probe"
+        );
+        assert!(
+            resolved_named(&rd, "worker").health_check.is_none(),
+            "port-less container does not inherit a default probe"
+        );
+    }
 }
 
 /// Workload identity configuration
@@ -338,18 +518,34 @@ pub struct EnvironmentConfig {
     pub deploy: Option<DeployConfig>,
 }
 
-/// Deployment resource configuration
+/// Deployment resource configuration.
+///
+/// Shared by the top-level `[deploy]`, per-environment `[environments.<name>.deploy]`,
+/// and per-container `[containers.<name>.deploy]` tables. Top-level values act as
+/// defaults that each container inherits per field.
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 #[cfg_attr(feature = "backend", derive(schemars::JsonSchema))]
 pub struct DeployConfig {
     /// Number of replicas
     pub replicas: Option<u32>,
 
-    /// CPU allocation (e.g., "500m", "1") — sets both K8s request and limit
+    /// CPU allocation. Either a fixed value that sets both the K8s request and
+    /// limit (e.g. `"500m"`, `"1"`), or a `request-limit` range (e.g. `"128m-1"`
+    /// → request `128m`, limit `1`). The request may not exceed the limit, and
+    /// the limit is validated against the environment/platform allowed range.
     pub cpu: Option<String>,
 
-    /// Memory allocation (e.g., "256Mi", "1Gi") — sets both K8s request and limit
+    /// Memory allocation. Either a fixed value that sets both the K8s request
+    /// and limit (e.g. `"256Mi"`, `"1Gi"`), or a `request-limit` range (e.g.
+    /// `"64Mi-256Mi"`). Same request/limit and range rules as `cpu`.
     pub memory: Option<String>,
+
+    /// Health check configuration. HTTP liveness+readiness probes are disabled
+    /// by default — they must be explicitly configured here. Set a config block
+    /// to enable probes with a custom path/timing, or `health_check = false` to
+    /// explicitly mark them disabled. At the container level this requires the
+    /// container to have a `port`.
+    pub health_check: Option<HealthCheckSetting>,
 }
 
 /// Project metadata configuration
@@ -407,4 +603,40 @@ pub struct BuildConfig {
     /// Target platform for the container image build (e.g., "linux/amd64", "linux/arm64").
     /// Defaults to linux/amd64.
     pub platform: Option<String>,
+}
+
+impl BuildConfig {
+    /// Merge `self` over `default`, field by field. Fields set on `self` win;
+    /// unset fields fall back to `default`. Used to apply a top-level `[build]`
+    /// table as defaults under each container's own `[build]`.
+    pub fn merge_over(&self, default: &BuildConfig) -> BuildConfig {
+        BuildConfig {
+            backend: self.backend.clone().or_else(|| default.backend.clone()),
+            builder: self.builder.clone().or_else(|| default.builder.clone()),
+            buildpacks: self
+                .buildpacks
+                .clone()
+                .or_else(|| default.buildpacks.clone()),
+            args: self.args.clone().or_else(|| default.args.clone()),
+            container_cli: self
+                .container_cli
+                .clone()
+                .or_else(|| default.container_cli.clone()),
+            managed_buildkit: self.managed_buildkit.or(default.managed_buildkit),
+            dockerfile: self
+                .dockerfile
+                .clone()
+                .or_else(|| default.dockerfile.clone()),
+            build_context: self
+                .build_context
+                .clone()
+                .or_else(|| default.build_context.clone()),
+            build_contexts: self
+                .build_contexts
+                .clone()
+                .or_else(|| default.build_contexts.clone()),
+            no_cache: self.no_cache.or(default.no_cache),
+            platform: self.platform.clone().or_else(|| default.platform.clone()),
+        }
+    }
 }

--- a/src/server/deployment/quantity.rs
+++ b/src/server/deployment/quantity.rs
@@ -81,6 +81,10 @@ fn split_request_limit(
     parse: impl Fn(&str) -> Result<u64>,
 ) -> Result<(String, String)> {
     let value = value.trim();
+    // Realistic CPU/memory quantities never contain a `-` (suffixes are
+    // Ki/Mi/Gi/… and `m`, never signs or exponents), so splitting on `-` is
+    // safe. An exotic value like `"1e-3"` would split into `["1e", "3"]` and
+    // error in `parse` below rather than silently mis-parsing — acceptable.
     let (req, lim) = match value.split('-').collect::<Vec<_>>().as_slice() {
         [single] => (single.trim().to_string(), single.trim().to_string()),
         [req, lim] => (req.trim().to_string(), lim.trim().to_string()),

--- a/src/server/deployment/quantity.rs
+++ b/src/server/deployment/quantity.rs
@@ -70,24 +70,76 @@ pub fn parse_memory_bytes(s: &str) -> Result<u64> {
         .with_context(|| format!("memory quantity too large: {s}"))
 }
 
-/// Validate that a CPU value (as a string) falls within [min, max].
+/// Split a resource value into its `(request, limit)` strings.
+///
+/// Accepts either a fixed value (`"256m"`), where request == limit, or a
+/// `request-limit` range (`"128m-1"`). Both sides must parse with `parse`, and
+/// the request may not exceed the limit. `kind` names the resource in errors.
+fn split_request_limit(
+    value: &str,
+    kind: &str,
+    parse: impl Fn(&str) -> Result<u64>,
+) -> Result<(String, String)> {
+    let value = value.trim();
+    let (req, lim) = match value.split('-').collect::<Vec<_>>().as_slice() {
+        [single] => (single.trim().to_string(), single.trim().to_string()),
+        [req, lim] => (req.trim().to_string(), lim.trim().to_string()),
+        _ => bail!("invalid {kind} value '{value}': expected 'value' or 'request-limit'"),
+    };
+    let req_v = parse(&req).with_context(|| format!("invalid {kind} request: {req}"))?;
+    let lim_v = parse(&lim).with_context(|| format!("invalid {kind} limit: {lim}"))?;
+    if req_v > lim_v {
+        bail!("{kind} request {req} exceeds limit {lim}");
+    }
+    Ok((req, lim))
+}
+
+/// Parse a CPU value into `(request, limit)` strings (see [`split_request_limit`]).
+pub fn parse_cpu_request_limit(value: &str) -> Result<(String, String)> {
+    split_request_limit(value, "CPU", parse_cpu_millicores)
+}
+
+/// Parse a memory value into `(request, limit)` strings (see [`split_request_limit`]).
+pub fn parse_memory_request_limit(value: &str) -> Result<(String, String)> {
+    split_request_limit(value, "memory", parse_memory_bytes)
+}
+
+/// Validate a CPU value (fixed or `request-limit` range) against `[min, max]`.
+///
+/// Enforces `min <= request <= limit <= max` (the request/limit ordering is
+/// checked by [`parse_cpu_request_limit`]).
 pub fn validate_cpu_range(value: &str, min: &str, max: &str) -> Result<()> {
-    let v = parse_cpu_millicores(value).with_context(|| format!("invalid CPU value: {value}"))?;
+    let (req, lim) =
+        parse_cpu_request_limit(value).with_context(|| format!("invalid CPU value: {value}"))?;
+    let req_v = parse_cpu_millicores(&req)?;
+    let lim_v = parse_cpu_millicores(&lim)?;
     let lo = parse_cpu_millicores(min).with_context(|| format!("invalid min CPU: {min}"))?;
     let hi = parse_cpu_millicores(max).with_context(|| format!("invalid max CPU: {max}"))?;
-    if v < lo || v > hi {
-        bail!("CPU value {value} is outside the allowed range [{min}, {max}]");
+    if req_v < lo {
+        bail!("CPU request {req} is below the allowed minimum {min}");
+    }
+    if lim_v > hi {
+        bail!("CPU limit {lim} is above the allowed maximum {max}");
     }
     Ok(())
 }
 
-/// Validate that a memory value (as a string) falls within [min, max].
+/// Validate a memory value (fixed or `request-limit` range) against `[min, max]`.
+///
+/// Enforces `min <= request <= limit <= max` (the request/limit ordering is
+/// checked by [`parse_memory_request_limit`]).
 pub fn validate_memory_range(value: &str, min: &str, max: &str) -> Result<()> {
-    let v = parse_memory_bytes(value).with_context(|| format!("invalid memory value: {value}"))?;
+    let (req, lim) = parse_memory_request_limit(value)
+        .with_context(|| format!("invalid memory value: {value}"))?;
+    let req_v = parse_memory_bytes(&req)?;
+    let lim_v = parse_memory_bytes(&lim)?;
     let lo = parse_memory_bytes(min).with_context(|| format!("invalid min memory: {min}"))?;
     let hi = parse_memory_bytes(max).with_context(|| format!("invalid max memory: {max}"))?;
-    if v < lo || v > hi {
-        bail!("Memory value {value} is outside the allowed range [{min}, {max}]");
+    if req_v < lo {
+        bail!("Memory request {req} is below the allowed minimum {min}");
+    }
+    if lim_v > hi {
+        bail!("Memory limit {lim} is above the allowed maximum {max}");
     }
     Ok(())
 }
@@ -156,5 +208,70 @@ mod tests {
 
         assert!(validate_memory_range("32Mi", "64Mi", "2Gi").is_err());
         assert!(validate_memory_range("4Gi", "64Mi", "2Gi").is_err());
+    }
+
+    #[test]
+    fn test_parse_cpu_request_limit() {
+        // Fixed value: request == limit.
+        assert_eq!(
+            parse_cpu_request_limit("256m").unwrap(),
+            ("256m".to_string(), "256m".to_string())
+        );
+        // Range: request and limit differ.
+        assert_eq!(
+            parse_cpu_request_limit("128m-1").unwrap(),
+            ("128m".to_string(), "1".to_string())
+        );
+        // Whitespace is tolerated around the separator.
+        assert_eq!(
+            parse_cpu_request_limit(" 128m - 500m ").unwrap(),
+            ("128m".to_string(), "500m".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_cpu_request_limit_errors() {
+        // Request exceeds limit.
+        assert!(parse_cpu_request_limit("1-128m").is_err());
+        // Empty sides.
+        assert!(parse_cpu_request_limit("-1").is_err());
+        assert!(parse_cpu_request_limit("128m-").is_err());
+        // Too many separators.
+        assert!(parse_cpu_request_limit("128m-256m-1").is_err());
+        // Unparseable side.
+        assert!(parse_cpu_request_limit("abc-1").is_err());
+    }
+
+    #[test]
+    fn test_parse_memory_request_limit() {
+        assert_eq!(
+            parse_memory_request_limit("256Mi").unwrap(),
+            ("256Mi".to_string(), "256Mi".to_string())
+        );
+        assert_eq!(
+            parse_memory_request_limit("64Mi-256Mi").unwrap(),
+            ("64Mi".to_string(), "256Mi".to_string())
+        );
+        assert!(parse_memory_request_limit("256Mi-64Mi").is_err());
+    }
+
+    #[test]
+    fn test_validate_cpu_range_with_ranges() {
+        // request >= min, limit <= max, request <= limit.
+        assert!(validate_cpu_range("128m-1", "100m", "2").is_ok());
+        assert!(validate_cpu_range("100m-2", "100m", "2").is_ok());
+        // Limit above max.
+        assert!(validate_cpu_range("128m-3", "100m", "2").is_err());
+        // Request below min.
+        assert!(validate_cpu_range("50m-1", "100m", "2").is_err());
+    }
+
+    #[test]
+    fn test_validate_memory_range_with_ranges() {
+        assert!(validate_memory_range("64Mi-1Gi", "64Mi", "2Gi").is_ok());
+        // Limit above max.
+        assert!(validate_memory_range("64Mi-4Gi", "64Mi", "2Gi").is_err());
+        // Request below min.
+        assert!(validate_memory_range("32Mi-1Gi", "64Mi", "2Gi").is_err());
     }
 }

--- a/src/server/deployment/resource_builder.rs
+++ b/src/server/deployment/resource_builder.rs
@@ -1120,20 +1120,32 @@ impl ResourceBuilder {
         cpu: &str,
         memory: &str,
     ) -> Option<ResourceRequirements> {
+        use crate::server::deployment::quantity;
         use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 
-        // Single-knob: same value for both request and limit
+        // Each value is either fixed (request == limit) or a `request-limit`
+        // range. Values were validated at deploy time; if parsing somehow fails
+        // here, log and fall back to using the raw string for both sides.
+        let (cpu_req, cpu_lim) = quantity::parse_cpu_request_limit(cpu).unwrap_or_else(|e| {
+            tracing::warn!("Failed to parse CPU quantity {cpu:?}, using as-is: {e:?}");
+            (cpu.to_string(), cpu.to_string())
+        });
+        let (mem_req, mem_lim) = quantity::parse_memory_request_limit(memory).unwrap_or_else(|e| {
+            tracing::warn!("Failed to parse memory quantity {memory:?}, using as-is: {e:?}");
+            (memory.to_string(), memory.to_string())
+        });
+
         Some(ResourceRequirements {
             requests: Some({
                 let mut map = BTreeMap::new();
-                map.insert("cpu".to_string(), Quantity(cpu.to_string()));
-                map.insert("memory".to_string(), Quantity(memory.to_string()));
+                map.insert("cpu".to_string(), Quantity(cpu_req));
+                map.insert("memory".to_string(), Quantity(mem_req));
                 map
             }),
             limits: Some({
                 let mut map = BTreeMap::new();
-                map.insert("cpu".to_string(), Quantity(cpu.to_string()));
-                map.insert("memory".to_string(), Quantity(memory.to_string()));
+                map.insert("cpu".to_string(), Quantity(cpu_lim));
+                map.insert("memory".to_string(), Quantity(mem_lim));
                 map
             }),
             ..Default::default()

--- a/src/server/deployment/resource_builder.rs
+++ b/src/server/deployment/resource_builder.rs
@@ -1125,14 +1125,26 @@ impl ResourceBuilder {
 
         // Each value is either fixed (request == limit) or a `request-limit`
         // range. Values were validated at deploy time; if parsing somehow fails
-        // here, log and fall back to using the raw string for both sides.
+        // here, log and fall back to splitting the raw string on `-`, using the
+        // first segment for the request and the last for the limit. A fixed
+        // value yields one segment (request == limit); this keeps each side an
+        // individually valid Quantity rather than feeding `"128m-1"` to both.
+        let split_raw = |raw: &str| -> (String, String) {
+            let mut parts = raw.split('-');
+            let first = parts.next().unwrap_or(raw).trim().to_string();
+            let last = parts.next_back().map(|s| s.trim().to_string());
+            match last {
+                Some(last) => (first, last),
+                None => (first.clone(), first),
+            }
+        };
         let (cpu_req, cpu_lim) = quantity::parse_cpu_request_limit(cpu).unwrap_or_else(|e| {
             tracing::warn!("Failed to parse CPU quantity {cpu:?}, using as-is: {e:?}");
-            (cpu.to_string(), cpu.to_string())
+            split_raw(cpu)
         });
         let (mem_req, mem_lim) = quantity::parse_memory_request_limit(memory).unwrap_or_else(|e| {
             tracing::warn!("Failed to parse memory quantity {memory:?}, using as-is: {e:?}");
-            (memory.to_string(), memory.to_string())
+            split_raw(memory)
         });
 
         Some(ResourceRequirements {


### PR DESCRIPTION
## Summary

Refactor multi-container configuration to support per-field inheritance of top-level `[build]` and `[deploy]` defaults, replacing the previous mutual-exclusion rule. This enables cleaner configuration by allowing containers to inherit common settings and override only what they need.

## Key Changes

- **ContainerConfig restructuring**: Moved `replicas`, `cpu`, `memory`, and `health_check` fields from `ContainerConfig` into a new nested `[containers.<name>.deploy]` table (mirroring the top-level `[deploy]` structure). This enables per-field inheritance semantics.

- **Build inheritance**: Implemented `BuildConfig::merge_over()` to merge container-level `[build]` over top-level `[build]` field-by-field. Containers with `image` set ignore the top-level `[build]` entirely.

- **Deploy inheritance**: Each `[deploy]` field (`replicas`, `cpu`, `memory`, `health_check`) now falls back to the top-level default when omitted at the container level. Special handling for `health_check`: inherited defaults only apply to containers with a `port` set (workers without ports skip inherited probes).

- **Validation updates**: Relaxed the mutual-exclusion check between top-level `[build]`/`[deploy]` and `[containers]`. Containers may now omit `[build]` and inherit the top-level default, or omit `[deploy]` fields and inherit them individually.

- **Resource quantity parsing**: Added `parse_cpu_request_limit()` and `parse_memory_request_limit()` functions to support `request-limit` range syntax (e.g., `"128m-1"` for CPU request 128m with limit 1, or `"64Mi-256Mi"` for memory). Updated validation functions to enforce `min <= request <= limit <= max`.

- **Kubernetes resource builder**: Updated to split fixed-or-range values into separate request/limit quantities for K8s ResourceRequirements.

- **Documentation and examples**: Updated user guide, schema, and example configs to reflect the new inheritance model. Added comprehensive test coverage for inheritance scenarios.

## Notable Implementation Details

- The `resolve_deploy()` method now hoists top-level defaults outside the container iteration loop for efficiency, then applies field-level merging/fallback per container.
- Health check inheritance respects container ports: a port-less worker silently skips an inherited default probe without error.
- The `request-limit` syntax is validated at deploy time; the resource builder includes a fallback parser for robustness.
- All changes maintain backward compatibility for single-container projects (top-level `[build]`/`[deploy]` with no `[containers]`).

https://claude.ai/code/session_01U1mZaWCbsxE7Cthp63Vx3L