### PR TITLE
docs: correct stale references and gaps in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,30 +21,37 @@ A typical session:
 ```console
 $ rise login
 Please login to rise at https://rise.dev/oauth/login?code=1234-abcd
-Login successful! Welcome back, Niklas!
+✓ Login successful!
+  Token saved to: ~/.config/rise/config.json
 
 $ rise p c secret-app --access-class private --owner team:devopsy
-Team 'devopsy' does not exist or you do not have permission to create projects for it. Did you mean 'devops'?
+Team 'devopsy' does not exist or you do not have permission to create projects for it.
+
+Did you mean one of these?
+  - devops
 
 $ rise p c secret-app --access-class private --owner team:devops
 ✓ Project 'secret-app' created successfully!
   ID: 0f3c…
-  Status: stopped
+  Status: Stopped
 ✓ Created rise.toml at ./rise.toml
 
 $ rise p ls
 NAME            STATUS     ACCESS CLASS   OWNER         ACTIVE DEPLOYMENT   URL
-my-first-app    running    public         user:niklas   2026-07-30T09:12Z   https://my-first-app.rise.dev
-secret-app      stopped    private        team:devops   -                   https://secret-app.rise.dev
+my-first-app    Running    public         user:niklas   Healthy             https://my-first-app.rise.dev
+secret-app      Stopped    private        team:devops   -                   https://secret-app.rise.dev
 
-$ cat rise.toml
+$ cat rise.toml           # what `project create` writes
 version = 1
 
 [project]
 name = "secret-app"
 
+$ cat >> rise.toml <<'TOML'   # pin the build backend
+
 [build]
 backend = "pack"
+TOML
 
 $ rise d c secret-app
 Building container image 'registry.rise.dev/secret-app:latest' using pack...

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,84 +1,132 @@
-Hi Gemini, my all time best software engineer in the world! I would like you to build a Rust-based project that is composed of a backend and
-an accompagnying CLI that can be used to deploy very simple apps based on container images to a container runtime, of which our first
-supported runtime will be Kubernetes but one could also imagine other runtimes such AWS Lambda or ECS, DO Apps, Docker, etc.
+# Rise
 
-The idea is that the CLI makes it extremely easy to deploy such apps from the most minimal of configurations, for example by building
-container images using buildpacks or nixpacks, but also supporting Dockerfiles, and possibly other methods.
+Rise is a Rust project — a backend and an accompanying `rise` CLI — for deploying
+apps packaged as container images to a container runtime. Kubernetes and Docker are
+the supported runtimes today; the design deliberately leaves room for others (ECS,
+Lambda, DO Apps, …).
 
-For now we'll except that the container image will be built locally as part of the CLI call, but a future extension could be that we pass
-through the details to a Buildkit daemon to be used when building the container image.
+The CLI deploys from the most minimal of configurations. It builds the container
+image locally (Dockerfile, Cloud Native Buildpacks, or Railpack), pushes it to a
+container registry using temporary credentials issued by the backend, and asks the
+backend to deploy it. A future extension is to hand the build off to a BuildKit
+daemon instead of building in-process.
 
-Container images are pushed to an internal container registry through temporary credentials that are passed to the frontend from the
-backend.
+A **project** is the unit of deployment. Its name determines how the app is reached
+under the install's common domain (e.g. `https://my-project.rise.dev`). Users
+authenticate against the backend to manage projects — via OAuth2/OIDC (Dex in
+development), or by presenting JWTs from a configured set of trusted issuers.
 
-The CLI allows creating and managing "projects" which represent an app that can be published. A project has a name, and the name defines how
-the app is accessible under the common domain name for it (e.g. https://my-project.rise.dev). Users need to authenticate with the backend to
-get access to manage projects. The backend must support local authentication (most useful for development) and OIDC (either login via OAuth2
-and/or accepting JWT from a set of configured trusted issuers).
+A typical session:
 
-An example interaction with the `rise` CLI that a user might perform might be:
+```console
+$ rise login
+Please login to rise at https://rise.dev/oauth/login?code=1234-abcd
+Login successful! Welcome back, Niklas!
 
-  $ rise login
-  Please login to rise at https://rise.dev/oauth/login?code=1234-abcd
-  Login successful! Welcome back, Niklas!
+$ rise p c secret-app --access-class private --owner team:devopsy
+Team 'devopsy' does not exist or you do not have permission to create projects for it. Did you mean 'devops'?
 
-  $ rise p c secret-app --visibility private --owner team:devopsy
-  Team 'devopsy' does not exist or you do not have permission to create projects for it. Did you mean 'devops'?
+$ rise p c secret-app --access-class private --owner team:devops
+✓ Project 'secret-app' created successfully!
+  ID: 0f3c…
+  Status: stopped
+✓ Created rise.toml at ./rise.toml
 
-  $ rise p c secret-app --visibility private --owner team:devops
-  Created project 'secret-app' with private visibility owned by team:devops.
+$ rise p ls
+NAME            STATUS     ACCESS CLASS   OWNER         ACTIVE DEPLOYMENT   URL
+my-first-app    running    public         user:niklas   2026-07-30T09:12Z   https://my-first-app.rise.dev
+secret-app      stopped    private        team:devops   -                   https://secret-app.rise.dev
 
-  $ rise p ls
-  PROJECT         STATUS        URL                             VISIBILITY    OWNER
-  my-first-app    running       https://my-first-app.rise.dev   public        user:niklas
-  secret-app      stopped       https://secret-app.rise.dev     private       team:devops
+$ cat rise.toml
+version = 1
 
-  $ cat .rise.toml
-  project = "secret-app"
+[project]
+name = "secret-app"
 
-  [build]
-  backend = "buildpacks"
+[build]
+backend = "pack"
 
-  $ rise d c secret-app
-  Building container image 'registry.rise.dev/secret-app:latest' using buildpacks...
-  Pushing container image to registry.rise.dev...
-  Deploying 'secret-app' ...
-  Deployment successful! Your app is now running at https://secret-app.rise.dev
+$ rise d c secret-app
+Building container image 'registry.rise.dev/secret-app:latest' using pack...
+Pushing container image to registry.rise.dev...
+Deploying 'secret-app' ...
+Deployment successful! Your app is now running at https://secret-app.rise.dev
+```
 
-The backend and CLI should be designed with extensibility in mind, allowing for future support of additional container
-runtimes, build methods, and authentication mechanisms. The CLI should provide clear and concise feedback to the user
-at each step of the process, ensuring a smooth and user-friendly experience.
-
-Let's outline the architecture and components needed for this Rust-based project, including both the backend and CLI.
+Backend and CLI are designed for extensibility — additional container runtimes,
+build methods, and authentication mechanisms. The CLI gives clear, concise feedback
+at each step.
 
 ## Architecture Overview
 
-**Note**: The project is a Cargo **workspace**. The primary crate `rise-deploy` produces the `rise` binary with both CLI and server capabilities enabled via feature flags. A few focused, backend-only support crates live under `crates/` and are depended on as optional, `backend`-feature-gated path deps: `rise-resource-api` / `rise-resource-store-postgres` (generic resource API contract / PostgreSQL adapter), `rise-backend-auth` (pure-core token signing, verification, and matching — the single home for auth-token logic; see `ROADMAP.md` § "Authentication & Token Exchange"), `rise-backend-core` (the deployment-backend contract seam: shared deployment models, the `DeploymentBackend` trait, registry/encryption provider traits, the pure `quantity`/`state_machine`/`runtime`/`url_builder`/`token_ttl`/`custom_domain` helpers, and the `DeploymentStore` trait — the database boundary implemented by `rise-deploy`'s `PgDeploymentStore`), and `rise-backend-docker` (the Docker deployment backend: `DockerBackend` + the in-process `DockerReconciler`, the first controller extracted onto the `rise-backend-core` seam — see issue #377; the Kubernetes controller is still in-tree pending the same treatment). `rise-backend-docker` is re-exported under `crate::server::deployment::controller::docker`, so existing module paths keep resolving.
+The project is a Cargo **workspace**. The primary crate `rise-deploy` produces the
+`rise` binary with both CLI and server capabilities enabled via feature flags.
+Focused support crates live under `crates/`:
+
+| Crate | Purpose | Linkage |
+|---|---|---|
+| `rise-deployment-spec` | Shared deployment/project-config model — `AccessRequirement`, `RouteAccess`, request spec, validation | workspace dep (both CLI and backend) |
+| `rise-backend-auth` | Pure-core token signing, verification, and claim matching — the single home for auth-token logic (see `ROADMAP.md` § 2, "Rise-issued authentication and token issuance") | `backend` |
+| `rise-backend-core` | The deployment-backend contract seam: shared deployment models, the `DeploymentBackend` trait, registry/encryption provider traits, the pure `quantity`/`state_machine`/`runtime`/`url_builder`/`token_ttl`/`custom_domain` helpers, and the `DeploymentStore` trait — the database boundary implemented by `rise-deploy`'s `PgDeploymentStore` | `backend` |
+| `rise-backend-docker` | The Docker deployment backend: `DockerBackend` + the in-process `DockerReconciler`, the first controller extracted onto the `rise-backend-core` seam. Re-exported under `crate::server::deployment::controller::docker`, so existing module paths keep resolving | `backend` |
+| `rise-authz` | Authorization policy evaluation. `policy` is a hard Tier-0 boundary: pure functions and canonical values only — no store, database, HTTP, or product-resource dependencies | `backend` |
+| `rise-resource-api` | Generic resource API contract (resource kinds, scopes, owner references, identity, policy types) | `backend` |
+| `rise-resource-store-postgres` | PostgreSQL adapter for the resource API. Owns its own migrations in a `resource_store` schema and its own SQLX offline cache | `backend` |
+| `rise-runtime-sync` | Postgres-backed cross-replica primitives: `GlobalLock`, `LeaderElection`, `GlobalSchedule`. Owns its own migrations in a `runtime_sync` schema and its own SQLX offline cache | `backend` |
+
+The Kubernetes controller is still in-tree (`src/server/deployment/controller/kubernetes.rs`)
+pending the same extraction onto the `rise-backend-core` seam that `rise-backend-docker`
+received.
+
+The **e2e harness** (`tests/e2e`) is a standalone workspace, `exclude`d from the root
+one so production image builds never compile it. It is linted and tested separately —
+see [Before Commit & Push](#before-commit--push).
 
 ### Crate Structure (`rise-deploy`)
 
 The codebase is organized into functional modules:
 
-- **`src/db/`**: Database access layer (PostgreSQL via SQLX) - shared by server modules
-- **`src/server/`**: Backend server implementation with feature-gated modules:
-   - **Authentication Module** (`auth/`): OAuth2/OIDC with Dex, JWT validation
+- **`src/db/`**: Database access layer (PostgreSQL via SQLX) — shared by server modules
+- **`src/server/`**: Backend server implementation (feature: `backend`)
+   - **Authentication** (`auth/`): OAuth2/OIDC with Dex, JWT validation, ingress auth subrequests, admin/operator classification
    - **Project Management** (`project/`): Project CRUD and lifecycle management
    - **Team Management** (`team/`): Team and membership management
+   - **Environments** (`environments/`): Named environments (production, staging, …)
+   - **Environment Variables** (`env_vars/`): Plain and encrypted per-project variables
+   - **Custom Domains** (`custom_domains/`): Custom domain registration, verification, TLS wiring
    - **Service Accounts** (`service_accounts/`): CI/CD service accounts (inbound OIDC federation into Rise)
    - **Workload Identity Tokens** (`workload_tokens/`): Token-exchange endpoint issuing Rise-signed workload JWTs to deployed apps
-   - **Container Registry** (`registry/`): Temporary credentials for ECR registries
-   - **Deployment Module** (`deployment/`): Kubernetes controller for deployments
+   - **Generic Resources** (`resources/`): The operator-gated generic resource API (`/api/v1/resources`) and its garbage collector
+   - **Platform** (`platform/`): Platform/organization-level concerns
+   - **Quickstart** (`quickstart/`): Catalog of ready-to-deploy templates (see `config/default.yaml`)
+   - **Extensions** (`extensions/`): Extension registry and providers
+   - **Container Registry** (`registry/`): Temporary registry credentials — ECR, GitLab, JFrog, and generic OCI basic-auth providers
+   - **Deployment Module** (`deployment/`): Deployment models, CRD, webhook, logs, resource builder, and the Kubernetes controller (the Docker controller lives in `rise-backend-docker`)
    - **ECR Integration** (`ecr/`): AWS ECR repository management
    - **Encryption** (`encryption/`): Local AES-GCM and AWS KMS providers
    - **OCI Client** (`oci/`): OCI registry interaction
-   - **Frontend** (`frontend/`): Static web UI assets
+   - **Frontend** (`frontend/`): Serves the built web UI assets
    - **API Layer**: RESTful endpoints via Axum
 - **`src/cli/`**: CLI command handlers (feature: `cli`)
-   - Authentication, project, team, deployment, environment variable commands
+   - `login`, `project`, `team`, `deployment`, `env`, `environment`, `domain`, `extension`,
+     `service_account`, `identity`, `encrypt`, `run`, `compose`, `skill`, `version`, and
+     `backend` (server/controller entrypoints, feature: `backend`)
 - **`src/build/`**: Container image build orchestration (feature: `cli`)
-   - Support for Docker, Pack (buildpacks), and Railpack backends
-   - BuildKit daemon management, SSL certificate handling
+   - Docker, Pack (buildpacks), and Railpack backends
+   - BuildKit daemon management, SSL certificate handling, registry/proxy plumbing
 - **`src/api/`**: Client-side API interface for server communication (feature: `cli`)
+- **`src/rise_toml.rs`**: Compatibility shim re-exporting `rise-deployment-spec`; the `rise.toml` model itself lives in `crates/rise-deployment-spec/src/project_config.rs`
+
+Other top-level directories:
+
+- **`frontend/`**: The React web UI (built and served by `src/server/frontend/`)
+- **`config/`**: Layered backend settings YAML (`default.yaml`, then run-mode, then `local.yaml`)
+- **`migrations/`**: `rise-deploy`'s SQLX migrations (support crates own theirs)
+- **`helm/`**: The `rise` Helm chart, including generated CRDs
+- **`modules/`**: Terraform modules (e.g. `rise-aws` for the required IAM resources)
+- **`skills/`**: Rise skills for AI assistants, installed via `rise skill install`
+- **`docs/`**: Two Astro Starlight sites — `docs/user` and `docs/engineering`
+- **`tests/`**: e2e harness and fixtures
 
 ### Feature Flags
 
@@ -87,41 +135,41 @@ The crate uses Cargo features for modular compilation:
 - **`cli`** (default): CLI commands and client-side functionality
 - **`backend`**: All server-side functionality including:
   - HTTP server, controllers, and backend logic
-  - Kubernetes deployment controller
-  - AWS ECR registry and KMS encryption
+  - Kubernetes deployment controller and the Docker deployment backend (bollard/Traefik)
+  - Generic resource API and its PostgreSQL store; cross-replica runtime sync; authorization policy
+  - Container registry providers and AWS ECR/KMS integration
   - Snowflake OAuth provisioner
 
 Examples:
+
 ```bash
 cargo build                    # CLI-only build (smallest binary)
 cargo build --features backend # Server with all backend capabilities
 cargo build --all-features     # Full build with CLI + backend
 ```
 
-## Implementation Steps
-
-**Project Structure**: A Cargo workspace whose primary crate `rise-deploy` carries both CLI and backend (feature-gated). Focused, backend-only support crates live under `crates/` — `rise-resource-api` / `rise-resource-store-postgres` and the pure-core `rise-backend-auth` (the single home for auth-token signing, verification, and matching).
-
-### Completed Implementation
+## Implemented Capabilities
 
 1. **Core Infrastructure** ✅
-   - [x] Single consolidated crate with feature flags (`cli`, `backend`)
+   - [x] Cargo workspace; primary crate feature-gated (`cli`, `backend`)
    - [x] PostgreSQL database with SQLX (compile-time verified queries and migrations)
    - [x] Dex OAuth2/OIDC integration for authentication
    - [x] Docker Compose setup for local development (PostgreSQL, Dex, Registry)
 
 2. **Server Implementation** (`--features backend`) ✅
    - [x] Axum-based HTTP API with RESTful endpoints
-   - [x] Authentication: OAuth2/OIDC with Dex, JWT validation, PKCE flow
-   - [x] Project management: CRUD operations, ownership, visibility
+   - [x] Authentication: OAuth2/OIDC with Dex, JWT validation, PKCE flow, Rise-issued tokens
+   - [x] Project management: CRUD operations, ownership, access classes
    - [x] Team management: Team creation, membership, role-based access
-   - [x] Deployment controller:
-     - [x] Kubernetes controller - K8s deployments with Ingress
-   - [x] Container registry integration:
-     - [x] AWS ECR provider with repository lifecycle management
+   - [x] Environments, environment variables (plain + encrypted), custom domains
+   - [x] Deployment backends:
+     - [x] Kubernetes controller — K8s deployments with Ingress
+     - [x] Docker backend — single-host Docker daemon with Traefik routing
+   - [x] Container registry integration: ECR, GitLab, JFrog, generic OCI basic-auth
    - [x] Encryption providers: Local AES-GCM and AWS KMS
    - [x] OCI client for image digest resolution
-   - [x] Frontend static web UI
+   - [x] Frontend web UI
+   - [x] Generic resource API (`/api/v1/resources`) with PostgreSQL store and GC
    - [x] Extensions system:
      - [x] Multiple instances per extension type
      - [x] Generic OAuth 2.0 provider for end-user authentication
@@ -132,35 +180,50 @@ cargo build --all-features     # Full build with CLI + backend
        - [x] Support for any OAuth 2.0 provider (Snowflake, Google, GitHub, custom SSO)
        - [x] Client secret stored as encrypted environment variables
      - [x] AWS RDS extension for database provisioning
+     - [x] AWS S3 extension for bucket provisioning
      - [x] Snowflake OAuth provisioner for Snowflake security integrations
 
 3. **CLI Implementation** (`--features cli`, default) ✅
-   - [x] OAuth2 authorization code flow with PKCE (browser-based, default)
+   - [x] OAuth2 authorization code flow with PKCE (browser-based, default) and device flow
    - [x] Project commands: `create`, `list`, `show`, `update`, `delete`
    - [x] Team commands: `create`, `list`, `show`, `update`, `delete`
-   - [x] Deployment commands: `create`, `list`, `show`, `rollback`, `stop`
-   - [x] Environment variable management
-   - [x] Service account (workload identity) management
+   - [x] Deployment commands: `create`, `list`, `show`, `stop`, `logs`
+   - [x] Environment commands: `create`, `list`, `show`, `update`, `delete`
+   - [x] Environment variable management (`set`, `get`, `list`, `delete`, `import`, `export`)
+   - [x] Custom domain management (`add`, `list`, `remove`)
+   - [x] Extension management (`create`, `update`, `patch`, `list`, `show`, `delete`)
+   - [x] Service account (workload identity) management and in-workload `identity token`
+   - [x] Skill installation for AI assistants (`skill install`)
 
 4. **Build System** (`--features cli`) ✅
    - [x] Docker backend: Standard Dockerfile builds
    - [x] Pack backend: Cloud Native Buildpacks integration
-   - [x] Railpack backend: Schema.org Railpacks with BuildKit/Buildx
+   - [x] Railpack backend: Railpacks with BuildKit/Buildx
    - [x] Automatic build method detection
    - [x] BuildKit daemon management with SSL certificate handling
    - [x] `rise build` command for local image builds without deployment
    - [x] `rise run` command for local development (build and run with docker/podman)
+   - [x] `rise compose up` for running multi-container projects locally
    - [x] Pre-built image deployment support (`--image` flag)
    - [x] Deployment following with auto-refresh and timeout support
 
-## User-Facing Documentation
+## Documentation
 
-For user-facing documentation, see the [`/docs`](./docs) directory. Key topics include:
-- Build backends (Docker, Pack, Railpack): [docs/user-guide/builds.md](docs/user-guide/builds.md)
-- SSL & proxy configuration: [docs/user-guide/ssl-proxy.md](docs/user-guide/ssl-proxy.md)
-- Architecture and process design: [docs/development.md](docs/development.md)
-- Configuration: [docs/configuration.md](docs/configuration.md)
-- OAuth extension (end-user authentication): [docs/user-guide/oauth.md](docs/user-guide/oauth.md)
+Documentation lives in two Astro Starlight sites under [`/docs`](./docs):
+
+- **User docs** — [`docs/user/src/content/docs/`](docs/user/src/content/docs/)
+  - Build backends (Docker, Pack, Railpack): [user-guide/builds.md](docs/user/src/content/docs/user-guide/builds.md)
+  - SSL & proxy configuration: [user-guide/ssl-proxy.md](docs/user/src/content/docs/user-guide/ssl-proxy.md)
+  - Project configuration: [user-guide/configuration.mdx](docs/user/src/content/docs/user-guide/configuration.mdx)
+  - OAuth extension (end-user authentication): [user-guide/oauth.md](docs/user/src/content/docs/user-guide/oauth.md)
+- **Engineering / operator docs** — [`docs/engineering/src/content/docs/`](docs/engineering/src/content/docs/)
+  - Architecture and process design: [development.md](docs/engineering/src/content/docs/development.md)
+  - Backend configuration: [configuration.md](docs/engineering/src/content/docs/configuration.md)
+  - Deployment backends and the feature matrix: [deployment-backends.md](docs/engineering/src/content/docs/deployment-backends.md)
+  - Generic resource API: [generic-resource-api.md](docs/engineering/src/content/docs/generic-resource-api.md)
+  - Architecture decision records: [adr/](docs/engineering/src/content/docs/adr/)
+
+Serve them locally with `mise run docs:serve` / `mise run docs:engineering:serve`.
 
 ## Git Branching
 
@@ -184,11 +247,13 @@ Keep it current as work merges:
   item. If `Operator impact` is not `None`, the item is **not** `Done` until the
   operator [Upgrade Notes](docs/engineering/src/content/docs/upgrade-notes.md) page
   has a matching entry for that release.
-- `ROADMAP.md` owns the *why*, phase rationale, and milestone checkboxes
-  for every in-flight architectural workstream (multi-tenancy + generic
-  resource API, authentication & token exchange, future workstreams). The
-  Project owns *live status*. Don't duplicate rationale into the board, and
-  don't create new `<TOPIC>_PLAN.md` / `<TOPIC>_ROADMAP.md` files.
+- `ROADMAP.md` owns the *why*, phase rationale, and milestone checkboxes for every
+  in-flight architectural workstream (its numbered sections: generic resource and
+  authorization foundation, Rise-issued authentication and token issuance,
+  subresource execution, typed-object migration, external controllers and
+  multi-org routing, codebase decomposition). The Project owns *live status*.
+  Don't duplicate rationale into the board, and don't create new
+  `<TOPIC>_PLAN.md` / `<TOPIC>_ROADMAP.md` files.
   Architectural decisions are recorded as ADRs under
   `docs/engineering/src/content/docs/adr/` — an ADR records the decision, its
   rationale, and (via its Status field) implementation progress. Prefer an
@@ -208,7 +273,7 @@ Keep it current as work merges:
 - Don't reference previous versions of the code in comments, docs, or commit-independent artifacts (e.g. "the previous design did X", "vs the old tick counter", "this used to be Y"). Comments must describe what the code does *now* and why — a reader has no access to the version you're contrasting against, and such notes rot. Git history is the place for that context. (Referring to runtime/domain concepts like "the previous leader replica" is fine — that's not code history.)
 - The CLI should first and foremost always accept the names of things (e.g. project names, or project names + deployment timestamp). The UUIDs in our tables are only for internal book-keeping.
 - Admin users (`auth.admin_users`) bypass the regular permission checks on the typed APIs (projects, teams, deployments, etc.) — they have full access there without passing ownership/membership checks. This does **not** extend to the generic resource API (`/api/v1/resources`), which is operator-gated (`auth.operator_users`): admins are not operators and do not bypass its checks. Granting admins access to the resource API is intentionally deferred (see `ROADMAP.md`).
-- Any SQLX queries are to be wrapped by helper functions in the `rise_deploy::db` crate. No SQLX queries outside of this crate are allowed.
+- In `rise-deploy`, all SQLX queries must be wrapped by helper functions in the `src/db/` module — no SQLX queries elsewhere in the crate's production code. The support crates that own their own schema and migrations (`rise-resource-store-postgres`, `rise-runtime-sync`) are the exception: their queries live in the crate that owns the tables, alongside its own migrations and offline query cache.
 - When we log errors and don't handle them further, we should include a sensible amount of information about the error. Often logging the error with `{:?}` is good enough.
 - When capturing screenshots, the playwright tool will successfully install the driver even if you might think its install step failed. Always use minimum 1280px width and 800px height for the browser.
 - Never use `// @ts-nocheck` (or `// @ts-ignore` / `// @ts-expect-error`) in frontend code. Existing files that still carry the directive are legacy; new files must not add it, and edits to legacy files should remove it where feasible. If TypeScript flags something, fix the types — don't suppress the diagnostic.
@@ -228,7 +293,7 @@ The frontend exposes a small set of reusable tag-like components from `frontend/
 
 ### Before Commit & Push
 
-**MANDATORY**: You MUST run `cargo fmt --all` before every commit. Always. No exceptions. CI will reject unformatted code. Run it, stage any formatting changes, then commit.
+**MANDATORY**: You MUST run `cargo fmt --all` before every commit. Always. No exceptions. CI will reject unformatted code. Run it, stage any formatting changes, then commit. If you touched `tests/e2e`, that crate is a **separate workspace** — `--all` does not reach it, so also run `cargo fmt --manifest-path tests/e2e/Cargo.toml`.
 
 **Always run** (fast, catches most issues):
 
@@ -241,24 +306,38 @@ cargo clippy --all-features --all-targets -- -D warnings  # Lint (uses cached bu
 
 | What changed | Command | Why |
 |---|---|---|
-| Any `.rs` file | `cargo test --workspace --all-features` | Unit tests (requires `mise run db:migrate` once); `--workspace` ensures crates such as `rise-backend-auth` and `rise-backend-core` are included |
-| SQLX queries (`sqlx::query!` etc.) | `mise run sqlx:prepare` | Regenerate offline query cache (commit the result) |
+| Any `.rs` file | `cargo test --workspace --all-features` | Unit tests (requires `mise run db:migrate` once); `--workspace` covers the support crates but **not** `tests/e2e` |
+| `tests/e2e/**` | `cargo fmt --manifest-path tests/e2e/Cargo.toml`, then `cargo clippy --manifest-path tests/e2e/Cargo.toml --all-targets -- -D warnings` and `cargo test --manifest-path tests/e2e/Cargo.toml` | Standalone workspace, checked by CI in its own job |
+| SQLX queries in `rise-deploy` | `mise run sqlx:prepare` | Regenerate offline query cache (commit the result) |
+| SQLX queries in `rise-resource-store-postgres` | `mise run resource-store-postgres:sqlx:prepare` | Crate-local offline cache (commit the result) |
+| SQLX queries in `rise-runtime-sync` | `mise run runtime-sync:db:migrate` once, then `mise run runtime-sync:sqlx:prepare` | Crate-local offline cache; needs the `runtime_sync` schema applied |
+| Dependencies (`Cargo.toml`/`Cargo.lock`) | `cargo audit` | CI fails on advisories |
 | Server settings structs (`src/server/settings.rs`) | `mise run config:schema:generate` | Regenerate `docs/engineering/public/schemas/backend-settings.schema.json` (commit the result) |
-| `src/rise_toml.rs` structs | `mise run rise-toml:schema:generate` | Regenerate `docs/user/public/schemas/rise-toml-v1.schema.json` (commit the result) |
+| `rise.toml` structs (`crates/rise-deployment-spec/src/project_config.rs`) | `mise run rise-toml:schema:generate` | Regenerate `docs/user/public/schemas/rise-toml-v1.schema.json` (commit the result) |
+| Resource API types (`crates/rise-resource-api/`) | `mise run resource:schema:generate` | Regenerate the resource/organization/controller-status schemas under `docs/engineering/public/schemas/` (commit the result) |
 | CRD structs (`src/server/deployment/crd.rs`) | `mise run crd:generate` | Regenerate `helm/rise/crds/riseproject-crd.yaml` (commit the result) |
 | Helm chart (`helm/rise/`) | `helm lint helm/rise` | Validate chart templates |
 
 **Full CI-equivalent check** (slower, runs everything):
 
 ```bash
-mise run lint                  # cargo check + clippy + fmt check + sqlx check + helm lint
+mise run lint                       # See below for what this covers
 mise run config:schema:check        # Verify backend config schema is up to date
-mise run rise-toml:schema:check    # Verify rise.toml schema is up to date
-mise run crd:check                 # Verify CRD YAML matches Rust definition
-cargo test --workspace --all-features  # Unit tests (all crates)
+mise run rise-toml:schema:check     # Verify rise.toml schema is up to date
+mise run crd:check                  # Verify CRD YAML matches Rust definition
+cargo audit                         # Dependency advisories
+cargo test --workspace --all-features  # Unit tests (all workspace crates)
 ```
 
-The `mise run lint` task runs: `cargo all-features check`, `cargo all-features clippy -- -D warnings`, `cargo fmt --check`, `mise sqlx:check`, and `helm lint helm/rise`.
+`mise run lint` runs, in order: `cargo all-features check --all-targets`; a
+per-crate `cargo check` for `rise-authz`, `rise-resource-api`,
+`rise-resource-store-postgres`, `rise-backend-auth`, `rise-backend-core`, and
+`rise-runtime-sync`; `cargo all-features clippy -- -D warnings` plus the same
+per-crate clippy sweep; `cargo fmt --all -- --check`; `mise sqlx:check`;
+`mise resource:schema:check`; `helm lint helm/rise`; and `cargo test` for
+`rise-authz`, `rise-backend-auth`, and `rise-backend-core`. It does **not** cover
+`config:schema:check`, `rise-toml:schema:check`, `crd:check`, `cargo audit`, or
+`tests/e2e` — CI does, so run those separately.
 
 ## Deployment Backend Parity (STRICT)
 
@@ -292,4 +371,4 @@ merely unimplemented is a **parity bug** to track and close.
 
 ## Ingress Authentication
 
-Ingress-level authentication is driven by each project's **access class** (`access_requirement`: `None` / `Authenticated` / `Member`), not the legacy `visibility` field. The Kubernetes controller is fully wired: for non-`None` access requirements it stamps nginx auth annotations (`nginx.ingress.kubernetes.io/auth-url` → `/api/v1/auth/ingress`, `auth-signin`, `auth-response-headers`) — see `ResourceBuilder::build_ingress_annotations` in `src/server/deployment/resource_builder.rs`. The subrequest is served by the `ingress_auth` handler in `src/server/auth/handlers.rs`, which validates the Rise JWT session cookie, then enforces `Authenticated` (any logged-in user) or `Member` (project owner/team member) and returns `X-Auth-Request-Email`/`X-Auth-Request-User` on success.
+Ingress-level authentication is driven by each project's **access class** (`access_requirement`: `None` / `Authenticated` / `Member`). The Kubernetes controller is fully wired: for non-`None` access requirements it stamps nginx auth annotations (`nginx.ingress.kubernetes.io/auth-url` → `/api/v1/auth/ingress`, `auth-signin`, `auth-response-headers`) — see `ResourceBuilder::build_ingress_annotations` in `src/server/deployment/resource_builder.rs`. The subrequest is served by the `ingress_auth` handler in `src/server/auth/handlers.rs`, which validates the Rise JWT session cookie, then enforces `Authenticated` (any logged-in user) or `Member` (project owner/team member) and returns `X-Auth-Request-Email`/`X-Auth-Request-User` on success. The Docker backend enforces the same access classes via Traefik forwardAuth against the same handler.


### PR DESCRIPTION
Audited CLAUDE.md against the tree and fixed everything that no longer
matched the code:

- Documentation links: all five pointed at the pre-Starlight layout and
  404'd. Repointed at docs/user and docs/engineering, and added the ADR,
  deployment-backends, and generic-resource-api entries.
- Workspace crates: rise-authz, rise-deployment-spec, and rise-runtime-sync
  were undocumented. Replaced the two divergent prose paragraphs with a
  single table covering all eight crates.
- tests/e2e is a separate workspace that `cargo fmt --all` and
  `cargo test --workspace` do not reach, but CI lints and tests it. Called
  that out in the pre-commit section and added a row for it.
- SQLX rule: `db` is a module, not a crate, and two support crates own their
  own queries, migrations, and offline caches. Scoped the rule accordingly
  and added the missing prepare tasks.
- `mise run lint` description was incomplete: it also runs per-crate check
  and clippy sweeps, resource:schema:check, and three crates' tests. Listed
  what it does and does not cover.
- Added missing rows for resource:schema:generate and cargo audit, both
  enforced by CI.
- Module inventories: filled in the seven undocumented server modules, the
  full CLI command surface, the AWS S3 extension, the four registry
  providers, and the top-level directories.
- rise.toml structs live in rise-deployment-spec; src/rise_toml.rs is a
  re-export shim. Pointed the schema-regeneration row at the real location.
- Deployment module and the backend feature list described Kubernetes only,
  contradicting the Deployment Backend Parity section. Both backends now
  documented as first-class.
- Product brief: --visibility is --access-class, the config file is
  rise.toml, and the build backends are docker/pack/railpack. Rewrote the
  example transcript to match actual command output and file shape.
- Deployment commands: `rollback` is not implemented (only an orphaned doc
  comment); the real set is create, list, show, stop, logs.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y7JonZWxuAMjwMGgKbCFRU