### PR TITLE
Restrict backend settings to YAML config files only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,15 +138,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "arc-swap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,9 +222,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.8.18"
+version = "1.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33f815b73a3899c03b380d543532e5865f230dce9678d108dc10732a8682275"
+checksum = "517aa062d8bd9015ee23d6daa5e1c1372328412fdae4e6c4c1be9b69c6ad37a2"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -459,11 +450,10 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.101.0"
+version = "1.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b647baea49ff551960b904f905681e9b4765a6c4ea08631e89dc52d8bd3f5896"
+checksum = "9f4055e6099b2ec264abdc0d9bbfffce306c1601809275c861594779a0b04b45"
 dependencies = [
- "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -484,11 +474,10 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.103.0"
+version = "1.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae401c65ff288aa7873117fe535cd32b7b1bb0bc43751d28901a1d5f20636b9"
+checksum = "02f009ba0284c5d696425fd7b4dcc5b189f5726f4041b7a5794daecb3a68d598"
 dependencies = [
- "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -509,11 +498,10 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.106.0"
+version = "1.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c80de7bb7d03e9ca8c9fd7b489f20f3948d3f3be91a7953591347d238115408"
+checksum = "6aa6622798e19e6a76b690562085dd4771c736cd48343464a53ab4ae2f2c9f84"
 dependencies = [
- "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -651,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.7"
+version = "0.62.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
+checksum = "517089205f18ab4adc5a3e02888cb139bbbbb2e168eac9f396216925d1fbeaf5"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-schema",
@@ -707,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.3"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
+checksum = "dc117c179ecf39a62a0a3f49f600e9ac26a7ad7dd172177999f83933af776c32"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -747,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.9"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f93074121a1be41317b9aa607143ae17900631f7f59a99f2b905d519d6783b"
+checksum = "056b66dbce2f81cc0c1e2b05bb402eb58f8a3530479d650efadd5bbae9a4050b"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -1106,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.45"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1264,16 +1252,8 @@ version = "0.15.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f316c6237b2d38be61949ecd15268a4c6ca32570079394a2444d9ce2c72a72d8"
 dependencies = [
- "async-trait",
- "convert_case",
- "json5",
  "pathdiff",
- "ron",
- "rust-ini",
- "serde-untagged",
  "serde_core",
- "serde_json",
- "toml",
  "winnow",
  "yaml-rust2",
 ]
@@ -1289,35 +1269,6 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
-name = "const-random"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
-dependencies = [
- "const-random-macro",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "tiny-keccak",
-]
-
-[[package]]
-name = "convert_case"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "core-foundation"
@@ -1464,12 +1415,6 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -1693,15 +1638,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dlv-list"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
-dependencies = [
- "const-random",
-]
-
-[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1819,17 +1755,6 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "erased-serde"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
-dependencies = [
- "serde",
- "serde_core",
- "typeid",
-]
 
 [[package]]
 name = "errno"
@@ -2232,12 +2157,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -2850,17 +2769,6 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "json5"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
-dependencies = [
- "pest",
- "pest_derive",
- "serde",
 ]
 
 [[package]]
@@ -3521,16 +3429,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "ordered-multimap"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
-dependencies = [
- "dlv-list",
- "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -4376,20 +4274,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ron"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc"
-dependencies = [
- "bitflags",
- "once_cell",
- "serde",
- "serde_derive",
- "typeid",
- "unicode-ident",
-]
-
-[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4407,16 +4291,6 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rust-ini"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
-dependencies = [
- "cfg-if",
- "ordered-multimap",
 ]
 
 [[package]]
@@ -4682,18 +4556,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-untagged"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058"
-dependencies = [
- "erased-serde",
- "serde",
- "serde_core",
- "typeid",
-]
-
-[[package]]
 name = "serde-value"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4815,9 +4677,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -5349,7 +5211,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -5455,15 +5317,6 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -5761,12 +5614,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typeid"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
-
-[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5889,9 +5736,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -6184,7 +6031,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ webbrowser = { version = "1.0.2", optional = true }
 serde_ignored = { version = "0.1", optional = true }
 
 # Server core dependencies
-config = { version = "0.15.19", optional = true }
+config = { version = "0.15.19", default-features = false, features = ["yaml"], optional = true }
 openssl = { version = "0.10.75", features = ["vendored"], optional = true }
 sqlx = { version = "0.8", features = ["runtime-tokio-native-tls", "postgres", "uuid", "chrono", "migrate"], optional = true }
 tower = { version = "0.5.2", optional = true }

--- a/docs/engineering/src/content/docs/configuration.md
+++ b/docs/engineering/src/content/docs/configuration.md
@@ -2,23 +2,21 @@
 title: "Configuration Guide"
 ---
 
-Rise backend uses YAML configuration files with environment variable substitution support. TOML is also supported for backward compatibility.
+Rise backend uses YAML configuration files with environment variable substitution support.
 
 ## Configuration Files
 
 Configuration files are located in `config/` and loaded in this order:
 
-1. `default.{toml,yaml,yml}` - Shipped defaults (optional). Ships with the Rise image at `/etc/rise/default.yaml` and carries built-in defaults such as the quickstart catalog.
-2. `{RISE_CONFIG_RUN_MODE}.{toml,yaml,yml}` - Environment-specific config (**required**)
-   - `development.toml` or `development.yaml` when `RISE_CONFIG_RUN_MODE=development`
-   - `production.toml` or `production.yaml` when `RISE_CONFIG_RUN_MODE=production`
-3. `local.{toml,yaml,yml}` - Local overrides (not checked into git, optional)
+1. `default.yaml` - Shipped defaults (optional). Ships with the Rise image at `/etc/rise/default.yaml` and carries built-in defaults such as the quickstart catalog.
+2. `{RISE_CONFIG_RUN_MODE}.yaml` - Environment-specific config (**required**)
+   - `development.yaml` when `RISE_CONFIG_RUN_MODE=development`
+   - `production.yaml` when `RISE_CONFIG_RUN_MODE=production`
+3. `local.yaml` - Local overrides (not checked into git, optional)
 
 Later files override earlier ones.
 
 In container deployments, `RISE_CONFIG_DIR` is typically `/etc/rise`.
-
-**File Format**: The backend supports both YAML and TOML formats. When multiple formats exist for the same config file name (for example `development.yaml` and `development.toml`), TOML takes precedence. YAML is the recommended format as it integrates seamlessly with Kubernetes/Helm deployments.
 
 ## Environment Variable Substitution
 
@@ -40,31 +38,27 @@ server:
 
 ### How It Works
 
-1. Configuration files are parsed as TOML or YAML
+1. Configuration files are parsed as YAML
 2. String values are scanned for `${...}` patterns
 3. Patterns are replaced with environment variable values
 4. Resulting configuration is deserialized into Settings struct
 
-This happens **after** TOML/YAML parsing but **before** deserialization, so:
+This happens **after** YAML parsing but **before** deserialization, so:
 - ✅ Works in all string values (including nested tables/maps and arrays)
 - ✅ Preserves structure and types
 - ✅ Clear error messages if required variables are missing
 
 ## Configuration Precedence
 
-Configuration is loaded in this order (later values override earlier ones):
+Values are resolved in this order (later steps override earlier ones):
 
-1. `default.{toml,yaml,yml}` - Shipped defaults (optional, e.g. the quickstart catalog)
-2. `{RISE_CONFIG_RUN_MODE}.{toml,yaml,yml}` - Active environment config (required)
-3. `local.{toml,yaml,yml}` - Local overrides (not in git, optional)
-4. Environment variable substitution - `${VAR}` patterns are replaced
-5. DATABASE_URL special case - Overrides `[database] url` if set
+1. The config files described in [Configuration Files](#configuration-files), in their loading order
+2. Environment variable substitution - `${VAR}` patterns are replaced
+3. DATABASE_URL special case - Overrides `[database] url` if set
 
 ### Merge semantics
 
 The config loader uses the [`config`](https://crates.io/crates/config) crate, which deep-merges *maps* but **replaces** *arrays*. Practically: if `default.yaml` defines `quickstart.templates` with four entries and `local.yaml` defines `quickstart.templates` with one entry, the resulting catalog contains only that one entry — the defaults are not preserved. To extend a shipped list, copy the entries from `default.yaml` into your override and add to the list.
-
-**Note**: When multiple file formats exist for the same config file, TOML takes precedence over YAML.
 
 Example:
 ```yaml

--- a/docs/engineering/src/content/docs/database.md
+++ b/docs/engineering/src/content/docs/database.md
@@ -149,7 +149,7 @@ CREATE INDEX idx_deployments_expires_at ON deployments(expires_at) WHERE expires
 
 ### Connection Pooling
 
-Configure connection pool size in `config/production.toml` based on load and database limits.
+Configure connection pool size in `config/production.yaml` based on load and database limits.
 
 ### Query Optimization
 

--- a/docs/engineering/src/content/docs/production.md
+++ b/docs/engineering/src/content/docs/production.md
@@ -69,7 +69,7 @@ If you use the Helm chart's built-in PostgreSQL, see [Upgrading PostgreSQL](./up
 
 ### Connection Pooling
 
-Rise uses SQLx with connection pooling. Configure pool size based on load in `config/production.toml` if needed.
+Rise uses SQLx with connection pooling. Configure pool size based on load in `config/production.yaml` if needed.
 
 ## High Availability
 

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -1652,7 +1652,7 @@ impl Settings {
         }
     }
 
-    /// Try to add a config file with multiple extension attempts (.toml, .yaml, .yml)
+    /// Try to add a `.yaml` config file.
     /// Returns Ok(true) if a file was loaded, Ok(false) if no file found (when not required)
     fn try_add_config_file(
         builder: &mut config::ConfigBuilder<config::builder::DefaultState>,
@@ -1660,31 +1660,24 @@ impl Settings {
         name: &str,
         required: bool,
     ) -> Result<bool, ConfigError> {
-        // Try extensions in order of preference
-        let extensions = ["toml", "yaml", "yml"];
-
-        for ext in extensions {
-            let path = format!("{}/{}.{}", config_dir, name, ext);
-            if std::path::Path::new(&path).exists() {
-                tracing::info!("Loading config file: {}", path);
-                *builder = builder
-                    .clone()
-                    .add_source(config::File::with_name(&format!("{}/{}", config_dir, name)));
-                return Ok(true);
-            }
+        let path = format!("{}/{}.yaml", config_dir, name);
+        if std::path::Path::new(&path).exists() {
+            tracing::info!("Loading config file: {}", path);
+            // Pass the explicit path and format so the loader can't pick up a
+            // sibling file with a different extension.
+            *builder = builder
+                .clone()
+                .add_source(config::File::with_name(&path).format(config::FileFormat::Yaml));
+            return Ok(true);
         }
 
         if required {
             Err(ConfigError::Message(format!(
-                "Required config file not found: {}/{}.{{toml,yaml,yml}}",
-                config_dir, name
+                "Required config file not found: {}",
+                path
             )))
         } else {
-            tracing::debug!(
-                "Optional config file not found: {}/{}.{{toml,yaml,yml}}",
-                config_dir,
-                name
-            );
+            tracing::debug!("Optional config file not found: {}", path);
             Ok(false)
         }
     }
@@ -1735,8 +1728,7 @@ impl Settings {
     ) -> Result<Self, ConfigError> {
         let mut builder = Config::builder();
 
-        // Load config files in order, trying both .toml and .yaml/.yml extensions.
-        // TOML takes precedence if both exist.
+        // Load `.yaml` config files in order. Later files override earlier ones.
 
         // 1. Load shipped defaults (optional). Carries the built-in quickstart
         //    catalog and other defaults that operators can override. Loaded


### PR DESCRIPTION
The backend settings loader previously accepted TOML, YAML, and YML config
files, with TOML taking precedence when multiple formats existed. In practice
only YAML is used, since it integrates naturally with Kubernetes/Helm
deployments.

- Load only `<name>.yaml` in `try_add_config_file`, passing the explicit path
  and format so a sibling file with another extension can't be picked up
- Disable the `config` crate's default features, keeping only `yaml`, which
  drops the JSON5/RON/INI/TOML parsers (and transitive deps) from the binary
- Update the configuration docs to state YAML (`.yaml`) is the only supported
  backend settings format

The per-project `rise.toml` config is a separate system and is unchanged.