### PR TITLE
docs: rollout tracking workflow + operator upgrade-notes page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,27 @@ For user-facing documentation, see the [`/docs`](./docs) directory. Key topics i
 - The default development branch is `develop`. PRs for feature work should target `develop`, not `main`.
 - Always target the branch your feature branch was created from when opening a PR.
 
+## Rollout Tracking
+
+High-impact, multi-PR, or operator-affecting changes are tracked in the **Rise
+Rollout Tracker** GitHub Project: <https://github.com/orgs/rise-deploy/projects/1>.
+Consult it when planning or reviewing large or breaking work to see in-flight
+workstreams, their phase, and outstanding finalization gates (deferred steps that
+flip a default, drop a compat shim, or tighten a constraint).
+
+Keep it current as work merges:
+
+- When a PR advances a tracked workstream, add it to the Project, link it from the
+  PR body, and move the item's `Status`. When you defer a finalization step, file
+  it as a `rollout-gate` issue and add it to the Project.
+- Set `Workstream`, `Breaking?`, `Operator impact`, and `Target release` on every
+  item. If `Operator impact` is not `None`, the item is **not** `Done` until the
+  operator [Upgrade Notes](docs/engineering/src/content/docs/upgrade-notes.md) page
+  has a matching entry for that release.
+- Plans like `MULTI_TENANCY_PLAN.md` and `AUTH_TOKEN_EXCHANGE_PLAN.md` own the
+  *why* and phase rationale; the Project owns *live status*. Don't duplicate
+  rationale into the board.
+
 ## Guidelines
 
 - Build features in small increments with frequent commits. Use Git history as a reference for what was done and why.

--- a/docs/engineering/astro.config.mjs
+++ b/docs/engineering/astro.config.mjs
@@ -59,6 +59,7 @@ export default defineConfig({
             { label: 'Production Deployment', slug: 'production' },
             { label: 'Database', slug: 'database' },
             { label: 'PostgreSQL Upgrades', slug: 'upgrading-postgresql' },
+            { label: 'Upgrade Notes & Breaking Changes', slug: 'upgrade-notes' },
           ],
         },
         {

--- a/docs/engineering/src/content/docs/upgrade-notes.md
+++ b/docs/engineering/src/content/docs/upgrade-notes.md
@@ -1,0 +1,81 @@
+---
+title: "Upgrade Notes & Breaking Changes"
+---
+
+This page is the canonical, per-release reference for changes that affect
+operators running a Rise installation: breaking changes, required actions, and
+new or changed configuration. Read the section for the version you are upgrading
+**to** before upgrading.
+
+:::note
+This page is fed from the [**Rise Rollout Tracker**](https://github.com/orgs/rise-deploy/projects/1)
+GitHub Project. Any tracked item whose `Operator impact` is not `None` must have a
+matching entry here for its `Target release` before it is marked `Done`. The
+project's "Operator impact" view is the worklist; this page is what operators read.
+:::
+
+## Impact legend
+
+| Badge | Meaning |
+|---|---|
+| **Breaking** | Requires action or behavior changes incompatibly; upgrading without reading may break installs. |
+| **Action required** | Upgrade succeeds, but an operator action is needed to get correct/expected behavior. |
+| **Config change** | New or changed configuration is available; defaults preserve existing behavior. |
+
+---
+
+## Unreleased
+
+_Changes merged to `develop` but not yet in a tagged release, plus in-flight PRs
+proposed for the next train. Moved into a version section at tag time._
+
+In-flight PRs with operator impact (not yet merged):
+
+- **Config change — auth token exchange (phase 1)** ([#367](https://github.com/rise-deploy/rise/pull/367)).
+  Adds the RFC 8693 exchange endpoint and a Rise `Access` token kind. Purely
+  additive; existing token flows are unchanged, legacy in-handler verification
+  remains the fallback. See
+  [`AUTH_TOKEN_EXCHANGE_PLAN.md`](https://github.com/rise-deploy/rise/blob/develop/AUTH_TOKEN_EXCHANGE_PLAN.md).
+- **Config change — Docker deployment backend** ([#358](https://github.com/rise-deploy/rise/pull/358)).
+  Selectable via `deployment_controller.type = "docker"`. Single-host; Kubernetes
+  remains the default. The deployment-backend feature matrix and Docker pages ship
+  with this PR.
+- **Action required — reserved `RISE_` env-var prefix** ([#355](https://github.com/rise-deploy/rise/pull/355)).
+  User-supplied environment variable keys beginning with `RISE_` are rejected at
+  the API and at deploy time (project env vars and per-container
+  `[containers.X.env]`). If any of your users' apps set `RISE_*` keys, rename them
+  before upgrading.
+
+---
+
+## 0.23.0
+
+First release of the generic resource substrate (compatibility phase). None of
+these change behavior for existing installs by default; the items below are the
+configuration knobs they introduce.
+
+- **Config change — Operator role (`auth.operator_users`).** The generic resource
+  API (`/api/v1/resources`) is gated to a new, separately configured Operator
+  role. `auth.admin_users` do **not** receive Operator access. No action needed
+  unless you want operators to manage generic resources. See
+  [`MULTI_TENANCY_PLAN.md`](https://github.com/rise-deploy/rise/blob/develop/MULTI_TENANCY_PLAN.md).
+- **Config change — default Organization / Kubernetes `controller_class_name`.**
+  Backend startup bootstraps a single default Organization and backfills existing
+  users, teams, and projects to it under an advisory lock. Existing installs
+  resolve to the **same** namespace names as before (`rise-` prefix → `rise-myapp`).
+  The Kubernetes controller's `controller_class_name` defaults to a stable value
+  for existing installs if unset.
+
+### Watch for later (not yet released)
+
+These are tracked as finalization gates and will land in a **future** release —
+listed here so operators can anticipate them:
+
+- **Breaking (future) — multi-tenancy phase 2.** Tightening
+  `organization_resource_uid` to `NOT NULL` after backfill, and migrating typed
+  tables onto the generic resource model. Tracked in
+  [#372](https://github.com/rise-deploy/rise/issues/372).
+- **Breaking (future, behind operator toggle) — removal of the legacy auth path.**
+  Auth token-exchange phase 3 removes the legacy in-handler verification path,
+  gated behind an operator toggle for a transparent fallback window. Tracked in
+  [#374](https://github.com/rise-deploy/rise/issues/374).


### PR DESCRIPTION
Establishes the **Rise Rollout Tracker** workflow for high-impact, multi-PR, and operator-affecting changes, and gives operators a canonical place to read about breaking changes.

The GitHub Project itself already exists: <https://github.com/orgs/rise-deploy/projects/1> (epics + 5 in-flight PRs + 8 `rollout-gate` finalization issues #368–#375, all tagged with Workstream / Breaking? / Operator impact / Target release). This PR adds the **repo-side** pieces that reference and sustain it.

## Changes

- **`CLAUDE.md` → new `Rollout Tracking` section.** Points at the Project and encodes the keep-it-updated discipline: link PRs to items, file deferred steps as `rollout-gate` issues, and set the four fields. An item is **not** `Done` until the operator upgrade-notes page has a matching entry when `Operator impact != None`. Plans (`MULTI_TENANCY_PLAN.md`, `AUTH_TOKEN_EXCHANGE_PLAN.md`) own the *why*; the Project owns *live status*.
- **New operator docs page** `docs/engineering/.../upgrade-notes.md` — 'Upgrade Notes & Breaking Changes', the per-release reference operators read. Seeded with an impact legend, an `Unreleased` section listing in-flight operator-impacting PRs (#367, #358, #355), a `0.23.0` section for the merged multi-tenancy compatibility-phase config, and a 'watch for later' block for the breaking gates (#372, #374). Wired into the Operator Docs sidebar.

## Notes

- Scoped to these 3 files only; no code changes.
- Content reflects what is actually merged to `develop` today — auth phase 1, Docker backend, and the `RISE_` prefix reservation are listed as **in-flight PRs**, not released, to avoid broken links and premature claims.
- Manual follow-up (not doable via API): create the Project's saved **"Operator impact"** board view (filter `Operator impact != None`, group by `Target release`) — that view is the worklist that feeds this page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)