### PR TITLE
Activate policy resource kinds with contextual admission

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,14 +31,14 @@ Status legend: `[x]` shipped · `[~]` in progress · `[ ]` planned.
 - [x] Move the dep-light `ResourceStore` contract and canonical `SubjectId`,
   dynamic-label `SubjectRef`, group-qualified `ResourceKind`, and `Scope` types into `rise-resource-api`;
   keep SQLX and Postgres adapters in `rise-resource-store-postgres`.
-- [~] Implement policy types and validation for `Role`, `RoleBinding`,
+- [x] Implement policy types and validation for `Role`, `RoleBinding`,
   `PlatformRole`, and `PlatformRoleBinding`: structured `roleRef`, one
   subject per binding, normalized PascalCase `subjectMembership: Any |
   ResourceOrganization` on platform bindings (omission becomes `Any`; null is
   invalid), canonical scopes, pure Allow/Deny tuple evaluation, placement
   provenance, wildcard replacement, and Deny-aware subset checks. Activate
   these resources only through transaction-scoped normalization/admission.
-- [~] Add closed contracts for the built-in identity resources: root `User`
+- [x] Add closed contracts for the built-in identity resources: root `User`
   and `Controller`; Organization-owned `Group` and `ServiceAccount`; and
   fixed-parent
   `UserIdentity`, `GroupMembership`, `ControllerTrustPolicy`, and

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -41,11 +41,11 @@ scope and avoiding dead-end compatibility layers.
 5. **Merged in PR #420 — generic lifecycle owner references.** Add the canonical
    owner-reference DAG, cascading collection, blocker reporting, and structured
    lifecycle logging required before GroupMembership activation.
-6. **In progress — identity activation and storage projections.** Add the
+6. **In review in PR #421 — identity activation and storage projections.** Add the
    transaction-owned admission seam, activate all eight identity built-ins,
    and add the ADR-required identity/trust/membership indexes and narrow lookup
    adapters. Policy activation remains a separate reviewable increment.
-7. **Planned — policy activation.** Activate the four policy built-ins through
+7. **In progress — policy activation.** Activate the four policy built-ins through
    contextual normalization, reference validation, and concurrency-safe
    admission without yet enforcing live authorization.
 8. **Planned — live authorization engine.** Add membership expansion, org-admin
@@ -425,3 +425,67 @@ scope and avoiding dead-end compatibility layers.
     concurrency, lookup, key-budget, and EXPLAIN coverage.
   - `SQLX_OFFLINE=true RUSTC_WRAPPER= cargo test --workspace --all-features
     -- --test-threads=1` passes serially; 2 documentation tests are ignored.
+
+## Increment 7 — policy activation
+
+- State: draft PR open for review.
+- Branch: `claude/policy-activation-admission-1ojwzz`.
+- Stacked on increment 6 (PR #421), whose admission seam it generalizes.
+- Acceptance criteria:
+  - Activate exactly the four kinds in `POLICY_KIND_DEFINITIONS`, consuming that
+    table for placement: `Role` and `RoleBinding` under an Organization,
+    `PlatformRole` and `PlatformRoleBinding` at the root.
+  - Keep the public `ResourceStore` and pure/local `SpecValidator` contracts
+    unchanged. Contextual admission owns every database read and row lock it
+    needs inside the mutation transaction and stays authoritative for direct
+    store calls with no trustworthy validator.
+  - Normalize each binding contextually and persist the normalized spec: an org
+    binding's omitted `scope` becomes its parent Organization's scope, a
+    platform binding's becomes its static org-native subject's organization or
+    `*`, and `subjectMembership` persists as PascalCase `Any` when omitted while
+    explicit null and unknown values fail closed.
+  - Resolve every reference a binding carries against live rows in the same
+    transaction: `roleRef` at the exact placement its kind implies, `scope`
+    down a registry- or ResourceDefinition-derived parent chain, and any
+    literal `subject`. Enforce both containment rules on the resolved rows.
+  - Audit legacy definitions and rows that policy route activation could shadow
+    and install the durable four-collection reservation guard, with the same
+    single-transaction, actionable-diagnostic behavior as increment 6.
+  - Add no authorization evaluation, grant gate, seeded policy, or binding
+    index. Nothing consults these resources yet.
+- Decisions:
+  - `IdentityAdmission` generalizes to `BuiltInAdmission`, splitting the
+    identity and policy contracts into sibling modules behind one seam. The
+    contextual `admit_*` methods now take `&mut` params, because policy
+    normalization rewrites the spec that gets persisted; identity admission,
+    which only validates, is unaffected.
+  - Canonicalization stays split rather than moving wholesale into the
+    transaction. A Role body and a binding's syntax are context-free and fail
+    before any lock is taken; only the parts that genuinely need a parent
+    Organization, a subject, or a live target run inside it.
+  - A binding's references must resolve at write time. This follows the ADR's
+    explicit "the target must exist or be created in the same atomic
+    transaction" for `scope`, its "nonexistent literals are rejected" for
+    subjects, and increment 6's precedent for GroupMembership's live User.
+    Lifecycle after the fact is unchanged: deleting a referenced Role leaves a
+    dangling binding exactly as deleting a User leaves a dangling membership,
+    which owner references — not write-time validation — are the answer to.
+  - Policy specs get no immutable-field enforcement. ADR-0001 governs Role and
+    binding edits through the write-time grant gate's effective before/after
+    delta, not by freezing fields, so adding immutability here would contradict
+    the increment that implements it.
+  - Reference locks are `FOR SHARE` and sit in the same band as increment 6's
+    identity lookups: after the global graph lock, owners, and structural
+    parents, and before the dependent row lock.
+  - No storage projection for bindings. The identity indexes serve a
+    per-request login path; the authorization engine's binding access patterns
+    are not yet measurable, and a speculative index would be a schema
+    commitment made blind.
+- Verification:
+  - `cargo fmt --all` passes.
+  - `cargo clippy --workspace --all-features --all-targets -- -D warnings` passes.
+  - The PostgreSQL-backed `rise-resource-store-postgres` integration suite
+    passes all 83 tests serially, including the nine new policy routing,
+    normalization, reference-resolution, containment, subject-resolution,
+    update-renormalization, concurrency, and migration-guard tests.
+  - `cargo test --workspace --all-features -- --test-threads=1` passes.

--- a/crates/rise-resource-api/src/builtin_kind.rs
+++ b/crates/rise-resource-api/src/builtin_kind.rs
@@ -1,0 +1,24 @@
+/// Static API identity and placement of one Rise built-in resource kind.
+///
+/// The PostgreSQL built-in registry consumes this contract metadata directly
+/// when installing its transaction-scoped normalization and admission path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BuiltInKindDefinition {
+    pub api_version: &'static str,
+    pub kind: &'static str,
+    pub collection: &'static str,
+    pub parent: Option<BuiltInKindParent>,
+}
+
+/// Fixed parent identity for a Rise built-in resource kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BuiltInKindParent {
+    pub api_version: &'static str,
+    pub kind: &'static str,
+}
+
+/// Shared by the Organization-owned identity and policy kinds.
+pub(crate) const ORGANIZATION_PARENT: BuiltInKindParent = BuiltInKindParent {
+    api_version: crate::API_VERSION_V1ALPHA1,
+    kind: crate::ORGANIZATION_KIND,
+};

--- a/crates/rise-resource-api/src/identity.rs
+++ b/crates/rise-resource-api/src/identity.rs
@@ -5,104 +5,81 @@ use schemars::{JsonSchema, Schema, SchemaGenerator};
 use serde::{Deserialize, Deserializer, Serialize};
 use url::Url;
 
+use crate::builtin_kind::ORGANIZATION_PARENT;
 use crate::{
-    ValidationError, API_VERSION_V1ALPHA1, CONTROLLER_COLLECTION, CONTROLLER_KIND,
-    CONTROLLER_TRUST_POLICY_COLLECTION, CONTROLLER_TRUST_POLICY_KIND, GROUP_COLLECTION, GROUP_KIND,
-    GROUP_MEMBERSHIP_COLLECTION, GROUP_MEMBERSHIP_KIND, ORGANIZATION_KIND,
-    SERVICE_ACCOUNT_COLLECTION, SERVICE_ACCOUNT_KIND, SERVICE_ACCOUNT_TRUST_POLICY_COLLECTION,
-    SERVICE_ACCOUNT_TRUST_POLICY_KIND, USER_COLLECTION, USER_IDENTITY_COLLECTION,
-    USER_IDENTITY_KIND, USER_KIND,
+    BuiltInKindDefinition, BuiltInKindParent, ValidationError, API_VERSION_V1ALPHA1,
+    CONTROLLER_COLLECTION, CONTROLLER_KIND, CONTROLLER_TRUST_POLICY_COLLECTION,
+    CONTROLLER_TRUST_POLICY_KIND, GROUP_COLLECTION, GROUP_KIND, GROUP_MEMBERSHIP_COLLECTION,
+    GROUP_MEMBERSHIP_KIND, SERVICE_ACCOUNT_COLLECTION, SERVICE_ACCOUNT_KIND,
+    SERVICE_ACCOUNT_TRUST_POLICY_COLLECTION, SERVICE_ACCOUNT_TRUST_POLICY_KIND, USER_COLLECTION,
+    USER_IDENTITY_COLLECTION, USER_IDENTITY_KIND, USER_KIND,
 };
 
-/// Static API identity and placement of one ADR-0001 identity resource kind.
-///
-/// The PostgreSQL built-in registry consumes this contract metadata directly
-/// when installing its transaction-scoped normalization and admission path.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct IdentityKindDefinition {
-    pub api_version: &'static str,
-    pub kind: &'static str,
-    pub collection: &'static str,
-    pub parent: Option<IdentityKindParent>,
-}
-
-/// Fixed parent identity for an ADR-0001 identity resource kind.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct IdentityKindParent {
-    pub api_version: &'static str,
-    pub kind: &'static str,
-}
-
-const ORGANIZATION_PARENT: IdentityKindParent = IdentityKindParent {
-    api_version: API_VERSION_V1ALPHA1,
-    kind: ORGANIZATION_KIND,
-};
-
-const USER_PARENT: IdentityKindParent = IdentityKindParent {
+const USER_PARENT: BuiltInKindParent = BuiltInKindParent {
     api_version: API_VERSION_V1ALPHA1,
     kind: USER_KIND,
 };
 
-const CONTROLLER_PARENT: IdentityKindParent = IdentityKindParent {
+const CONTROLLER_PARENT: BuiltInKindParent = BuiltInKindParent {
     api_version: API_VERSION_V1ALPHA1,
     kind: CONTROLLER_KIND,
 };
 
-const GROUP_PARENT: IdentityKindParent = IdentityKindParent {
+const GROUP_PARENT: BuiltInKindParent = BuiltInKindParent {
     api_version: API_VERSION_V1ALPHA1,
     kind: GROUP_KIND,
 };
 
-const SERVICE_ACCOUNT_PARENT: IdentityKindParent = IdentityKindParent {
+const SERVICE_ACCOUNT_PARENT: BuiltInKindParent = BuiltInKindParent {
     api_version: API_VERSION_V1ALPHA1,
     kind: SERVICE_ACCOUNT_KIND,
 };
 
 /// All persisted ADR-0001 identity kinds and their fixed placement.
-pub const IDENTITY_KIND_DEFINITIONS: [IdentityKindDefinition; 8] = [
-    IdentityKindDefinition {
+pub const IDENTITY_KIND_DEFINITIONS: [BuiltInKindDefinition; 8] = [
+    BuiltInKindDefinition {
         api_version: API_VERSION_V1ALPHA1,
         kind: USER_KIND,
         collection: USER_COLLECTION,
         parent: None,
     },
-    IdentityKindDefinition {
+    BuiltInKindDefinition {
         api_version: API_VERSION_V1ALPHA1,
         kind: USER_IDENTITY_KIND,
         collection: USER_IDENTITY_COLLECTION,
         parent: Some(USER_PARENT),
     },
-    IdentityKindDefinition {
+    BuiltInKindDefinition {
         api_version: API_VERSION_V1ALPHA1,
         kind: CONTROLLER_KIND,
         collection: CONTROLLER_COLLECTION,
         parent: None,
     },
-    IdentityKindDefinition {
+    BuiltInKindDefinition {
         api_version: API_VERSION_V1ALPHA1,
         kind: CONTROLLER_TRUST_POLICY_KIND,
         collection: CONTROLLER_TRUST_POLICY_COLLECTION,
         parent: Some(CONTROLLER_PARENT),
     },
-    IdentityKindDefinition {
+    BuiltInKindDefinition {
         api_version: API_VERSION_V1ALPHA1,
         kind: GROUP_KIND,
         collection: GROUP_COLLECTION,
         parent: Some(ORGANIZATION_PARENT),
     },
-    IdentityKindDefinition {
+    BuiltInKindDefinition {
         api_version: API_VERSION_V1ALPHA1,
         kind: GROUP_MEMBERSHIP_KIND,
         collection: GROUP_MEMBERSHIP_COLLECTION,
         parent: Some(GROUP_PARENT),
     },
-    IdentityKindDefinition {
+    BuiltInKindDefinition {
         api_version: API_VERSION_V1ALPHA1,
         kind: SERVICE_ACCOUNT_KIND,
         collection: SERVICE_ACCOUNT_COLLECTION,
         parent: Some(ORGANIZATION_PARENT),
     },
-    IdentityKindDefinition {
+    BuiltInKindDefinition {
         api_version: API_VERSION_V1ALPHA1,
         kind: SERVICE_ACCOUNT_TRUST_POLICY_KIND,
         collection: SERVICE_ACCOUNT_TRUST_POLICY_COLLECTION,

--- a/crates/rise-resource-api/src/lib.rs
+++ b/crates/rise-resource-api/src/lib.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use uuid::Uuid;
 
+mod builtin_kind;
 mod identity;
 mod owner_reference;
 mod policy;
@@ -14,11 +15,11 @@ mod store;
 mod subject_id;
 mod subject_ref;
 
+pub use builtin_kind::{BuiltInKindDefinition, BuiltInKindParent};
 pub use identity::{
     ControllerSpec, ControllerTrustPolicySpec, ExternalSubject, GroupMembershipSpec, GroupSpec,
-    IdentityKindDefinition, IdentityKindParent, Issuer, ServiceAccountSpec,
-    ServiceAccountTrustPolicySpec, TrustPolicyClaims, UserIdentitySpec, UserSpec,
-    IDENTITY_KIND_DEFINITIONS, MAX_EXTERNAL_SUBJECT_CHARS, MAX_ISSUER_BYTES,
+    Issuer, ServiceAccountSpec, ServiceAccountTrustPolicySpec, TrustPolicyClaims, UserIdentitySpec,
+    UserSpec, IDENTITY_KIND_DEFINITIONS, MAX_EXTERNAL_SUBJECT_CHARS, MAX_ISSUER_BYTES,
 };
 pub use owner_reference::OwnerReference;
 pub use policy::{
@@ -26,7 +27,7 @@ pub use policy::{
     LocallyNormalizedPlatformRoleBindingSpec, LocallyNormalizedRoleBindingSpec,
     PlatformRoleBindingSpec, PlatformRoleRef, PlatformRoleRefKind, PolicyStatement,
     ResourceKindPattern, RoleBindingSpec, RoleRef, RoleRefKind, RoleSpec, SubjectMembership,
-    SubresourceMatcher, SubresourceName, Verb, VerbMatcher,
+    SubresourceMatcher, SubresourceName, Verb, VerbMatcher, POLICY_KIND_DEFINITIONS,
 };
 pub use resource_kind::ResourceKind;
 pub use resource_row::ResourceRow;

--- a/crates/rise-resource-api/src/policy.rs
+++ b/crates/rise-resource-api/src/policy.rs
@@ -5,10 +5,45 @@ use std::str::FromStr;
 use schemars::{JsonSchema, Schema, SchemaGenerator};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+use crate::builtin_kind::ORGANIZATION_PARENT;
 use crate::{
-    validate_resource_group, validate_resource_name, ResourceKind, Scope, SubjectId,
-    ValidationError,
+    validate_resource_group, validate_resource_name, BuiltInKindDefinition, ResourceKind, Scope,
+    SubjectId, ValidationError, API_VERSION_V1ALPHA1, PLATFORM_ROLE_BINDING_COLLECTION,
+    PLATFORM_ROLE_BINDING_KIND, PLATFORM_ROLE_COLLECTION, PLATFORM_ROLE_KIND,
+    ROLE_BINDING_COLLECTION, ROLE_BINDING_KIND, ROLE_COLLECTION, ROLE_KIND,
 };
+
+/// All persisted ADR-0001 policy kinds and their fixed placement.
+///
+/// The parent model is exact, so each policy object comes as an
+/// organization-parented and a root-parented kind rather than one kind with a
+/// choice of parents (ADR-0001 §3).
+pub const POLICY_KIND_DEFINITIONS: [BuiltInKindDefinition; 4] = [
+    BuiltInKindDefinition {
+        api_version: API_VERSION_V1ALPHA1,
+        kind: ROLE_KIND,
+        collection: ROLE_COLLECTION,
+        parent: Some(ORGANIZATION_PARENT),
+    },
+    BuiltInKindDefinition {
+        api_version: API_VERSION_V1ALPHA1,
+        kind: ROLE_BINDING_KIND,
+        collection: ROLE_BINDING_COLLECTION,
+        parent: Some(ORGANIZATION_PARENT),
+    },
+    BuiltInKindDefinition {
+        api_version: API_VERSION_V1ALPHA1,
+        kind: PLATFORM_ROLE_KIND,
+        collection: PLATFORM_ROLE_COLLECTION,
+        parent: None,
+    },
+    BuiltInKindDefinition {
+        api_version: API_VERSION_V1ALPHA1,
+        kind: PLATFORM_ROLE_BINDING_KIND,
+        collection: PLATFORM_ROLE_BINDING_COLLECTION,
+        parent: None,
+    },
+];
 
 macro_rules! string_serde {
     ($type:ty) => {

--- a/crates/rise-resource-api/src/subject_id.rs
+++ b/crates/rise-resource-api/src/subject_id.rs
@@ -43,6 +43,21 @@ impl SubjectId {
     pub fn kind(&self) -> &str {
         self.0.split_once(':').expect("validated SubjectId").0
     }
+
+    /// The identity's own name, without its kind prefix or organization
+    /// segment: `group:acme/platform` is named `platform`, `user:alice` is
+    /// named `alice`.
+    ///
+    /// For a virtual subject this is the predicate's own tail (`acme` for
+    /// `org:acme`, `authenticated` for `system:authenticated`) — parsing does
+    /// not imply a resource of that name exists.
+    pub fn name(&self) -> &str {
+        let (_, value) = self.0.split_once(':').expect("validated SubjectId");
+        match self.kind() {
+            "group" | "serviceaccount" => value.split_once('/').expect("validated SubjectId").1,
+            _ => value,
+        }
+    }
 }
 
 impl fmt::Debug for SubjectId {

--- a/crates/rise-resource-api/tests/canonical_types.rs
+++ b/crates/rise-resource-api/tests/canonical_types.rs
@@ -65,19 +65,41 @@ fn subject_id_accepts_exactly_the_seven_canonical_forms() {
 
 #[test]
 fn subject_id_classifies_virtual_and_org_native_forms_exhaustively() {
+    // organization/name are what policy write-time resolution looks a subject
+    // up by, so they are pinned for every form including the virtual ones.
     let cases = [
-        ("user:u-01jz", false, false),
-        ("controller:deployment-controller", false, false),
-        ("group:acme-corp/platform", false, true),
-        ("serviceaccount:acme-corp/ci-bot", false, true),
-        ("org:acme-corp", true, false),
-        ("system:authenticated", true, false),
-        ("system:operators", true, false),
+        ("user:u-01jz", false, false, None, "u-01jz"),
+        (
+            "controller:deployment-controller",
+            false,
+            false,
+            None,
+            "deployment-controller",
+        ),
+        (
+            "group:acme-corp/platform",
+            false,
+            true,
+            Some("acme-corp"),
+            "platform",
+        ),
+        (
+            "serviceaccount:acme-corp/ci-bot",
+            false,
+            true,
+            Some("acme-corp"),
+            "ci-bot",
+        ),
+        ("org:acme-corp", true, false, Some("acme-corp"), "acme-corp"),
+        ("system:authenticated", true, false, None, "authenticated"),
+        ("system:operators", true, false, None, "operators"),
     ];
-    for (value, is_virtual, is_org_native) in cases {
+    for (value, is_virtual, is_org_native, organization, name) in cases {
         let subject: SubjectId = value.parse().unwrap();
         assert_eq!(subject.is_virtual(), is_virtual, "{value}");
         assert_eq!(subject.is_org_native(), is_org_native, "{value}");
+        assert_eq!(subject.organization(), organization, "{value}");
+        assert_eq!(subject.name(), name, "{value}");
     }
 }
 

--- a/crates/rise-resource-api/tests/policy_contracts.rs
+++ b/crates/rise-resource-api/tests/policy_contracts.rs
@@ -1,6 +1,8 @@
 use jsonschema::validator_for;
 use rise_resource_api::{
     BindingSubject, PlatformRoleBindingSpec, RoleBindingSpec, SubjectMembership,
+    API_VERSION_V1ALPHA1, ORGANIZATION_KIND, PLATFORM_ROLE_BINDING_KIND, PLATFORM_ROLE_KIND,
+    POLICY_KIND_DEFINITIONS, ROLE_BINDING_KIND, ROLE_KIND,
 };
 use schemars::{schema_for, JsonSchema};
 use serde_json::{json, Value};
@@ -237,7 +239,7 @@ fn generated_binding_schemas_match_omission_and_null_rules() {
 }
 
 #[test]
-fn future_policy_collections_are_reserved_before_registration() {
+fn policy_collections_are_reserved_against_external_definitions() {
     for collection in [
         rise_resource_api::ROLE_COLLECTION,
         rise_resource_api::ROLE_BINDING_COLLECTION,
@@ -245,5 +247,36 @@ fn future_policy_collections_are_reserved_before_registration() {
         rise_resource_api::PLATFORM_ROLE_BINDING_COLLECTION,
     ] {
         assert!(rise_resource_api::is_reserved_collection_name(collection));
+    }
+}
+
+#[test]
+fn policy_kind_definitions_capture_fixed_adr_placement() {
+    // Two same-shaped pairs, one per placement level: the org pair hangs under
+    // an Organization, the platform pair at the root (ADR-0001 §3).
+    let definitions: Vec<_> = POLICY_KIND_DEFINITIONS
+        .iter()
+        .map(|definition| {
+            (
+                definition.kind,
+                definition.collection,
+                definition.parent.map(|parent| parent.kind),
+            )
+        })
+        .collect();
+    assert_eq!(
+        definitions,
+        vec![
+            (ROLE_KIND, "roles", Some(ORGANIZATION_KIND)),
+            (ROLE_BINDING_KIND, "rolebindings", Some(ORGANIZATION_KIND)),
+            (PLATFORM_ROLE_KIND, "platformroles", None),
+            (PLATFORM_ROLE_BINDING_KIND, "platformrolebindings", None),
+        ]
+    );
+    for definition in POLICY_KIND_DEFINITIONS {
+        assert_eq!(definition.api_version, API_VERSION_V1ALPHA1);
+        if let Some(parent) = definition.parent {
+            assert_eq!(parent.api_version, API_VERSION_V1ALPHA1);
+        }
     }
 }

--- a/crates/rise-resource-store-postgres/README.md
+++ b/crates/rise-resource-store-postgres/README.md
@@ -45,16 +45,31 @@ Lifecycle owner references are stored once, in the resource row's
 UID containment queries for garbage collection. No separate edge table is
 maintained.
 
-## Built-in identity admission and projections
+## Built-in identity and policy admission
 
-The eight `rise.dev/v1alpha1` identity kinds are routed from the immutable
-built-in registry. Pure typed validation and canonicalization run before the
-mutation transaction; contextual admission then locks and verifies the exact
-live built-in parent chain in the same transaction as persistence. Every
-built-in registration's validator is authoritative even when the caller omits
-or forges its optional `SpecValidator`. Identity admission also enforces
+The eight `rise.dev/v1alpha1` identity kinds and the four policy kinds
+(`Role`, `RoleBinding`, `PlatformRole`, `PlatformRoleBinding`) are routed from
+the immutable built-in registry. Pure typed validation and canonicalization run
+before the mutation transaction; contextual admission then locks and verifies
+the exact live built-in parent chain in the same transaction as persistence.
+Every built-in registration's validator is authoritative even when the caller
+omits or forges its optional `SpecValidator`. Identity admission also enforces
 mapping immutability and GroupMembership's optional matching-User owner
 reference. Custom same-named kinds in other API groups remain generic.
+
+Policy admission adds the contextual half a JSON Schema cannot express. A
+binding's `scope` is normalized against facts known only at write time — its
+parent Organization for an org `RoleBinding`, its subject for a
+`PlatformRoleBinding` — and every reference it carries is then resolved against
+live rows under `FOR SHARE`: the `roleRef` at the exact placement its kind
+implies, the `scope` path down a registry- or ResourceDefinition-derived parent
+chain, and any literal `subject`. Containment is checked on the resolved rows,
+so an org binding cannot leave its own organization's subtree and a static
+org-native subject cannot reach outside its own organization. Updates run the
+same path, which is idempotent for an already-normalized spec.
+
+Nothing consults these resources yet: a stored binding grants no access until
+the authorization engine lands.
 
 Three partial expression indexes project only live built-in rows: global
 UserIdentity issuer/subject uniqueness (including inactive mappings),
@@ -62,14 +77,21 @@ parent-and-issuer workload trust lookup, and reverse GroupMembership name
 lookup. `IdentityLookup`, `TrustPolicyLookup`, and `MembershipLookup` expose
 these fixed reads without adding JSON filters to `ResourceStore`.
 
-Before these routes activate, the activation migration audits tombstoned and
+Before these routes activate, each activation migration audits tombstoned and
 live legacy ResourceDefinitions and resource rows that would be shadowed,
-reporting a bounded count plus sample. It then installs the durable write
-guard, which reserves the whole `rise.dev` group against external
-ResourceDefinitions plus the eight identity collection names in any group.
-Audit and guard share one transaction, so an upgrade that reports a conflict
-leaves the database untouched: remove every resource the diagnostic names using
-the previously deployed Rise binary, then retry.
+reporting a bounded count plus sample. It then installs a durable write
+guard: the identity migration reserves the whole `rise.dev` group against
+external ResourceDefinitions plus the eight identity collection names in any
+group, and the policy migration adds the four policy collection names. Audit
+and guard share one transaction, so an upgrade that reports a conflict leaves
+the database untouched: remove every resource the diagnostic names using the
+previously deployed Rise binary, then retry.
+
+The policy activation adds no index. The identity indexes exist because
+authentication resolves a login through them on every request; bindings are
+read through ordinary tree and collection reads, so an index for them stays
+speculative until the authorization engine makes its access patterns
+measurable.
 
 Every index here is built inside its migration's transaction, so the build and
 SQLx's bookkeeping commit together. `CREATE INDEX CONCURRENTLY` would avoid the

--- a/crates/rise-resource-store-postgres/migrations/20260814000000_activate_policy_resources.sql
+++ b/crates/rise-resource-store-postgres/migrations/20260814000000_activate_policy_resources.sql
@@ -1,0 +1,105 @@
+-- Activate the four rise.dev/v1alpha1 policy built-ins.
+--
+-- One transaction, so a rejected upgrade leaves the database exactly as it was.
+-- The compatibility audit runs before the reservation constraint is added: an
+-- installation holding conflicting rows gets a counted, sampled diagnostic
+-- naming what to remove, rather than a bare constraint violation.
+--
+-- No storage projection accompanies this activation. The identity indexes exist
+-- because authentication resolves a login through them on every request;
+-- bindings are read by the authorization engine through ordinary tree and
+-- collection reads, so an index here would be speculative until that engine
+-- lands and its access patterns are measurable.
+
+-- ---------------------------------------------------------------------------
+-- Compatibility audit
+-- ---------------------------------------------------------------------------
+
+-- The identity activation already closed the whole rise.dev group to external
+-- ResourceDefinitions, so only the four policy collection names in other groups
+-- can still conflict. Collection names are globally unique
+-- (resource_definitions_plural_unique), so this reserves nothing that was
+-- addressable anyway -- it keeps the guard and the audit describing the same
+-- rule. Tombstoned definitions are included: route activation would shadow them
+-- if they were later restored or inspected through their collection identity.
+DO $$
+DECLARE
+    conflict_count bigint;
+    conflict_sample text;
+BEGIN
+    WITH conflicts AS (
+        SELECT name, uid, spec
+        FROM resource_store.resources
+        WHERE kind = 'ResourceDefinition'
+          AND spec->>'plural' IN (
+              'roles', 'rolebindings', 'platformroles', 'platformrolebindings'
+          )
+    ), sample AS (
+        SELECT * FROM conflicts ORDER BY name, uid LIMIT 10
+    )
+    SELECT (SELECT count(*) FROM conflicts),
+           (SELECT string_agg(
+               format('%s (uid=%s, group=%s, plural=%s)', name, uid,
+                   COALESCE(spec->>'group', '<missing>'),
+                   COALESCE(spec->>'plural', '<missing>')),
+               ', ' ORDER BY name, uid)
+            FROM sample)
+    INTO conflict_count, conflict_sample;
+
+    IF conflict_count > 0 THEN
+        RAISE EXCEPTION USING
+            MESSAGE = format(
+                'policy built-in activation is blocked by %s legacy ResourceDefinition(s); sample: %s',
+                conflict_count, conflict_sample),
+            HINT = 'remove each conflicting ResourceDefinition with the previously deployed Rise version, then retry the upgrade';
+    END IF;
+END $$;
+
+-- Reject orphan/legacy rows that would be silently reinterpreted as trusted
+-- built-ins once the immutable registry starts routing these exact identities.
+DO $$
+DECLARE
+    conflict_count bigint;
+    conflict_sample text;
+BEGIN
+    WITH conflicts AS (
+        SELECT api_version, kind, name, uid
+        FROM resource_store.resources
+        WHERE split_part(api_version, '/', 1) = 'rise.dev'
+          AND kind IN (
+              'Role', 'RoleBinding', 'PlatformRole', 'PlatformRoleBinding'
+          )
+    ), sample AS (
+        SELECT * FROM conflicts ORDER BY api_version, kind, name, uid LIMIT 10
+    )
+    SELECT (SELECT count(*) FROM conflicts),
+           (SELECT string_agg(
+               format('%s/%s %s (uid=%s)', api_version, kind, name, uid),
+               ', ' ORDER BY api_version, kind, name, uid)
+            FROM sample)
+    INTO conflict_count, conflict_sample;
+
+    IF conflict_count > 0 THEN
+        RAISE EXCEPTION USING
+            MESSAGE = format(
+                'policy built-in activation is blocked by %s legacy resource row(s); sample: %s',
+                conflict_count, conflict_sample),
+            HINT = 'remove the legacy rows with the previously deployed Rise version, then retry the upgrade';
+    END IF;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- Durable reservation guard
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE resource_store.resources
+    ADD CONSTRAINT resource_definitions_policy_reservations
+    CHECK (
+        kind <> 'ResourceDefinition'
+        OR COALESCE(spec->>'plural', '') NOT IN (
+            'roles',
+            'rolebindings',
+            'platformroles',
+            'platformrolebindings'
+        )
+    );

--- a/crates/rise-resource-store-postgres/src/admission/identity.rs
+++ b/crates/rise-resource-store-postgres/src/admission/identity.rs
@@ -1,14 +1,14 @@
 use rise_resource_api::{
     ControllerSpec, ControllerTrustPolicySpec, CreateResourceParams, GroupMembershipSpec,
-    GroupSpec, OwnerReference, ServiceAccountSpec, ServiceAccountTrustPolicySpec, SpecValidator,
-    StoreError, UpdateResourceParams, UserIdentitySpec, UserSpec, ValidationError,
-    API_VERSION_V1ALPHA1, CONTROLLER_KIND, CONTROLLER_TRUST_POLICY_KIND, GROUP_KIND,
-    GROUP_MEMBERSHIP_KIND, SERVICE_ACCOUNT_KIND, SERVICE_ACCOUNT_TRUST_POLICY_KIND,
-    USER_IDENTITY_KIND, USER_KIND,
+    GroupSpec, OwnerReference, ServiceAccountSpec, ServiceAccountTrustPolicySpec, StoreError,
+    UpdateResourceParams, UserIdentitySpec, UserSpec, API_VERSION_V1ALPHA1, CONTROLLER_KIND,
+    CONTROLLER_TRUST_POLICY_KIND, GROUP_KIND, GROUP_MEMBERSHIP_KIND, SERVICE_ACCOUNT_KIND,
+    SERVICE_ACCOUNT_TRUST_POLICY_KIND, USER_IDENTITY_KIND, USER_KIND,
 };
-use serde::{de::DeserializeOwned, Serialize};
+use serde::de::DeserializeOwned;
 use sqlx::PgConnection;
 
+use crate::admission::{canonicalize, parse_existing};
 use crate::models::PgResourceRow;
 
 /// Identity-specific admission attached to an immutable built-in registration.
@@ -119,40 +119,6 @@ impl IdentityAdmission {
         }
         Ok(())
     }
-}
-
-/// Pure/local validator projected into `CollectionInfo`. Contextual admission
-/// above remains authoritative for every direct store call.
-pub(crate) struct IdentitySpecValidator(pub(crate) IdentityAdmission);
-
-impl SpecValidator for IdentitySpecValidator {
-    fn validate_spec(&self, spec: &serde_json::Value) -> Result<(), ValidationError> {
-        self.0
-            .canonicalize(spec)
-            .map(|_| ())
-            .map_err(|error| ValidationError::new(error.to_string()))
-    }
-
-    fn validate_status(&self, _status: &serde_json::Value) -> Result<(), ValidationError> {
-        Ok(())
-    }
-}
-
-fn canonicalize<T>(value: &serde_json::Value, kind: &str) -> Result<serde_json::Value, StoreError>
-where
-    T: DeserializeOwned + Serialize,
-{
-    let typed: T = serde_json::from_value(value.clone())
-        .map_err(|error| StoreError::Validation(format!("invalid {kind} spec: {error}")))?;
-    serde_json::to_value(typed).map_err(StoreError::backend)
-}
-
-fn parse_existing<T: DeserializeOwned>(
-    value: &serde_json::Value,
-    kind: &str,
-) -> Result<T, StoreError> {
-    serde_json::from_value(value.clone())
-        .map_err(|error| StoreError::Validation(format!("stored {kind} spec is invalid: {error}")))
 }
 
 fn immutable_trust<T>(

--- a/crates/rise-resource-store-postgres/src/admission/mod.rs
+++ b/crates/rise-resource-store-postgres/src/admission/mod.rs
@@ -1,0 +1,159 @@
+//! Transaction-scoped admission for Rise's built-in resource kinds.
+//!
+//! Built-ins are activated through this seam rather than through a JSON Schema
+//! on a `ResourceDefinition` row, because their contracts need facts a schema
+//! cannot see: the identity kinds bind a resource name to a live `User`, and
+//! the policy kinds normalize a binding against its parent Organization and
+//! resolve `roleRef` and `scope` against rows in the same transaction.
+//!
+//! Two phases, deliberately separated:
+//!
+//! - [`BuiltInAdmission::canonicalize`] is pure and runs before the write
+//!   transaction opens. It parses the caller's spec into the typed contract
+//!   and re-serializes it, so unknown fields, malformed values, and
+//!   non-canonical spellings fail before any lock is taken.
+//! - The `admit_*` methods run inside the write transaction, own every
+//!   database read and lock they need, and may rewrite `params.spec` with a
+//!   contextually normalized value. They are authoritative: a caller that
+//!   omits or forges the optional [`SpecValidator`] cannot bypass them.
+
+mod identity;
+mod policy;
+mod reference;
+
+use rise_resource_api::{
+    CreateResourceParams, SpecValidator, StoreError, UpdateResourceParams, ValidationError,
+};
+use serde::{de::DeserializeOwned, Serialize};
+use sqlx::PgConnection;
+
+use crate::builtin::BuiltInRegistry;
+use crate::models::PgResourceRow;
+
+pub(crate) use identity::IdentityAdmission;
+pub(crate) use policy::PolicyAdmission;
+
+/// Kind-specific admission attached to an immutable built-in registration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BuiltInAdmission {
+    Identity(IdentityAdmission),
+    Policy(PolicyAdmission),
+}
+
+impl BuiltInAdmission {
+    /// Resolve the admission for an exact built-in storage identity, or `None`
+    /// for a built-in that needs no typed admission beyond its own validator.
+    pub(crate) fn for_kind(api_version: &str, kind: &str) -> Option<Self> {
+        IdentityAdmission::for_identity(api_version, kind)
+            .map(Self::Identity)
+            .or_else(|| PolicyAdmission::for_policy(api_version, kind).map(Self::Policy))
+    }
+
+    /// Context-free canonicalization. Runs before the write transaction opens.
+    pub(crate) fn canonicalize(
+        self,
+        value: &serde_json::Value,
+    ) -> Result<serde_json::Value, StoreError> {
+        match self {
+            Self::Identity(admission) => admission.canonicalize(value),
+            Self::Policy(admission) => admission.canonicalize(value),
+        }
+    }
+
+    /// Contextual create admission. Runs inside the write transaction, after
+    /// structural placement is verified and before the row is inserted, and
+    /// may replace `params.spec` with its normalized form.
+    pub(crate) async fn admit_create_context(
+        self,
+        conn: &mut PgConnection,
+        builtins: &BuiltInRegistry,
+        params: &mut CreateResourceParams,
+    ) -> Result<(), StoreError> {
+        match self {
+            Self::Identity(admission) => admission.admit_create_context(conn, params).await,
+            Self::Policy(admission) => {
+                params.spec = admission
+                    .admit_context(conn, builtins, params.parent_uid, &params.spec)
+                    .await?;
+                Ok(())
+            }
+        }
+    }
+
+    /// Contextual update admission. Runs on the pre-lock snapshot, before the
+    /// dependent row lock, so it shares the lock order creates use.
+    pub(crate) async fn admit_update_before_dependent(
+        self,
+        conn: &mut PgConnection,
+        builtins: &BuiltInRegistry,
+        current: &PgResourceRow,
+        params: &mut UpdateResourceParams,
+    ) -> Result<(), StoreError> {
+        match self {
+            Self::Identity(admission) => {
+                admission
+                    .admit_update_before_dependent(conn, current, params)
+                    .await
+            }
+            Self::Policy(admission) => {
+                params.spec = admission
+                    .admit_context(conn, builtins, current.parent_uid, &params.spec)
+                    .await?;
+                Ok(())
+            }
+        }
+    }
+
+    /// Re-checked against the locked row, so a writer that committed between
+    /// the snapshot and the lock cannot slip an immutable-field change through.
+    pub(crate) fn validate_update_immutable(
+        self,
+        current: &PgResourceRow,
+        params: &UpdateResourceParams,
+    ) -> Result<(), StoreError> {
+        match self {
+            Self::Identity(admission) => admission.validate_update_immutable(current, params),
+            // Policy specs carry no immutable fields: ADR-0001 governs binding
+            // and Role edits through the write-time grant gate, which evaluates
+            // the effective before/after delta rather than freezing fields.
+            Self::Policy(_) => Ok(()),
+        }
+    }
+}
+
+/// Pure/local validator projected into `CollectionInfo`. Contextual admission
+/// above remains authoritative for every direct store call.
+pub(crate) struct BuiltInSpecValidator(pub(crate) BuiltInAdmission);
+
+impl SpecValidator for BuiltInSpecValidator {
+    fn validate_spec(&self, spec: &serde_json::Value) -> Result<(), ValidationError> {
+        self.0
+            .canonicalize(spec)
+            .map(|_| ())
+            .map_err(|error| ValidationError::new(error.to_string()))
+    }
+
+    fn validate_status(&self, _status: &serde_json::Value) -> Result<(), ValidationError> {
+        Ok(())
+    }
+}
+
+pub(crate) fn canonicalize<T>(
+    value: &serde_json::Value,
+    kind: &str,
+) -> Result<serde_json::Value, StoreError>
+where
+    T: DeserializeOwned + Serialize,
+{
+    let typed: T = serde_json::from_value(value.clone())
+        .map_err(|error| StoreError::Validation(format!("invalid {kind} spec: {error}")))?;
+    serde_json::to_value(typed).map_err(StoreError::backend)
+}
+
+pub(crate) fn parse_existing<T: DeserializeOwned>(
+    value: &serde_json::Value,
+    kind: &str,
+) -> Result<T, StoreError> {
+    serde_json::from_value(value.clone())
+        .map_err(|error| StoreError::Validation(format!("stored {kind} spec is invalid: {error}")))
+}

--- a/crates/rise-resource-store-postgres/src/admission/policy.rs
+++ b/crates/rise-resource-store-postgres/src/admission/policy.rs
@@ -1,0 +1,220 @@
+use rise_resource_api::{
+    PlatformRoleBindingSpec, PlatformRoleRefKind, RoleBindingSpec, RoleRefKind, RoleSpec,
+    StoreError, API_VERSION_V1ALPHA1, ORGANIZATION_KIND, PLATFORM_ROLE_BINDING_KIND,
+    PLATFORM_ROLE_KIND, ROLE_BINDING_KIND, ROLE_KIND,
+};
+use sqlx::PgConnection;
+use uuid::Uuid;
+
+use crate::admission::reference::{
+    require_scope_within_organization, resolve_binding_subject, resolve_policy_ref, resolve_scope,
+};
+use crate::admission::{canonicalize, parse_existing};
+use crate::builtin::BuiltInRegistry;
+use crate::models::PgResourceRow;
+
+/// Policy-specific admission attached to an immutable built-in registration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PolicyAdmission {
+    Role,
+    RoleBinding,
+    PlatformRole,
+    PlatformRoleBinding,
+}
+
+impl PolicyAdmission {
+    pub(crate) fn for_policy(api_version: &str, kind: &str) -> Option<Self> {
+        if api_version != API_VERSION_V1ALPHA1 {
+            return None;
+        }
+        Some(match kind {
+            ROLE_KIND => Self::Role,
+            ROLE_BINDING_KIND => Self::RoleBinding,
+            PLATFORM_ROLE_KIND => Self::PlatformRole,
+            PLATFORM_ROLE_BINDING_KIND => Self::PlatformRoleBinding,
+            _ => return None,
+        })
+    }
+
+    /// Context-free canonicalization.
+    ///
+    /// A Role body is fully canonical after this: its statements are pure
+    /// policy data. A binding is only *syntactically* canonical — its `scope`
+    /// may still be absent, because the default depends on the parent
+    /// Organization or on the subject, neither of which is knowable here.
+    /// [`Self::admit_context`] completes it inside the transaction.
+    ///
+    /// `subjectMembership` is the exception that does normalize here: it is
+    /// context-free, so an omitted value becomes the persisted PascalCase
+    /// `Any` at this point, while an explicit `null` or unknown value fails.
+    pub(crate) fn canonicalize(
+        self,
+        value: &serde_json::Value,
+    ) -> Result<serde_json::Value, StoreError> {
+        match self {
+            Self::Role => canonicalize::<RoleSpec>(value, ROLE_KIND),
+            Self::PlatformRole => canonicalize::<RoleSpec>(value, PLATFORM_ROLE_KIND),
+            Self::RoleBinding => canonicalize::<RoleBindingSpec>(value, ROLE_BINDING_KIND),
+            Self::PlatformRoleBinding => {
+                canonicalize::<PlatformRoleBindingSpec>(value, PLATFORM_ROLE_BINDING_KIND)
+            }
+        }
+    }
+
+    /// Contextual normalization and reference validation, returning the spec to
+    /// persist.
+    ///
+    /// Shared by create and update so a binding that was normalized once keeps
+    /// being re-validated against current rows: an update carries the stored
+    /// normalized spec back through the same path, which is idempotent because
+    /// an explicit `scope` normalizes to itself.
+    pub(crate) async fn admit_context(
+        self,
+        conn: &mut PgConnection,
+        builtins: &BuiltInRegistry,
+        parent_uid: Option<Uuid>,
+        spec: &serde_json::Value,
+    ) -> Result<serde_json::Value, StoreError> {
+        match self {
+            // A Role body references nothing and grants nothing until a binding
+            // names it, so canonicalization already left it complete.
+            Self::Role | Self::PlatformRole => Ok(spec.clone()),
+            Self::RoleBinding => {
+                self.admit_role_binding(conn, builtins, parent_uid, spec)
+                    .await
+            }
+            Self::PlatformRoleBinding => {
+                self.admit_platform_role_binding(conn, builtins, spec).await
+            }
+        }
+    }
+
+    async fn admit_role_binding(
+        self,
+        conn: &mut PgConnection,
+        builtins: &BuiltInRegistry,
+        parent_uid: Option<Uuid>,
+        spec: &serde_json::Value,
+    ) -> Result<serde_json::Value, StoreError> {
+        let organization = self.parent_organization(conn, parent_uid).await?;
+        let parsed: RoleBindingSpec = parse_existing(spec, ROLE_BINDING_KIND)?;
+        let normalized = parsed
+            .normalize(&organization.name)
+            .map_err(|error| StoreError::Validation(error.to_string()))?;
+
+        resolve_binding_subject(conn, normalized.subject()).await?;
+
+        // Reference direction (ADR-0001 §4): an org binding reaches its own
+        // org's Roles or any PlatformRole, never another org's Role.
+        let (kind, parent) = match normalized.role_ref().kind {
+            RoleRefKind::Role => (ROLE_KIND, Some(organization.uid)),
+            RoleRefKind::PlatformRole => (PLATFORM_ROLE_KIND, None),
+        };
+        resolve_policy_ref(
+            conn,
+            API_VERSION_V1ALPHA1,
+            kind,
+            &normalized.role_ref().name,
+            parent,
+        )
+        .await?;
+
+        // `normalize` already rejected a wildcard scope for an org binding.
+        let scope = normalized.scope();
+        let resolved = resolve_scope(conn, builtins, scope).await?;
+        require_scope_within_organization(
+            scope,
+            &resolved,
+            organization.uid,
+            &organization.name,
+            "an org RoleBinding's scope must lie within its own Organization's subtree",
+        )?;
+
+        serde_json::to_value(normalized).map_err(StoreError::backend)
+    }
+
+    async fn admit_platform_role_binding(
+        self,
+        conn: &mut PgConnection,
+        builtins: &BuiltInRegistry,
+        spec: &serde_json::Value,
+    ) -> Result<serde_json::Value, StoreError> {
+        let parsed: PlatformRoleBindingSpec = parse_existing(spec, PLATFORM_ROLE_BINDING_KIND)?;
+        let normalized = parsed
+            .normalize()
+            .map_err(|error| StoreError::Validation(error.to_string()))?;
+
+        let subject_organization = resolve_binding_subject(conn, normalized.subject()).await?;
+
+        let PlatformRoleRefKind::PlatformRole = normalized.role_ref().kind;
+        resolve_policy_ref(
+            conn,
+            API_VERSION_V1ALPHA1,
+            PLATFORM_ROLE_KIND,
+            &normalized.role_ref().name,
+            None,
+        )
+        .await?;
+
+        // A platform binding's scope is otherwise unrestricted: `*`, any org's
+        // subtree, or a root-scoped instance are all legitimate platform policy.
+        let scope = normalized.scope();
+        if !scope.is_wildcard() {
+            let resolved = resolve_scope(conn, builtins, scope).await?;
+            // A Group or ServiceAccount subject carries its organization in its
+            // own identifier, so a binding for one cannot reach outside it —
+            // `normalize` already rejected the explicit-wildcard spelling of
+            // the same escape.
+            if let Some(organization) = subject_organization {
+                require_scope_within_organization(
+                    scope,
+                    &resolved,
+                    organization.uid,
+                    &organization.name,
+                    "a static org-native subject's binding cannot reach outside that subject's own Organization",
+                )?;
+            }
+        }
+
+        serde_json::to_value(normalized).map_err(StoreError::backend)
+    }
+
+    /// Read the parent Organization the binding hangs under.
+    ///
+    /// `validate_builtin_placement` has already proven this parent is a live
+    /// Organization and left it `FOR SHARE`-locked; this read is for its
+    /// *name*, which is what scope defaulting and the containment message need.
+    async fn parent_organization(
+        self,
+        conn: &mut PgConnection,
+        parent_uid: Option<Uuid>,
+    ) -> Result<PgResourceRow, StoreError> {
+        let parent_uid = parent_uid.ok_or_else(|| {
+            StoreError::Validation(format!(
+                "{ROLE_BINDING_KIND} requires an Organization parent"
+            ))
+        })?;
+        sqlx::query_as::<_, PgResourceRow>(
+            r#"
+            SELECT *
+            FROM resource_store.resources
+            WHERE uid = $1
+              AND api_version = $2
+              AND kind = $3
+              AND deletion_timestamp IS NULL
+            FOR SHARE
+            "#,
+        )
+        .bind(parent_uid)
+        .bind(API_VERSION_V1ALPHA1)
+        .bind(ORGANIZATION_KIND)
+        .fetch_optional(&mut *conn)
+        .await
+        .map_err(StoreError::backend)?
+        .ok_or_else(|| {
+            StoreError::Validation(format!(
+                "{ROLE_BINDING_KIND} parent must identify a live {API_VERSION_V1ALPHA1} {ORGANIZATION_KIND}"
+            ))
+        })
+    }
+}

--- a/crates/rise-resource-store-postgres/src/admission/reference.rs
+++ b/crates/rise-resource-store-postgres/src/admission/reference.rs
@@ -1,0 +1,385 @@
+//! Same-transaction resolution of the references a policy binding carries.
+//!
+//! ADR-0001 §4 makes both of a binding's references resolvable facts rather
+//! than free-form strings: a `Scope` names a real node in the resource tree,
+//! and a `roleRef` names a real policy object at a placement the binding is
+//! allowed to reach. Resolving them here — inside the write transaction, under
+//! `FOR SHARE` — is what makes a stored binding mean the same thing when the
+//! authorization engine later reads it back.
+
+use rise_resource_api::{
+    BindingSubject, ResourceDefinitionSpec, Scope, StoreError, SubjectId, API_GROUP,
+    CONTROLLER_KIND, GROUP_KIND, MAX_PARENT_CHAIN_DEPTH, ORGANIZATION_KIND, SERVICE_ACCOUNT_KIND,
+    USER_KIND,
+};
+use sqlx::{PgConnection, Row};
+use uuid::Uuid;
+
+use crate::builtin::BuiltInRegistry;
+use crate::models::PgResourceRow;
+
+/// One resolved node of a `Scope` path.
+pub(crate) struct ScopeNode {
+    pub(crate) uid: Uuid,
+    pub(crate) kind: String,
+    pub(crate) name: String,
+}
+
+/// A fully resolved, non-wildcard `Scope`: every ancestor root-first, then the
+/// leaf the scope names.
+pub(crate) struct ResolvedScope {
+    nodes: Vec<ScopeNode>,
+}
+
+impl ResolvedScope {
+    /// The outermost ancestor. For an org-contained scope this is the
+    /// Organization the whole path hangs under, which is what both containment
+    /// rules are stated against.
+    pub(crate) fn root(&self) -> &ScopeNode {
+        self.nodes
+            .first()
+            .expect("a resolved scope always has at least its leaf")
+    }
+}
+
+/// Resolve a non-wildcard `Scope` against live rows, locking each node against
+/// concurrent deletion for the rest of the transaction.
+///
+/// The caller handles `*` before calling: a wildcard names no node.
+pub(crate) async fn resolve_scope(
+    conn: &mut PgConnection,
+    builtins: &BuiltInRegistry,
+    scope: &Scope,
+) -> Result<ResolvedScope, StoreError> {
+    let resource_kind = scope
+        .resource_kind()
+        .ok_or_else(|| StoreError::Validation("a wildcard scope names no resource".into()))?;
+    let chain = kind_chain(conn, builtins, resource_kind.group(), resource_kind.kind()).await?;
+
+    let names: Vec<&str> = scope.names().collect();
+    if names.len() != chain.len() {
+        return Err(StoreError::Validation(format!(
+            "scope '{scope}' must name {} ancestor(s) and then its own name; got {}",
+            chain.len().saturating_sub(1),
+            names.len()
+        )));
+    }
+
+    // Root-first, so each step already holds its parent's UID. This is also the
+    // order `validate_builtin_placement` leaves the parent chain locked in for
+    // a built-in write, keeping one direction of traversal across admission.
+    let mut nodes: Vec<ScopeNode> = Vec::with_capacity(chain.len());
+    let mut parent_uid: Option<Uuid> = None;
+    for ((group, kind), name) in chain.iter().zip(&names) {
+        let row = live_row_by_name(conn, group, kind, name, parent_uid).await?;
+        let Some(row) = row else {
+            return Err(StoreError::Validation(format!(
+                "scope '{scope}' must identify a live resource; no {group}/{kind} named '{name}' exists at that position"
+            )));
+        };
+        parent_uid = Some(row.uid);
+        nodes.push(ScopeNode {
+            uid: row.uid,
+            kind: row.kind,
+            name: row.name,
+        });
+    }
+
+    Ok(ResolvedScope { nodes })
+}
+
+/// Every `(group, kind)` from the scope's leaf up to its root ancestor,
+/// returned root-first.
+///
+/// Built-in kinds resolve through the immutable registry; external kinds
+/// through their `ResourceDefinition`. A scope may therefore target any
+/// registered kind, which is what lets a binding reach product resources once
+/// they migrate onto the generic store.
+async fn kind_chain(
+    conn: &mut PgConnection,
+    builtins: &BuiltInRegistry,
+    group: &str,
+    kind: &str,
+) -> Result<Vec<(String, String)>, StoreError> {
+    let mut chain: Vec<(String, String)> = Vec::new();
+    let mut current = (group.to_owned(), kind.to_owned());
+    loop {
+        if chain.len() >= MAX_PARENT_CHAIN_DEPTH {
+            return Err(StoreError::Validation(format!(
+                "scope kind '{group}/{kind}' exceeds the maximum parent chain depth"
+            )));
+        }
+        let parent = parent_of_kind(conn, builtins, &current.0, &current.1).await?;
+        chain.push(current);
+        match parent {
+            Some(parent) => current = parent,
+            None => break,
+        }
+    }
+    chain.reverse();
+    Ok(chain)
+}
+
+/// The declared parent `(group, kind)` of one registered kind, or `None` when
+/// the kind is root-scoped.
+async fn parent_of_kind(
+    conn: &mut PgConnection,
+    builtins: &BuiltInRegistry,
+    group: &str,
+    kind: &str,
+) -> Result<Option<(String, String)>, StoreError> {
+    if let Some(registration) = builtins.lookup_by_group_kind(group, kind) {
+        return registration
+            .parent
+            .as_ref()
+            .map(|parent| split_group(&parent.api_version, &parent.kind))
+            .transpose();
+    }
+
+    let row = sqlx::query(
+        r#"
+        SELECT resource.spec
+        FROM resource_store.resource_definitions definition
+        JOIN resource_store.resources resource ON resource.uid = definition.uid
+        WHERE definition.group_name = $1 AND definition.kind = $2
+        "#,
+    )
+    .bind(group)
+    .bind(kind)
+    .fetch_optional(&mut *conn)
+    .await
+    .map_err(StoreError::backend)?
+    .ok_or_else(|| {
+        StoreError::Validation(format!("scope names unknown ResourceKind '{group}/{kind}'"))
+    })?;
+
+    let spec: ResourceDefinitionSpec = serde_json::from_value(
+        row.try_get("spec").map_err(StoreError::backend)?,
+    )
+    .map_err(|error| {
+        StoreError::Validation(format!(
+            "ResourceDefinition for '{group}/{kind}' has an invalid spec: {error}"
+        ))
+    })?;
+
+    spec.parent
+        .as_ref()
+        .map(|parent| split_group(&parent.api_version, &parent.kind))
+        .transpose()
+}
+
+fn split_group(api_version: &str, kind: &str) -> Result<(String, String), StoreError> {
+    let (group, _) = api_version.split_once('/').ok_or_else(|| {
+        StoreError::Validation(format!(
+            "parent reference '{api_version}' is not '<group>/<version>'"
+        ))
+    })?;
+    Ok((group.to_owned(), kind.to_owned()))
+}
+
+/// Look up one live row by API group, kind, name, and parent, holding it for
+/// the rest of the transaction.
+///
+/// Matching on the API *group* rather than the full `api_version` mirrors
+/// `get_by_name`: a scope is version-independent (ADR-0001 §8), so it resolves
+/// the row whichever declared version it is stored at.
+async fn live_row_by_name(
+    conn: &mut PgConnection,
+    group: &str,
+    kind: &str,
+    name: &str,
+    parent_uid: Option<Uuid>,
+) -> Result<Option<PgResourceRow>, StoreError> {
+    let row = match parent_uid {
+        None => {
+            sqlx::query_as::<_, PgResourceRow>(
+                r#"
+                SELECT *
+                FROM resource_store.resources
+                WHERE split_part(api_version, '/', 1) = $1
+                  AND kind = $2
+                  AND name = $3
+                  AND parent_uid IS NULL
+                  AND deletion_timestamp IS NULL
+                FOR SHARE
+                "#,
+            )
+            .bind(group)
+            .bind(kind)
+            .bind(name)
+            .fetch_optional(&mut *conn)
+            .await
+        }
+        Some(parent_uid) => {
+            sqlx::query_as::<_, PgResourceRow>(
+                r#"
+                SELECT *
+                FROM resource_store.resources
+                WHERE split_part(api_version, '/', 1) = $1
+                  AND kind = $2
+                  AND name = $3
+                  AND parent_uid = $4
+                  AND deletion_timestamp IS NULL
+                FOR SHARE
+                "#,
+            )
+            .bind(group)
+            .bind(kind)
+            .bind(name)
+            .bind(parent_uid)
+            .fetch_optional(&mut *conn)
+            .await
+        }
+    };
+    row.map_err(StoreError::backend)
+}
+
+/// Resolve one live policy object by name at an exact placement.
+///
+/// `parent_uid` is `None` for the root-parented `PlatformRole` and the owning
+/// Organization's UID for an org `Role`. Placement is part of the lookup, not
+/// a check after it: that is what makes ADR-0001's "references are never
+/// resolved by bare-name fallback" structural — an org's own `Role` named
+/// `resource-owner` is simply not a candidate for a `{ kind: PlatformRole }`
+/// reference.
+pub(crate) async fn resolve_policy_ref(
+    conn: &mut PgConnection,
+    api_version: &str,
+    kind: &str,
+    name: &str,
+    parent_uid: Option<Uuid>,
+) -> Result<PgResourceRow, StoreError> {
+    let (group, _) = api_version.split_once('/').ok_or_else(|| {
+        StoreError::Validation(format!(
+            "built-in api_version '{api_version}' is not '<group>/<version>'"
+        ))
+    })?;
+    live_row_by_name(conn, group, kind, name, parent_uid)
+        .await?
+        .ok_or_else(|| {
+            StoreError::Validation(match parent_uid {
+                Some(_) => format!("roleRef must identify a live {kind} named '{name}' in this binding's own Organization"),
+                None => format!("roleRef must identify a live root-scoped {kind} named '{name}'"),
+            })
+        })
+}
+
+/// One resolved Organization, kept so a caller that both resolves an
+/// org-native subject and checks containment reads the row once.
+pub(crate) struct ResolvedOrganization {
+    pub(crate) uid: Uuid,
+    pub(crate) name: String,
+}
+
+/// Resolve a binding's literal subject against live rows.
+///
+/// `SubjectId` parsing is syntax only; ADR-0001 requires the identity a
+/// literal subject names to exist at policy write time, so a typo in a Group
+/// or User name fails the write instead of silently producing a binding that
+/// can never match. Returns the subject's Organization when the subject is
+/// org-native, because the platform containment rule is stated against it.
+///
+/// A dynamic template resolves per-resource at evaluation time and has nothing
+/// to look up here. `system:authenticated` names a population rather than a
+/// row; `system:operators` never reaches this point.
+pub(crate) async fn resolve_binding_subject(
+    conn: &mut PgConnection,
+    subject: &BindingSubject,
+) -> Result<Option<ResolvedOrganization>, StoreError> {
+    let Some(literal) = subject.literal() else {
+        return Ok(None);
+    };
+    let name = literal.name();
+    match literal.kind() {
+        "system" => Ok(None),
+        "user" => {
+            resolve_subject_row(conn, USER_KIND, name, None, literal).await?;
+            Ok(None)
+        }
+        "controller" => {
+            resolve_subject_row(conn, CONTROLLER_KIND, name, None, literal).await?;
+            Ok(None)
+        }
+        // `org:<name>` is a virtual predicate over that org's members rather
+        // than a stored identity, but the organization it predicates over must
+        // still exist.
+        "org" => {
+            resolve_subject_row(conn, ORGANIZATION_KIND, name, None, literal).await?;
+            Ok(None)
+        }
+        kind => {
+            let organization = literal.organization().ok_or_else(|| {
+                StoreError::Validation(format!("subject '{literal}' names no organization"))
+            })?;
+            let organization_row =
+                resolve_subject_row(conn, ORGANIZATION_KIND, organization, None, literal).await?;
+            let identity_kind = if kind == "group" {
+                GROUP_KIND
+            } else {
+                SERVICE_ACCOUNT_KIND
+            };
+            resolve_subject_row(
+                conn,
+                identity_kind,
+                name,
+                Some(organization_row.uid),
+                literal,
+            )
+            .await?;
+            Ok(Some(ResolvedOrganization {
+                uid: organization_row.uid,
+                name: organization_row.name,
+            }))
+        }
+    }
+}
+
+async fn resolve_subject_row(
+    conn: &mut PgConnection,
+    kind: &str,
+    name: &str,
+    parent_uid: Option<Uuid>,
+    subject: &SubjectId,
+) -> Result<PgResourceNode, StoreError> {
+    let row = live_row_by_name(conn, API_GROUP, kind, name, parent_uid)
+        .await?
+        .ok_or_else(|| {
+            StoreError::Validation(format!(
+                "subject '{subject}' must identify a live {kind} named '{name}'"
+            ))
+        })?;
+    Ok(PgResourceNode {
+        uid: row.uid,
+        name: row.name,
+    })
+}
+
+struct PgResourceNode {
+    uid: Uuid,
+    name: String,
+}
+
+/// Require a resolved scope to hang under one specific Organization.
+///
+/// Both of ADR-0001 §4's containment rules reduce to this: an org
+/// `RoleBinding` may not leave its parent org's subtree, and a
+/// `PlatformRoleBinding` naming a static org-native subject may not reach
+/// outside that subject's own org. A scope whose outermost node is not an
+/// Organization at all — a root-scoped kind such as `rise.dev/User/alice` —
+/// lies in no org subtree and fails the same way.
+pub(crate) fn require_scope_within_organization(
+    scope: &Scope,
+    resolved: &ResolvedScope,
+    organization_uid: Uuid,
+    organization_name: &str,
+    explanation: &str,
+) -> Result<(), StoreError> {
+    let root = resolved.root();
+    if root.kind == ORGANIZATION_KIND && root.uid == organization_uid {
+        return Ok(());
+    }
+    Err(StoreError::Validation(format!(
+        "scope '{scope}' resolves under {} '{}', not Organization '{organization_name}'; {explanation}",
+        root.kind, root.name
+    )))
+}

--- a/crates/rise-resource-store-postgres/src/builtin.rs
+++ b/crates/rise-resource-store-postgres/src/builtin.rs
@@ -1,9 +1,9 @@
 //! Built-in resource registry.
 //!
-//! Rise's structural and identity built-ins are first-class resource kinds
-//! owned by Rise itself: they have typed Rust validators, their identity (group,
-//! version, kind, plural) is fixed at compile time, and they have no row in
-//! the `resource_definitions` projection table. Routing for these kinds is
+//! Rise's structural, identity, and policy built-ins are first-class resource
+//! kinds owned by Rise itself: they have typed Rust validators, their identity
+//! (group, version, kind, plural) is fixed at compile time, and they have no row
+//! in the `resource_definitions` projection table. Routing for these kinds is
 //! resolved through this registry instead of through the database.
 //!
 //! The registry is the single source of truth for "what built-ins does this
@@ -17,12 +17,12 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use rise_resource_api::{
-    CollectionInfo, ResourceParentRef, SpecValidator, API_VERSION_V1ALPHA1,
-    IDENTITY_KIND_DEFINITIONS, ORGANIZATION_COLLECTION, ORGANIZATION_KIND,
+    BuiltInKindDefinition, CollectionInfo, ResourceParentRef, SpecValidator, API_VERSION_V1ALPHA1,
+    IDENTITY_KIND_DEFINITIONS, ORGANIZATION_COLLECTION, ORGANIZATION_KIND, POLICY_KIND_DEFINITIONS,
     RESOURCE_DEFINITION_COLLECTION, RESOURCE_DEFINITION_KIND,
 };
 
-use crate::admission::{IdentityAdmission, IdentitySpecValidator};
+use crate::admission::{BuiltInAdmission, BuiltInSpecValidator};
 use crate::validation::{OrganizationValidator, ResourceDefinitionValidator};
 
 /// Static description of one built-in resource kind.
@@ -131,22 +131,30 @@ impl BuiltInRegistry {
             parent: None,
             spec_validator: Arc::new(ResourceDefinitionValidator),
         });
-        for definition in IDENTITY_KIND_DEFINITIONS {
-            let admission =
-                IdentityAdmission::for_identity(definition.api_version, definition.kind)
-                    .expect("every identity definition has typed admission");
-            r.register(BuiltInRegistration {
-                collection: definition.collection,
-                api_version: definition.api_version,
-                kind: definition.kind,
-                parent: definition.parent.map(|parent| ResourceParentRef {
-                    api_version: parent.api_version.to_string(),
-                    kind: parent.kind.to_string(),
-                }),
-                spec_validator: Arc::new(IdentitySpecValidator(admission)),
-            });
+        for definition in IDENTITY_KIND_DEFINITIONS
+            .iter()
+            .chain(&POLICY_KIND_DEFINITIONS)
+        {
+            r.register(Self::admitted(definition));
         }
         r
+    }
+
+    /// Build the registration for a built-in whose contract is enforced by the
+    /// typed admission seam rather than by a JSON Schema.
+    fn admitted(definition: &BuiltInKindDefinition) -> BuiltInRegistration {
+        let admission = BuiltInAdmission::for_kind(definition.api_version, definition.kind)
+            .expect("every identity and policy definition has typed admission");
+        BuiltInRegistration {
+            collection: definition.collection,
+            api_version: definition.api_version,
+            kind: definition.kind,
+            parent: definition.parent.map(|parent| ResourceParentRef {
+                api_version: parent.api_version.to_string(),
+                kind: parent.kind.to_string(),
+            }),
+            spec_validator: Arc::new(BuiltInSpecValidator(admission)),
+        }
     }
 
     /// Insert a registration. Panics on:
@@ -240,20 +248,35 @@ mod tests {
     use super::*;
 
     #[test]
-    fn defaults_register_structural_and_identity_builtins() {
+    fn defaults_register_structural_identity_and_policy_builtins() {
         let r = BuiltInRegistry::defaults();
-        assert_eq!(r.len(), 2 + IDENTITY_KIND_DEFINITIONS.len());
+        assert_eq!(
+            r.len(),
+            2 + IDENTITY_KIND_DEFINITIONS.len() + POLICY_KIND_DEFINITIONS.len()
+        );
         assert!(r.lookup_collection(ORGANIZATION_COLLECTION).is_some());
         assert!(r
             .lookup_collection(RESOURCE_DEFINITION_COLLECTION)
             .is_some());
         assert!(r.lookup_collection("unknown").is_none());
-        for definition in IDENTITY_KIND_DEFINITIONS {
+        for definition in IDENTITY_KIND_DEFINITIONS
+            .iter()
+            .chain(&POLICY_KIND_DEFINITIONS)
+        {
             let registration = r
                 .lookup_collection(definition.collection)
-                .expect("identity collection is active");
+                .expect("built-in collection is active");
             assert_eq!(registration.api_version, definition.api_version);
             assert_eq!(registration.kind, definition.kind);
+            assert_eq!(
+                registration
+                    .parent
+                    .as_ref()
+                    .map(|parent| (parent.api_version.as_str(), parent.kind.as_str())),
+                definition
+                    .parent
+                    .map(|parent| (parent.api_version, parent.kind))
+            );
         }
     }
 
@@ -369,6 +392,7 @@ mod tests {
         expected.extend(
             IDENTITY_KIND_DEFINITIONS
                 .iter()
+                .chain(&POLICY_KIND_DEFINITIONS)
                 .map(|definition| definition.collection),
         );
         expected.sort_unstable();

--- a/crates/rise-resource-store-postgres/src/pg_store.rs
+++ b/crates/rise-resource-store-postgres/src/pg_store.rs
@@ -12,7 +12,7 @@ use rise_resource_api::{
 };
 use sqlx::{PgPool, Row};
 
-use crate::admission::IdentityAdmission;
+use crate::admission::BuiltInAdmission;
 use crate::builtin::{BuiltInRegistration, BuiltInRegistry};
 use crate::discriminator;
 use crate::models::PgResourceRow;
@@ -868,7 +868,7 @@ impl ResourceStore for PgResourceStore {
         let builtin = self.builtin_for_write(&params.api_version, &params.kind)?;
         if let Some(registration) = builtin {
             if let Some(admission) =
-                IdentityAdmission::for_identity(registration.api_version, registration.kind)
+                BuiltInAdmission::for_kind(registration.api_version, registration.kind)
             {
                 params.spec = admission.canonicalize(&params.spec)?;
             }
@@ -897,9 +897,11 @@ impl ResourceStore for PgResourceStore {
             self.validate_builtin_placement(&mut tx, registration, params.parent_uid)
                 .await?;
             if let Some(admission) =
-                IdentityAdmission::for_identity(registration.api_version, registration.kind)
+                BuiltInAdmission::for_kind(registration.api_version, registration.kind)
             {
-                admission.admit_create_context(&mut tx, &params).await?;
+                admission
+                    .admit_create_context(&mut tx, &self.builtins, &mut params)
+                    .await?;
             }
         }
 
@@ -1074,7 +1076,7 @@ impl ResourceStore for PgResourceStore {
         }
         if let Some(registration) = preflight_current_builtin {
             if let Some(admission) =
-                IdentityAdmission::for_identity(registration.api_version, registration.kind)
+                BuiltInAdmission::for_kind(registration.api_version, registration.kind)
             {
                 params.spec = admission.canonicalize(&params.spec)?;
             }
@@ -1137,10 +1139,10 @@ impl ResourceStore for PgResourceStore {
             self.validate_builtin_placement(&mut tx, registration, snapshot.parent_uid)
                 .await?;
             if let Some(admission) =
-                IdentityAdmission::for_identity(registration.api_version, registration.kind)
+                BuiltInAdmission::for_kind(registration.api_version, registration.kind)
             {
                 admission
-                    .admit_update_before_dependent(&mut tx, &snapshot, &params)
+                    .admit_update_before_dependent(&mut tx, &self.builtins, &snapshot, &mut params)
                     .await?;
             }
         }
@@ -1199,7 +1201,7 @@ impl ResourceStore for PgResourceStore {
         // another writer may have committed between the snapshot and this lock.
         if let Some(registration) = current_builtin {
             if let Some(admission) =
-                IdentityAdmission::for_identity(registration.api_version, registration.kind)
+                BuiltInAdmission::for_kind(registration.api_version, registration.kind)
             {
                 admission.validate_update_immutable(&current, &params)?;
             }

--- a/crates/rise-resource-store-postgres/tests/integration_tests.rs
+++ b/crates/rise-resource-store-postgres/tests/integration_tests.rs
@@ -3,7 +3,8 @@ use rise_resource_api::{
     PathSegment, ResourceRow, ResourceStore, StoreError, UpdateResourceParams,
     API_VERSION_V1ALPHA1, CASCADE_DELETION_FINALIZER, CONTROLLER_KIND,
     CONTROLLER_TRUST_POLICY_KIND, GROUP_KIND, GROUP_MEMBERSHIP_KIND, IDENTITY_KIND_DEFINITIONS,
-    ORGANIZATION_KIND, RESOURCE_DEFINITION_KIND, SERVICE_ACCOUNT_KIND,
+    ORGANIZATION_KIND, PLATFORM_ROLE_BINDING_KIND, PLATFORM_ROLE_KIND, POLICY_KIND_DEFINITIONS,
+    RESOURCE_DEFINITION_KIND, ROLE_BINDING_KIND, ROLE_KIND, SERVICE_ACCOUNT_KIND,
     SERVICE_ACCOUNT_TRUST_POLICY_KIND, USER_IDENTITY_KIND, USER_KIND,
 };
 use rise_resource_store_postgres::{
@@ -3044,7 +3045,7 @@ async fn resolve_path_empty_returns_error(pool: sqlx::PgPool) -> sqlx::Result<()
     Ok(())
 }
 
-async fn create_identity_resource(
+async fn create_builtin_resource(
     store: &PgResourceStore,
     kind: &str,
     name: &str,
@@ -3134,7 +3135,7 @@ async fn builtin_placement_rejects_nonroot_organizations_and_malformed_parent_ch
     .await?;
 
     for kind in [GROUP_KIND, SERVICE_ACCOUNT_KIND] {
-        let error = create_identity_resource(
+        let error = create_builtin_resource(
             &store,
             kind,
             &format!("malformed-{}", kind.to_ascii_lowercase()),
@@ -3156,10 +3157,9 @@ async fn create_with_owner_reference_obeys_the_global_graph_lock_order(
     pool: sqlx::PgPool,
 ) -> sqlx::Result<()> {
     let store = Arc::new(PgResourceStore::new(pool.clone()));
-    let owner =
-        create_identity_resource(&store, USER_KIND, "create-owner", None, json!({}), vec![])
-            .await
-            .unwrap();
+    let owner = create_builtin_resource(&store, USER_KIND, "create-owner", None, json!({}), vec![])
+        .await
+        .unwrap();
     store
         .register_resource_definition(CreateResourceParams {
             api_version: API_VERSION_V1ALPHA1.into(),
@@ -3258,7 +3258,7 @@ async fn identity_admission_is_unbypassable_and_persists_canonical_defaults(
     assert_eq!(user.spec, json!({"active": true}));
 
     let org = create_org(&store, "acme").await;
-    let wrong_parent = create_identity_resource(
+    let wrong_parent = create_builtin_resource(
         &store,
         USER_IDENTITY_KIND,
         "primary",
@@ -3272,7 +3272,7 @@ async fn identity_admission_is_unbypassable_and_persists_canonical_defaults(
         matches!(wrong_parent, StoreError::Validation(message) if message.contains("live rise.dev/v1alpha1 User"))
     );
 
-    let malformed = create_identity_resource(
+    let malformed = create_builtin_resource(
         &store,
         USER_IDENTITY_KIND,
         "malformed",
@@ -3361,17 +3361,17 @@ async fn user_identity_uniqueness_is_live_global_and_concurrency_authoritative(
     pool: sqlx::PgPool,
 ) -> sqlx::Result<()> {
     let store = Arc::new(PgResourceStore::new(pool.clone()));
-    let user_a = create_identity_resource(&store, USER_KIND, "user-a", None, json!({}), vec![])
+    let user_a = create_builtin_resource(&store, USER_KIND, "user-a", None, json!({}), vec![])
         .await
         .unwrap();
-    let user_b = create_identity_resource(&store, USER_KIND, "user-b", None, json!({}), vec![])
+    let user_b = create_builtin_resource(&store, USER_KIND, "user-b", None, json!({}), vec![])
         .await
         .unwrap();
 
     let a = {
         let store = store.clone();
         tokio::spawn(async move {
-            create_identity_resource(
+            create_builtin_resource(
                 &store,
                 USER_IDENTITY_KIND,
                 "mapping-a",
@@ -3385,7 +3385,7 @@ async fn user_identity_uniqueness_is_live_global_and_concurrency_authoritative(
     let b = {
         let store = store.clone();
         tokio::spawn(async move {
-            create_identity_resource(
+            create_builtin_resource(
                 &store,
                 USER_IDENTITY_KIND,
                 "mapping-b",
@@ -3424,7 +3424,7 @@ async fn user_identity_uniqueness_is_live_global_and_concurrency_authoritative(
     assert!(matches!(immutable, StoreError::Validation(message) if message.contains("immutable")));
 
     store.delete(winner.uid).await.unwrap();
-    let replacement = create_identity_resource(
+    let replacement = create_builtin_resource(
         &store,
         USER_IDENTITY_KIND,
         "replacement",
@@ -3469,7 +3469,7 @@ async fn membership_owner_rules_and_name_bound_reactivation_are_enforced(
 ) -> sqlx::Result<()> {
     let store = PgResourceStore::new(pool.clone());
     let org = create_org(&store, "membership-org").await;
-    let group = create_identity_resource(
+    let group = create_builtin_resource(
         &store,
         GROUP_KIND,
         "developers",
@@ -3479,7 +3479,7 @@ async fn membership_owner_rules_and_name_bound_reactivation_are_enforced(
     )
     .await
     .unwrap();
-    let group_owned = create_identity_resource(
+    let group_owned = create_builtin_resource(
         &store,
         GROUP_KIND,
         "managed",
@@ -3489,7 +3489,7 @@ async fn membership_owner_rules_and_name_bound_reactivation_are_enforced(
     )
     .await
     .unwrap();
-    let group_second = create_identity_resource(
+    let group_second = create_builtin_resource(
         &store,
         GROUP_KIND,
         "second",
@@ -3499,14 +3499,14 @@ async fn membership_owner_rules_and_name_bound_reactivation_are_enforced(
     )
     .await
     .unwrap();
-    let user = create_identity_resource(&store, USER_KIND, "member", None, json!({}), vec![])
+    let user = create_builtin_resource(&store, USER_KIND, "member", None, json!({}), vec![])
         .await
         .unwrap();
-    let other = create_identity_resource(&store, USER_KIND, "other", None, json!({}), vec![])
+    let other = create_builtin_resource(&store, USER_KIND, "other", None, json!({}), vec![])
         .await
         .unwrap();
 
-    let unowned = create_identity_resource(
+    let unowned = create_builtin_resource(
         &store,
         GROUP_MEMBERSHIP_KIND,
         "member",
@@ -3516,7 +3516,7 @@ async fn membership_owner_rules_and_name_bound_reactivation_are_enforced(
     )
     .await
     .unwrap();
-    create_identity_resource(
+    create_builtin_resource(
         &store,
         GROUP_MEMBERSHIP_KIND,
         "member",
@@ -3528,7 +3528,7 @@ async fn membership_owner_rules_and_name_bound_reactivation_are_enforced(
     .unwrap();
     let wrong_owner =
         OwnerReference::new(API_VERSION_V1ALPHA1, USER_KIND, "other", other.uid).unwrap();
-    assert!(create_identity_resource(
+    assert!(create_builtin_resource(
         &store,
         GROUP_MEMBERSHIP_KIND,
         "member",
@@ -3540,7 +3540,7 @@ async fn membership_owner_rules_and_name_bound_reactivation_are_enforced(
     .is_err());
 
     let owner = OwnerReference::new("rise.dev/v9", USER_KIND, "member", user.uid).unwrap();
-    let owned = create_identity_resource(
+    let owned = create_builtin_resource(
         &store,
         GROUP_MEMBERSHIP_KIND,
         "member",
@@ -3581,7 +3581,7 @@ async fn membership_owner_rules_and_name_bound_reactivation_are_enforced(
         .await
         .unwrap()
         .is_empty());
-    let recreated = create_identity_resource(&store, USER_KIND, "member", None, json!({}), vec![])
+    let recreated = create_builtin_resource(&store, USER_KIND, "member", None, json!({}), vec![])
         .await
         .unwrap();
     store
@@ -3627,7 +3627,7 @@ async fn narrow_identity_trust_and_membership_lookups_filter_live_builtin_facts(
     pool: sqlx::PgPool,
 ) -> sqlx::Result<()> {
     let store = PgResourceStore::new(pool.clone());
-    let user = create_identity_resource(
+    let user = create_builtin_resource(
         &store,
         USER_KIND,
         "lookup-user",
@@ -3637,7 +3637,7 @@ async fn narrow_identity_trust_and_membership_lookups_filter_live_builtin_facts(
     )
     .await
     .unwrap();
-    let identity = create_identity_resource(
+    let identity = create_builtin_resource(
         &store,
         USER_IDENTITY_KIND,
         "login",
@@ -3661,11 +3661,11 @@ async fn narrow_identity_trust_and_membership_lookups_filter_live_builtin_facts(
     assert!(!fact.user.active);
 
     let controller =
-        create_identity_resource(&store, CONTROLLER_KIND, "builder", None, json!({}), vec![])
+        create_builtin_resource(&store, CONTROLLER_KIND, "builder", None, json!({}), vec![])
             .await
             .unwrap();
     for name in ["github-a", "github-b"] {
-        create_identity_resource(
+        create_builtin_resource(
             &store,
             CONTROLLER_TRUST_POLICY_KIND,
             name,
@@ -3676,7 +3676,7 @@ async fn narrow_identity_trust_and_membership_lookups_filter_live_builtin_facts(
         .await
         .unwrap();
     }
-    let deleted = create_identity_resource(
+    let deleted = create_builtin_resource(
         &store,
         CONTROLLER_TRUST_POLICY_KIND,
         "deleted",
@@ -3742,7 +3742,7 @@ async fn narrow_identity_trust_and_membership_lookups_filter_live_builtin_facts(
         .is_empty());
 
     let org = create_org(&store, "trust-org").await;
-    let service_account = create_identity_resource(
+    let service_account = create_builtin_resource(
         &store,
         SERVICE_ACCOUNT_KIND,
         "deployer",
@@ -3752,7 +3752,7 @@ async fn narrow_identity_trust_and_membership_lookups_filter_live_builtin_facts(
     )
     .await
     .unwrap();
-    create_identity_resource(
+    create_builtin_resource(
         &store,
         SERVICE_ACCOUNT_TRUST_POLICY_KIND,
         "ci",
@@ -3878,7 +3878,7 @@ async fn membership_create_racing_user_delete_never_leaves_a_live_dangling_edge(
 ) -> sqlx::Result<()> {
     let store = Arc::new(PgResourceStore::new(pool.clone()));
     let org = create_org(&store, "race-org").await;
-    let group = create_identity_resource(
+    let group = create_builtin_resource(
         &store,
         GROUP_KIND,
         "race-group",
@@ -3888,7 +3888,7 @@ async fn membership_create_racing_user_delete_never_leaves_a_live_dangling_edge(
     )
     .await
     .unwrap();
-    let user = create_identity_resource(&store, USER_KIND, "race-user", None, json!({}), vec![])
+    let user = create_builtin_resource(&store, USER_KIND, "race-user", None, json!({}), vec![])
         .await
         .unwrap();
     let owner =
@@ -3901,7 +3901,7 @@ async fn membership_create_racing_user_delete_never_leaves_a_live_dangling_edge(
         let barrier = barrier.clone();
         tokio::spawn(async move {
             barrier.wait().await;
-            create_identity_resource(
+            create_builtin_resource(
                 &store,
                 GROUP_MEMBERSHIP_KIND,
                 "race-user",
@@ -3955,13 +3955,13 @@ async fn maximum_identity_index_keys_fit_and_projection_queries_use_their_indexe
     pool: sqlx::PgPool,
 ) -> sqlx::Result<()> {
     let store = PgResourceStore::new(pool.clone());
-    let user = create_identity_resource(&store, USER_KIND, "max-key", None, json!({}), vec![])
+    let user = create_builtin_resource(&store, USER_KIND, "max-key", None, json!({}), vec![])
         .await
         .unwrap();
     let issuer = format!("https://issuer.example/{}", "a".repeat(1000));
     assert!(issuer.len() <= rise_resource_api::MAX_ISSUER_BYTES);
     let subject = "🦀".repeat(rise_resource_api::MAX_EXTERNAL_SUBJECT_CHARS);
-    create_identity_resource(
+    create_builtin_resource(
         &store,
         USER_IDENTITY_KIND,
         "max-key-login",
@@ -4034,5 +4034,1099 @@ async fn maximum_identity_index_keys_fit_and_projection_queries_use_their_indexe
     assert!(membership_plan
         .join("\n")
         .contains("group_memberships_user_name"));
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Policy resources (ADR-0001 §3, §4)
+// ---------------------------------------------------------------------------
+
+async fn create_platform_role(store: &PgResourceStore, name: &str) -> ResourceRow {
+    create_builtin_resource(store, PLATFORM_ROLE_KIND, name, None, json!({}), vec![])
+        .await
+        .unwrap()
+}
+
+async fn create_role(store: &PgResourceStore, organization: Uuid, name: &str) -> ResourceRow {
+    create_builtin_resource(
+        store,
+        ROLE_KIND,
+        name,
+        Some(organization),
+        json!({}),
+        vec![],
+    )
+    .await
+    .unwrap()
+}
+
+async fn create_binding(
+    store: &PgResourceStore,
+    kind: &str,
+    name: &str,
+    parent_uid: Option<Uuid>,
+    spec: serde_json::Value,
+) -> Result<ResourceRow, StoreError> {
+    create_builtin_resource(store, kind, name, parent_uid, spec, vec![]).await
+}
+
+/// An Organization-parented external kind, so scope resolution is exercised
+/// against a `ResourceDefinition` parent chain and not only built-in kinds.
+async fn register_org_widget_rd(store: &PgResourceStore) {
+    store
+        .register_resource_definition(CreateResourceParams {
+            api_version: API_VERSION_V1ALPHA1.to_string(),
+            kind: RESOURCE_DEFINITION_KIND.to_string(),
+            name: "orgwidgets.example.dev".to_string(),
+            spec: json!({
+                "group": "example.dev",
+                "kind": "OrgWidget",
+                "plural": "orgwidgets",
+                "parent": {"apiVersion": API_VERSION_V1ALPHA1, "kind": ORGANIZATION_KIND},
+                "versions": [{"name": "v1", "served": true, "storage": true}],
+                "allowedStatusControllerIds": []
+            }),
+            ..Default::default()
+        })
+        .await
+        .expect("org widget definition registers");
+}
+
+/// `UpdateResourceParams` has no `Default` (a caller must state the revision it
+/// expects), so policy update tests build one through this.
+fn update_spec(revision: i64, spec: serde_json::Value) -> UpdateResourceParams {
+    UpdateResourceParams {
+        api_version: None,
+        revision,
+        annotations: BTreeMap::new(),
+        finalizers: vec![],
+        owner_references: vec![],
+        spec,
+        validator: None,
+    }
+}
+
+#[sqlx::test]
+async fn policy_routes_and_placement_are_activated_from_contract_definitions(
+    pool: sqlx::PgPool,
+) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    for definition in POLICY_KIND_DEFINITIONS {
+        let info = store
+            .resolve_collection(definition.collection)
+            .await
+            .unwrap()
+            .expect("policy collection is routed");
+        assert_eq!(info.api_version, definition.api_version);
+        assert_eq!(info.kind, definition.kind);
+        assert_eq!(
+            info.parent
+                .as_ref()
+                .map(|parent| (parent.api_version.as_str(), parent.kind.as_str())),
+            definition
+                .parent
+                .map(|parent| (parent.api_version, parent.kind))
+        );
+    }
+
+    // The org pair is Organization-parented and the platform pair is root-scoped.
+    assert!(store
+        .resolve_collection("roles")
+        .await
+        .unwrap()
+        .unwrap()
+        .parent
+        .is_some());
+    assert!(store
+        .resolve_collection("platformroles")
+        .await
+        .unwrap()
+        .unwrap()
+        .parent
+        .is_none());
+
+    // Another version of a reserved policy identity is not silently treated as
+    // a custom resource.
+    assert!(store
+        .resolve_collection_version("rise.dev", "v2", "rolebindings")
+        .await
+        .unwrap()
+        .is_none());
+    Ok(())
+}
+
+#[sqlx::test]
+async fn policy_admission_normalizes_bindings_and_is_unbypassable(
+    pool: sqlx::PgPool,
+) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    let acme = create_org(&store, "acme").await;
+    create_platform_role(&store, "resource-owner").await;
+    create_role(&store, acme.uid, "deploy-viewer").await;
+    create_builtin_resource(&store, USER_KIND, "alice", None, json!({}), vec![])
+        .await
+        .unwrap();
+
+    // A Role body is context-free: `statements` defaults, and the canonical
+    // form is what gets persisted.
+    let role = store
+        .get_by_name(
+            API_VERSION_V1ALPHA1,
+            ROLE_KIND,
+            "deploy-viewer",
+            Some(acme.uid),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(role.spec, json!({"statements": []}));
+
+    // An org binding's omitted scope becomes its parent Organization's scope,
+    // and a caller-supplied validator cannot suppress that normalization.
+    let binding = store
+        .create(CreateResourceParams {
+            api_version: API_VERSION_V1ALPHA1.into(),
+            kind: ROLE_BINDING_KIND.into(),
+            name: "alice-viewer".into(),
+            parent_uid: Some(acme.uid),
+            spec: json!({
+                "subject": "user:alice",
+                "roleRef": {"kind": "Role", "name": "deploy-viewer"}
+            }),
+            validator: Some(Arc::new(NoOpValidator)),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        binding.spec,
+        json!({
+            "subject": "user:alice",
+            "scope": "rise.dev/Organization/acme",
+            "roleRef": {"kind": "Role", "name": "deploy-viewer"}
+        })
+    );
+
+    // Platform bindings persist the PascalCase membership enum; omission is Any.
+    let platform = create_binding(
+        &store,
+        PLATFORM_ROLE_BINDING_KIND,
+        "alice-platform",
+        None,
+        json!({
+            "subject": "user:alice",
+            "roleRef": {"kind": "PlatformRole", "name": "resource-owner"}
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        platform.spec,
+        json!({
+            "subject": "user:alice",
+            "subjectMembership": "Any",
+            "scope": "*",
+            "roleRef": {"kind": "PlatformRole", "name": "resource-owner"}
+        })
+    );
+
+    let constrained = create_binding(
+        &store,
+        PLATFORM_ROLE_BINDING_KIND,
+        "alice-members-only",
+        None,
+        json!({
+            "subject": "user:alice",
+            "subjectMembership": "ResourceOrganization",
+            "roleRef": {"kind": "PlatformRole", "name": "resource-owner"}
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        constrained.spec["subjectMembership"],
+        json!("ResourceOrganization")
+    );
+
+    // The closed schema: one lowercase `subject` field, no plural or
+    // capitalized spellings, and `subjectMembership` only on platform bindings.
+    for (kind, parent_uid, spec) in [
+        (
+            ROLE_BINDING_KIND,
+            Some(acme.uid),
+            json!({
+                "subjects": ["user:alice"],
+                "roleRef": {"kind": "Role", "name": "deploy-viewer"}
+            }),
+        ),
+        (
+            ROLE_BINDING_KIND,
+            Some(acme.uid),
+            json!({
+                "Subject": "user:alice",
+                "roleRef": {"kind": "Role", "name": "deploy-viewer"}
+            }),
+        ),
+        (
+            ROLE_BINDING_KIND,
+            Some(acme.uid),
+            json!({
+                "subject": "user:alice",
+                "subjectMembership": "Any",
+                "roleRef": {"kind": "Role", "name": "deploy-viewer"}
+            }),
+        ),
+        (
+            PLATFORM_ROLE_BINDING_KIND,
+            None,
+            json!({
+                "subject": "user:alice",
+                "subjectMembership": null,
+                "roleRef": {"kind": "PlatformRole", "name": "resource-owner"}
+            }),
+        ),
+        (
+            PLATFORM_ROLE_BINDING_KIND,
+            None,
+            json!({
+                "subject": "user:alice",
+                "subjectMembership": "any",
+                "roleRef": {"kind": "PlatformRole", "name": "resource-owner"}
+            }),
+        ),
+        (
+            PLATFORM_ROLE_BINDING_KIND,
+            None,
+            json!({
+                "subject": "user:alice",
+                "roleRef": {"kind": "Role", "name": "deploy-viewer"}
+            }),
+        ),
+    ] {
+        let error = create_binding(&store, kind, "rejected", parent_uid, spec.clone())
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(error, StoreError::Validation(_)),
+            "expected {kind} {spec} to be rejected"
+        );
+    }
+
+    // `system:operators` is reserved for the seeded bootstrap binding.
+    let reserved = create_binding(
+        &store,
+        PLATFORM_ROLE_BINDING_KIND,
+        "operators",
+        None,
+        json!({
+            "subject": "system:operators",
+            "roleRef": {"kind": "PlatformRole", "name": "resource-owner"}
+        }),
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        matches!(reserved, StoreError::Validation(message) if message.contains("system:operators"))
+    );
+
+    // A dynamic subject needs a selector to resolve against; a static one
+    // cannot pair with a value-less selector.
+    let dynamic = create_binding(
+        &store,
+        PLATFORM_ROLE_BINDING_KIND,
+        "dynamic",
+        None,
+        json!({
+            "subject": "group:${ref.name}",
+            "roleRef": {"kind": "PlatformRole", "name": "resource-owner"}
+        }),
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        matches!(dynamic, StoreError::Validation(message) if message.contains("labelSelector"))
+    );
+
+    let valueless = create_binding(
+        &store,
+        PLATFORM_ROLE_BINDING_KIND,
+        "valueless",
+        None,
+        json!({
+            "subject": "user:alice",
+            "labelSelector": {"key": "rise.dev/owner"},
+            "roleRef": {"kind": "PlatformRole", "name": "resource-owner"}
+        }),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(valueless, StoreError::Validation(_)));
+
+    // A dynamic subject resolves per-resource at evaluation time, so it needs
+    // no identity to exist now.
+    let templated = create_binding(
+        &store,
+        PLATFORM_ROLE_BINDING_KIND,
+        "owner-template",
+        None,
+        json!({
+            "subject": "${ref.subject}",
+            "labelSelector": {"key": "rise.dev/owner"},
+            "roleRef": {"kind": "PlatformRole", "name": "resource-owner"}
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(templated.spec["subject"], json!("${ref.subject}"));
+    Ok(())
+}
+
+#[sqlx::test]
+async fn policy_role_ref_resolves_by_kind_and_placement(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    let acme = create_org(&store, "acme").await;
+    let other = create_org(&store, "other").await;
+    create_builtin_resource(&store, USER_KIND, "alice", None, json!({}), vec![])
+        .await
+        .unwrap();
+    create_platform_role(&store, "resource-owner").await;
+    create_role(&store, acme.uid, "deploy-viewer").await;
+    create_role(&store, other.uid, "other-only").await;
+    // An org Role deliberately sharing a PlatformRole's name.
+    create_role(&store, acme.uid, "resource-owner").await;
+
+    let binding_spec = |kind: &str, name: &str| {
+        json!({
+            "subject": "user:alice",
+            "roleRef": {"kind": kind, "name": name}
+        })
+    };
+
+    // Own-org Role and any PlatformRole both resolve for an org binding.
+    for (index, (kind, name)) in [
+        ("Role", "deploy-viewer"),
+        ("PlatformRole", "resource-owner"),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        create_binding(
+            &store,
+            ROLE_BINDING_KIND,
+            &format!("ok-{index}"),
+            Some(acme.uid),
+            binding_spec(kind, name),
+        )
+        .await
+        .unwrap();
+    }
+
+    // Another organization's Role is not a candidate: references resolve by
+    // placement, never by bare name.
+    let cross_org = create_binding(
+        &store,
+        ROLE_BINDING_KIND,
+        "cross-org",
+        Some(acme.uid),
+        binding_spec("Role", "other-only"),
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        matches!(cross_org, StoreError::Validation(message) if message.contains("own Organization"))
+    );
+
+    let missing = create_binding(
+        &store,
+        ROLE_BINDING_KIND,
+        "missing",
+        Some(acme.uid),
+        binding_spec("PlatformRole", "does-not-exist"),
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        matches!(missing, StoreError::Validation(message) if message.contains("root-scoped PlatformRole"))
+    );
+
+    // The org Role named `resource-owner` shadows nothing: deleting the
+    // PlatformRole of that name breaks the PlatformRole reference even though a
+    // same-named org Role remains.
+    let platform_role = store
+        .get_by_name(
+            API_VERSION_V1ALPHA1,
+            PLATFORM_ROLE_KIND,
+            "resource-owner",
+            None,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    store.delete(platform_role.uid).await.unwrap();
+    let shadowed = create_binding(
+        &store,
+        ROLE_BINDING_KIND,
+        "shadowed",
+        Some(acme.uid),
+        binding_spec("PlatformRole", "resource-owner"),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(shadowed, StoreError::Validation(_)));
+
+    // A platform binding can only reference a PlatformRole; the closed enum
+    // rejects `Role` before any lookup happens.
+    let org_role_from_platform = create_binding(
+        &store,
+        PLATFORM_ROLE_BINDING_KIND,
+        "platform-org-role",
+        None,
+        binding_spec("Role", "deploy-viewer"),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(org_role_from_platform, StoreError::Validation(_)));
+    Ok(())
+}
+
+#[sqlx::test]
+async fn role_binding_scope_is_resolved_and_contained_by_its_organization(
+    pool: sqlx::PgPool,
+) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    let acme = create_org(&store, "acme").await;
+    let other = create_org(&store, "other").await;
+    create_builtin_resource(&store, USER_KIND, "alice", None, json!({}), vec![])
+        .await
+        .unwrap();
+    create_role(&store, acme.uid, "deploy-viewer").await;
+    create_builtin_resource(
+        &store,
+        GROUP_KIND,
+        "platform",
+        Some(acme.uid),
+        json!({}),
+        vec![],
+    )
+    .await
+    .unwrap();
+    register_org_widget_rd(&store).await;
+    store
+        .create(CreateResourceParams {
+            api_version: "example.dev/v1".into(),
+            kind: "OrgWidget".into(),
+            name: "w1".into(),
+            parent_uid: Some(acme.uid),
+            spec: json!({}),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    let with_scope = |scope: &str| {
+        json!({
+            "subject": "user:alice",
+            "scope": scope,
+            "roleRef": {"kind": "Role", "name": "deploy-viewer"}
+        })
+    };
+
+    // A built-in and an external kind inside the parent org both resolve; the
+    // ancestor chain of an external kind comes from its ResourceDefinition.
+    for (index, scope) in [
+        "rise.dev/Organization/acme",
+        "rise.dev/Group/acme/platform",
+        "example.dev/OrgWidget/acme/w1",
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let row = create_binding(
+            &store,
+            ROLE_BINDING_KIND,
+            &format!("scoped-{index}"),
+            Some(acme.uid),
+            with_scope(scope),
+        )
+        .await
+        .unwrap_or_else(|error| panic!("{scope}: {error:?}"));
+        assert_eq!(row.spec["scope"], json!(scope));
+    }
+
+    // Containment, existence, arity, and the wildcard escape all fail closed.
+    for (label, scope, fragment) in [
+        (
+            "another org",
+            "rise.dev/Organization/other",
+            "not Organization 'acme'",
+        ),
+        (
+            "another org's subtree",
+            "rise.dev/Group/other/nope",
+            "live resource",
+        ),
+        (
+            "a root-scoped kind",
+            "rise.dev/User/alice",
+            "not Organization 'acme'",
+        ),
+        (
+            "an absent target",
+            "rise.dev/Group/acme/absent",
+            "live resource",
+        ),
+        (
+            "an unknown kind",
+            "unknown.example/Widget/acme/x",
+            "unknown ResourceKind",
+        ),
+        ("too few names", "rise.dev/Group/acme", "ancestor"),
+        (
+            "too many names",
+            "rise.dev/Organization/acme/extra",
+            "ancestor",
+        ),
+    ] {
+        let error = create_binding(
+            &store,
+            ROLE_BINDING_KIND,
+            "rejected",
+            Some(acme.uid),
+            with_scope(scope),
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(&error, StoreError::Validation(message) if message.contains(fragment)),
+            "{label} ({scope}) produced {error:?}"
+        );
+    }
+
+    let wildcard = create_binding(
+        &store,
+        ROLE_BINDING_KIND,
+        "wildcard",
+        Some(acme.uid),
+        with_scope("*"),
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        matches!(wildcard, StoreError::Validation(message) if message.contains("wildcard scope"))
+    );
+
+    // A tombstoned target is not a live anchor for a new binding.
+    let group = store
+        .get_by_name(API_VERSION_V1ALPHA1, GROUP_KIND, "platform", Some(acme.uid))
+        .await
+        .unwrap()
+        .unwrap();
+    store
+        .update(
+            group.uid,
+            UpdateResourceParams {
+                finalizers: vec!["example.dev/keep".to_string()],
+                ..update_spec(group.revision, json!({}))
+            },
+        )
+        .await
+        .unwrap();
+    store.delete(group.uid).await.unwrap();
+    let tombstoned = create_binding(
+        &store,
+        ROLE_BINDING_KIND,
+        "tombstoned-scope",
+        Some(acme.uid),
+        with_scope("rise.dev/Group/acme/platform"),
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        matches!(tombstoned, StoreError::Validation(message) if message.contains("live resource"))
+    );
+
+    // `other` is untouched by acme's failures.
+    assert!(store.get(other.uid).await.unwrap().is_some());
+    Ok(())
+}
+
+#[sqlx::test]
+async fn platform_role_binding_scope_defaults_to_the_subjects_own_reach(
+    pool: sqlx::PgPool,
+) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    let acme = create_org(&store, "acme").await;
+    create_org(&store, "beta").await;
+    create_platform_role(&store, "resource-owner").await;
+    create_builtin_resource(&store, USER_KIND, "alice", None, json!({}), vec![])
+        .await
+        .unwrap();
+    create_builtin_resource(
+        &store,
+        GROUP_KIND,
+        "platform",
+        Some(acme.uid),
+        json!({}),
+        vec![],
+    )
+    .await
+    .unwrap();
+    create_builtin_resource(
+        &store,
+        SERVICE_ACCOUNT_KIND,
+        "ci",
+        Some(acme.uid),
+        json!({}),
+        vec![],
+    )
+    .await
+    .unwrap();
+
+    let spec = |subject: &str, scope: Option<&str>| {
+        let mut spec = json!({
+            "subject": subject,
+            "roleRef": {"kind": "PlatformRole", "name": "resource-owner"}
+        });
+        if let Some(scope) = scope {
+            spec["scope"] = json!(scope);
+        }
+        spec
+    };
+
+    // An org-agnostic subject defaults to the wildcard; a static org-native one
+    // defaults to its own organization.
+    for (index, (subject, expected)) in [
+        ("user:alice", "*"),
+        ("group:acme/platform", "rise.dev/Organization/acme"),
+        ("serviceaccount:acme/ci", "rise.dev/Organization/acme"),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let row = create_binding(
+            &store,
+            PLATFORM_ROLE_BINDING_KIND,
+            &format!("default-{index}"),
+            None,
+            spec(subject, None),
+        )
+        .await
+        .unwrap_or_else(|error| panic!("{subject}: {error:?}"));
+        assert_eq!(row.spec["scope"], json!(expected), "{subject}");
+    }
+
+    // A platform binding's scope is otherwise unrestricted: a root-scoped
+    // instance and another org's subtree are both legitimate platform policy.
+    for (index, scope) in ["rise.dev/User/alice", "rise.dev/Organization/beta"]
+        .into_iter()
+        .enumerate()
+    {
+        create_binding(
+            &store,
+            PLATFORM_ROLE_BINDING_KIND,
+            &format!("platform-scope-{index}"),
+            None,
+            spec("user:alice", Some(scope)),
+        )
+        .await
+        .unwrap_or_else(|error| panic!("{scope}: {error:?}"));
+    }
+
+    // A static org-native subject cannot leave its own org, by explicit
+    // wildcard or by naming another org.
+    let explicit_wildcard = create_binding(
+        &store,
+        PLATFORM_ROLE_BINDING_KIND,
+        "org-native-wildcard",
+        None,
+        spec("group:acme/platform", Some("*")),
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        matches!(explicit_wildcard, StoreError::Validation(message) if message.contains("wildcard scope"))
+    );
+
+    let cross_org = create_binding(
+        &store,
+        PLATFORM_ROLE_BINDING_KIND,
+        "org-native-cross",
+        None,
+        spec("serviceaccount:acme/ci", Some("rise.dev/Organization/beta")),
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        matches!(cross_org, StoreError::Validation(message) if message.contains("own Organization"))
+    );
+    Ok(())
+}
+
+#[sqlx::test]
+async fn policy_subjects_must_identify_live_identities(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    let acme = create_org(&store, "acme").await;
+    create_platform_role(&store, "resource-owner").await;
+    create_builtin_resource(&store, USER_KIND, "alice", None, json!({}), vec![])
+        .await
+        .unwrap();
+    create_builtin_resource(&store, CONTROLLER_KIND, "deployer", None, json!({}), vec![])
+        .await
+        .unwrap();
+    create_builtin_resource(
+        &store,
+        GROUP_KIND,
+        "platform",
+        Some(acme.uid),
+        json!({}),
+        vec![],
+    )
+    .await
+    .unwrap();
+    create_builtin_resource(
+        &store,
+        SERVICE_ACCOUNT_KIND,
+        "ci",
+        Some(acme.uid),
+        json!({}),
+        vec![],
+    )
+    .await
+    .unwrap();
+
+    // A static org-native subject rejects a wildcard scope outright, so each
+    // case carries the scope its own subject kind admits.
+    let spec = |subject: &str| {
+        let scope = match subject.split_once(':') {
+            Some(("group" | "serviceaccount", name)) => {
+                format!("rise.dev/Organization/{}", name.split('/').next().unwrap())
+            }
+            _ => "*".to_string(),
+        };
+        json!({
+            "subject": subject,
+            "scope": scope,
+            "roleRef": {"kind": "PlatformRole", "name": "resource-owner"}
+        })
+    };
+
+    // Every literal identity kind resolves, and the two virtual populations
+    // that name no row are accepted as written.
+    for (index, subject) in [
+        "user:alice",
+        "controller:deployer",
+        "group:acme/platform",
+        "serviceaccount:acme/ci",
+        "org:acme",
+        "system:authenticated",
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        create_binding(
+            &store,
+            PLATFORM_ROLE_BINDING_KIND,
+            &format!("subject-{index}"),
+            None,
+            spec(subject),
+        )
+        .await
+        .unwrap_or_else(|error| panic!("{subject}: {error:?}"));
+    }
+
+    // A syntactically valid subject naming nothing fails the write rather than
+    // persisting a binding that could never match.
+    for subject in [
+        "user:nobody",
+        "controller:nobody",
+        "group:acme/nobody",
+        "group:nowhere/platform",
+        "serviceaccount:acme/nobody",
+        "org:nowhere",
+    ] {
+        let error = create_binding(
+            &store,
+            PLATFORM_ROLE_BINDING_KIND,
+            "absent-subject",
+            None,
+            spec(subject),
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(&error, StoreError::Validation(message) if message.contains("must identify a live")),
+            "{subject} produced {error:?}"
+        );
+    }
+
+    // A Group is looked up under its own organization, not globally: acme's
+    // Group name does not satisfy a subject naming another org.
+    create_org(&store, "beta").await;
+    let wrong_org = create_binding(
+        &store,
+        PLATFORM_ROLE_BINDING_KIND,
+        "wrong-org-group",
+        None,
+        spec("group:beta/platform"),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(wrong_org, StoreError::Validation(_)));
+    Ok(())
+}
+
+#[sqlx::test]
+async fn policy_updates_renormalize_and_revalidate_references(
+    pool: sqlx::PgPool,
+) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    let acme = create_org(&store, "acme").await;
+    create_builtin_resource(&store, USER_KIND, "alice", None, json!({}), vec![])
+        .await
+        .unwrap();
+    create_platform_role(&store, "resource-owner").await;
+    let role = create_role(&store, acme.uid, "deploy-viewer").await;
+
+    let binding = create_binding(
+        &store,
+        ROLE_BINDING_KIND,
+        "alice-viewer",
+        Some(acme.uid),
+        json!({
+            "subject": "user:alice",
+            "roleRef": {"kind": "Role", "name": "deploy-viewer"}
+        }),
+    )
+    .await
+    .unwrap();
+    let normalized = binding.spec.clone();
+
+    // Re-submitting the stored normalized spec is idempotent: an explicit scope
+    // normalizes to itself.
+    let updated = store
+        .update(
+            binding.uid,
+            update_spec(binding.revision, normalized.clone()),
+        )
+        .await
+        .unwrap();
+    assert_eq!(updated.spec, normalized);
+
+    // An update is re-validated against current rows, so a reference that has
+    // since been deleted cannot be carried forward untouched.
+    store.delete(role.uid).await.unwrap();
+    let dangling = store
+        .update(
+            updated.uid,
+            update_spec(updated.revision, normalized.clone()),
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(dangling, StoreError::Validation(message) if message.contains("roleRef")));
+
+    // Retargeting at a live reference succeeds and renormalizes in place.
+    let retargeted = store
+        .update(
+            updated.uid,
+            update_spec(
+                updated.revision,
+                json!({
+                    "subject": "user:alice",
+                    "roleRef": {"kind": "PlatformRole", "name": "resource-owner"}
+                }),
+            ),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        retargeted.spec,
+        json!({
+            "subject": "user:alice",
+            "scope": "rise.dev/Organization/acme",
+            "roleRef": {"kind": "PlatformRole", "name": "resource-owner"}
+        })
+    );
+    Ok(())
+}
+
+#[sqlx::test]
+async fn role_binding_create_never_resolves_a_reference_the_deleter_already_won(
+    pool: sqlx::PgPool,
+) -> sqlx::Result<()> {
+    let store = Arc::new(PgResourceStore::new(pool.clone()));
+    let acme = create_org(&store, "race-org").await;
+    create_builtin_resource(&store, USER_KIND, "alice", None, json!({}), vec![])
+        .await
+        .unwrap();
+
+    // Deterministic half: a reference that has already entered deletion is not
+    // a live target, so the FOR SHARE lookup rejects it outright.
+    let tombstoned = create_builtin_resource(
+        &store,
+        ROLE_KIND,
+        "tombstoned",
+        Some(acme.uid),
+        json!({}),
+        vec![],
+    )
+    .await
+    .unwrap();
+    store
+        .update(
+            tombstoned.uid,
+            UpdateResourceParams {
+                finalizers: vec!["example.dev/keep".to_string()],
+                ..update_spec(tombstoned.revision, json!({}))
+            },
+        )
+        .await
+        .unwrap();
+    store.delete(tombstoned.uid).await.unwrap();
+    let error = create_binding(
+        &store,
+        ROLE_BINDING_KIND,
+        "against-tombstone",
+        Some(acme.uid),
+        json!({
+            "subject": "user:alice",
+            "roleRef": {"kind": "Role", "name": "tombstoned"}
+        }),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(error, StoreError::Validation(message) if message.contains("roleRef")));
+
+    // Concurrent half: the binding's FOR SHARE lock on its roleRef target and
+    // the deleter's FOR UPDATE lock serialize, so the pair always lands on one
+    // of two consistent outcomes -- never a half-normalized binding.
+    let role = create_role(&store, acme.uid, "raced").await;
+    let role_uid = role.uid;
+    let barrier = Arc::new(tokio::sync::Barrier::new(3));
+    let create = {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        let parent = acme.uid;
+        tokio::spawn(async move {
+            barrier.wait().await;
+            create_binding(
+                &store,
+                ROLE_BINDING_KIND,
+                "raced-binding",
+                Some(parent),
+                json!({
+                    "subject": "user:alice",
+                    "roleRef": {"kind": "Role", "name": "raced"}
+                }),
+            )
+            .await
+        })
+    };
+    let delete = {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        tokio::spawn(async move {
+            barrier.wait().await;
+            store.delete(role_uid).await
+        })
+    };
+    barrier.wait().await;
+    let created = create.await.unwrap();
+    delete.await.unwrap().unwrap();
+
+    match created {
+        Ok(row) => assert_eq!(
+            row.spec,
+            json!({
+                "subject": "user:alice",
+                "scope": "rise.dev/Organization/race-org",
+                "roleRef": {"kind": "Role", "name": "raced"}
+            }),
+            "a committed binding is always fully normalized"
+        ),
+        Err(StoreError::Validation(message)) => assert!(message.contains("roleRef")),
+        Err(other) => panic!("unexpected outcome: {other:?}"),
+    }
+    Ok(())
+}
+
+#[sqlx::test(migrations = false)]
+async fn policy_activation_upgrade_audit_is_actionable_and_guard_is_durable(
+    pool: sqlx::PgPool,
+) -> sqlx::Result<()> {
+    // The upgrade this exercises is from an installation that has the identity
+    // built-ins but not the policy ones.
+    execute_resource_migration(&pool, 20260519000000).await?;
+    execute_resource_migration(&pool, 20260719000000).await?;
+    execute_resource_migration(&pool, 20260719000001).await?;
+
+    sqlx::query(
+        r#"
+        INSERT INTO resource_store.resources
+            (api_version, kind, name, discriminator, spec)
+        VALUES
+            ('rise.dev/v1alpha1', 'ResourceDefinition', 'legacy.example', 'legacy02',
+             '{"group":"legacy.example","kind":"Legacy","plural":"rolebindings","versions":[{"name":"v1","served":true,"storage":true}]}'::jsonb),
+            ('rise.dev/v9', 'Role', 'orphan', 'orphan02', '{}'::jsonb),
+            ('custom.example/v1', 'Role', 'custom-role', 'custom02', '{}'::jsonb)
+        "#,
+    )
+    .execute(&pool)
+    .await?;
+
+    let activation = sqlx::migrate!("./migrations")
+        .iter()
+        .find(|migration| migration.version == 20260814000000)
+        .expect("activation migration exists")
+        .sql
+        .clone();
+
+    // Each conflicting population is named specifically, and a rejected upgrade
+    // leaves nothing behind — including the guard it would have installed.
+    let error = pool.execute(&*activation).await.unwrap_err();
+    assert!(error.to_string().contains("legacy ResourceDefinition(s)"));
+    let guard_exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'resource_definitions_policy_reservations')",
+    )
+    .fetch_one(&pool)
+    .await?;
+    assert!(!guard_exists, "a rejected upgrade rolls back in full");
+
+    sqlx::query("DELETE FROM resource_store.resources WHERE name = 'legacy.example'")
+        .execute(&pool)
+        .await?;
+    let error = pool.execute(&*activation).await.unwrap_err();
+    assert!(error.to_string().contains("legacy resource row(s)"));
+
+    sqlx::query("DELETE FROM resource_store.resources WHERE name = 'orphan'")
+        .execute(&pool)
+        .await?;
+    execute_resource_migration(&pool, 20260814000000).await?;
+
+    // A same-named Kind in another API group was never a policy built-in and
+    // survives activation untouched.
+    let custom_survives: bool = sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM resource_store.resources WHERE api_version = 'custom.example/v1' AND kind = 'Role')",
+    )
+    .fetch_one(&pool)
+    .await?;
+    assert!(custom_survives);
+
+    let guarded = sqlx::query(
+        r#"
+        INSERT INTO resource_store.resources
+            (api_version, kind, name, discriminator, spec)
+        VALUES ('rise.dev/v1alpha1', 'ResourceDefinition', 'blocked.example', 'blocked2',
+                '{"group":"other.example","kind":"Blocked","plural":"platformroles","versions":[{"name":"v1","served":true,"storage":true}]}'::jsonb)
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .unwrap_err();
+    assert_eq!(
+        guarded
+            .as_database_error()
+            .and_then(|error| error.constraint()),
+        Some("resource_definitions_policy_reservations")
+    );
     Ok(())
 }

--- a/docs/engineering/src/content/docs/upgrade-notes.md
+++ b/docs/engineering/src/content/docs/upgrade-notes.md
@@ -49,6 +49,23 @@ In-flight PRs with operator impact (not yet merged):
   runs in one transaction, so an upgrade rejected by the audit leaves the
   database exactly as it was — clean up the conflicts it names under the
   previous Rise version and retry.
+- **Action required if conflicts exist — policy resource activation**.
+  Rise activates the four reserved `rise.dev/v1alpha1` policy resource kinds —
+  `Role` and `RoleBinding` under an Organization, `PlatformRole` and
+  `PlatformRoleBinding` at the root — in the PostgreSQL resource store. The
+  same fail-closed pattern as the identity activation above applies: before
+  upgrading, remove any stored rows in the `rise.dev` group using those four
+  Kind names, and any ResourceDefinition claiming one of the four collection
+  names (`roles`, `rolebindings`, `platformroles`, `platformrolebindings`) in
+  any group. Startup reports the total plus a bounded sample and leaves the
+  database unchanged, so clean up under the previous Rise version and retry.
+  Installations with no reported conflicts require no action.
+
+  Nothing yet consults these resources: writing a `RoleBinding` grants no
+  access, and `/api/v1/resources` remains operator-gated. Bindings are
+  validated at write time, so creating one requires its `roleRef` target, its
+  `scope` target, and any literal `subject` it names to already exist — create
+  the Role before the RoleBinding that references it.
 - **Behavior change — workload identity on the Docker backend** ([#378](https://github.com/rise-deploy/rise/issues/378)).
   The Docker controller now delivers the same workload-identity material as
   Kubernetes — the bootstrap credential and one token file per `[identity].audiences`


### PR DESCRIPTION
Implements ADR-0001 §3–4 policy resource activation by adding transaction-scoped admission for the four policy built-ins (`Role`, `RoleBinding`, `PlatformRole`, `PlatformRoleBinding`), enabling contextual normalization and reference validation.

## Summary

This PR activates Rise's policy resource kinds through the same built-in admission seam used for identity kinds. Policy admission runs inside the write transaction to normalize binding specs against their parent Organization, resolve `roleRef` and `scope` references against live rows, and validate subject identities. The implementation ensures that a stored binding means the same thing when read back by the authorization engine.

## Key Changes

- **New admission modules** (`crates/rise-resource-store-postgres/src/admission/`):
  - `policy.rs`: Policy-specific canonicalization and contextual admission for Role, RoleBinding, PlatformRole, and PlatformRoleBinding
  - `reference.rs`: Same-transaction resolution of scope paths and role references, with parent chain traversal supporting both built-in and external kinds
  - `mod.rs`: Unified `BuiltInAdmission` enum dispatching to identity or policy admission

- **Built-in registry updates** (`crates/rise-resource-store-postgres/src/builtin.rs`):
  - Extended to register all four policy kinds from `POLICY_KIND_DEFINITIONS`
  - Routes policy collections through the immutable registry (no `ResourceDefinition` rows)

- **API contract formalization** (`crates/rise-resource-api/src/`):
  - New `builtin_kind.rs`: `BuiltInKindDefinition` struct capturing static API identity and placement metadata consumed by PostgreSQL admission
  - Updated `identity.rs` and `policy.rs` to export `IDENTITY_KIND_DEFINITIONS` and `POLICY_KIND_DEFINITIONS` as arrays of `BuiltInKindDefinition`
  - Extended `SubjectId` with `organization()` and `name()` accessors for policy resolution

- **Database migration** (`20260814000000_activate_policy_resources.sql`):
  - Compatibility audit checking for conflicting ResourceDefinition plurals before reserving collection names
  - Adds constraint preventing external definitions from using reserved policy collection names

- **Comprehensive test coverage** (`crates/rise-resource-store-postgres/tests/integration_tests.rs`):
  - `policy_routes_and_placement_are_activated_from_contract_definitions`: Verifies routing and parent chain
  - `policy_admission_normalizes_bindings_and_is_unbypassable`: Tests spec normalization, scope defaulting, subject validation, and schema enforcement
  - `policy_role_ref_resolution_validates_placement_and_existence`: Validates roleRef resolution and containment rules
  - `policy_scope_resolution_traverses_parent_chains_and_rejects_malformed_paths`: Tests scope path resolution including external kinds
  - `policy_binding_subject_resolution_validates_identity_existence`: Validates subject identity lookups
  - Additional tests for update idempotence, concurrent writes, and edge cases

## Notable Implementation Details

- **Contextual normalization**: RoleBinding specs omit `scope` at write time; admission defaults it to the parent Organization's scope. PlatformRoleBinding specs omit `subjectMembership`; admission defaults it to the canonical `Any` enum value.

- **Reference resolution under lock**: Both `scope` and `roleRef` are resolved inside the write transaction under `FOR SHARE` locks, ensuring a binding's meaning is stable when read back.

- **Parent chain traversal**: Scope resolution walks the full parent chain from leaf to root, supporting both built-in kinds (via registry) and external kinds (via `ResourceDefinition` queries), enabling bindings to reach product resources once they migrate to the generic store.

- **Admission is authoritative**: Policy admission runs even when a caller omits or forges the optional `SpecValidator`, preventing bypass of normalization and validation rules.

- **Idempotent updates**: An update carries the stored normalized spec back through the same admission path, which is idempotent because an explicit `scope` normalizes to itself.

- **Helper function rename**: `create_identity_resource

https://claude.ai/code/session_01RmjcV5fVTqsairV4HKLPg6