### PR TITLE
ADR-0003: Resource Families

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,6 +13,9 @@ Status legend: `[x]` shipped · `[~]` in progress · `[ ]` planned.
 - [ADR-0002: Generic Resource Subresource Execution Model](docs/engineering/src/content/docs/adr/0002-generic-resource-subresource-execution-model.md)
   is Draft and defines the intended execution seam for `status`,
   `finalizers`, `token`, and future generated or streaming subresources.
+- [ADR-0003: Resource Families](docs/engineering/src/content/docs/adr/0003-resource-families.md)
+  groups kinds that share a name pool and list as a unit; it gates the
+  extension-kind migration in §4.
 - Where shipped compatibility behavior differs from an ADR, it is transitional;
   new work converges on the ADR rather than extending the old shape.
 
@@ -185,7 +188,12 @@ Ordering: the built-in registry enables data-plane migration; unified RBAC
 must land before user-facing routes flip to the generic API. Pagination/Watch
 and secret handling remain kind-specific prerequisites.
 
-- [ ] Migrate extension kinds to external `ResourceDefinition` resources;
+- [ ] Implement resource families (ADR-0003): `ResourceFamily`, the family
+  name pool, the unversioned family collection route, and printer columns.
+  A family cannot be retrofitted onto kinds that already have instances, so
+  this lands **before** the extension migration below.
+- [ ] Migrate extension kinds to external `ResourceDefinition` resources under
+  the `Extension` family, preserving today's per-project extension name pool;
   secret-bearing extensions wait for encrypted fields.
 - [ ] Migrate `Project` (Organization child) and `Environment` (Project
   child) as built-ins. Authorization ownership is `rise.dev/owner` plus policy;

--- a/docs/engineering/src/content/docs/adr/0003-resource-families.md
+++ b/docs/engineering/src/content/docs/adr/0003-resource-families.md
@@ -4,12 +4,12 @@ title: "ADR-0003: Resource Families"
 
 ## Status
 
-**Draft.** Date: 2026-08-17.
+**Proposed** (under review). Date: 2026-08-17.
 
-This is an exploratory design, not yet a proposed decision. It may change
-substantially before promotion to **Proposed**. ADR-0001 fixes the
-authorization shape `(verb, ResourceKind, subresource?)` and the collection-read
-semantics this draft builds on; nothing here changes them.
+ADR-0001 fixes the authorization shape `(verb, ResourceKind, subresource?)`, the
+declared-reference `use` rule, and the collection-read semantics this decision
+builds on; nothing here changes them. Two questions are deliberately left to
+their own decisions — see Open questions.
 
 ## Context
 
@@ -48,7 +48,7 @@ The store already enforces a cross-kind, per-scope allocation pool for
 `discriminator` (`resources_child_discriminator_unique`), so the mechanism is
 not novel — only its exposure as a user-chosen, kind-spanning identity is.
 
-## Draft decision
+## Decision
 
 Introduce a **resource family**: a named set of kinds that share one name pool
 within a parent scope and can be listed and addressed as a unit.
@@ -99,7 +99,17 @@ Registration of a member validates:
 2. **Same parent kind.** An RD declares exactly one parent, and it must equal
    the family's `parent`. Members parented under different kinds have no common
    scope, leaving "unique within the family under this scope" undefined and
-   family-scoped listing unaddressable.
+   family-scoped listing unaddressable — a mixed-depth result also has no
+   copy-pasteable `NAME`, since each item's path differs.
+
+   The known counterexample is a **placement-tier pair**: `Role` and
+   `PlatformRole` are the same concept at two levels, and exist as two kinds
+   only because ADR-0001's parent model is exact (§3, "two kind pairs, one per
+   placement level"). That is the natural cross-parent grouping this rule
+   forbids, and it is deferred rather than dismissed — nothing needs it today,
+   and admitting it requires answering how a single list spans an org-parented
+   and a root-scoped collection without asserting the root-scoped members live
+   under the org. It is not a case extension-land will produce.
 3. **Immutable after RD creation.** `family` may be set only at RD create.
    Adding one to a kind with live instances would require reconciling existing
    collisions; removing one would silently widen the pool under resources that
@@ -202,6 +212,16 @@ construction. Two implementation constraints:
   a stable-but-odd order rather than a pagination cursor that skips or repeats
   rows.
 
+Pagination and Watch do not exist yet for any collection — both are ROADMAP §4
+prerequisites for the typed-object migration, and designing family pagination
+before the base model exists would be backwards. This decision therefore states
+only what families *require* of whatever lands: a cursor ordered by
+`(name COLLATE "C", uid)` **within a family scope**, and a defined answer for a
+member kind registered or removed mid-pagination — a family's membership can
+change under a paging client in a way a single kind's cannot. Whether that
+answer is a snapshot, a documented weak guarantee, or a cursor invalidation
+belongs to the pagination decision, not this one.
+
 ### Printer columns
 
 A family list is heterogeneous, so a column cannot be a single path evaluated
@@ -221,6 +241,7 @@ render only under `-o wide`).
 ```yaml
 kind: ResourceFamily
 spec:
+  family: Extension
   columns:
     - {name: Status,   type: string, description: Provisioning state}
     - {name: Endpoint, type: string, priority: 1}
@@ -228,21 +249,35 @@ spec:
 kind: ResourceDefinition
 spec:
   kind: AwsRdsInstance
-  family: extensions
+  family: Extension
   versions:
     - name: v1
-      familyColumns:
+      familyColumns:                       # fills the family's table
         Status: .status.phase
         Endpoint: .status.endpoint
+      columns:                             # this kind's own table
+        - {name: Engine,   type: string, path: .spec.engine}
+        - {name: Class,    type: string, path: .spec.instanceClass}
+        - {name: Endpoint, type: string, path: .status.endpoint, priority: 1}
 ```
 
-Rules:
+**A kind declares its own columns** the same way, per version, for single-kind
+lists (`risectl get awsrdsinstances …`). Same field shape, same evaluator, same
+renderer — a kind's own table simply carries the contract and the binding in one
+place, because there is no second party to agree with. Without this, a kind in a
+family would print a richer table than the same kind listed directly, and kinds
+outside any family would never print more than `NAME` and `AGE`. A kind's own
+columns are unrelated to its `familyColumns`: the family's table shows what the
+family agreed on, the kind's table shows what that kind finds worth showing.
 
-- **An unbound column renders empty**, and is never a registration error.
-  Otherwise adding a column to a family breaks every member RD already
-  registered against it.
-- **Bindings match by column `name`**, exactly. A binding naming a column the
-  family does not declare is rejected at RD registration.
+Rules (applying to both column sets unless stated):
+
+- **An unbound family column renders empty**, and is never a registration
+  error. Otherwise adding a column to a family breaks every member RD already
+  registered against it. A kind's own columns cannot be unbound — contract and
+  path are declared together.
+- **Family bindings match by column `name`**, exactly. A binding naming a
+  column the family does not declare is rejected at RD registration.
 - **Paths use a restricted JSONPath subset** — field traversal and array
   indexing only, no filters, recursion, or wildcards. Evaluation stays bounded
   and deterministic, which matters once RD creation is delegated beyond
@@ -252,8 +287,9 @@ Rules:
   that does not match renders empty rather than failing the request. Where a
   version does declare a schema, registration may validate the binding against
   it.
-- **`NAME` and `KIND` are implicit and always present**, first and second;
-  family columns follow in declared order; `AGE` renders last.
+- **`NAME` is implicit and first, `AGE` implicit and last**, with declared
+  columns in between. A family table additionally carries `KIND` second; a
+  single-kind table omits it, being redundant with the request.
 
 **Tables are rendered server-side**, through content negotiation on the
 ordinary collection GET rather than a subresource. A client sends one request
@@ -343,18 +379,15 @@ the deliberate divergence from kubectl — the hierarchy is the argument, not an
 as an ordinary column and family-declared columns beside it — the printer-column
 split above exists to serve this.
 
-## Open questions before Proposed
+## Open questions
 
-- **Per-kind printer columns.** A family list is covered above, but a
-  single-kind list (`risectl get awsrdsinstances …`) still has no columns
-  beyond the base ones. Presumably the same binding mechanism with a per-RD
-  contract, but it is a separate decision and not required by this one.
-- **Cross-kind pagination and Watch.** Both are already prerequisites for the
-  typed-object migration (`ROADMAP.md` §4); a family list inherits them and may
-  add constraints of its own — notably a cursor that stays stable while a
-  member kind is registered or removed mid-page.
+- **Pagination and Watch semantics** for a collection whose membership can
+  change mid-page. This decision states the constraint (see Ordering) and
+  defers the model to the ROADMAP §4 pagination work.
+- **Cross-parent families.** Deferred with a known motivating case — the
+  placement-tier pair under validation rule 2 — and no current need.
 
-## Consequences if adopted
+## Consequences
 
 - The extension name guarantee users have today survives the move to per-kind
   `ResourceDefinition`s, and `rise extension list` keeps its single query.

--- a/docs/engineering/src/content/docs/adr/0003-resource-families.md
+++ b/docs/engineering/src/content/docs/adr/0003-resource-families.md
@@ -1,0 +1,246 @@
+---
+title: "ADR-0003: Resource Families"
+---
+
+## Status
+
+**Draft.** Date: 2026-08-17.
+
+This is an exploratory design, not yet a proposed decision. It may change
+substantially before promotion to **Proposed**. ADR-0001 fixes the
+authorization shape `(verb, ResourceKind, subresource?)` and the collection-read
+semantics this draft builds on; nothing here changes them.
+
+## Context
+
+The generic resource store keys name uniqueness per kind, per parent:
+
+```sql
+-- crates/rise-resource-store-postgres/migrations/20260519000000_create_resource_store.sql
+CREATE UNIQUE INDEX resources_child_kind_name_unique
+    ON resource_store.resources (parent_uid, split_part(api_version, '/', 1), kind, name)
+    WHERE parent_uid IS NOT NULL;
+```
+
+The pool is `(parent, group, kind)`. An API group namespaces kind *identity*
+(`resource_definitions_group_kind_unique`) but is not itself a name pool: two
+kinds in one group may hold the same name under the same parent. Nothing in
+`ResourceDefinitionSpec` lets a set of kinds opt into a shared pool.
+
+Two product requirements do not fit that model.
+
+**Polymorphic listing.** Extensions are presented to users as one concept with
+several providers. Today that is one table and one query: `project_extensions`
+is keyed `PRIMARY KEY (project_id, extension)` with `extension_type` as an
+ordinary column, and the HTTP surface addresses an instance as
+`(project, name)` with the provider type nowhere in the path. `ROADMAP.md` §4
+migrates extension kinds to external `ResourceDefinition`s, at which point
+"list this project's extensions" becomes "discover which registered kinds are
+extensions, then issue one list call per kind" — and the resource API has no
+way to express which kinds *are* extensions. This is the primary motivation.
+
+**A shared allocatable name pool.** The same migration would let
+`AwsRdsInstance/db` and `SnowflakeOAuth/db` coexist under one project. That is
+legal in the store and a silent regression from the guarantee users have
+today, where a name identifies at most one extension in a project.
+
+The store already enforces a cross-kind, per-scope allocation pool for
+`discriminator` (`resources_child_discriminator_unique`), so the mechanism is
+not novel — only its exposure as a user-chosen, kind-spanning identity is.
+
+## Draft decision
+
+Introduce a **resource family**: a named set of kinds that share one name pool
+within a parent scope and can be listed and addressed as a unit.
+
+A family is *only* those two things — a name pool and a discovery grouping. It
+is deliberately not a schema, a controller boundary, or an authorization
+grouping.
+
+### Declaration
+
+`ResourceDefinitionSpec` gains an optional `family` field naming the family the
+kind joins. A family has no separate registry object; it exists as the set of
+RDs that name it.
+
+Registration validates:
+
+1. **Same API group.** Every member kind's `group` equals the family's group.
+   Without this, any RD author could inject a kind into another group's family,
+   consuming names in its pool and appearing in its listings. RD creation is
+   operator-gated today, so this is latent — but ADR-0001 delegates creation,
+   so the rule is encoded now rather than retrofitted.
+2. **Same parent kind.** An RD declares exactly one parent. Members that parent
+   under different kinds have no common scope, leaving "unique within the
+   family under this scope" undefined and family-scoped listing unaddressable.
+3. **Immutable after RD creation.** `family` may be set only at RD create.
+   Adding one to a kind with live instances would require reconciling existing
+   collisions; removing one would silently widen the pool under resources that
+   were admitted under the narrower rule.
+4. **Shared identifier namespace.** Family names are unique against each other
+   *and* against every kind's `plural`, `singular`, and `shortNames`
+   (below), and follow the existing collection-name grammar and reserved-name
+   list. A CLI argument resolves to exactly one family or one kind, never both.
+
+Nothing else is required of members. Family kinds need not share spec fields, a
+status shape, a controller, or a served version set. A family is not an
+inheritance mechanism, and no part of the engine may read a member's spec
+through a family-level schema.
+
+### Storage and uniqueness
+
+`family` is denormalized onto `resource_store.resources` at write time — the
+store already resolves the RD on every write, and a unique index cannot reach
+across tables. Two partial unique indexes mirror the existing kind-scoped pair:
+
+```sql
+CREATE UNIQUE INDEX resources_child_family_name_unique
+    ON resource_store.resources (parent_uid, family, name)
+    WHERE parent_uid IS NOT NULL AND family IS NOT NULL;
+
+CREATE UNIQUE INDEX resources_root_family_name_unique
+    ON resource_store.resources (family, name)
+    WHERE parent_uid IS NULL AND family IS NOT NULL;
+```
+
+Concurrent creates of two different kinds claiming one name conflict in a
+single index on a single table, so no new locking is required. The index also
+backs the family-scoped `(parent_uid, family, name)` lookup that named
+addressing needs.
+
+### Ordering
+
+Family lists sort by `name`, which is unique within a family scope by
+construction. Two implementation constraints:
+
+- Sort `ORDER BY name COLLATE "C"`. Resource names admit `-` and `.`, and
+  non-`C` collations treat punctuation as ignorable at the primary level, so
+  ordering would otherwise be locale-dependent and unstable across databases —
+  unacceptable if a cursor is ever a name value.
+- Keep `uid` as a tiebreak. It costs nothing and degrades a uniqueness bug into
+  a stable-but-odd order rather than a pagination cursor that skips or repeats
+  rows.
+
+### Authorization
+
+A family confers no permissions. ADR-0001 keys policy on `ResourceKind` and
+admits only `kinds: "*"` as a wildcard; a family that implicitly granted across
+its members would be an escalation surface.
+
+Consequently a family-scoped list is an ordinary ADR-0001 collection read,
+evaluated per item against its own kind, with non-listable items omitted and
+masked rather than refused — otherwise `risectl get extensions` becomes a probe
+for which extension kinds exist under a project. A family-scoped *get* resolves
+a name to a kind and then evaluates `get` on that kind; a caller without it
+receives not-found, never a 403 that would disclose which kind holds the name.
+
+A family-scoped list is a collection route, not a subresource. It is outside
+ADR-0002's registration seam entirely.
+
+## Derived requirements on the resource API
+
+The intended consumer is `risectl`, a future CLI speaking only to the generic
+resource API, kubectl-shaped but optimized for Rise's hierarchical resource
+tree. Two commands drive the design:
+
+```console
+$ risectl get extensions acme-corp/web-app          # every kind in the family
+NAME        KIND               AGE
+analytics   SnowflakeOAuth     12d
+db          AwsRdsInstance     30d
+uploads     AwsS3Bucket        5d
+
+$ risectl get extension acme-corp/web-app/db        # one named item
+```
+
+They force four things the API does not have today:
+
+**Singular and short names.** `ResourceDefinitionSpec` carries only `plural`.
+`get extension` versus `get extensions` needs `singular`, and kubectl parity
+needs `shortNames`. Both join the shared identifier namespace above.
+
+**A discovery endpoint.** None exists. risectl cannot resolve `extensions` to a
+family, enumerate its member kinds, learn their parent-chain depth, or pick a
+served version without hardcoding. Family-aware discovery is therefore a
+prerequisite for the CLI, not an enhancement, and must report families and
+their members alongside per-kind aliases, parent chain, and served versions.
+
+**The positional path is the scope.** `<org>/<project>[/<name>]` is the
+existing URL grammar minus `{group}/{version}`, whose ancestor *types* are
+already derived from the leaf's parent chain. List versus get follows from
+depth: `D` ancestor segments list the collection, `D+1` gets an item. This is
+the deliberate divergence from kubectl — the hierarchy is the argument, not an
+`-n namespace` flag.
+
+**Heterogeneous table output.** `KIND` as a column is free: ADR-0001's list
+projector allowlists `apiVersion`, `kind`, and `metadata`, so it renders even
+for items the caller can `list` but not `get`. Beyond NAME/KIND/AGE, a
+cross-kind table can only show columns every member carries — see open
+questions.
+
+## Open questions before Proposed
+
+- **Printer columns.** Either family lists stay at base metadata columns, or a
+  family declares its own printer columns resolved by JSONPath into each member
+  object (with kinds declaring their own for single-kind lists). The latter is
+  more useful and more machinery; undecided.
+- **Family membership governance.** Once RD creation is delegable beyond
+  operators, same-group is the only gate on joining an existing family, which
+  reduces to "who governs an API group" — a concept Rise does not have yet.
+- **Route shape for family collections.** Whether a family occupies the same
+  URL position as a `plural` (relying on the shared identifier namespace) or a
+  distinct segment.
+- **Cross-kind pagination and Watch.** Both are already prerequisites for the
+  typed-object migration (`ROADMAP.md` §4); a family list inherits them and may
+  add constraints of its own.
+- **Whether built-in kinds may declare families.** Nothing here requires it,
+  and admitting it early risks a family becoming a de-facto type hierarchy.
+
+## Consequences if adopted
+
+- The extension name guarantee users have today survives the move to per-kind
+  `ResourceDefinition`s, and `rise extension list` keeps its single query.
+- The store carries a denormalized `family` column that must be written from
+  the RD on every create — a new write-time coupling between the RD registry
+  and the resource row, in the same position as existing kind resolution.
+- Adopting a family for kinds that already have instances is not possible
+  without a collision-reconciling migration. Families must be declared when a
+  kind is first registered — for extensions, that means this decision lands
+  *before* the `ROADMAP.md` §4 extension migration, not after.
+- `ResourceDefinitionSpec` grows `family`, `singular`, and `shortNames`, and
+  the schema under `docs/engineering/public/schemas/` regenerates with it.
+- Discovery becomes a hard dependency of the CLI workstream.
+
+## Alternatives considered
+
+**One `Extension` kind with a discriminated `spec.type`.** Mirrors today's
+table exactly, needs no store change, and preserves both the name pool and
+single-query listing for free. Rejected because it puts per-provider schema
+validation back inside one union spec, which is much of what moving to per-kind
+`ResourceDefinition`s was meant to buy, and because it solves the problem only
+for extensions — any later set of sibling kinds faces it again.
+
+**Make the API group the name pool.** Requires no new field: uniqueness would
+key on `(parent, group, name)`. Rejected because a group is a namespace for
+kind identity, not a product grouping — it would force unrelated kinds sharing
+a vendor's group into one pool, and would still leave polymorphic listing
+without a way to name which kinds belong together.
+
+**Client-side aggregation.** risectl could fan out one list per kind and merge.
+Rejected because it needs the same discovery data anyway, gives no name-pool
+guarantee, multiplies round trips by member count, and pushes cross-kind
+ordering and pagination into every client.
+
+**Do nothing.** Accept cross-kind name collisions and per-kind listing.
+Rejected on the listing requirement above, and because the resulting collision
+is a silent user-visible regression rather than a deferred feature.
+
+## References
+
+- ADR-0001 §collection authorization — per-item `list` filtering, the response
+  projector's base-field allowlist, and existence masking.
+- ADR-0002 — the subresource execution seam a family list is *not* part of.
+- `ROADMAP.md` §4, Typed-object migration — the extension-kind migration this
+  decision must precede.
+- [Generic resource API](../generic-resource-api.md) — path grammar, parent
+  chains, and discriminators.

--- a/docs/engineering/src/content/docs/adr/0003-resource-families.md
+++ b/docs/engineering/src/content/docs/adr/0003-resource-families.md
@@ -59,28 +59,52 @@ grouping.
 
 ### Declaration
 
-`ResourceDefinitionSpec` gains an optional `family` field naming the family the
-kind joins. A family has no separate registry object; it exists as the set of
-RDs that name it.
+A family is a registry resource, `ResourceFamily`, and `ResourceDefinitionSpec`
+gains an optional `family` field naming the family the kind joins. The family
+must exist before a kind joins it.
 
-Registration validates:
+A family could instead have been implicit — the set of RDs naming a string —
+but three things need a declaration site that a bare string does not have: the
+family's own `plural`/`singular`/`shortNames` (which a CLI resolves against),
+its printer-column contract (below), and eventually its membership governance.
 
-1. **Same API group.** Every member kind's `group` equals the family's group.
+```yaml
+apiVersion: rise.dev/v1alpha1
+kind: ResourceFamily
+metadata:
+  name: extensions.extensions.rise.dev
+spec:
+  group: extensions.rise.dev
+  plural: extensions
+  singular: extension
+  shortNames: [ext]
+  parent:
+    apiVersion: rise.dev/v1alpha1
+    kind: Project
+```
+
+Registration of a member validates:
+
+1. **Same API group.** A member kind's `group` equals the family's `group`.
    Without this, any RD author could inject a kind into another group's family,
    consuming names in its pool and appearing in its listings. RD creation is
    operator-gated today, so this is latent — but ADR-0001 delegates creation,
    so the rule is encoded now rather than retrofitted.
-2. **Same parent kind.** An RD declares exactly one parent. Members that parent
-   under different kinds have no common scope, leaving "unique within the
-   family under this scope" undefined and family-scoped listing unaddressable.
+2. **Same parent kind.** An RD declares exactly one parent, and it must equal
+   the family's `parent`. Members parented under different kinds have no common
+   scope, leaving "unique within the family under this scope" undefined and
+   family-scoped listing unaddressable.
 3. **Immutable after RD creation.** `family` may be set only at RD create.
    Adding one to a kind with live instances would require reconciling existing
    collisions; removing one would silently widen the pool under resources that
    were admitted under the narrower rule.
-4. **Shared identifier namespace.** Family names are unique against each other
-   *and* against every kind's `plural`, `singular`, and `shortNames`
-   (below), and follow the existing collection-name grammar and reserved-name
-   list. A CLI argument resolves to exactly one family or one kind, never both.
+4. **Shared identifier namespace.** A family's `plural`, `singular`, and
+   `shortNames` are unique against each other and against every kind's, and
+   follow the existing collection-name grammar and reserved-name list. A CLI
+   argument resolves to exactly one family or one kind, never both.
+
+Nothing here requires a family to know its members: membership is declared
+outward-in by each RD, so registering a kind never mutates the family object.
 
 Nothing else is required of members. Family kinds need not share spec fields, a
 status shape, a controller, or a served version set. A family is not an
@@ -121,6 +145,73 @@ construction. Two implementation constraints:
   a stable-but-odd order rather than a pagination cursor that skips or repeats
   rows.
 
+### Printer columns
+
+A family list is heterogeneous, so a column cannot be a single path evaluated
+against every row: members share no spec shape, and requiring one would make a
+family the inheritance mechanism this decision refuses to make it. The
+declaration therefore splits in two.
+
+**The family declares the contract** — an ordered list of columns, each with a
+`name` (the header, and the identifier members bind against), a `type`
+(`string`, `integer`, `number`, `boolean`, `date`), an optional `description`,
+and an optional `priority` (`0`, the default, always renders; higher values
+render only under `-o wide`).
+
+**Each member binds the data**, per version, alongside that version's `schema`
+— the place where shape already varies:
+
+```yaml
+kind: ResourceFamily
+spec:
+  columns:
+    - {name: Status,   type: string, description: Provisioning state}
+    - {name: Endpoint, type: string, priority: 1}
+---
+kind: ResourceDefinition
+spec:
+  kind: AwsRdsInstance
+  family: extensions
+  versions:
+    - name: v1
+      familyColumns:
+        Status: .status.phase
+        Endpoint: .status.endpoint
+```
+
+Rules:
+
+- **An unbound column renders empty**, and is never a registration error.
+  Otherwise adding a column to a family breaks every member RD already
+  registered against it.
+- **Bindings match by column `name`**, exactly. A binding naming a column the
+  family does not declare is rejected at RD registration.
+- **Paths use a restricted JSONPath subset** — field traversal and array
+  indexing only, no filters, recursion, or wildcards. Evaluation stays bounded
+  and deterministic, which matters once RD creation is delegated beyond
+  operators.
+- **Types are advisory at registration.** A version's `schema` is optional, so
+  the store generally cannot prove a path yields the declared type; a value
+  that does not match renders empty rather than failing the request. Where a
+  version does declare a schema, registration may validate the binding against
+  it.
+- **`NAME` and `KIND` are implicit and always present**, first and second;
+  family columns follow in declared order; `AGE` renders last.
+
+**Tables are rendered server-side**, through content negotiation on the
+ordinary collection GET rather than a subresource. Clients never receive column
+definitions or evaluate paths, and the projection rule below applies in exactly
+one place.
+
+That projection rule is the notable consequence: column *values* follow
+ADR-0001's per-item read granularity exactly. `KIND` is free — the list
+projector's base-field allowlist includes it — but a column pathing into `spec`
+or `status` has nothing to read for an item the caller can `list` but not
+`get`. Those cells render empty, so a table is ragged across rows of differing
+access. Widening the projection because a column was declared would let an RD
+author make fields readable under `list` alone, which is a policy hole, not a
+formatting choice.
+
 ### Authorization
 
 A family confers no permissions. ADR-0001 keys policy on `ResourceKind` and
@@ -145,10 +236,10 @@ tree. Two commands drive the design:
 
 ```console
 $ risectl get extensions acme-corp/web-app          # every kind in the family
-NAME        KIND               AGE
-analytics   SnowflakeOAuth     12d
-db          AwsRdsInstance     30d
-uploads     AwsS3Bucket        5d
+NAME        KIND               STATUS      AGE
+analytics   SnowflakeOAuth     Ready       12d
+db          AwsRdsInstance     Available   30d
+uploads     AwsS3Bucket        Ready       5d
 
 $ risectl get extension acme-corp/web-app/db        # one named item
 ```
@@ -157,13 +248,15 @@ They force four things the API does not have today:
 
 **Singular and short names.** `ResourceDefinitionSpec` carries only `plural`.
 `get extension` versus `get extensions` needs `singular`, and kubectl parity
-needs `shortNames`. Both join the shared identifier namespace above.
+needs `shortNames` — on kinds and on families alike, all in one identifier
+namespace.
 
 **A discovery endpoint.** None exists. risectl cannot resolve `extensions` to a
 family, enumerate its member kinds, learn their parent-chain depth, or pick a
 served version without hardcoding. Family-aware discovery is therefore a
 prerequisite for the CLI, not an enhancement, and must report families and
 their members alongside per-kind aliases, parent chain, and served versions.
+Column definitions need not be published there — tables render server-side.
 
 **The positional path is the scope.** `<org>/<project>[/<name>]` is the
 existing URL grammar minus `{group}/{version}`, whose ancestor *types* are
@@ -172,21 +265,25 @@ depth: `D` ancestor segments list the collection, `D+1` gets an item. This is
 the deliberate divergence from kubectl — the hierarchy is the argument, not an
 `-n namespace` flag.
 
-**Heterogeneous table output.** `KIND` as a column is free: ADR-0001's list
-projector allowlists `apiVersion`, `kind`, and `metadata`, so it renders even
-for items the caller can `list` but not `get`. Beyond NAME/KIND/AGE, a
-cross-kind table can only show columns every member carries — see open
-questions.
+**Heterogeneous table output.** One table, not one table per kind, with `KIND`
+as an ordinary column and family-declared columns beside it — the printer-column
+split above exists to serve this.
 
 ## Open questions before Proposed
 
-- **Printer columns.** Either family lists stay at base metadata columns, or a
-  family declares its own printer columns resolved by JSONPath into each member
-  object (with kinds declaring their own for single-kind lists). The latter is
-  more useful and more machinery; undecided.
 - **Family membership governance.** Once RD creation is delegable beyond
   operators, same-group is the only gate on joining an existing family, which
   reduces to "who governs an API group" — a concept Rise does not have yet.
+  A `ResourceFamily` object gives that rule somewhere to live; it does not
+  supply the rule.
+- **Per-kind printer columns.** A family list is covered above, but a
+  single-kind list (`risectl get awsrdsinstances …`) still has no columns
+  beyond the base ones. Presumably the same binding mechanism with a per-RD
+  contract, but it is a separate decision and not required by this one.
+- **`ResourceFamily` lifecycle.** What deleting a family with live member RDs
+  (or live instances) means — reject, cascade, or tombstone — and whether
+  `columns` may be edited after members bind to them. Adding a column is safe
+  by the unbound-renders-empty rule; removing or retyping one is not.
 - **Route shape for family collections.** Whether a family occupies the same
   URL position as a `plural` (relying on the shared identifier namespace) or a
   distinct segment.
@@ -207,8 +304,11 @@ questions.
   without a collision-reconciling migration. Families must be declared when a
   kind is first registered — for extensions, that means this decision lands
   *before* the `ROADMAP.md` §4 extension migration, not after.
-- `ResourceDefinitionSpec` grows `family`, `singular`, and `shortNames`, and
-  the schema under `docs/engineering/public/schemas/` regenerates with it.
+- `ResourceDefinitionSpec` grows `family`, `singular`, `shortNames`, and
+  per-version `familyColumns`; `ResourceFamily` arrives as a new built-in kind.
+  The schemas under `docs/engineering/public/schemas/` regenerate with them.
+- The API gains server-side table rendering — a restricted JSONPath evaluator
+  and a table content type — which no current endpoint needs.
 - Discovery becomes a hard dependency of the CLI workstream.
 
 ## Alternatives considered
@@ -225,6 +325,19 @@ key on `(parent, group, name)`. Rejected because a group is a namespace for
 kind identity, not a product grouping — it would force unrelated kinds sharing
 a vendor's group into one pool, and would still leave polymorphic listing
 without a way to name which kinds belong together.
+
+**One table per member kind, each with its own columns** (`kubectl get all`).
+Sidesteps the heterogeneous-column problem entirely and needs no family-level
+column contract. Rejected because the result is not one sortable, scannable
+list — the thing that makes `KIND` a column rather than a section heading — and
+because it scales badly as a family grows: three providers become three
+stanzas to read.
+
+**A single family-level path per column.** One JSONPath evaluated against every
+member, no per-member binding. Rejected because it only reaches fields every
+member happens to share, so either the columns stay trivial or the family
+acquires a de-facto common schema — exactly the inheritance this decision
+refuses.
 
 **Client-side aggregation.** risectl could fan out one list per kind and merge.
 Rejected because it needs the same discovery data anyway, gives no name-pool

--- a/docs/engineering/src/content/docs/adr/0003-resource-families.md
+++ b/docs/engineering/src/content/docs/adr/0003-resource-families.md
@@ -485,9 +485,11 @@ is a silent user-visible regression rather than a deferred feature.
 
 ## References
 
-- ADR-0001 §collection authorization — per-item `list` filtering, the response
-  projector's base-field allowlist, and existence masking.
-- ADR-0002 — the subresource execution seam a family list is *not* part of.
+- [ADR-0001: Unified Permission Model](./0001-unified-permission-model.md) —
+  per-item `list` filtering, the response projector's base-field allowlist,
+  existence masking, and the declared-reference `use` rule.
+- [ADR-0002: Generic Resource Subresource Execution Model](./0002-generic-resource-subresource-execution-model.md)
+  — the execution seam a family list is *not* part of.
 - `ROADMAP.md` §4, Typed-object migration — the extension-kind migration this
   decision must precede.
 - [Generic resource API](../generic-resource-api.md) — path grammar, parent

--- a/docs/engineering/src/content/docs/adr/0003-resource-families.md
+++ b/docs/engineering/src/content/docs/adr/0003-resource-families.md
@@ -199,11 +199,27 @@ Rules:
   family columns follow in declared order; `AGE` renders last.
 
 **Tables are rendered server-side**, through content negotiation on the
-ordinary collection GET rather than a subresource. Clients never receive column
-definitions or evaluate paths, and the projection rule below applies in exactly
-one place.
+ordinary collection GET rather than a subresource. A client sends one request
+and receives cells rather than whole objects, and no client reimplements path
+evaluation.
 
-That projection rule is the notable consequence: column *values* follow
+This is a convenience and a transfer optimization, never a security boundary.
+`ResourceFamily` and `ResourceDefinition` are ordinary resources, so a client
+holding `get` on them reads the column contract and the members' bindings and
+may render the same table itself, from the same objects the server would have
+read. Column definitions are therefore public API surface, not private
+configuration.
+
+The transfer saving is on the wire and in client parsing; the store still reads
+whole rows to evaluate paths. A database-side saving is available but not
+automatic: the bound paths can be extracted in SQL, selecting scalars instead
+of whole `spec`/`status` documents. That extraction must run *after* the
+per-item read decision, which is decidable from metadata and ancestry alone —
+so the shape is: read metadata for the scope, authorize per item, extract
+columns only for items that cleared `get`. Worth doing when a family list is
+measurably slow, not before.
+
+The per-item read decision is the notable consequence: column *values* follow
 ADR-0001's per-item read granularity exactly. `KIND` is free — the list
 projector's base-field allowlist includes it — but a column pathing into `spec`
 or `status` has nothing to read for an item the caller can `list` but not
@@ -256,7 +272,8 @@ family, enumerate its member kinds, learn their parent-chain depth, or pick a
 served version without hardcoding. Family-aware discovery is therefore a
 prerequisite for the CLI, not an enhancement, and must report families and
 their members alongside per-kind aliases, parent chain, and served versions.
-Column definitions need not be published there — tables render server-side.
+Column definitions need not be duplicated there: a client that wants them reads
+the `ResourceFamily` and the member RDs directly.
 
 **The positional path is the scope.** `<org>/<project>[/<name>]` is the
 existing URL grammar minus `{group}/{version}`, whose ancestor *types* are
@@ -283,7 +300,8 @@ split above exists to serve this.
 - **`ResourceFamily` lifecycle.** What deleting a family with live member RDs
   (or live instances) means — reject, cascade, or tombstone — and whether
   `columns` may be edited after members bind to them. Adding a column is safe
-  by the unbound-renders-empty rule; removing or retyping one is not.
+  by the unbound-renders-empty rule; removing or retyping one breaks both
+  existing bindings and any client rendering the table itself.
 - **Route shape for family collections.** Whether a family occupies the same
   URL position as a `plural` (relying on the shared identifier namespace) or a
   distinct segment.
@@ -309,6 +327,9 @@ split above exists to serve this.
   The schemas under `docs/engineering/public/schemas/` regenerate with them.
 - The API gains server-side table rendering — a restricted JSONPath evaluator
   and a table content type — which no current endpoint needs.
+- A family's `columns` become public API surface, readable by any client that
+  can `get` the `ResourceFamily`. Adding one stays compatible; removing or
+  retyping one breaks clients that render tables themselves.
 - Discovery becomes a hard dependency of the CLI workstream.
 
 ## Alternatives considered

--- a/docs/engineering/src/content/docs/adr/0003-resource-families.md
+++ b/docs/engineering/src/content/docs/adr/0003-resource-families.md
@@ -68,6 +68,11 @@ but three things need a declaration site that a bare string does not have: the
 family's own `plural`/`singular`/`shortNames` (which a CLI resolves against),
 its printer-column contract (below), and eventually its membership governance.
 
+A family carries both spellings a kind carries, for the same two jobs:
+`{group}/{Family}` is its canonical identity, in the same namespace
+`ResourceKind` occupies, while `plural`/`singular`/`shortNames` are what URLs
+and CLI arguments resolve against.
+
 ```yaml
 apiVersion: rise.dev/v1alpha1
 kind: ResourceFamily
@@ -75,6 +80,7 @@ metadata:
   name: extensions.extensions.rise.dev
 spec:
   group: extensions.rise.dev
+  family: Extension
   plural: extensions
   singular: extension
   shortNames: [ext]
@@ -98,10 +104,19 @@ Registration of a member validates:
    Adding one to a kind with live instances would require reconciling existing
    collisions; removing one would silently widen the pool under resources that
    were admitted under the narrower rule.
-4. **Shared identifier namespace.** A family's `plural`, `singular`, and
-   `shortNames` are unique against each other and against every kind's, and
-   follow the existing collection-name grammar and reserved-name list. A CLI
-   argument resolves to exactly one family or one kind, never both.
+4. **Distinct identity.** `{group}/{Family}` must not collide with any
+   `ResourceKind` in that group, and a family's `plural`, `singular`, and
+   `shortNames` must not collide with any kind's or any other family's. Both
+   levels matter: the first keeps canonical identities unambiguous, the second
+   keeps a URL segment or CLI argument resolving to exactly one family or one
+   kind, never both. Family collection names follow the existing
+   collection-name grammar and reserved-name list.
+5. **`use` on the family.** Registering a member sets a declared reference to
+   the `ResourceFamily`, so ADR-0001's reference rule applies unchanged: the
+   writer must hold `use` on the referenced instance. A family owner controls
+   who may join by granting `use`; no bespoke allowlist is introduced. This is
+   inert while RD creation is operator-gated and becomes the operative gate
+   when ADR-0001 delegates it.
 
 Nothing here requires a family to know its members: membership is declared
 outward-in by each RD, so registering a kind never mutates the family object.
@@ -110,6 +125,48 @@ Nothing else is required of members. Family kinds need not share spec fields, a
 status shape, a controller, or a served version set. A family is not an
 inheritance mechanism, and no part of the engine may read a member's spec
 through a family-level schema.
+
+Built-in `rise.dev` kinds may declare a family. Because the reserved group
+rejects `ResourceDefinition`s, a built-in family is registered in the built-in
+registry rather than created through the API: `BuiltInKindDefinition` gains a
+`family` field and its `ResourceFamily` is seeded alongside the kinds. No
+built-in family is declared by this decision — see the note under Consequences
+on why the policy kinds are not one.
+
+### Addressing
+
+A family collection route carries **no version segment**. Diverse schemas imply
+diverse versioning: members version independently, a result is heterogeneous,
+and a single collection-wide version would either exclude members that do not
+serve it or assert a uniformity that does not exist. Each item is served at its
+own kind's preferred served version and self-describes through its
+`apiVersion`, exactly as a mixed result must.
+
+That makes the family route a second, shorter grammar beside the kind route,
+distinguished by a leading keyword rather than by parsing:
+
+```
+{group}/{version}/{plural}/{ancestor}…        # kind collection (existing)
+families/{group}/{plural}/{ancestor}…         # family collection
+families/{group}/{plural}/{ancestor}…/{name}  # family item
+```
+
+List versus get follows from depth exactly as it does for kinds: `D` ancestor
+segments list, `D+1` gets, where `D` is the family's parent-chain depth — well
+defined because every member shares the family's parent.
+
+### Lifecycle
+
+Deleting a `ResourceFamily` is **rejected while any member RD names it**. A
+family is a namespace its members and their instances depend on; cascading
+would let one delete of a registry object destroy customer data, and
+tombstoning would leave instances in a pool with no contract. Deleting the
+member RDs first is the deliberate, visible path.
+
+`columns` are **append-only**. Adding one is safe by the unbound-renders-empty
+rule. Removing or retyping one breaks existing member bindings and any client
+rendering the table itself (columns are public API surface — see below), so
+both are rejected rather than left to operator discipline.
 
 ### Storage and uniqueness
 
@@ -288,28 +345,14 @@ split above exists to serve this.
 
 ## Open questions before Proposed
 
-- **Family membership governance.** Once RD creation is delegable beyond
-  operators, same-group is the only gate on joining an existing family, which
-  reduces to "who governs an API group" — a concept Rise does not have yet.
-  A `ResourceFamily` object gives that rule somewhere to live; it does not
-  supply the rule.
 - **Per-kind printer columns.** A family list is covered above, but a
   single-kind list (`risectl get awsrdsinstances …`) still has no columns
   beyond the base ones. Presumably the same binding mechanism with a per-RD
   contract, but it is a separate decision and not required by this one.
-- **`ResourceFamily` lifecycle.** What deleting a family with live member RDs
-  (or live instances) means — reject, cascade, or tombstone — and whether
-  `columns` may be edited after members bind to them. Adding a column is safe
-  by the unbound-renders-empty rule; removing or retyping one breaks both
-  existing bindings and any client rendering the table itself.
-- **Route shape for family collections.** Whether a family occupies the same
-  URL position as a `plural` (relying on the shared identifier namespace) or a
-  distinct segment.
 - **Cross-kind pagination and Watch.** Both are already prerequisites for the
   typed-object migration (`ROADMAP.md` §4); a family list inherits them and may
-  add constraints of its own.
-- **Whether built-in kinds may declare families.** Nothing here requires it,
-  and admitting it early risks a family becoming a de-facto type hierarchy.
+  add constraints of its own — notably a cursor that stays stable while a
+  member kind is registered or removed mid-page.
 
 ## Consequences if adopted
 
@@ -323,13 +366,25 @@ split above exists to serve this.
   kind is first registered — for extensions, that means this decision lands
   *before* the `ROADMAP.md` §4 extension migration, not after.
 - `ResourceDefinitionSpec` grows `family`, `singular`, `shortNames`, and
-  per-version `familyColumns`; `ResourceFamily` arrives as a new built-in kind.
-  The schemas under `docs/engineering/public/schemas/` regenerate with them.
+  per-version `familyColumns`; `BuiltInKindDefinition` grows `family`; and
+  `ResourceFamily` arrives as a new built-in kind. The schemas under
+  `docs/engineering/public/schemas/` regenerate with them.
 - The API gains server-side table rendering — a restricted JSONPath evaluator
   and a table content type — which no current endpoint needs.
 - A family's `columns` become public API surface, readable by any client that
-  can `get` the `ResourceFamily`. Adding one stays compatible; removing or
-  retyping one breaks clients that render tables themselves.
+  can `get` the `ResourceFamily`. Hence append-only.
+- The API gains a second collection grammar under a `families/` keyword,
+  unversioned where the kind grammar is versioned. Discovery, client libraries,
+  and any path-aware middleware must handle both.
+- **A family asserts that its members' names must not collide — a semantic
+  claim, not just a listing convenience — and for some obvious groupings that
+  claim is false.** The org-parented policy kinds are the sharp case: `Role` and
+  `RoleBinding` share a parent and a group, so they *could* form a family, but
+  naming a binding after the role it binds is a common and useful pattern that a
+  shared pool would forbid. Built-ins may declare families; that is not a reason
+  for any particular set of them to be one. Plausible first candidates are the
+  org-parented subject kinds (`Group`, `ServiceAccount`) and the root-scoped
+  identities (`User`, `Controller`), each deferred to its own decision.
 - Discovery becomes a hard dependency of the CLI workstream.
 
 ## Alternatives considered

--- a/docs/engineering/src/content/docs/adr/0003-resource-families.md
+++ b/docs/engineering/src/content/docs/adr/0003-resource-families.md
@@ -8,8 +8,8 @@ title: "ADR-0003: Resource Families"
 
 ADR-0001 fixes the authorization shape `(verb, ResourceKind, subresource?)`, the
 declared-reference `use` rule, and the collection-read semantics this decision
-builds on; nothing here changes them. Two questions are deliberately left to
-their own decisions — see Open questions.
+builds on; nothing here changes them. Pagination and Watch mechanics are decided
+by separate work this depends on — see Dependencies.
 
 ## Context
 
@@ -105,11 +105,16 @@ Registration of a member validates:
    The known counterexample is a **placement-tier pair**: `Role` and
    `PlatformRole` are the same concept at two levels, and exist as two kinds
    only because ADR-0001's parent model is exact (§3, "two kind pairs, one per
-   placement level"). That is the natural cross-parent grouping this rule
-   forbids, and it is deferred rather than dismissed — nothing needs it today,
-   and admitting it requires answering how a single list spans an org-parented
-   and a root-scoped collection without asserting the root-scoped members live
-   under the org. It is not a case extension-land will produce.
+   placement level"). A family is *not* the mechanism for that grouping, and
+   this is a decision rather than a deferral. Spanning tiers would require two
+   things a family deliberately does not have: transitive listing across depths
+   (the store matches `parent_uid` exactly, and a root-scoped `PlatformRole`
+   does not live under any organization, so listing it beneath one would be
+   false), and a name pool decoupled from the grouping (names cannot be unique
+   "within a scope" when members occupy different depths). Wanting the second
+   is a signal that listing and name-pooling should be separate concepts — a
+   different feature, arrived at deliberately, not a widened family. Nothing
+   needs it today, and extension-land will not produce the case.
 3. **Immutable after RD creation.** `family` may be set only at RD create.
    Adding one to a kind with live instances would require reconciling existing
    collisions; removing one would silently widen the pool under resources that
@@ -212,15 +217,32 @@ construction. Two implementation constraints:
   a stable-but-odd order rather than a pagination cursor that skips or repeats
   rows.
 
-Pagination and Watch do not exist yet for any collection — both are ROADMAP §4
-prerequisites for the typed-object migration, and designing family pagination
-before the base model exists would be backwards. This decision therefore states
-only what families *require* of whatever lands: a cursor ordered by
-`(name COLLATE "C", uid)` **within a family scope**, and a defined answer for a
-member kind registered or removed mid-pagination — a family's membership can
-change under a paging client in a way a single kind's cannot. Whether that
-answer is a snapshot, a documented weak guarantee, or a cursor invalidation
-belongs to the pagination decision, not this one.
+### Membership stability under pagination and Watch
+
+Pagination and Watch do not exist for any collection yet — both are ROADMAP §4
+prerequisites — so their mechanics are not decided here. One thing is specific
+to families and decidable independently: a family's *membership* can change
+under a client mid-read, which no single-kind collection can do. Registering an
+RD mid-pagination would otherwise inject a kind's entire population into the
+middle of someone's page sequence.
+
+**A family's member-kind set is resolved once, at the first page, and carried in
+the cursor.** Later pages read exactly that set, so a page sequence reflects one
+coherent membership even though it is not a data snapshot. This is cheap in a
+way a data snapshot is not — the frozen set is a short list of kinds, not a
+transaction held open across round trips — and it is orthogonal to whatever
+cursor encoding the base pagination decision picks. Rows admitted under a kind
+that leaves the family mid-sequence still appear; that is correct, since they
+remain in the family's name pool until they are deleted.
+
+**A Watch over a family closes with a defined reason when membership changes**,
+and the client re-establishes against the new set. Silently adding or dropping
+event streams mid-watch would make a member kind's registration
+indistinguishable from a burst of resource creations. Whether the client then
+re-lists follows the general Watch decision.
+
+Beyond membership, families require of whatever pagination model lands only
+that the cursor order be `(name COLLATE "C", uid)` **within a family scope**.
 
 ### Printer columns
 
@@ -379,13 +401,17 @@ the deliberate divergence from kubectl — the hierarchy is the argument, not an
 as an ordinary column and family-declared columns beside it — the printer-column
 split above exists to serve this.
 
-## Open questions
+## Dependencies
 
-- **Pagination and Watch semantics** for a collection whose membership can
-  change mid-page. This decision states the constraint (see Ordering) and
-  defers the model to the ROADMAP §4 pagination work.
-- **Cross-parent families.** Deferred with a known motivating case — the
-  placement-tier pair under validation rule 2 — and no current need.
+No open questions remain. Two items are settled here but land elsewhere:
+
+- **Pagination and Watch mechanics** are decided by the ROADMAP §4 pagination
+  work. This decision fixes the family-specific part — frozen member set in the
+  cursor, Watch closes on membership change, `(name COLLATE "C", uid)` ordering
+  within a family scope — and inherits the rest.
+- **Per-kind printer columns** are specified here because they share the
+  evaluator and renderer, but they are useful independently of families and may
+  ship before the first family exists.
 
 ## Consequences
 

--- a/docs/engineering/src/content/docs/adr/index.md
+++ b/docs/engineering/src/content/docs/adr/index.md
@@ -36,4 +36,4 @@ open questions but is not yet ready for review as a proposed architecture.
 |---|---|---|
 | [ADR-0001](./0001-unified-permission-model.md) — Unified Permission Model | Proposed | One Role/RoleBinding model for all subject kinds (Users, Groups, ServiceAccounts, Controllers, Operators) on the generic resource API and token issuance, plus the crate structure that realizes it. |
 | [ADR-0002](./0002-generic-resource-subresource-execution-model.md) — Generic Resource Subresource Execution Model | Draft | A typed registration and execution seam for stored, virtual, generated, streaming, and possible connection-oriented subresources. |
-| [ADR-0003](./0003-resource-families.md) — Resource Families | Draft | A named set of kinds sharing one name pool within a parent scope, listable and addressable as a unit — the grouping polymorphic listing and the extension-kind migration need. |
+| [ADR-0003](./0003-resource-families.md) — Resource Families | Proposed | A named set of kinds sharing one name pool within a parent scope, listable and addressable as a unit — the grouping polymorphic listing and the extension-kind migration need. |

--- a/docs/engineering/src/content/docs/adr/index.md
+++ b/docs/engineering/src/content/docs/adr/index.md
@@ -36,3 +36,4 @@ open questions but is not yet ready for review as a proposed architecture.
 |---|---|---|
 | [ADR-0001](./0001-unified-permission-model.md) — Unified Permission Model | Proposed | One Role/RoleBinding model for all subject kinds (Users, Groups, ServiceAccounts, Controllers, Operators) on the generic resource API and token issuance, plus the crate structure that realizes it. |
 | [ADR-0002](./0002-generic-resource-subresource-execution-model.md) — Generic Resource Subresource Execution Model | Draft | A typed registration and execution seam for stored, virtual, generated, streaming, and possible connection-oriented subresources. |
+| [ADR-0003](./0003-resource-families.md) — Resource Families | Draft | A named set of kinds sharing one name pool within a parent scope, listable and addressable as a unit — the grouping polymorphic listing and the extension-kind migration need. |


### PR DESCRIPTION
## Summary

Adds ADR-0003 (**Proposed**) introducing **resource families**: a named set of kinds that share one name pool within a parent scope and list and address as a unit. Docs only — no code changes.

The motivating case is the extension-kind migration in `ROADMAP.md` §4. Extensions are one concept with several providers, and `project_extensions` gives them two guarantees today: `PRIMARY KEY (project_id, extension)` means a name identifies at most one extension per project, and a single table means "list this project's extensions" is one query. Splitting extensions into per-kind `ResourceDefinition`s loses both — `AwsRdsInstance/db` and `SnowflakeOAuth/db` would legally coexist, and listing would become "discover which kinds are extensions, then one call per kind", which the resource API cannot express.

Polymorphic listing is the stronger motivation; the shared name pool prevents a silent user-visible regression.

## What the ADR decides

- **`ResourceFamily` as a registry resource.** Homes the family's own `plural`/`singular`/`shortNames`, its printer-column contract, and its membership gate. Canonical identity is `{group}/{Family}`, in the same namespace `ResourceKind` occupies.
- **Membership rules.** Same API group, same parent kind, `family` immutable at RD create, distinct identity against every kind and family, and `use` on the `ResourceFamily` — reusing ADR-0001's declared-reference rule rather than inventing an allowlist.
- **Storage.** `family` denormalized onto `resource_store.resources`, with partial unique indexes mirroring the existing discriminator pair. Cross-kind name conflicts resolve in one index on one table, so no new locking.
- **Addressing.** The family collection route carries no version segment — diverse schemas imply diverse versioning, so each item serves at its own kind's preferred version and self-describes via `apiVersion`.
- **Printer columns.** The family declares the contract; each member RD binds each column to a path in its own object, per version. An unbound column renders empty rather than failing registration. Kinds also declare their own columns for single-kind lists, on the same mechanism.
- **Rendering.** Server-side, via content negotiation on the ordinary collection GET. This is a transfer optimization, never a security boundary: column values follow ADR-0001's per-item read granularity exactly, so cells pathing into `spec`/`status` stay empty for items a caller can `list` but not `get`.
- **Membership stability.** A family's member-kind set is resolved at the first page and carried in the cursor; a Watch closes with a defined reason when membership changes.
- **Lifecycle.** Deleting a family is rejected while member RDs name it; `columns` are append-only.

## Notable non-decisions

- **No built-in family is declared.** Built-ins *may* declare one, but a family asserts that its members' names must not collide — a semantic claim, not a listing convenience — and for the obvious candidate that claim is false: naming a `RoleBinding` after the `Role` it binds is a useful pattern a shared pool would forbid.
- **Cross-parent families are ruled out**, not deferred. Spanning placement tiers (`Role`/`PlatformRole`) would need transitive listing across depths and a name pool decoupled from the grouping; wanting the latter means listing and name-pooling should be separate concepts, which is a different feature.

## Roadmap

`ROADMAP.md` §4 gains the family work **ahead of** the extension migration, and the extension bullet now names the `Extension` family. The ordering is load-bearing: `family` is immutable at RD create, so adopting one for kinds that already have instances would require a collision-reconciling migration.

## Derived requirements

The ADR records what a future `risectl` imposes on the API, so those requirements are visible before they are built: `singular`/`shortNames` on RDs, a family-aware discovery endpoint (none exists today), and the positional-path scope grammar (`<org>/<project>[/<name>]`, with list-vs-get following from parent-chain depth).

## Test plan

Documentation only — no code, schemas, or migrations changed. Reviewed for link style against the sibling ADRs; the Astro docs build was not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011m7tNHEEnTbk8wBX499L6M

---
_Generated by [Claude Code](https://claude.ai/code/session_011m7tNHEEnTbk8wBX499L6M)_