### PR TITLE
Migrate K8s backend routing from Endpoints to EndpointSlice

### DIFF
--- a/docs/engineering/src/content/docs/kubernetes/operations.md
+++ b/docs/engineering/src/content/docs/kubernetes/operations.md
@@ -42,9 +42,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["get", "list", "watch"]
-  # Endpoints for backend service routing (applied directly via kube-rs)
-  - apiGroups: [""]
-    resources: ["endpoints"]
+  # EndpointSlices for backend service routing (applied directly via kube-rs)
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
     verbs: ["get", "patch"]
 ```
 

--- a/helm/rise/templates/clusterrole.yaml
+++ b/helm/rise/templates/clusterrole.yaml
@@ -33,7 +33,7 @@ rules:
   resources: ["events"]
   verbs: ["get", "list", "watch"]
 
-# Endpoints (for backend service routing, applied directly via kube-rs)
-- apiGroups: [""]
-  resources: ["endpoints"]
+# EndpointSlices (for backend service routing, applied directly via kube-rs)
+- apiGroups: ["discovery.k8s.io"]
+  resources: ["endpointslices"]
   verbs: ["get", "patch"]

--- a/src/server/deployment/resource_builder.rs
+++ b/src/server/deployment/resource_builder.rs
@@ -19,7 +19,7 @@ use k8s_openapi::api::networking::v1::{
     HTTPIngressPath, HTTPIngressRuleValue, Ingress, IngressBackend, IngressRule,
     IngressServiceBackend, IngressSpec, NetworkPolicy, NetworkPolicySpec, ServiceBackendPort,
 };
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta, OwnerReference};
 use k8s_openapi::ByteString;
 use std::collections::BTreeMap;
 use tracing::warn;
@@ -661,6 +661,7 @@ impl ResourceBuilder {
         namespace: &str,
         ip: &str,
         port: u16,
+        rise_project_uid: Option<&str>,
     ) -> k8s_openapi::api::discovery::v1::EndpointSlice {
         use k8s_openapi::api::discovery::v1::{Endpoint, EndpointPort, EndpointSlice};
 
@@ -678,11 +679,32 @@ impl ResourceBuilder {
             _ => "IPv4",
         };
 
+        // The slice is applied directly (outside Metacontroller), so anchor it to
+        // the cluster-scoped `RiseProject` CR for garbage collection: a
+        // cluster-scoped owner can be referenced by a namespaced dependent in any
+        // namespace, so Kubernetes deletes the slice when the project's CR is
+        // removed. Only emit the reference when the UID is known — an owner
+        // reference with an empty UID would make the GC delete the slice
+        // immediately (owner treated as not found).
+        let owner_references = rise_project_uid.map(|uid| {
+            vec![OwnerReference {
+                // Mirrors the RiseProject CRD definition in crd.rs (group
+                // `rise.dev`, version `v1alpha1`).
+                api_version: "rise.dev/v1alpha1".to_string(),
+                kind: "RiseProject".to_string(),
+                name: project.name.clone(),
+                uid: uid.to_string(),
+                controller: Some(false),
+                block_owner_deletion: None,
+            }]
+        });
+
         EndpointSlice {
             metadata: ObjectMeta {
                 name: Some("rise-backend".to_string()),
                 namespace: Some(namespace.to_string()),
                 labels: Some(labels),
+                owner_references,
                 ..Default::default()
             },
             address_type: address_type.to_string(),
@@ -1809,7 +1831,13 @@ mod tests {
         let builder = test_resource_builder();
         let project = test_project();
 
-        let slice = builder.create_backend_endpoint_slice(&project, "demo", "10.0.0.5", 3000);
+        let slice = builder.create_backend_endpoint_slice(
+            &project,
+            "demo",
+            "10.0.0.5",
+            3000,
+            Some("rp-uid-1"),
+        );
 
         assert_eq!(slice.metadata.name.as_deref(), Some("rise-backend"));
         assert_eq!(slice.metadata.namespace.as_deref(), Some("demo"));
@@ -1827,6 +1855,18 @@ mod tests {
             Some("rise-backend")
         );
 
+        // GC anchor: owned by the cluster-scoped RiseProject CR.
+        let owners = slice
+            .metadata
+            .owner_references
+            .as_ref()
+            .expect("owner reference present");
+        assert_eq!(owners.len(), 1);
+        assert_eq!(owners[0].kind, "RiseProject");
+        assert_eq!(owners[0].api_version, "rise.dev/v1alpha1");
+        assert_eq!(owners[0].name, "demo");
+        assert_eq!(owners[0].uid, "rp-uid-1");
+
         assert_eq!(slice.endpoints.len(), 1);
         assert_eq!(slice.endpoints[0].addresses, vec!["10.0.0.5".to_string()]);
 
@@ -1842,10 +1882,28 @@ mod tests {
         let builder = test_resource_builder();
         let project = test_project();
 
-        let slice = builder.create_backend_endpoint_slice(&project, "demo", "fd00::1", 3000);
+        let slice = builder.create_backend_endpoint_slice(
+            &project,
+            "demo",
+            "fd00::1",
+            3000,
+            Some("rp-uid-1"),
+        );
 
         assert_eq!(slice.address_type, "IPv6");
         assert_eq!(slice.endpoints[0].addresses, vec!["fd00::1".to_string()]);
+    }
+
+    #[test]
+    fn create_backend_endpoint_slice_without_uid_has_no_owner_reference() {
+        let builder = test_resource_builder();
+        let project = test_project();
+
+        // A missing UID must yield no owner reference at all — an owner reference
+        // with an empty UID would make the GC delete the slice immediately.
+        let slice = builder.create_backend_endpoint_slice(&project, "demo", "10.0.0.5", 3000, None);
+
+        assert!(slice.metadata.owner_references.is_none());
     }
 
     /// Test helper: build the single implicit `app` container Deployment the

--- a/src/server/deployment/resource_builder.rs
+++ b/src/server/deployment/resource_builder.rs
@@ -655,33 +655,45 @@ impl ResourceBuilder {
         }
     }
 
-    pub fn create_backend_endpoints(
+    pub fn create_backend_endpoint_slice(
         &self,
         project: &Project,
         namespace: &str,
         ip: &str,
         port: u16,
-    ) -> k8s_openapi::api::core::v1::Endpoints {
-        use k8s_openapi::api::core::v1::{EndpointAddress, EndpointPort, EndpointSubset};
+    ) -> k8s_openapi::api::discovery::v1::EndpointSlice {
+        use k8s_openapi::api::discovery::v1::{Endpoint, EndpointPort, EndpointSlice};
 
-        k8s_openapi::api::core::v1::Endpoints {
+        // An EndpointSlice is associated with its Service via the
+        // `kubernetes.io/service-name` label (not by name-matching as core/v1
+        // Endpoints were), so it must be stamped for kube-proxy to route to it.
+        let mut labels = Self::common_labels(project, None);
+        labels.insert(
+            "kubernetes.io/service-name".to_string(),
+            "rise-backend".to_string(),
+        );
+
+        let address_type = match ip.parse::<std::net::IpAddr>() {
+            Ok(addr) if addr.is_ipv6() => "IPv6",
+            _ => "IPv4",
+        };
+
+        EndpointSlice {
             metadata: ObjectMeta {
                 name: Some("rise-backend".to_string()),
                 namespace: Some(namespace.to_string()),
-                labels: Some(Self::common_labels(project, None)),
+                labels: Some(labels),
                 ..Default::default()
             },
-            subsets: Some(vec![EndpointSubset {
-                addresses: Some(vec![EndpointAddress {
-                    ip: ip.to_string(),
-                    ..Default::default()
-                }]),
-                ports: Some(vec![EndpointPort {
-                    name: Some("http".to_string()),
-                    port: port as i32,
-                    protocol: Some("TCP".to_string()),
-                    ..Default::default()
-                }]),
+            address_type: address_type.to_string(),
+            endpoints: vec![Endpoint {
+                addresses: vec![ip.to_string()],
+                ..Default::default()
+            }],
+            ports: Some(vec![EndpointPort {
+                name: Some("http".to_string()),
+                port: Some(port as i32),
+                protocol: Some("TCP".to_string()),
                 ..Default::default()
             }]),
         }
@@ -1790,6 +1802,50 @@ mod tests {
             Some("abc123")
         );
         assert_eq!(secret.data, Some(data));
+    }
+
+    #[test]
+    fn create_backend_endpoint_slice_ipv4() {
+        let builder = test_resource_builder();
+        let project = test_project();
+
+        let slice = builder.create_backend_endpoint_slice(&project, "demo", "10.0.0.5", 3000);
+
+        assert_eq!(slice.metadata.name.as_deref(), Some("rise-backend"));
+        assert_eq!(slice.metadata.namespace.as_deref(), Some("demo"));
+        assert_eq!(slice.address_type, "IPv4");
+
+        // The `kubernetes.io/service-name` label is what associates the slice
+        // with the `rise-backend` Service so kube-proxy routes to it.
+        assert_eq!(
+            slice
+                .metadata
+                .labels
+                .as_ref()
+                .and_then(|labels| labels.get("kubernetes.io/service-name"))
+                .map(String::as_str),
+            Some("rise-backend")
+        );
+
+        assert_eq!(slice.endpoints.len(), 1);
+        assert_eq!(slice.endpoints[0].addresses, vec!["10.0.0.5".to_string()]);
+
+        let ports = slice.ports.expect("ports present");
+        assert_eq!(ports.len(), 1);
+        assert_eq!(ports[0].name.as_deref(), Some("http"));
+        assert_eq!(ports[0].port, Some(3000));
+        assert_eq!(ports[0].protocol.as_deref(), Some("TCP"));
+    }
+
+    #[test]
+    fn create_backend_endpoint_slice_ipv6() {
+        let builder = test_resource_builder();
+        let project = test_project();
+
+        let slice = builder.create_backend_endpoint_slice(&project, "demo", "fd00::1", 3000);
+
+        assert_eq!(slice.address_type, "IPv6");
+        assert_eq!(slice.endpoints[0].addresses, vec!["fd00::1".to_string()]);
     }
 
     /// Test helper: build the single implicit `app` container Deployment the

--- a/src/server/deployment/webhook.rs
+++ b/src/server/deployment/webhook.rs
@@ -156,7 +156,23 @@ pub async fn handle_sync(
         }
     };
 
-    match process_sync(&state, &project_name, &request.children).await {
+    // The parent RiseProject CR's UID is the GC anchor for resources we apply
+    // directly (outside Metacontroller), e.g. the backend EndpointSlice.
+    let project_uid = request
+        .parent
+        .get("metadata")
+        .and_then(|m| m.get("uid"))
+        .and_then(|u| u.as_str())
+        .map(|s| s.to_string());
+
+    match process_sync(
+        &state,
+        &project_name,
+        project_uid.as_deref(),
+        &request.children,
+    )
+    .await
+    {
         Ok(response) => (StatusCode::OK, Json(response)).into_response(),
         Err(SyncError::WrongController {
             project,
@@ -206,6 +222,7 @@ pub async fn handle_sync(
 async fn process_sync(
     state: &AppState,
     project_name: &str,
+    rise_project_uid: Option<&str>,
     observed: &ObservedChildren,
 ) -> Result<SyncResponse, SyncError> {
     // 1. Load project from DB
@@ -306,6 +323,7 @@ async fn process_sync(
         state,
         resource_builder,
         &project,
+        rise_project_uid,
         &all_deployments,
         observed,
         &namespace_prefix,
@@ -1315,6 +1333,7 @@ async fn compute_desired_children(
     state: &AppState,
     resource_builder: &ResourceBuilder,
     project: &Project,
+    rise_project_uid: Option<&str>,
     all_deployments: &[Deployment],
     observed: &ObservedChildren,
     namespace_prefix: &str,
@@ -1360,6 +1379,7 @@ async fn compute_desired_children(
             &mut children,
             resource_builder,
             project,
+            rise_project_uid,
             &namespace,
             backend_address,
         )
@@ -2330,6 +2350,7 @@ async fn add_backend_resources(
     children: &mut Vec<serde_json::Value>,
     resource_builder: &ResourceBuilder,
     project: &Project,
+    rise_project_uid: Option<&str>,
     namespace: &str,
     backend_address: &crate::server::settings::BackendAddress,
 ) -> anyhow::Result<()> {
@@ -2347,6 +2368,7 @@ async fn add_backend_resources(
             namespace,
             &backend_address.host,
             backend_address.port,
+            rise_project_uid,
         );
         apply_backend_endpoint_slice(state, &endpoint_slice, namespace).await;
     } else {

--- a/src/server/deployment/webhook.rs
+++ b/src/server/deployment/webhook.rs
@@ -2316,15 +2316,15 @@ fn prepare_deployment_env_secret(
     }
 }
 
-/// Add backend service + endpoints resources.
+/// Add backend service + EndpointSlice resources.
 ///
 /// The Service is returned as a Metacontroller child. For IP-based backends,
-/// the Endpoints are applied directly via kube-rs because Endpoints cannot be
-/// a Metacontroller child resource type — Kubernetes auto-creates Endpoints
-/// for Services with selectors (e.g. the deployment `default` Service), and
-/// Metacontroller would thrash deleting/adopting those in an infinite loop.
-/// Since child resource types are all-or-nothing, we manage the `rise-backend`
-/// Endpoints outside of Metacontroller as well.
+/// the EndpointSlice is applied directly via kube-rs because EndpointSlices
+/// cannot be a Metacontroller child resource type — Kubernetes auto-creates
+/// EndpointSlices for Services with selectors (e.g. the deployment `default`
+/// Service), and Metacontroller would thrash deleting/adopting those in an
+/// infinite loop. Since child resource types are all-or-nothing, we manage the
+/// `rise-backend` EndpointSlice outside of Metacontroller as well.
 async fn add_backend_resources(
     state: &AppState,
     children: &mut Vec<serde_json::Value>,
@@ -2334,7 +2334,7 @@ async fn add_backend_resources(
     backend_address: &crate::server::settings::BackendAddress,
 ) -> anyhow::Result<()> {
     if backend_address.is_ip_address() {
-        // IP address → ClusterIP Service (as child) + Endpoints (applied directly)
+        // IP address → ClusterIP Service (as child) + EndpointSlice (applied directly)
         let svc = resource_builder.create_backend_service_clusterip(
             project,
             namespace,
@@ -2342,13 +2342,13 @@ async fn add_backend_resources(
         );
         children.push(serde_json::to_value(&svc)?);
 
-        let endpoints = resource_builder.create_backend_endpoints(
+        let endpoint_slice = resource_builder.create_backend_endpoint_slice(
             project,
             namespace,
             &backend_address.host,
             backend_address.port,
         );
-        apply_backend_endpoints(state, &endpoints, namespace).await;
+        apply_backend_endpoint_slice(state, &endpoint_slice, namespace).await;
     } else {
         // DNS name → ExternalName
         let svc = resource_builder.create_backend_service_externalname(
@@ -2362,39 +2362,43 @@ async fn add_backend_resources(
     Ok(())
 }
 
-/// Apply backend Endpoints directly via kube-rs server-side apply.
+/// Apply backend EndpointSlice directly via kube-rs server-side apply.
 ///
 /// On the first sync for a new project the namespace returned in this sync's
 /// children list has not yet been applied by Metacontroller, so the apply
 /// 404s. That's expected and self-heals on the next resync, so the 404 is
 /// logged at debug instead of warning.
-async fn apply_backend_endpoints(
+async fn apply_backend_endpoint_slice(
     state: &AppState,
-    endpoints: &k8s_openapi::api::core::v1::Endpoints,
+    endpoint_slice: &k8s_openapi::api::discovery::v1::EndpointSlice,
     namespace: &str,
 ) {
     let Some(ref kube_client) = state.kube_client else {
         return;
     };
-    let api: kube::Api<k8s_openapi::api::core::v1::Endpoints> =
+    let api: kube::Api<k8s_openapi::api::discovery::v1::EndpointSlice> =
         kube::Api::namespaced(kube_client.clone(), namespace);
-    let name = endpoints.metadata.name.as_deref().unwrap_or("rise-backend");
+    let name = endpoint_slice
+        .metadata
+        .name
+        .as_deref()
+        .unwrap_or("rise-backend");
     let params = kube::api::PatchParams::apply("rise-controller").force();
     match api
-        .patch(name, &params, &kube::api::Patch::Apply(endpoints))
+        .patch(name, &params, &kube::api::Patch::Apply(endpoint_slice))
         .await
     {
         Ok(_) => {}
         Err(kube::Error::Api(err)) if err.code == 404 => {
             debug!(
                 namespace = %namespace,
-                "Backend Endpoints apply deferred: namespace not yet created (will retry on next resync)"
+                "Backend EndpointSlice apply deferred: namespace not yet created (will retry on next resync)"
             );
         }
         Err(e) => {
             warn!(
                 namespace = %namespace,
-                "Failed to apply backend Endpoints: {:?}", e
+                "Failed to apply backend EndpointSlice: {:?}", e
             );
         }
     }


### PR DESCRIPTION
The Kubernetes API server emits a deprecation warning for the core/v1
Endpoints API ("v1 Endpoints is deprecated in v1.33+; use
discovery.k8s.io/v1 EndpointSlice"). Rise creates a single `rise-backend`
Endpoints object per project namespace to route a selector-less ClusterIP
Service to an IP-based backend address (used for in-cluster ingress auth).

Migrate that object to discovery.k8s.io/v1 EndpointSlice:

- `ResourceBuilder::create_backend_endpoint_slice` builds an EndpointSlice
  with the required `kubernetes.io/service-name=rise-backend` label (how
  EndpointSlices associate with their Service, replacing core/v1's
  name-matching) and an `addressType` derived from the backend IP.
- The webhook applies it via kube-rs server-side apply against
  `Api<EndpointSlice>`, preserving the existing field-manager and
  404-on-first-sync handling.
- Update the ClusterRole (and the mirrored operations doc) to grant
  `discovery.k8s.io/endpointslices` instead of core `endpoints`.

Adds unit tests covering IPv4/IPv6 address-type detection, the
service-name label, and the address/port mapping.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KLaEnjAyJ4L4qrJvgN3nZ8