### PR TITLE
Reserve control-plane project hostnames

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -6,6 +6,12 @@
 # catalog with custom entries, copy the templates below into your own config
 # and add to the list.
 
+# Project labels used by control-plane hostnames. Project creation rejects
+# these names before either deployment backend can create a colliding route.
+# Later config layers replace this list, so repeat these defaults when adding
+# topology-specific labels.
+reserved_project_names: [rise, dex, registry, www]
+
 quickstart:
   templates:
     - id: welcome

--- a/docs/engineering/public/schemas/backend-settings.schema.json
+++ b/docs/engineering/public/schemas/backend-settings.schema.json
@@ -2139,6 +2139,19 @@
         }
       ]
     },
+    "reserved_project_names": {
+      "default": [
+        "rise",
+        "dex",
+        "registry",
+        "www"
+      ],
+      "description": "Project names that are reserved for control-plane hostnames and cannot\nbe used when creating a project. Later config layers replace this list\nas a whole. Default: [\"rise\", \"dex\", \"registry\", \"www\"].",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
     "resource_gc": {
       "anyOf": [
         {

--- a/docs/engineering/src/content/docs/configuration.md
+++ b/docs/engineering/src/content/docs/configuration.md
@@ -90,6 +90,26 @@ database:
 
 **Note**: `DATABASE_URL` is also required at **compile time** for SQLX query verification. See the [Developer Guide](./developer-guide.md#database_url-at-compile-time) for details.
 
+## Reserved project names
+
+Project names become application host labels. To prevent an application route
+from shadowing a control-plane service, Rise rejects project creation when the
+name appears in the top-level `reserved_project_names` list. This applies to
+both Docker and Kubernetes deployment controllers.
+
+```yaml
+reserved_project_names:
+  - rise
+  - dex
+  - registry
+  - www
+  - grafana # topology-specific control-plane hostname
+```
+
+When omitted, the list defaults to `rise`, `dex`, `registry`, and `www`. Config
+arrays are replaced rather than merged, so an override that adds names must
+repeat the defaults it still needs to reserve.
+
 ## Examples
 
 ### Development (development.yaml)

--- a/src/server/project/handlers.rs
+++ b/src/server/project/handlers.rs
@@ -36,7 +36,10 @@ pub fn validate_http_url(url: &str) -> Result<String, String> {
 /// (`<name>.<domain>`) and part of Kubernetes resource names, so it must be
 /// lowercase alphanumeric plus hyphens, start and end alphanumeric, contain no
 /// dots or spaces, and be at most 63 characters.
-pub fn validate_project_name(name: &str) -> Result<(), String> {
+pub fn validate_project_name(
+    name: &str,
+    reserved_project_names: &std::collections::HashSet<String>,
+) -> Result<(), String> {
     if name.is_empty() {
         return Err("must not be empty".to_string());
     }
@@ -57,6 +60,9 @@ pub fn validate_project_name(name: &str) -> Result<(), String> {
     let ends_ok = name.chars().last().unwrap().is_ascii_alphanumeric();
     if !starts_ok || !ends_ok {
         return Err("must start and end with a letter or digit".to_string());
+    }
+    if reserved_project_names.contains(name) {
+        return Err("is reserved for a control-plane hostname".to_string());
     }
     Ok(())
 }
@@ -135,7 +141,7 @@ pub async fn create_project(
 ) -> Result<Json<CreateProjectResponse>, ServerError> {
     let user = auth.user()?;
     // Validate the project name (becomes a subdomain + K8s resource names).
-    validate_project_name(&payload.name).map_err(|e| {
+    validate_project_name(&payload.name, &state.reserved_project_names).map_err(|e| {
         ServerError::bad_request(format!("Invalid project name '{}': {e}", payload.name))
     })?;
     // Validate access_class against configured access classes
@@ -1272,15 +1278,27 @@ pub async fn check_write_permission(
 mod tests {
     use super::validate_project_name;
 
+    fn reserved_project_names() -> std::collections::HashSet<String> {
+        ["rise", "dex", "registry", "www"]
+            .into_iter()
+            .map(str::to_string)
+            .collect()
+    }
+
     #[test]
     fn accepts_dns_label_names() {
+        let reserved = reserved_project_names();
         for ok in ["app", "my-app", "web1", "a", "a1-b2-c3"] {
-            assert!(validate_project_name(ok).is_ok(), "{ok} should be valid");
+            assert!(
+                validate_project_name(ok, &reserved).is_ok(),
+                "{ok} should be valid"
+            );
         }
     }
 
     #[test]
     fn rejects_non_dns_names() {
+        let reserved = reserved_project_names();
         for bad in [
             "",       // empty
             "My-App", // uppercase
@@ -1291,11 +1309,32 @@ mod tests {
             "app_1",  // underscore
         ] {
             assert!(
-                validate_project_name(bad).is_err(),
+                validate_project_name(bad, &reserved).is_err(),
                 "{bad:?} should be rejected"
             );
         }
         // Over 63 chars.
-        assert!(validate_project_name(&"a".repeat(64)).is_err());
+        assert!(validate_project_name(&"a".repeat(64), &reserved).is_err());
+    }
+
+    #[test]
+    fn rejects_reserved_control_plane_names() {
+        let reserved = reserved_project_names();
+
+        for name in ["rise", "dex", "registry", "www"] {
+            assert_eq!(
+                validate_project_name(name, &reserved),
+                Err("is reserved for a control-plane hostname".to_string()),
+                "{name} should be reserved"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_operator_configured_reserved_names() {
+        let reserved = ["grafana".to_string()].into_iter().collect();
+
+        assert!(validate_project_name("grafana", &reserved).is_err());
+        assert!(validate_project_name("rise", &reserved).is_ok());
     }
 }

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -7,6 +7,11 @@ use std::env;
 pub struct Settings {
     pub server: ServerSettings,
     pub auth: AuthSettings,
+    /// Project names that are reserved for control-plane hostnames and cannot
+    /// be used when creating a project. Later config layers replace this list
+    /// as a whole. Default: ["rise", "dex", "registry", "www"].
+    #[serde(default = "default_reserved_project_names")]
+    pub reserved_project_names: Vec<String>,
     #[serde(default)]
     pub database: DatabaseSettings,
     #[serde(default)]
@@ -45,6 +50,13 @@ pub struct Settings {
     /// who want to add to the defaults must re-include them.
     #[serde(default)]
     pub quickstart: Option<QuickstartSettings>,
+}
+
+fn default_reserved_project_names() -> Vec<String> {
+    ["rise", "dex", "registry", "www"]
+        .into_iter()
+        .map(str::to_string)
+        .collect()
 }
 
 /// Catalog of quickstart templates exposed via `GET /api/v1/quickstart-templates`.
@@ -2007,6 +2019,42 @@ impl Settings {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn minimal_settings_json() -> serde_json::Value {
+        serde_json::json!({
+            "server": {
+                "host": "0.0.0.0",
+                "port": 3000,
+                "public_url": "http://test.local",
+                "jwt_signing_secret": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+            },
+            "auth": {
+                "issuer": "http://test.local",
+                "client_id": "test",
+                "client_secret": "test"
+            }
+        })
+    }
+
+    #[test]
+    fn reserved_project_names_use_control_plane_defaults() {
+        let settings: Settings = serde_json::from_value(minimal_settings_json()).unwrap();
+
+        assert_eq!(
+            settings.reserved_project_names,
+            ["rise", "dex", "registry", "www"]
+        );
+    }
+
+    #[test]
+    fn reserved_project_names_can_be_replaced_by_configuration() {
+        let mut json = minimal_settings_json();
+        json["reserved_project_names"] = serde_json::json!(["grafana", "prometheus"]);
+
+        let settings: Settings = serde_json::from_value(json).unwrap();
+
+        assert_eq!(settings.reserved_project_names, ["grafana", "prometheus"]);
+    }
 
     #[test]
     fn deserialize_u32_flexible_accepts_number_and_numeric_string() {

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -116,6 +116,9 @@ pub struct AppState {
     pub oauth_rate_limiter: Arc<crate::server::rate_limit::OAuthRateLimiter>,
     pub access_classes:
         Arc<std::collections::HashMap<String, crate::server::settings::AccessClass>>,
+    /// Project-name labels reserved for control-plane hosts. Normalized to
+    /// lowercase at startup because DNS hostnames are case-insensitive.
+    pub reserved_project_names: Arc<std::collections::HashSet<String>>,
     /// Browser-facing base URL used to build the login redirect when the
     /// `ingress_auth` handler runs in Traefik mode (`signin_redirect=1`).
     /// Sourced from the Docker controller's `auth_signin_url` (falling back to
@@ -955,6 +958,13 @@ impl AppState {
         }
 
         let public_url = settings.server.public_url.clone();
+        let reserved_project_names = Arc::new(
+            settings
+                .reserved_project_names
+                .iter()
+                .map(|name| name.trim().to_ascii_lowercase())
+                .collect(),
+        );
         tracing::info!("Public URL: {}", public_url);
         if let Some(ref docs_dir) = settings.server.docs_dir {
             tracing::info!("Documentation directory: {}", docs_dir);
@@ -1626,6 +1636,7 @@ impl AppState {
             encrypt_rate_limiter,
             oauth_rate_limiter,
             access_classes,
+            reserved_project_names,
             signin_base_url,
             production_ingress_url_template,
             staging_ingress_url_template,


### PR DESCRIPTION
## Summary
Reject project names that would collide with control-plane host labels before either deployment backend creates routes. The reserved set defaults to `rise`, `dex`, `registry`, and `www`, can be replaced through configuration for topology-specific services, and is documented in the generated settings schema and operator configuration guide.

Closes #363.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] Regenerated the backend settings schema and verified it matches the committed artifact
- [x] Engineering documentation check and build (49 pages, zero diagnostics)
- [ ] Full backend Rust test run: fresh-worktree compilation timed out, and the existing `develop` lockfile currently prevents a clean `--locked` run
