### PR TITLE
feat(authz): add policy schemas and pure algebra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,9 @@ jobs:
       - name: Run Clippy (resource API crate)
         run: cargo clippy --package rise-resource-api --all-targets -- -D warnings
 
+      - name: Run Clippy (authorization crate)
+        run: cargo clippy --package rise-authz --all-targets -- -D warnings
+
       - name: Run cargo audit
         run: cargo audit
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4139,6 +4139,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "rise-authz"
+version = "0.1.0"
+dependencies = [
+ "rise-resource-api",
+ "serde_json",
+]
+
+[[package]]
 name = "rise-backend-auth"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     ".",
+    "crates/rise-authz",
     "crates/rise-backend-auth",
     "crates/rise-backend-core",
     "crates/rise-backend-docker",

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ FROM chef AS planner
 
 # Copy workspace project files
 COPY Cargo.toml Cargo.lock ./
+COPY crates/rise-authz/Cargo.toml ./crates/rise-authz/Cargo.toml
 COPY crates/rise-resource-api/Cargo.toml ./crates/rise-resource-api/Cargo.toml
 COPY crates/rise-resource-store-postgres/Cargo.toml ./crates/rise-resource-store-postgres/Cargo.toml
 COPY crates/rise-backend-auth/Cargo.toml ./crates/rise-backend-auth/Cargo.toml
@@ -29,6 +30,8 @@ COPY crates/rise-runtime-sync/Cargo.toml ./crates/rise-runtime-sync/Cargo.toml
 # Create dummy sources for cargo to be happy
 RUN mkdir -p src && \
     echo "fn main() {}" > src/main.rs && \
+    mkdir -p crates/rise-authz/src && \
+    echo "" > crates/rise-authz/src/lib.rs && \
     mkdir -p crates/rise-resource-api/src && \
     echo "" > crates/rise-resource-api/src/lib.rs && \
     mkdir -p crates/rise-resource-store-postgres/src && \

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,13 +31,13 @@ Status legend: `[x]` shipped · `[~]` in progress · `[ ]` planned.
 - [x] Move the dep-light `ResourceStore` contract and canonical `SubjectId`,
   dynamic-label `SubjectRef`, group-qualified `ResourceKind`, and `Scope` types into `rise-resource-api`;
   keep SQLX and Postgres adapters in `rise-resource-store-postgres`.
-- [ ] Implement policy types and validation for `Role`, `RoleBinding`,
+- [~] Implement policy types and validation for `Role`, `RoleBinding`,
   `PlatformRole`, and `PlatformRoleBinding`: structured `roleRef`, one
   subject per binding, normalized PascalCase `subjectMembership: Any |
   ResourceOrganization` on platform bindings (omission becomes `Any`; null is
-  invalid), canonical
-  scopes, tiered platform/org Deny evaluation, admin-tier filtering, and
-  wildcard replacement.
+  invalid), canonical scopes, pure Allow/Deny tuple evaluation, placement
+  provenance, wildcard replacement, and Deny-aware subset checks. Activate
+  these resources only through transaction-scoped normalization/admission.
 - [ ] Add built-in identity resources: root `User` and `Controller`;
   Organization-owned `Group` and `ServiceAccount`; and fixed-parent
   `UserIdentity`, `GroupMembership`, `ControllerTrustPolicy`, and
@@ -49,7 +49,8 @@ Status legend: `[x]` shipped · `[~]` in progress · `[ ]` planned.
   resource API shape.
 - [ ] Implement live membership expansion, per-item list filtering/projection,
   effective-label resolution, typed `SubjectRef` values for dynamic ownership,
-  platform ceilings, and the centralized authorization choke point replacing
+  tiered platform/org Deny filtering, admin/operator classification, platform
+  ceilings, and the centralized authorization choke point replacing
   `require_operator`.
 - [ ] Add Role/policy audit and explain diagnostics for semantically inert
   configuration: no-op recipient or membership constraints, owners with no

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -29,10 +29,10 @@ scope and avoiding dead-end compatibility layers.
    PostgreSQL adapters in `rise-resource-store-postgres`. Cover parsing,
    canonicalization, rejection behavior, serialization, and
    store-implementation compatibility.
-2. **In progress — name the PostgreSQL adapter boundary explicitly.** Rename the
+2. **Merged in PR #417 — name the PostgreSQL adapter boundary explicitly.** Rename the
    concrete adapter crate to `rise-resource-store-postgres` without changing
    behavior or adding compatibility aliases.
-3. **Planned — policy resources and pure policy algebra.** Add the Role/binding
+3. **In progress — policy resources and pure policy algebra.** Add the Role/binding
    schemas, validation, Allow/Deny tuple evaluation, wildcard replacement, and
    subset checks with database-free conformance coverage.
 4. **Planned — identity resources and storage projections.** Register the
@@ -113,8 +113,8 @@ scope and avoiding dead-end compatibility layers.
 
 ## Increment 2 — explicit PostgreSQL adapter crate name
 
-- State: implementation, local verification, and independent review complete;
-  ready for draft-PR review.
+- State: merged in PR #417 at commit
+  `1eabe9cc12c32fefbc71d7ed54ffddcfa2448caa`.
 - Branch: `refactor/resource-store-postgres`.
 - Acceptance criteria:
   - Rename the package and directory to `rise-resource-store-postgres` and
@@ -154,4 +154,58 @@ scope and avoiding dead-end compatibility layers.
     migration. Because SQLX hashes the full migration text, the edits would
     have caused version-mismatch startup failures on upgraded databases; the
     historical migration was restored byte-for-byte.
-- PR: #417, open as a draft for review.
+- PR: #417, merged.
+
+## Increment 3 — policy resource contracts and pure policy algebra
+
+- State: implementation, local verification, and independent review complete;
+  ready for draft PR review.
+- Branch: `feat/adr0001-policy-algebra`.
+- Acceptance criteria:
+  - `rise-resource-api` owns the closed serialized contracts for `Role`,
+    `RoleBinding`, `PlatformRole`, and `PlatformRoleBinding`, reusing its
+    canonical `ResourceKind`, `Scope`, `SubjectId`, and `SubjectRef` types.
+  - A new `rise-authz` crate owns a hard, database-free `policy` module for
+    authorization tuple matching, Deny-wins evaluation, placement-provenance
+    preservation, wildcard replacement, subject substitution, and
+    scope/selector subset checks.
+  - Policy syntax rejects unqualified kinds, empty pattern lists, unknown
+    fields and enum values, plural subjects, invalid templates, invalid
+    static/dynamic selector combinations, and explicit null defaults.
+  - Omitted `PlatformRoleBinding.subjectMembership` normalizes to `Any` in the
+    typed contract; binding scope normalization remains an explicit contextual
+    operation because its default depends on placement, parent, and subject.
+  - Database-free conformance tests cover the applicable portions of ADR-0001
+    scenarios 1, 2, 4-6, 11, 15, 20, 31, 32, 49, 50, and 57.
+  - Focused tests plus the relevant workspace format, lint, and test gates pass.
+- Decisions:
+  - Use one `rise-authz` crate with a hard `policy` module rather than splitting
+    Tier 0 and Tier 1 before the engine seam exists; the pure module remains
+    extractable later.
+  - Reuse API-owned canonical types instead of creating a second kind/scope/
+    subject vocabulary and a security-sensitive mapping layer.
+  - Do not register writable policy built-ins in this increment. The current
+    `SpecValidator` is deliberately pure and pre-transactional, cannot rewrite
+    the JSON that the store persists, and cannot atomically validate scope,
+    subject, or role references. Registration lands with a transaction-scoped
+    normalization/admission seam.
+  - Preserve binding placement on statement contributions, but perform live
+    operator/admin classification and Deny-tier filtering in Tier 1 alongside
+    membership expansion; these are not ordinary statement algebra.
+- Verification:
+  - Focused `rise-resource-api` and `rise-authz` tests pass with the lockfile in
+    offline mode, including policy contract and algebra regression coverage.
+  - `mise run lint` passes, including all-features checks, strict Clippy,
+    formatting, SQLX metadata checks, generated resource schemas, Helm lint,
+    and the existing auth/core tests.
+  - The full all-features workspace test suite passes serially with offline
+    SQLX metadata, including all 56 PostgreSQL-backed integration tests.
+  - The Docker planner stage builds successfully with the new crate included.
+- Review:
+  - Independent reviews covered the public API and normalization boundary,
+    policy-domain/subset semantics, migration and integration safety, and the
+    final pinned diff.
+  - Confirmed findings fixed before publication include domain widening on an
+    unchanged policy, grant creation by deleting Deny statements, ordinary use
+    of `system:operators`, construction of unchecked normalized values, and
+    fail-open handling of concrete-scope ancestry.

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -209,3 +209,4 @@ scope and avoiding dead-end compatibility layers.
     unchanged policy, grant creation by deleting Deny statements, ordinary use
     of `system:operators`, construction of unchecked normalized values, and
     fail-open handling of concrete-scope ancestry.
+- PR: #418, draft.

--- a/crates/rise-authz/Cargo.toml
+++ b/crates/rise-authz/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rise-authz"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/rise-deploy/rise"
+description = "Database-free authorization policy algebra for Rise"
+publish = false
+
+[dependencies]
+rise-resource-api = { path = "../rise-resource-api" }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/rise-authz/src/lib.rs
+++ b/crates/rise-authz/src/lib.rs
@@ -1,0 +1,7 @@
+//! Authorization policy evaluation and, later, store-backed engine orchestration.
+//!
+//! The [`policy`] module is a hard Tier-0 boundary: it contains pure functions
+//! and canonical values only. It must not acquire store, database, HTTP, or
+//! product-resource dependencies when the live engine is added beside it.
+
+pub mod policy;

--- a/crates/rise-authz/src/policy.rs
+++ b/crates/rise-authz/src/policy.rs
@@ -1,0 +1,405 @@
+use std::collections::BTreeSet;
+
+use rise_resource_api::{
+    BindingSubject, Effect, KindMatcher, LabelSelector, PolicyStatement, ResourceKind,
+    ResourceKindPattern, Scope, SubjectId, SubjectRef, SubresourceMatcher, SubresourceName, Verb,
+    VerbMatcher,
+};
+
+/// One version-independent authorization operation.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PermissionTuple {
+    pub verb: Verb,
+    pub kind: ResourceKind,
+    /// `None` is the main resource. A named value is a distinct subresource.
+    pub subresource: Option<SubresourceName>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Decision {
+    Allow,
+    Deny,
+}
+
+/// Evaluate an additive statement union. Default deny applies, and any matching
+/// Deny overrides every matching Allow.
+pub fn evaluate<'a>(
+    statements: impl IntoIterator<Item = &'a PolicyStatement>,
+    request: &PermissionTuple,
+) -> Decision {
+    let mut allowed = false;
+    for statement in statements {
+        if !statement_matches(statement, request) {
+            continue;
+        }
+        match statement.effect {
+            Effect::Allow => allowed = true,
+            Effect::Deny => return Decision::Deny,
+        }
+    }
+    if allowed {
+        Decision::Allow
+    } else {
+        Decision::Deny
+    }
+}
+
+pub fn statement_matches(statement: &PolicyStatement, request: &PermissionTuple) -> bool {
+    kind_matches(&statement.kinds, &request.kind)
+        && verb_matches(&statement.verbs, request.verb)
+        && subresource_matches(
+            statement.subresources.as_ref(),
+            request.subresource.as_ref(),
+        )
+}
+
+pub fn kind_matches(matcher: &KindMatcher, kind: &ResourceKind) -> bool {
+    match matcher {
+        KindMatcher::All => true,
+        KindMatcher::Patterns(patterns) => patterns.iter().any(|pattern| match pattern {
+            ResourceKindPattern::Exact(exact) => exact == kind,
+            ResourceKindPattern::Group(group) => group == kind.group(),
+        }),
+    }
+}
+
+pub fn verb_matches(matcher: &VerbMatcher, verb: Verb) -> bool {
+    match matcher {
+        VerbMatcher::All => true,
+        VerbMatcher::Verbs(verbs) => verbs.contains(&verb),
+    }
+}
+
+pub fn subresource_matches(
+    matcher: Option<&SubresourceMatcher>,
+    subresource: Option<&SubresourceName>,
+) -> bool {
+    match (matcher, subresource) {
+        (None, None) => true,
+        (None, Some(_)) | (Some(_), None) => false,
+        (Some(SubresourceMatcher::All), Some(_)) => true,
+        (Some(SubresourceMatcher::Names(names)), Some(name)) => names.contains(name),
+    }
+}
+
+/// Resolve one authored subject against the value selected from a resource.
+/// Literal subjects ignore `selected_value`; templates fail closed without it.
+pub fn resolve_subject(
+    subject: &BindingSubject,
+    selected_value: Option<&str>,
+    resource_organization: Option<&str>,
+) -> Result<SubjectId, rise_resource_api::ValidationError> {
+    match subject {
+        BindingSubject::Literal(subject) => Ok(subject.clone()),
+        BindingSubject::UserNameTemplate => {
+            let name = required_selected_value(selected_value)?;
+            format!("user:{name}").parse()
+        }
+        BindingSubject::GroupNameTemplate => {
+            let name = required_selected_value(selected_value)?;
+            let organization = resource_organization.ok_or_else(|| {
+                rise_resource_api::ValidationError::new(
+                    "relative group subject requires an organization",
+                )
+            })?;
+            format!("group:{organization}/{name}").parse()
+        }
+        BindingSubject::SubjectRefTemplate => {
+            let subject_ref: SubjectRef = required_selected_value(selected_value)?.parse()?;
+            subject_ref.resolve(resource_organization)
+        }
+    }
+}
+
+fn required_selected_value(
+    value: Option<&str>,
+) -> Result<&str, rise_resource_api::ValidationError> {
+    value.ok_or_else(|| {
+        rise_resource_api::ValidationError::new("dynamic subject requires a selected label value")
+    })
+}
+
+/// The placement tier that supplied a statement. Tier-1 decides which Denies
+/// survive for a live caller; Tier-0 carries this fact without interpreting
+/// membership or administrator status.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BindingTier {
+    Platform,
+    Organization(String),
+}
+
+/// A binding already found applicable to the resource being evaluated.
+///
+/// `apply_wildcard_replacement` deliberately consumes already-applicable
+/// bindings. This makes value-specific selectors compete only on resources
+/// whose current effective label matched them, as ADR-0001 requires.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApplicableBinding<P> {
+    pub provenance: P,
+    pub subject: BindingSubject,
+    pub scope: Scope,
+    pub selector: Option<LabelSelector>,
+    pub tier: BindingTier,
+    pub statements: Vec<PolicyStatement>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatementContribution<P> {
+    pub provenance: P,
+    pub tier: BindingTier,
+    pub statement: PolicyStatement,
+}
+
+/// Replace wildcard Allows when an applicable specific binding has the same
+/// authored subject and selector key. Denies are never removed, and every
+/// surviving statement retains binding and placement provenance.
+pub fn apply_wildcard_replacement<P: Clone>(
+    bindings: &[ApplicableBinding<P>],
+) -> Vec<StatementContribution<P>> {
+    let mut contributions = Vec::new();
+    for binding in bindings {
+        let replace_wildcard_allows = binding.scope.is_wildcard()
+            && bindings.iter().any(|candidate| {
+                !candidate.scope.is_wildcard()
+                    && candidate.subject == binding.subject
+                    && selector_key(candidate.selector.as_ref())
+                        == selector_key(binding.selector.as_ref())
+            });
+
+        for statement in &binding.statements {
+            if replace_wildcard_allows && statement.effect == Effect::Allow {
+                continue;
+            }
+            contributions.push(StatementContribution {
+                provenance: binding.provenance.clone(),
+                tier: binding.tier.clone(),
+                statement: statement.clone(),
+            });
+        }
+    }
+    contributions
+}
+
+fn selector_key(selector: Option<&LabelSelector>) -> Option<&rise_resource_api::LabelKey> {
+    selector.map(|selector| &selector.key)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PolicyDomain {
+    pub scope: Scope,
+    pub selector: Option<LabelSelector>,
+}
+
+/// Whether `covering` contains every resource domain represented by `covered`.
+///
+/// Scope comparison is deliberately fail-closed without registry facts:
+/// wildcard covers every scope, while concrete scopes cover only the identical
+/// canonical path. Selector order is none > key-exists > key-equals-value;
+/// different keys are never assumed disjoint.
+pub fn domain_covers(covering: &PolicyDomain, covered: &PolicyDomain) -> bool {
+    domain_covers_with(covering, covered, &|left, right| left == right)
+}
+
+/// Domain containment with registry-resolved concrete-scope ancestry supplied
+/// by the caller. The callback is consulted only for two non-wildcard scopes;
+/// Tier-0 remains independent of the resource registry and store.
+pub fn domain_covers_with<F>(
+    covering: &PolicyDomain,
+    covered: &PolicyDomain,
+    concrete_scope_covers: &F,
+) -> bool
+where
+    F: Fn(&Scope, &Scope) -> bool + ?Sized,
+{
+    let scope_covers = if covering.scope.is_wildcard() {
+        true
+    } else if covered.scope.is_wildcard() {
+        false
+    } else {
+        concrete_scope_covers(&covering.scope, &covered.scope)
+    };
+    scope_covers && selector_covers(covering.selector.as_ref(), covered.selector.as_ref())
+}
+
+pub fn selector_covers(covering: Option<&LabelSelector>, covered: Option<&LabelSelector>) -> bool {
+    match (covering, covered) {
+        (None, _) => true,
+        (Some(_), None) => false,
+        (Some(left), Some(right)) if left.key != right.key => false,
+        (Some(LabelSelector { value: None, .. }), Some(_)) => true,
+        (Some(left), Some(right)) => left.value == right.value,
+    }
+}
+
+/// Test the tuple-level implication `(after - before) ⊆ writer` exactly over
+/// the closed matcher grammar. The implementation uses one representative for
+/// every equivalence class induced by exact/group/global kind patterns and
+/// named/wildcard subresource patterns; it does not enumerate stored resources.
+pub fn newly_allowed_is_subset(
+    before: &[PolicyStatement],
+    after: &[PolicyStatement],
+    writer: &[PolicyStatement],
+) -> bool {
+    let representatives = tuple_representatives([before, after, writer]);
+    representatives.into_iter().all(|tuple| {
+        evaluate(after, &tuple) != Decision::Allow
+            || evaluate(before, &tuple) == Decision::Allow
+            || evaluate(writer, &tuple) == Decision::Allow
+    })
+}
+
+pub fn policy_is_subset(candidate: &[PolicyStatement], covering: &[PolicyStatement]) -> bool {
+    newly_allowed_is_subset(&[], candidate, covering)
+}
+
+/// Combine domain movement with the Deny-aware tuple delta check.
+///
+/// `None` before represents creation. Callers must always supply the fully
+/// resolved aggregate after-policy over the affected domain, including for a
+/// binding deletion: removing a Deny may expose another binding's Allow and is
+/// therefore a grant. If the old domain covers the new domain, only the
+/// tuple-level policy delta is new. Otherwise the move/expansion may reach
+/// resources that had no prior policy, so the writer must cover the complete
+/// after policy and domain.
+pub fn scoped_newly_allowed_is_subset(
+    before: Option<(&[PolicyStatement], &PolicyDomain)>,
+    after: (&[PolicyStatement], &PolicyDomain),
+    writer: &[PolicyStatement],
+    writer_domain: &PolicyDomain,
+) -> bool {
+    scoped_newly_allowed_is_subset_with(before, after, writer, writer_domain, &|left, right| {
+        left == right
+    })
+}
+
+/// Complete scoped delta check using caller-supplied concrete-scope ancestry.
+pub fn scoped_newly_allowed_is_subset_with<F>(
+    before: Option<(&[PolicyStatement], &PolicyDomain)>,
+    after: (&[PolicyStatement], &PolicyDomain),
+    writer: &[PolicyStatement],
+    writer_domain: &PolicyDomain,
+    concrete_scope_covers: &F,
+) -> bool
+where
+    F: Fn(&Scope, &Scope) -> bool + ?Sized,
+{
+    let (after_policy, after_domain) = after;
+    if policy_is_subset(after_policy, &[]) {
+        return true;
+    }
+
+    let Some((before_policy, before_domain)) = before else {
+        return domain_covers_with(writer_domain, after_domain, concrete_scope_covers)
+            && policy_is_subset(after_policy, writer);
+    };
+    if !domain_covers_with(before_domain, after_domain, concrete_scope_covers) {
+        return domain_covers_with(writer_domain, after_domain, concrete_scope_covers)
+            && policy_is_subset(after_policy, writer);
+    }
+    if newly_allowed_is_subset(before_policy, after_policy, &[]) {
+        return true;
+    }
+    domain_covers_with(writer_domain, after_domain, concrete_scope_covers)
+        && newly_allowed_is_subset(before_policy, after_policy, writer)
+}
+
+fn tuple_representatives<'a>(
+    policies: impl IntoIterator<Item = &'a [PolicyStatement]>,
+) -> Vec<PermissionTuple> {
+    let policies: Vec<&[PolicyStatement]> = policies.into_iter().collect();
+    let mut kinds = BTreeSet::new();
+    let mut groups = BTreeSet::new();
+    let mut subresources = BTreeSet::new();
+
+    for statement in policies.iter().flat_map(|policy| policy.iter()) {
+        if let KindMatcher::Patterns(patterns) = &statement.kinds {
+            for pattern in patterns {
+                groups.insert(pattern.group().to_owned());
+                if let ResourceKindPattern::Exact(kind) = pattern {
+                    kinds.insert(kind.clone());
+                }
+            }
+        }
+        if let Some(SubresourceMatcher::Names(names)) = &statement.subresources {
+            subresources.extend(names.iter().cloned());
+        }
+    }
+
+    for group in groups {
+        kinds.insert(probe_kind(&group, &kinds));
+    }
+    let unknown_group = probe_group(&kinds);
+    kinds.insert(ResourceKind::new(&unknown_group, "PolicySubsetProbe").expect("valid probe kind"));
+    subresources.insert(probe_subresource(&subresources));
+
+    const VERBS: [Verb; 6] = [
+        Verb::Get,
+        Verb::List,
+        Verb::Create,
+        Verb::Update,
+        Verb::Delete,
+        Verb::Use,
+    ];
+    let mut tuples = Vec::new();
+    for verb in VERBS {
+        for kind in &kinds {
+            tuples.push(PermissionTuple {
+                verb,
+                kind: kind.clone(),
+                subresource: None,
+            });
+            for subresource in &subresources {
+                tuples.push(PermissionTuple {
+                    verb,
+                    kind: kind.clone(),
+                    subresource: Some(subresource.clone()),
+                });
+            }
+        }
+    }
+    tuples
+}
+
+fn probe_kind(group: &str, existing: &BTreeSet<ResourceKind>) -> ResourceKind {
+    for suffix in 0.. {
+        let kind = if suffix == 0 {
+            "PolicySubsetProbe".to_owned()
+        } else {
+            format!("PolicySubsetProbe{suffix}")
+        };
+        let candidate = ResourceKind::new(group, &kind).expect("validated source group");
+        if !existing.contains(&candidate) {
+            return candidate;
+        }
+    }
+    unreachable!()
+}
+
+fn probe_group(existing: &BTreeSet<ResourceKind>) -> String {
+    for suffix in 0.. {
+        let group = if suffix == 0 {
+            "policy-subset-probe.invalid".to_owned()
+        } else {
+            format!("policy-subset-probe-{suffix}.invalid")
+        };
+        if existing.iter().all(|kind| kind.group() != group) {
+            return group;
+        }
+    }
+    unreachable!()
+}
+
+fn probe_subresource(existing: &BTreeSet<SubresourceName>) -> SubresourceName {
+    for suffix in 0.. {
+        let name = if suffix == 0 {
+            "policy-subset-probe".to_owned()
+        } else {
+            format!("policy-subset-probe-{suffix}")
+        };
+        let candidate: SubresourceName = name.parse().expect("valid probe subresource");
+        if !existing.contains(&candidate) {
+            return candidate;
+        }
+    }
+    unreachable!()
+}

--- a/crates/rise-authz/tests/policy.rs
+++ b/crates/rise-authz/tests/policy.rs
@@ -1,0 +1,462 @@
+use rise_authz::policy::{
+    apply_wildcard_replacement, domain_covers, domain_covers_with, evaluate,
+    newly_allowed_is_subset, policy_is_subset, resolve_subject, scoped_newly_allowed_is_subset,
+    scoped_newly_allowed_is_subset_with, ApplicableBinding, BindingTier, Decision, PermissionTuple,
+    PolicyDomain,
+};
+use rise_resource_api::{
+    BindingSubject, Effect, LabelSelector, PolicyStatement, ResourceKind, Scope, SubresourceName,
+    Verb,
+};
+use serde_json::json;
+
+fn statement(value: serde_json::Value) -> PolicyStatement {
+    serde_json::from_value(value).unwrap()
+}
+
+fn tuple(verb: Verb, kind: &str, subresource: Option<&str>) -> PermissionTuple {
+    PermissionTuple {
+        verb,
+        kind: kind.parse().unwrap(),
+        subresource: subresource.map(|name| name.parse().unwrap()),
+    }
+}
+
+fn selector(key: &str, value: Option<&str>) -> LabelSelector {
+    LabelSelector {
+        key: key.parse().unwrap(),
+        value: value.map(str::to_owned),
+    }
+}
+
+#[test]
+fn qualified_kind_matching_is_version_independent() {
+    let exact = statement(json!({
+        "effect": "Allow",
+        "kinds": ["alpha.example/Widget"],
+        "verbs": ["get"]
+    }));
+    assert_eq!(
+        evaluate([&exact], &tuple(Verb::Get, "alpha.example/Widget", None)),
+        Decision::Allow
+    );
+    assert_eq!(
+        evaluate([&exact], &tuple(Verb::Get, "beta.example/Widget", None)),
+        Decision::Deny
+    );
+
+    let v1 = ResourceKind::from_api_route("alpha.example/v1", "Widget").unwrap();
+    let v2 = ResourceKind::from_api_route("alpha.example/v2", "Widget").unwrap();
+    assert_eq!(v1, v2);
+}
+
+#[test]
+fn group_and_global_kind_wildcards_have_distinct_reach() {
+    let group = statement(json!({
+        "effect": "Allow", "kinds": ["alpha.example/*"], "verbs": "*"
+    }));
+    let global = statement(json!({
+        "effect": "Allow", "kinds": "*", "verbs": "*"
+    }));
+    let alpha = tuple(Verb::Use, "alpha.example/Gadget", None);
+    let beta = tuple(Verb::Use, "beta.example/Gadget", None);
+    assert_eq!(evaluate([&group], &alpha), Decision::Allow);
+    assert_eq!(evaluate([&group], &beta), Decision::Deny);
+    assert_eq!(evaluate([&global], &beta), Decision::Allow);
+}
+
+#[test]
+fn main_and_subresource_permissions_are_disjoint() {
+    let main = statement(json!({
+        "effect": "Allow", "kinds": "*", "verbs": "*"
+    }));
+    let all_subresources = statement(json!({
+        "effect": "Allow", "kinds": "*", "verbs": "*", "subresources": "*"
+    }));
+    let status_only = statement(json!({
+        "effect": "Allow", "kinds": "*", "verbs": ["update"], "subresources": ["status"]
+    }));
+    let main_request = tuple(Verb::Update, "rise.dev/Deployment", None);
+    let status_request = tuple(Verb::Update, "rise.dev/Deployment", Some("status"));
+    let token_request = tuple(Verb::Create, "rise.dev/ServiceAccount", Some("token"));
+
+    assert_eq!(evaluate([&main], &main_request), Decision::Allow);
+    assert_eq!(evaluate([&main], &status_request), Decision::Deny);
+    assert_eq!(evaluate([&all_subresources], &main_request), Decision::Deny);
+    assert_eq!(
+        evaluate([&all_subresources], &status_request),
+        Decision::Allow
+    );
+    assert_eq!(evaluate([&status_only], &status_request), Decision::Allow);
+    assert_eq!(evaluate([&status_only], &token_request), Decision::Deny);
+}
+
+#[test]
+fn union_defaults_to_deny_and_matching_deny_wins() {
+    let allow = statement(json!({
+        "effect": "Allow", "kinds": ["rise.dev/*"], "verbs": ["get", "delete"]
+    }));
+    let deny = statement(json!({
+        "effect": "Deny", "kinds": ["rise.dev/Environment"], "verbs": ["delete"]
+    }));
+    let get = tuple(Verb::Get, "rise.dev/Environment", None);
+    let delete = tuple(Verb::Delete, "rise.dev/Environment", None);
+    let update = tuple(Verb::Update, "rise.dev/Environment", None);
+    assert_eq!(evaluate([&allow, &deny], &get), Decision::Allow);
+    assert_eq!(evaluate([&allow, &deny], &delete), Decision::Deny);
+    assert_eq!(evaluate([&allow, &deny], &update), Decision::Deny);
+}
+
+#[test]
+fn subject_substitution_uses_the_closed_subject_ref_grammar() {
+    assert_eq!(
+        resolve_subject(
+            &"group:${ref.name}".parse().unwrap(),
+            Some("platform"),
+            Some("acme")
+        )
+        .unwrap()
+        .to_string(),
+        "group:acme/platform"
+    );
+    assert_eq!(
+        resolve_subject(
+            &"${ref.subject}".parse().unwrap(),
+            Some("group:platform"),
+            Some("acme")
+        )
+        .unwrap()
+        .to_string(),
+        "group:acme/platform"
+    );
+    assert!(resolve_subject(
+        &"${ref.subject}".parse().unwrap(),
+        Some("serviceaccount:ci"),
+        Some("acme")
+    )
+    .is_err());
+    assert!(resolve_subject(
+        &"group:${ref.name}".parse().unwrap(),
+        Some("platform"),
+        None
+    )
+    .is_err());
+}
+
+#[test]
+fn wildcard_replacement_uses_authored_identity_and_preserves_deny_provenance() {
+    let wildcard_allow = statement(json!({
+        "effect": "Allow", "kinds": "*", "verbs": ["get"]
+    }));
+    let wildcard_deny = statement(json!({
+        "effect": "Deny", "kinds": "*", "verbs": ["delete"]
+    }));
+    let specific_allow = statement(json!({
+        "effect": "Allow", "kinds": ["rise.dev/Deployment"], "verbs": ["get"]
+    }));
+    let bindings = vec![
+        ApplicableBinding {
+            provenance: "wildcard",
+            subject: "${ref.subject}".parse().unwrap(),
+            scope: Scope::wildcard(),
+            selector: Some(selector("rise.dev/owner", None)),
+            tier: BindingTier::Platform,
+            statements: vec![wildcard_allow, wildcard_deny],
+        },
+        ApplicableBinding {
+            provenance: "specific",
+            subject: "${ref.subject}".parse().unwrap(),
+            scope: "rise.dev/Organization/acme".parse().unwrap(),
+            selector: Some(selector("rise.dev/owner", Some("user:alice"))),
+            tier: BindingTier::Organization("acme".to_owned()),
+            statements: vec![specific_allow],
+        },
+    ];
+    let result = apply_wildcard_replacement(&bindings);
+    assert_eq!(result.len(), 2);
+    assert!(result
+        .iter()
+        .all(|item| item.provenance != "wildcard" || item.statement.effect == Effect::Deny));
+    let retained = result
+        .iter()
+        .find(|item| item.provenance == "wildcard")
+        .unwrap();
+    assert_eq!(retained.tier, BindingTier::Platform);
+}
+
+#[test]
+fn literals_templates_and_different_selector_keys_do_not_collide() {
+    let allow = statement(json!({"effect":"Allow", "kinds":"*", "verbs":"*"}));
+    let wildcard = ApplicableBinding {
+        provenance: 1,
+        subject: "group:acme/platform".parse().unwrap(),
+        scope: Scope::wildcard(),
+        selector: Some(selector("rise.dev/owner", None)),
+        tier: BindingTier::Platform,
+        statements: vec![allow.clone()],
+    };
+    let template = ApplicableBinding {
+        provenance: 2,
+        subject: "group:${ref.name}".parse().unwrap(),
+        scope: "rise.dev/Organization/acme".parse().unwrap(),
+        selector: Some(selector("rise.dev/owner", None)),
+        tier: BindingTier::Organization("acme".to_owned()),
+        statements: vec![allow.clone()],
+    };
+    assert_eq!(
+        apply_wildcard_replacement(&[wildcard.clone(), template]).len(),
+        2
+    );
+
+    let different_key = ApplicableBinding {
+        provenance: 3,
+        subject: wildcard.subject.clone(),
+        scope: "rise.dev/Organization/acme".parse().unwrap(),
+        selector: Some(selector("rise.dev/squad", None)),
+        tier: BindingTier::Organization("acme".to_owned()),
+        statements: vec![allow],
+    };
+    assert_eq!(
+        apply_wildcard_replacement(&[wildcard, different_key]).len(),
+        2
+    );
+}
+
+#[test]
+fn deny_aware_subset_detects_removed_denies_as_new_authority() {
+    let allow_all = statement(json!({"effect":"Allow", "kinds":"*", "verbs":"*"}));
+    let deny_delete = statement(json!({
+        "effect":"Deny", "kinds":["rise.dev/Environment"], "verbs":["delete"]
+    }));
+    let allow_delete = statement(json!({
+        "effect":"Allow", "kinds":["rise.dev/Environment"], "verbs":["delete"]
+    }));
+    let before = vec![allow_all.clone(), deny_delete];
+    let after = vec![allow_all];
+    assert!(!newly_allowed_is_subset(&before, &after, &[]));
+    assert!(newly_allowed_is_subset(&before, &after, &[allow_delete]));
+}
+
+#[test]
+fn scoped_binding_deletion_checks_authority_exposed_by_removed_deny() {
+    let allow_all = statement(json!({"effect":"Allow", "kinds":"*", "verbs":"*"}));
+    let deny_delete = statement(json!({
+        "effect":"Deny", "kinds":["rise.dev/Environment"], "verbs":["delete"]
+    }));
+    let allow_delete = statement(json!({
+        "effect":"Allow", "kinds":["rise.dev/Environment"], "verbs":["delete"]
+    }));
+    let before = vec![allow_all.clone(), deny_delete];
+    let after = vec![allow_all];
+    let domain = PolicyDomain {
+        scope: "rise.dev/Organization/acme".parse().unwrap(),
+        selector: None,
+    };
+
+    assert!(!scoped_newly_allowed_is_subset(
+        Some((&before, &domain)),
+        (&after, &domain),
+        &[],
+        &domain,
+    ));
+    assert!(scoped_newly_allowed_is_subset(
+        Some((&before, &domain)),
+        (&after, &domain),
+        std::slice::from_ref(&allow_delete),
+        &domain,
+    ));
+}
+
+#[test]
+fn subset_is_exact_across_kind_and_subresource_partitions() {
+    let exact = statement(json!({
+        "effect":"Allow", "kinds":["rise.dev/Deployment"], "verbs":["get"]
+    }));
+    let group = statement(json!({
+        "effect":"Allow", "kinds":["rise.dev/*"], "verbs":["get"]
+    }));
+    let main = statement(json!({
+        "effect":"Allow", "kinds":"*", "verbs":"*"
+    }));
+    let subresources = statement(json!({
+        "effect":"Allow", "kinds":"*", "verbs":"*", "subresources":"*"
+    }));
+    assert!(policy_is_subset(
+        std::slice::from_ref(&exact),
+        std::slice::from_ref(&group)
+    ));
+    assert!(!policy_is_subset(
+        std::slice::from_ref(&group),
+        &[statement(json!({
+            "effect":"Allow", "kinds":["rise.dev/Deployment"], "verbs":"*"
+        }))]
+    ));
+    assert!(!policy_is_subset(
+        std::slice::from_ref(&subresources),
+        std::slice::from_ref(&main)
+    ));
+    assert!(!policy_is_subset(&[main], &[subresources]));
+}
+
+#[test]
+fn policy_subset_is_transitive_across_representative_matchers() {
+    let policies = [
+        vec![],
+        vec![statement(json!({
+            "effect":"Allow", "kinds":["rise.dev/Deployment"], "verbs":["get"]
+        }))],
+        vec![statement(json!({
+            "effect":"Allow", "kinds":["rise.dev/*"], "verbs":["get"]
+        }))],
+        vec![statement(json!({
+            "effect":"Allow", "kinds":"*", "verbs":["get"]
+        }))],
+        vec![statement(json!({
+            "effect":"Allow", "kinds":"*", "verbs":"*"
+        }))],
+        vec![
+            statement(json!({"effect":"Allow", "kinds":"*", "verbs":"*"})),
+            statement(json!({
+                "effect":"Deny", "kinds":["rise.dev/Environment"], "verbs":["delete"]
+            })),
+        ],
+    ];
+
+    for left in &policies {
+        for middle in &policies {
+            for right in &policies {
+                if policy_is_subset(left, middle) && policy_is_subset(middle, right) {
+                    assert!(policy_is_subset(left, right));
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn domain_containment_uses_the_fail_closed_selector_lattice() {
+    let scope: Scope = "rise.dev/Organization/acme".parse().unwrap();
+    let no_selector = PolicyDomain {
+        scope: scope.clone(),
+        selector: None,
+    };
+    let exists = PolicyDomain {
+        scope: scope.clone(),
+        selector: Some(selector("rise.dev/owner", None)),
+    };
+    let equal_alice = PolicyDomain {
+        scope: scope.clone(),
+        selector: Some(selector("rise.dev/owner", Some("user:alice"))),
+    };
+    let equal_bob = PolicyDomain {
+        scope: scope.clone(),
+        selector: Some(selector("rise.dev/owner", Some("user:bob"))),
+    };
+    let other_key = PolicyDomain {
+        scope,
+        selector: Some(selector("rise.dev/squad", None)),
+    };
+    assert!(domain_covers(&no_selector, &exists));
+    assert!(domain_covers(&exists, &equal_alice));
+    assert!(!domain_covers(&equal_alice, &exists));
+    assert!(!domain_covers(&equal_alice, &equal_bob));
+    assert!(!domain_covers(&exists, &other_key));
+}
+
+#[test]
+fn registry_resolved_scope_ancestry_can_cover_descendants() {
+    let organization = PolicyDomain {
+        scope: "rise.dev/Organization/acme".parse().unwrap(),
+        selector: None,
+    };
+    let project = PolicyDomain {
+        scope: "rise.dev/Project/acme/app".parse().unwrap(),
+        selector: None,
+    };
+    let ancestry = |covering: &Scope, covered: &Scope| {
+        covering == covered
+            || (covering.to_string() == "rise.dev/Organization/acme"
+                && covered.names().next() == Some("acme"))
+    };
+    assert!(domain_covers_with(&organization, &project, &ancestry));
+    assert!(!domain_covers_with(&project, &organization, &ancestry));
+
+    let allow = statement(json!({"effect":"Allow", "kinds":"*", "verbs":"*"}));
+    assert!(scoped_newly_allowed_is_subset_with(
+        None,
+        (std::slice::from_ref(&allow), &project),
+        std::slice::from_ref(&allow),
+        &organization,
+        &ancestry,
+    ));
+}
+
+#[test]
+fn narrow_domain_cannot_justify_a_broader_grant() {
+    let allow = statement(json!({"effect":"Allow", "kinds":"*", "verbs":"*"}));
+    let broad = PolicyDomain {
+        scope: Scope::wildcard(),
+        selector: None,
+    };
+    let narrow = PolicyDomain {
+        scope: "rise.dev/Organization/acme".parse().unwrap(),
+        selector: None,
+    };
+    assert!(!scoped_newly_allowed_is_subset(
+        None,
+        (std::slice::from_ref(&allow), &broad),
+        std::slice::from_ref(&allow),
+        &narrow
+    ));
+}
+
+#[test]
+fn unchanged_statements_do_not_hide_scope_or_selector_expansion() {
+    let allow = statement(json!({"effect":"Allow", "kinds":"*", "verbs":"*"}));
+    let broad = PolicyDomain {
+        scope: Scope::wildcard(),
+        selector: None,
+    };
+    let narrow_scope = PolicyDomain {
+        scope: "rise.dev/Organization/acme".parse().unwrap(),
+        selector: None,
+    };
+    let narrow_selector = PolicyDomain {
+        scope: Scope::wildcard(),
+        selector: Some(selector("rise.dev/owner", Some("user:alice"))),
+    };
+    let exists_selector = PolicyDomain {
+        scope: Scope::wildcard(),
+        selector: Some(selector("rise.dev/owner", None)),
+    };
+
+    for (before, after) in [
+        (&narrow_scope, &broad),
+        (&narrow_selector, &exists_selector),
+    ] {
+        assert!(!scoped_newly_allowed_is_subset(
+            Some((std::slice::from_ref(&allow), before)),
+            (std::slice::from_ref(&allow), after),
+            &[],
+            &broad,
+        ));
+        assert!(scoped_newly_allowed_is_subset(
+            Some((std::slice::from_ref(&allow), before)),
+            (std::slice::from_ref(&allow), after),
+            std::slice::from_ref(&allow),
+            &broad,
+        ));
+    }
+}
+
+#[test]
+fn typed_subject_values_remain_canonical() {
+    let subject: BindingSubject = "user:alice".parse().unwrap();
+    assert_eq!(
+        resolve_subject(&subject, Some("ignored"), Some("acme"))
+            .unwrap()
+            .to_string(),
+        "user:alice"
+    );
+    let _: SubresourceName = "status".parse().unwrap();
+}

--- a/crates/rise-resource-api/src/lib.rs
+++ b/crates/rise-resource-api/src/lib.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use uuid::Uuid;
 
+mod policy;
 mod resource_kind;
 mod resource_row;
 mod scope;
@@ -11,6 +12,13 @@ mod store;
 mod subject_id;
 mod subject_ref;
 
+pub use policy::{
+    BindingSubject, Effect, KindMatcher, LabelKey, LabelSelector,
+    LocallyNormalizedPlatformRoleBindingSpec, LocallyNormalizedRoleBindingSpec,
+    PlatformRoleBindingSpec, PlatformRoleRef, PlatformRoleRefKind, PolicyStatement,
+    ResourceKindPattern, RoleBindingSpec, RoleRef, RoleRefKind, RoleSpec, SubjectMembership,
+    SubresourceMatcher, SubresourceName, Verb, VerbMatcher,
+};
 pub use resource_kind::ResourceKind;
 pub use resource_row::ResourceRow;
 pub use scope::Scope;
@@ -30,9 +38,25 @@ pub const ORGANIZATION_COLLECTION: &str = "organizations";
 pub const RESOURCE_DEFINITION_KIND: &str = "ResourceDefinition";
 pub const RESOURCE_DEFINITION_COLLECTION: &str = "resourcedefinitions";
 
+// Policy resources are reserved here before store registration so a custom
+// ResourceDefinition cannot claim a collection that the built-in admission
+// path will own in a later increment.
+pub const ROLE_KIND: &str = "Role";
+pub const ROLE_COLLECTION: &str = "roles";
+pub const ROLE_BINDING_KIND: &str = "RoleBinding";
+pub const ROLE_BINDING_COLLECTION: &str = "rolebindings";
+pub const PLATFORM_ROLE_KIND: &str = "PlatformRole";
+pub const PLATFORM_ROLE_COLLECTION: &str = "platformroles";
+pub const PLATFORM_ROLE_BINDING_KIND: &str = "PlatformRoleBinding";
+pub const PLATFORM_ROLE_BINDING_COLLECTION: &str = "platformrolebindings";
+
 pub const RESERVED_COLLECTION_NAMES: &[&str] = &[
     ORGANIZATION_COLLECTION,
     RESOURCE_DEFINITION_COLLECTION,
+    ROLE_COLLECTION,
+    ROLE_BINDING_COLLECTION,
+    PLATFORM_ROLE_COLLECTION,
+    PLATFORM_ROLE_BINDING_COLLECTION,
     "projects",
     "users",
     "teams",

--- a/crates/rise-resource-api/src/policy.rs
+++ b/crates/rise-resource-api/src/policy.rs
@@ -1,0 +1,723 @@
+use std::collections::BTreeSet;
+use std::fmt;
+use std::str::FromStr;
+
+use schemars::{JsonSchema, Schema, SchemaGenerator};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::{
+    validate_resource_group, validate_resource_name, ResourceKind, Scope, SubjectId,
+    ValidationError,
+};
+
+macro_rules! string_serde {
+    ($type:ty) => {
+        impl Serialize for $type {
+            fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                serializer.serialize_str(&self.to_string())
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $type {
+            fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+                String::deserialize(deserializer)?
+                    .parse()
+                    .map_err(serde::de::Error::custom)
+            }
+        }
+    };
+}
+
+macro_rules! matcher_serde {
+    ($type:ty, $variant:ident, $item:ty, $field:literal) => {
+        impl Serialize for $type {
+            fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                match self {
+                    Self::All => serializer.serialize_str("*"),
+                    Self::$variant(values) => values.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $type {
+            fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+                #[derive(Deserialize)]
+                #[serde(untagged)]
+                enum Repr<T> {
+                    Wildcard(String),
+                    Values(Vec<T>),
+                }
+
+                match Repr::<$item>::deserialize(deserializer)? {
+                    Repr::Wildcard(value) if value == "*" => Ok(Self::All),
+                    Repr::Wildcard(_) => Err(serde::de::Error::custom(concat!(
+                        $field,
+                        " wildcard must be '*'"
+                    ))),
+                    Repr::Values(values) if values.is_empty() => Err(serde::de::Error::custom(
+                        concat!($field, " must not be empty"),
+                    )),
+                    Repr::Values(values) => {
+                        let original_len = values.len();
+                        let values: BTreeSet<$item> = values.into_iter().collect();
+                        if values.len() != original_len {
+                            return Err(serde::de::Error::custom(concat!(
+                                $field,
+                                " must not contain duplicates"
+                            )));
+                        }
+                        Ok(Self::$variant(values))
+                    }
+                }
+            }
+        }
+    };
+}
+
+/// The closed verb vocabulary used by Role statements and authorization requests.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum Verb {
+    Get,
+    List,
+    Create,
+    Update,
+    Delete,
+    Use,
+}
+
+/// A Role statement's outcome when it matches an authorization tuple.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+pub enum Effect {
+    Allow,
+    Deny,
+}
+
+/// One exact kind or API-group wildcard inside a Role statement's `kinds` list.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ResourceKindPattern {
+    Exact(ResourceKind),
+    Group(String),
+}
+
+impl ResourceKindPattern {
+    pub fn group(&self) -> &str {
+        match self {
+            Self::Exact(kind) => kind.group(),
+            Self::Group(group) => group,
+        }
+    }
+}
+
+impl fmt::Debug for ResourceKindPattern {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("ResourceKindPattern")
+            .field(&self.to_string())
+            .finish()
+    }
+}
+
+impl fmt::Display for ResourceKindPattern {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Exact(kind) => kind.fmt(f),
+            Self::Group(group) => write!(f, "{group}/*"),
+        }
+    }
+}
+
+impl FromStr for ResourceKindPattern {
+    type Err = ValidationError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if let Some(group) = value.strip_suffix("/*") {
+            if group.contains('/') {
+                return Err(ValidationError::new(
+                    "kind pattern must be '<api-group>/<Kind>' or '<api-group>/*'",
+                ));
+            }
+            validate_resource_group(group)?;
+            return Ok(Self::Group(group.to_owned()));
+        }
+        Ok(Self::Exact(value.parse()?))
+    }
+}
+
+string_serde!(ResourceKindPattern);
+
+impl JsonSchema for ResourceKindPattern {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "ResourceKindPattern".into()
+    }
+
+    fn json_schema(_generator: &mut SchemaGenerator) -> Schema {
+        schemars::json_schema!({
+            "type": "string",
+            "pattern": "^(?=.{1,253}\\/)[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*\\/(?:[A-Z][A-Za-z0-9]*|\\*)$",
+            "minLength": 3
+        })
+    }
+}
+
+/// A canonical lowercase subresource name. Registration is checked transactionally.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SubresourceName(String);
+
+impl fmt::Debug for SubresourceName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("SubresourceName").field(&self.0).finish()
+    }
+}
+
+impl fmt::Display for SubresourceName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for SubresourceName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl FromStr for SubresourceName {
+    type Err = ValidationError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        validate_resource_name(value)?;
+        Ok(Self(value.to_owned()))
+    }
+}
+
+string_serde!(SubresourceName);
+
+impl JsonSchema for SubresourceName {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "SubresourceName".into()
+    }
+
+    fn json_schema(_generator: &mut SchemaGenerator) -> Schema {
+        schemars::json_schema!({
+            "type": "string",
+            "pattern": "^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$",
+            "maxLength": 63
+        })
+    }
+}
+
+/// `"*"` or a non-empty, canonical set of kind patterns.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KindMatcher {
+    All,
+    Patterns(BTreeSet<ResourceKindPattern>),
+}
+
+/// `"*"` or a non-empty, canonical set of verbs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VerbMatcher {
+    All,
+    Verbs(BTreeSet<Verb>),
+}
+
+/// `"*"` or a non-empty, canonical set of named subresources.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SubresourceMatcher {
+    All,
+    Names(BTreeSet<SubresourceName>),
+}
+
+matcher_serde!(KindMatcher, Patterns, ResourceKindPattern, "kinds");
+matcher_serde!(VerbMatcher, Verbs, Verb, "verbs");
+matcher_serde!(SubresourceMatcher, Names, SubresourceName, "subresources");
+
+impl JsonSchema for KindMatcher {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "KindMatcher".into()
+    }
+
+    fn json_schema(_generator: &mut SchemaGenerator) -> Schema {
+        schemars::json_schema!({
+            "oneOf": [
+                { "const": "*" },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "pattern": "^(?=.{1,253}\\/)[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*\\/(?:[A-Z][A-Za-z0-9]*|\\*)$"
+                    },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        })
+    }
+}
+
+impl JsonSchema for VerbMatcher {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "VerbMatcher".into()
+    }
+
+    fn json_schema(_generator: &mut SchemaGenerator) -> Schema {
+        schemars::json_schema!({
+            "oneOf": [
+                { "const": "*" },
+                {
+                    "type": "array",
+                    "items": { "enum": ["get", "list", "create", "update", "delete", "use"] },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        })
+    }
+}
+
+impl JsonSchema for SubresourceMatcher {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "SubresourceMatcher".into()
+    }
+
+    fn json_schema(_generator: &mut SchemaGenerator) -> Schema {
+        schemars::json_schema!({
+            "oneOf": [
+                { "const": "*" },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "pattern": "^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$",
+                        "maxLength": 63
+                    },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PolicyStatement {
+    pub effect: Effect,
+    pub kinds: KindMatcher,
+    pub verbs: VerbMatcher,
+    /// Omission selects the main resource. `All` selects subresources only.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_non_null"
+    )]
+    #[schemars(with = "SubresourceMatcher")]
+    pub subresources: Option<SubresourceMatcher>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RoleSpec {
+    #[serde(default)]
+    pub statements: Vec<PolicyStatement>,
+}
+
+/// Kubernetes-shaped label key syntax used by binding selectors.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LabelKey(String);
+
+impl fmt::Debug for LabelKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("LabelKey").field(&self.0).finish()
+    }
+}
+
+impl fmt::Display for LabelKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for LabelKey {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl FromStr for LabelKey {
+    type Err = ValidationError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let (prefix, name) = match value.rsplit_once('/') {
+            Some((prefix, name)) => {
+                validate_resource_group(prefix)?;
+                (Some(prefix), name)
+            }
+            None => (None, value),
+        };
+        if prefix.is_some_and(str::is_empty)
+            || name.is_empty()
+            || name.len() > 63
+            || !name.as_bytes()[0].is_ascii_alphanumeric()
+            || !name.as_bytes()[name.len() - 1].is_ascii_alphanumeric()
+            || !name
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.'))
+        {
+            return Err(ValidationError::new("invalid label key"));
+        }
+        Ok(Self(value.to_owned()))
+    }
+}
+
+string_serde!(LabelKey);
+
+impl JsonSchema for LabelKey {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "LabelKey".into()
+    }
+
+    fn json_schema(_generator: &mut SchemaGenerator) -> Schema {
+        schemars::json_schema!({
+            "type": "string",
+            "pattern": "^(?:(?=.{1,253}\\/)[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*\\/)?[A-Za-z0-9](?:[A-Za-z0-9_.-]{0,61}[A-Za-z0-9])?$",
+            "maxLength": 317
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LabelSelector {
+    pub key: LabelKey,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_non_null"
+    )]
+    #[schemars(with = "String")]
+    pub value: Option<String>,
+}
+
+/// A literal subject or one of ADR-0001's three closed subject templates.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum BindingSubject {
+    Literal(SubjectId),
+    UserNameTemplate,
+    GroupNameTemplate,
+    SubjectRefTemplate,
+}
+
+impl BindingSubject {
+    pub fn is_dynamic(&self) -> bool {
+        !matches!(self, Self::Literal(_))
+    }
+
+    pub fn literal(&self) -> Option<&SubjectId> {
+        match self {
+            Self::Literal(subject) => Some(subject),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Debug for BindingSubject {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("BindingSubject")
+            .field(&self.to_string())
+            .finish()
+    }
+}
+
+impl fmt::Display for BindingSubject {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Literal(subject) => subject.fmt(f),
+            Self::UserNameTemplate => f.write_str("user:${ref.name}"),
+            Self::GroupNameTemplate => f.write_str("group:${ref.name}"),
+            Self::SubjectRefTemplate => f.write_str("${ref.subject}"),
+        }
+    }
+}
+
+impl FromStr for BindingSubject {
+    type Err = ValidationError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "user:${ref.name}" => Ok(Self::UserNameTemplate),
+            "group:${ref.name}" => Ok(Self::GroupNameTemplate),
+            "${ref.subject}" => Ok(Self::SubjectRefTemplate),
+            _ if value.contains("${") => Err(ValidationError::new("unknown subject template")),
+            _ => Ok(Self::Literal(value.parse()?)),
+        }
+    }
+}
+
+string_serde!(BindingSubject);
+
+impl JsonSchema for BindingSubject {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "BindingSubject".into()
+    }
+
+    fn json_schema(_generator: &mut SchemaGenerator) -> Schema {
+        schemars::json_schema!({
+            "oneOf": [
+                {
+                    "oneOf": [
+                        {
+                            "pattern": "^(?:user|controller|org):[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$",
+                            "maxLength": 74
+                        },
+                        {
+                            "pattern": "^(?:group|serviceaccount):[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?/[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$",
+                            "maxLength": 142
+                        },
+                        { "enum": ["system:authenticated", "system:operators"] }
+                    ]
+                },
+                { "enum": ["user:${ref.name}", "group:${ref.name}", "${ref.subject}"] }
+            ]
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub enum SubjectMembership {
+    #[default]
+    Any,
+    ResourceOrganization,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub enum RoleRefKind {
+    Role,
+    PlatformRole,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RoleRef {
+    pub kind: RoleRefKind,
+    #[serde(deserialize_with = "deserialize_resource_name")]
+    #[schemars(pattern("^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$"), length(max = 63))]
+    pub name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PlatformRoleRef {
+    pub kind: PlatformRoleRefKind,
+    #[serde(deserialize_with = "deserialize_resource_name")]
+    #[schemars(pattern("^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$"), length(max = 63))]
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub enum PlatformRoleRefKind {
+    PlatformRole,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RoleBindingSpec {
+    pub subject: BindingSubject,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_non_null"
+    )]
+    #[schemars(with = "Scope")]
+    pub scope: Option<Scope>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_non_null"
+    )]
+    #[schemars(with = "LabelSelector")]
+    pub label_selector: Option<LabelSelector>,
+    pub role_ref: RoleRef,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PlatformRoleBindingSpec {
+    pub subject: BindingSubject,
+    #[serde(default)]
+    pub subject_membership: SubjectMembership,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_non_null"
+    )]
+    #[schemars(with = "Scope")]
+    pub scope: Option<Scope>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_non_null"
+    )]
+    #[schemars(with = "LabelSelector")]
+    pub label_selector: Option<LabelSelector>,
+    pub role_ref: PlatformRoleRef,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LocallyNormalizedRoleBindingSpec {
+    subject: BindingSubject,
+    scope: Scope,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(with = "LabelSelector")]
+    label_selector: Option<LabelSelector>,
+    role_ref: RoleRef,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LocallyNormalizedPlatformRoleBindingSpec {
+    subject: BindingSubject,
+    subject_membership: SubjectMembership,
+    scope: Scope,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(with = "LabelSelector")]
+    label_selector: Option<LabelSelector>,
+    role_ref: PlatformRoleRef,
+}
+
+impl LocallyNormalizedRoleBindingSpec {
+    pub fn subject(&self) -> &BindingSubject {
+        &self.subject
+    }
+
+    pub fn scope(&self) -> &Scope {
+        &self.scope
+    }
+
+    pub fn label_selector(&self) -> Option<&LabelSelector> {
+        self.label_selector.as_ref()
+    }
+
+    pub fn role_ref(&self) -> &RoleRef {
+        &self.role_ref
+    }
+}
+
+impl LocallyNormalizedPlatformRoleBindingSpec {
+    pub fn subject(&self) -> &BindingSubject {
+        &self.subject
+    }
+
+    pub fn subject_membership(&self) -> SubjectMembership {
+        self.subject_membership
+    }
+
+    pub fn scope(&self) -> &Scope {
+        &self.scope
+    }
+
+    pub fn label_selector(&self) -> Option<&LabelSelector> {
+        self.label_selector.as_ref()
+    }
+
+    pub fn role_ref(&self) -> &PlatformRoleRef {
+        &self.role_ref
+    }
+}
+
+impl RoleBindingSpec {
+    pub fn normalize(
+        self,
+        parent_organization: &str,
+    ) -> Result<LocallyNormalizedRoleBindingSpec, ValidationError> {
+        validate_resource_name(parent_organization)?;
+        validate_subject_selector(&self.subject, self.label_selector.as_ref())?;
+        let scope = match self.scope {
+            Some(scope) if scope.is_wildcard() => {
+                return Err(ValidationError::new(
+                    "an organization RoleBinding cannot use wildcard scope",
+                ));
+            }
+            Some(scope) => scope,
+            None => format!("rise.dev/Organization/{parent_organization}").parse()?,
+        };
+        Ok(LocallyNormalizedRoleBindingSpec {
+            subject: self.subject,
+            scope,
+            label_selector: self.label_selector,
+            role_ref: self.role_ref,
+        })
+    }
+}
+
+impl PlatformRoleBindingSpec {
+    pub fn normalize(self) -> Result<LocallyNormalizedPlatformRoleBindingSpec, ValidationError> {
+        validate_subject_selector(&self.subject, self.label_selector.as_ref())?;
+        let static_org = self
+            .subject
+            .literal()
+            .filter(|subject| subject.is_org_native())
+            .and_then(SubjectId::organization);
+        let scope = match (self.scope, static_org) {
+            (Some(scope), Some(_)) if scope.is_wildcard() => {
+                return Err(ValidationError::new(
+                    "a static org-native subject cannot use wildcard scope",
+                ));
+            }
+            (Some(scope), _) => scope,
+            (None, Some(organization)) => {
+                format!("rise.dev/Organization/{organization}").parse()?
+            }
+            (None, None) => Scope::wildcard(),
+        };
+        Ok(LocallyNormalizedPlatformRoleBindingSpec {
+            subject: self.subject,
+            subject_membership: self.subject_membership,
+            scope,
+            label_selector: self.label_selector,
+            role_ref: self.role_ref,
+        })
+    }
+}
+
+fn validate_subject_selector(
+    subject: &BindingSubject,
+    selector: Option<&LabelSelector>,
+) -> Result<(), ValidationError> {
+    if subject
+        .literal()
+        .is_some_and(|subject| subject.as_ref() == "system:operators")
+    {
+        return Err(ValidationError::new(
+            "system:operators is reserved for the seeded bootstrap binding",
+        ));
+    }
+    match (subject.is_dynamic(), selector) {
+        (true, None) => Err(ValidationError::new(
+            "a dynamic subject requires labelSelector",
+        )),
+        (false, Some(LabelSelector { value: None, .. })) => Err(ValidationError::new(
+            "a static subject requires labelSelector.value when a selector is present",
+        )),
+        _ => Ok(()),
+    }
+}
+
+fn deserialize_resource_name<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    validate_resource_name(&value).map_err(serde::de::Error::custom)?;
+    Ok(value)
+}
+
+fn deserialize_optional_non_null<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    T::deserialize(deserializer).map(Some)
+}

--- a/crates/rise-resource-api/tests/policy_contracts.rs
+++ b/crates/rise-resource-api/tests/policy_contracts.rs
@@ -1,0 +1,249 @@
+use jsonschema::validator_for;
+use rise_resource_api::{
+    BindingSubject, PlatformRoleBindingSpec, RoleBindingSpec, SubjectMembership,
+};
+use schemars::{schema_for, JsonSchema};
+use serde_json::{json, Value};
+
+fn schema_accepts<T: JsonSchema>(value: Value) -> bool {
+    let schema = serde_json::to_value(schema_for!(T)).unwrap();
+    validator_for(&schema).unwrap().is_valid(&value)
+}
+
+fn platform_binding(subject: &str) -> Value {
+    json!({
+        "subject": subject,
+        "roleRef": { "kind": "PlatformRole", "name": "viewer" }
+    })
+}
+
+#[test]
+fn role_statement_contract_is_closed_and_non_empty() {
+    let valid = json!({
+        "statements": [{
+            "effect": "Allow",
+            "kinds": ["rise.dev/Deployment", "widgets.example/Widget", "rise.dev/*"],
+            "verbs": ["get", "use"],
+            "subresources": ["status"]
+        }]
+    });
+    assert!(serde_json::from_value::<rise_resource_api::RoleSpec>(valid.clone()).is_ok());
+    assert!(schema_accepts::<rise_resource_api::RoleSpec>(valid));
+
+    for invalid in [
+        json!({"statements":[{"effect":"allow","kinds":"*","verbs":"*"}]}),
+        json!({"statements":[{"effect":"Allow","kinds":[],"verbs":"*"}]}),
+        json!({"statements":[{"effect":"Allow","kinds":["Deployment"],"verbs":"*"}]}),
+        json!({"statements":[{"effect":"Allow","kinds":"*","verbs":[]}]}),
+        json!({"statements":[{"effect":"Allow","kinds":"*","verbs":["read"]}]}),
+        json!({"statements":[{"effect":"Allow","kinds":"*","verbs":"*","subresources":[]}]}),
+        json!({"statements":[{"effect":"Allow","kinds":"*","verbs":"*","subresources":null}]}),
+        json!({"statements":[{"effect":"Allow","kinds":"*","verbs":"*","extra":true}]}),
+        json!({"statements":[],"extra":true}),
+    ] {
+        assert!(
+            serde_json::from_value::<rise_resource_api::RoleSpec>(invalid.clone()).is_err(),
+            "serde accepted {invalid}"
+        );
+        assert!(
+            !schema_accepts::<rise_resource_api::RoleSpec>(invalid.clone()),
+            "schema accepted {invalid}"
+        );
+    }
+}
+
+#[test]
+fn matcher_sets_reject_duplicates_and_serialize_canonically() {
+    let duplicate = json!({
+        "statements": [{
+            "effect": "Allow",
+            "kinds": ["rise.dev/Deployment", "rise.dev/Deployment"],
+            "verbs": "*"
+        }]
+    });
+    assert!(serde_json::from_value::<rise_resource_api::RoleSpec>(duplicate).is_err());
+
+    let role: rise_resource_api::RoleSpec = serde_json::from_value(json!({
+        "statements": [{
+            "effect": "Deny",
+            "kinds": ["widgets.example/Widget", "rise.dev/Deployment"],
+            "verbs": ["use", "get"]
+        }]
+    }))
+    .unwrap();
+    assert_eq!(
+        serde_json::to_value(role).unwrap(),
+        json!({
+            "statements": [{
+                "effect": "Deny",
+                "kinds": ["rise.dev/Deployment", "widgets.example/Widget"],
+                "verbs": ["get", "use"]
+            }]
+        })
+    );
+}
+
+#[test]
+fn platform_membership_omission_normalizes_but_null_fails() {
+    let parsed: PlatformRoleBindingSpec =
+        serde_json::from_value(platform_binding("user:alice")).unwrap();
+    assert_eq!(parsed.subject_membership, SubjectMembership::Any);
+    assert_eq!(
+        serde_json::to_value(parsed).unwrap()["subjectMembership"],
+        json!("Any")
+    );
+
+    let mut null_membership = platform_binding("user:alice");
+    null_membership["subjectMembership"] = Value::Null;
+    assert!(serde_json::from_value::<PlatformRoleBindingSpec>(null_membership.clone()).is_err());
+    assert!(!schema_accepts::<PlatformRoleBindingSpec>(null_membership));
+
+    let mut invalid_membership = platform_binding("user:alice");
+    invalid_membership["subjectMembership"] = json!("Organization");
+    assert!(serde_json::from_value::<PlatformRoleBindingSpec>(invalid_membership).is_err());
+}
+
+#[test]
+fn binding_shapes_reject_plural_wrong_case_and_wrong_reference_direction() {
+    for invalid in [
+        json!({
+            "subjects": ["user:alice"],
+            "roleRef": { "kind": "PlatformRole", "name": "viewer" }
+        }),
+        json!({
+            "Subject": "user:alice",
+            "roleRef": { "kind": "PlatformRole", "name": "viewer" }
+        }),
+        json!({
+            "subject": "user:alice",
+            "subjectMembership": "Any",
+            "roleRef": { "kind": "Role", "name": "viewer" }
+        }),
+        json!({
+            "subject": "user:alice",
+            "scope": null,
+            "roleRef": { "kind": "PlatformRole", "name": "viewer" }
+        }),
+        json!({
+            "subject": "user:alice",
+            "labelSelector": { "key": "rise.dev/owner", "value": null },
+            "roleRef": { "kind": "PlatformRole", "name": "viewer" }
+        }),
+    ] {
+        assert!(serde_json::from_value::<RoleBindingSpec>(invalid.clone()).is_err());
+    }
+
+    let wrong_platform_ref = json!({
+        "subject": "user:alice",
+        "roleRef": { "kind": "Role", "name": "viewer" }
+    });
+    assert!(serde_json::from_value::<PlatformRoleBindingSpec>(wrong_platform_ref).is_err());
+}
+
+#[test]
+fn binding_subject_grammar_is_closed() {
+    for value in [
+        "user:alice",
+        "group:acme/platform",
+        "user:${ref.name}",
+        "group:${ref.name}",
+        "${ref.subject}",
+    ] {
+        let parsed: BindingSubject = serde_json::from_value(json!(value)).unwrap();
+        assert_eq!(serde_json::to_value(parsed).unwrap(), json!(value));
+    }
+    for value in [
+        "serviceaccount:${ref.name}",
+        "controller:${ref.name}",
+        "group:${label.value}",
+        "${ref.name}",
+    ] {
+        assert!(serde_json::from_value::<BindingSubject>(json!(value)).is_err());
+    }
+}
+
+#[test]
+fn binding_normalization_is_contextual_and_fail_closed() {
+    let org: RoleBindingSpec = serde_json::from_value(json!({
+        "subject": "user:alice",
+        "roleRef": { "kind": "Role", "name": "viewer" }
+    }))
+    .unwrap();
+    assert_eq!(
+        org.normalize("acme").unwrap().scope().to_string(),
+        "rise.dev/Organization/acme"
+    );
+
+    let group: PlatformRoleBindingSpec =
+        serde_json::from_value(platform_binding("group:acme/platform")).unwrap();
+    assert_eq!(
+        group.normalize().unwrap().scope().to_string(),
+        "rise.dev/Organization/acme"
+    );
+
+    let user: PlatformRoleBindingSpec =
+        serde_json::from_value(platform_binding("user:alice")).unwrap();
+    assert!(user.normalize().unwrap().scope().is_wildcard());
+
+    let explicit_wildcard: PlatformRoleBindingSpec = serde_json::from_value(json!({
+        "subject": "serviceaccount:acme/ci",
+        "scope": "*",
+        "roleRef": { "kind": "PlatformRole", "name": "viewer" }
+    }))
+    .unwrap();
+    assert!(explicit_wildcard.normalize().is_err());
+
+    let dynamic_without_selector: PlatformRoleBindingSpec =
+        serde_json::from_value(platform_binding("${ref.subject}")).unwrap();
+    assert!(dynamic_without_selector.normalize().is_err());
+
+    let static_exists_selector: PlatformRoleBindingSpec = serde_json::from_value(json!({
+        "subject": "user:alice",
+        "labelSelector": { "key": "rise.dev/owner" },
+        "roleRef": { "kind": "PlatformRole", "name": "viewer" }
+    }))
+    .unwrap();
+    assert!(static_exists_selector.normalize().is_err());
+
+    let reserved_platform: PlatformRoleBindingSpec =
+        serde_json::from_value(platform_binding("system:operators")).unwrap();
+    assert!(reserved_platform.normalize().is_err());
+
+    let reserved_org: RoleBindingSpec = serde_json::from_value(json!({
+        "subject": "system:operators",
+        "roleRef": { "kind": "PlatformRole", "name": "system-admin" }
+    }))
+    .unwrap();
+    assert!(reserved_org.normalize("acme").is_err());
+}
+
+#[test]
+fn generated_binding_schemas_match_omission_and_null_rules() {
+    let omitted = platform_binding("user:alice");
+    assert!(schema_accepts::<PlatformRoleBindingSpec>(omitted));
+
+    let org = json!({
+        "subject": "user:alice",
+        "roleRef": { "kind": "Role", "name": "viewer" }
+    });
+    assert!(schema_accepts::<RoleBindingSpec>(org));
+
+    let null_scope = json!({
+        "subject": "user:alice",
+        "scope": null,
+        "roleRef": { "kind": "Role", "name": "viewer" }
+    });
+    assert!(!schema_accepts::<RoleBindingSpec>(null_scope));
+}
+
+#[test]
+fn future_policy_collections_are_reserved_before_registration() {
+    for collection in [
+        rise_resource_api::ROLE_COLLECTION,
+        rise_resource_api::ROLE_BINDING_COLLECTION,
+        rise_resource_api::PLATFORM_ROLE_COLLECTION,
+        rise_resource_api::PLATFORM_ROLE_BINDING_COLLECTION,
+    ] {
+        assert!(rise_resource_api::is_reserved_collection_name(collection));
+    }
+}

--- a/mise.toml
+++ b/mise.toml
@@ -110,12 +110,14 @@ run = "cargo sqlx prepare --check -- --all-targets"
 description = "Run all linting checks (clippy, formatting, sqlx, helm)."
 run = """
 cargo all-features check --all-targets
+cargo check --package rise-authz --all-targets
 cargo check --package rise-resource-api --all-targets
 cargo check --package rise-resource-store-postgres --all-targets
 cargo check --package rise-backend-auth --all-targets
 cargo check --package rise-backend-core --all-targets
 cargo check --package rise-runtime-sync --all-targets
 cargo all-features clippy --all-targets -- -D warnings
+cargo clippy --package rise-authz --all-targets -- -D warnings
 cargo clippy --package rise-resource-api --all-targets -- -D warnings
 cargo clippy --package rise-resource-store-postgres --all-targets -- -D warnings
 cargo clippy --package rise-backend-auth --all-targets -- -D warnings
@@ -125,6 +127,7 @@ cargo fmt --all -- --check
 mise sqlx:check
 mise resource:schema:check
 helm lint helm/rise
+cargo test --package rise-authz --all-targets
 cargo test --package rise-backend-auth --all-targets
 cargo test --package rise-backend-core --all-targets
 """


### PR DESCRIPTION
## Summary

- add closed serialized contracts for `Role`, `RoleBinding`, `PlatformRole`, and `PlatformRoleBinding` to `rise-resource-api`
- add a database-free `rise-authz::policy` algebra for matching, Deny-wins evaluation, subject substitution, wildcard replacement, and scoped subset checks
- reserve the policy collections and wire the new crate into workspace CI, linting, and Docker planning without registering writable policy resources yet

## Why

This establishes the auditable Tier-0 policy core for ADR-0001 while keeping API-owned wire types canonical. Writable built-in registration is intentionally deferred: the current pure, pre-transactional `SpecValidator` cannot persist contextual normalization or atomically validate role, subject, and scope references. That belongs with the transaction-scoped admission seam in the next integration slice.

Part of #371.

## Test plan

- [x] focused offline tests for `rise-resource-api` and `rise-authz`
- [x] `mise run lint`
- [x] full all-features workspace test suite, serialized, including PostgreSQL integration tests
- [x] Docker planner-stage build
- [x] independent API-boundary, policy-semantics, integration-safety, and final-diff reviews

## Notes

- no database migrations or runtime authorization behavior change in this PR
- live membership/admin/operator expansion and Deny-tier filtering remain Tier-1 responsibilities
