### PR TITLE
Harden OAuth redirect URI validation

### DIFF
--- a/src/server/auth/handlers.rs
+++ b/src/server/auth/handlers.rs
@@ -214,14 +214,8 @@ fn validate_redirect_url(redirect_url: &str, public_url: &str, allowed_hosts: &[
         }
     };
 
-    // Allow redirects to the same host as public_url
-    if redirect_host == public_host {
-        return redirect_url.to_string();
-    }
-
-    // Allow redirects to subdomains of the public domain
-    // e.g., if public_url is "https://rise.dev", allow "https://app.rise.dev"
-    if redirect_host.ends_with(&format!(".{}", public_host)) {
+    // Allow the public host and its dot-anchored subdomains.
+    if crate::server::auth::redirect::host_is_same_or_subdomain(redirect_host, public_host) {
         return redirect_url.to_string();
     }
 
@@ -232,23 +226,19 @@ fn validate_redirect_url(redirect_url: &str, public_url: &str, allowed_hosts: &[
     // (case-insensitive) against the project's canonical + deployment hosts —
     // never a string prefix and never the whole parent domain — so a sibling
     // project's host or a lookalike (`secret.example.com.evil.com`) is rejected.
-    if allowed_hosts
-        .iter()
-        .any(|h| redirect_host.eq_ignore_ascii_case(h))
-    {
+    if allowed_hosts.iter().any(|allowed_host| {
+        // This policy requires exact host equality, so check the shared
+        // same-or-subdomain primitive in both directions.
+        crate::server::auth::redirect::host_is_same_or_subdomain(redirect_host, allowed_host)
+            && crate::server::auth::redirect::host_is_same_or_subdomain(allowed_host, redirect_host)
+    }) {
         return redirect_url.to_string();
     }
 
-    // Allow localhost and 127.0.0.1 for development (only if public_url is also local)
-    // Extract host without port for comparison
-    let redirect_host_base = redirect_host.split(':').next().unwrap_or(redirect_host);
-    let public_host_base = public_host.split(':').next().unwrap_or(public_host);
-
-    let is_redirect_localhost =
-        redirect_host_base == "localhost" || redirect_host_base == "127.0.0.1";
-    let is_public_localhost = public_host_base == "localhost" || public_host_base == "127.0.0.1";
-
-    if is_redirect_localhost && is_public_localhost {
+    // Allow loopback redirects for development only when Rise itself is local.
+    if crate::server::auth::redirect::is_loopback_host(redirect_host)
+        && crate::server::auth::redirect::is_loopback_host(public_host)
+    {
         return redirect_url.to_string();
     }
 

--- a/src/server/auth/mod.rs
+++ b/src/server/auth/mod.rs
@@ -9,6 +9,7 @@ pub mod jwt;
 pub mod middleware;
 pub mod oauth;
 pub mod platform_access;
+pub(crate) mod redirect;
 pub mod roles;
 pub mod routes;
 pub mod sa_match;

--- a/src/server/auth/redirect.rs
+++ b/src/server/auth/redirect.rs
@@ -1,0 +1,140 @@
+//! Shared URL matching primitives for authentication redirects.
+//!
+//! These helpers operate on parsed URL components. Callers must never use raw
+//! string prefix matching for redirect targets: userinfo, lookalike hosts, and
+//! host suffixes can all make a URL string appear to start with a trusted URL
+//! while resolving to a different origin.
+
+use url::Url;
+
+fn normalized_host(host: &str) -> &str {
+    host.trim_end_matches('.')
+}
+
+/// Returns whether `candidate` is `base` or a dot-anchored subdomain of it.
+///
+/// DNS hostnames are case-insensitive and a trailing root dot is semantically
+/// equivalent, so both are ignored for matching.
+pub(crate) fn host_is_same_or_subdomain(candidate: &str, base: &str) -> bool {
+    let candidate = normalized_host(candidate);
+    let base = normalized_host(base);
+
+    if candidate.is_empty() || base.is_empty() {
+        return false;
+    }
+
+    candidate.eq_ignore_ascii_case(base)
+        || (candidate.len() > base.len()
+            && candidate
+                .get(candidate.len() - base.len()..)
+                .is_some_and(|suffix| suffix.eq_ignore_ascii_case(base))
+            && candidate.as_bytes()[candidate.len() - base.len() - 1] == b'.')
+}
+
+/// Returns whether two URLs have the same HTTP(S) origin.
+///
+/// Paths, queries, and fragments are deliberately ignored. Explicit default
+/// ports compare equal to their implicit equivalents (`:443` for HTTPS and
+/// `:80` for HTTP).
+pub(crate) fn origins_match(candidate: &Url, allowed: &Url) -> bool {
+    if !matches!(candidate.scheme(), "http" | "https") || candidate.scheme() != allowed.scheme() {
+        return false;
+    }
+
+    let (Some(candidate_host), Some(allowed_host)) = (candidate.host_str(), allowed.host_str())
+    else {
+        return false;
+    };
+
+    host_is_same_or_subdomain(candidate_host, allowed_host)
+        && host_is_same_or_subdomain(allowed_host, candidate_host)
+        && candidate.port_or_known_default() == allowed.port_or_known_default()
+}
+
+/// Returns whether a URL host is a loopback name or address.
+///
+/// The entire `.localhost` namespace is reserved for loopback use by RFC 6761.
+pub(crate) fn is_loopback_host(host: &str) -> bool {
+    let host = normalized_host(host);
+
+    host.eq_ignore_ascii_case("localhost")
+        || host
+            .to_ascii_lowercase()
+            .strip_suffix(".localhost")
+            .is_some_and(|prefix| !prefix.is_empty())
+        || host == "127.0.0.1"
+        || matches!(host, "::1" | "[::1]")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn host_matching_is_case_insensitive_dot_anchored_and_trailing_dot_agnostic() {
+        assert!(host_is_same_or_subdomain("b.com", "b.com"));
+        assert!(host_is_same_or_subdomain("APP.B.COM", "b.com"));
+        assert!(host_is_same_or_subdomain("app.b.com.", "B.COM."));
+
+        assert!(!host_is_same_or_subdomain("bb.com", "b.com"));
+        assert!(!host_is_same_or_subdomain("b.com.evil.com", "b.com"));
+        assert!(!host_is_same_or_subdomain("notb.com", "b.com"));
+    }
+
+    #[test]
+    fn origins_require_http_scheme_host_and_effective_port_equality() {
+        let allowed = Url::parse("https://victim.example.com/callback").unwrap();
+
+        assert!(origins_match(
+            &Url::parse("https://victim.example.com/elsewhere?x=1").unwrap(),
+            &allowed
+        ));
+        assert!(origins_match(
+            &Url::parse("https://victim.example.com:443/cb").unwrap(),
+            &allowed
+        ));
+        assert!(origins_match(
+            &Url::parse("https://victim.example.com./cb").unwrap(),
+            &allowed
+        ));
+
+        assert!(!origins_match(
+            &Url::parse("http://victim.example.com/cb").unwrap(),
+            &allowed
+        ));
+        assert!(!origins_match(
+            &Url::parse("https://victim.example.com:444/cb").unwrap(),
+            &allowed
+        ));
+        assert!(!origins_match(
+            &Url::parse("https://sub.victim.example.com/cb").unwrap(),
+            &allowed
+        ));
+        assert!(!origins_match(
+            &Url::parse("javascript://victim.example.com/cb").unwrap(),
+            &allowed
+        ));
+    }
+
+    #[test]
+    fn loopback_matching_covers_reserved_names_and_addresses() {
+        for host in [
+            "localhost",
+            "LOCALHOST.",
+            "rise.localhost",
+            "app.rise.localhost.",
+            "127.0.0.1",
+            "::1",
+            "[::1]",
+        ] {
+            assert!(is_loopback_host(host), "expected {host} to be loopback");
+        }
+
+        for host in ["localhost.evil.com", "notlocalhost", "127.0.0.2", "::2"] {
+            assert!(
+                !is_loopback_host(host),
+                "expected {host} not to be loopback"
+            );
+        }
+    }
+}

--- a/src/server/extensions/providers/oauth/handlers.rs
+++ b/src/server/extensions/providers/oauth/handlers.rs
@@ -3,6 +3,7 @@ use super::models::{
     OAuthExtensionSpec, OAuthExtensionStatus, OAuthState, TokenRequest,
 };
 use crate::db::{extensions as db_extensions, oauth_transient_state, projects as db_projects};
+use crate::server::auth::redirect::{is_loopback_host, origins_match};
 use crate::server::state::AppState;
 use axum::{
     extract::{Path, Query, State},
@@ -24,6 +25,134 @@ struct OidcDiscoveryDocument {
     authorization_endpoint: Option<String>,
     token_endpoint: Option<String>,
     jwks_uri: Option<String>,
+}
+
+#[cfg(test)]
+mod redirect_tests {
+    use super::redirect_uri_is_allowed;
+    use url::Url;
+
+    fn is_allowed(redirect: &str, public_url: &str, app_origins: &[&str]) -> bool {
+        let Ok(redirect) = Url::parse(redirect) else {
+            return false;
+        };
+        let public_url = Url::parse(public_url).unwrap();
+        let app_origins = app_origins
+            .iter()
+            .map(|origin| Url::parse(origin).unwrap())
+            .collect::<Vec<_>>();
+
+        redirect_uri_is_allowed(&redirect, &public_url, &app_origins)
+    }
+
+    #[test]
+    fn oauth_redirect_requires_an_exact_trusted_origin() {
+        let public_url = "https://rise.example.com";
+        let app_origins = ["https://victim.example.com"];
+
+        for redirect in [
+            "https://rise.example.com/oidc/done",
+            "https://rise.example.com:443/oidc/done",
+            "https://victim.example.com/callback",
+            "https://victim.example.com:443/callback?state=ok",
+            "https://victim.example.com./callback",
+        ] {
+            assert!(
+                is_allowed(redirect, public_url, &app_origins),
+                "expected {redirect} to be allowed"
+            );
+        }
+
+        for redirect in [
+            // Raw string prefix attacks: both URLs resolve to evil.com.
+            "https://victim.example.com.evil.com/callback",
+            "https://victim.example.com@evil.com/callback",
+            // Origin mismatches.
+            "https://victim.example.com:444/callback",
+            "http://victim.example.com/callback",
+            "https://sub.victim.example.com/callback",
+            "https://victim-example.com/callback",
+            "https://other.example.com/callback",
+        ] {
+            assert!(
+                !is_allowed(redirect, public_url, &app_origins),
+                "expected {redirect} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn oauth_redirect_rejects_invalid_and_non_http_schemes_before_loopback() {
+        let public_url = "http://rise.localhost:3000";
+
+        for redirect in [
+            "javascript://localhost/alert(1)",
+            "data:text/html,hello",
+            "file://localhost/tmp/code",
+            "//localhost/callback",
+            "not a URL",
+        ] {
+            assert!(
+                !is_allowed(redirect, public_url, &[]),
+                "expected {redirect} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn oauth_loopback_exception_is_limited_to_local_rise_installations() {
+        for redirect in [
+            "http://localhost:5173/callback",
+            "http://app.localhost:8080/callback",
+            "http://127.0.0.1:9000/callback",
+            "http://[::1]:9000/callback",
+        ] {
+            assert!(
+                is_allowed(redirect, "http://rise.localhost:3000", &[]),
+                "expected {redirect} to be allowed for local Rise"
+            );
+            assert!(
+                !is_allowed(redirect, "https://rise.example.com", &[]),
+                "expected {redirect} to be rejected for production Rise"
+            );
+        }
+
+        assert!(!is_allowed(
+            "http://localhost.evil.com/callback",
+            "http://rise.localhost:3000",
+            &[]
+        ));
+    }
+
+    #[test]
+    fn oauth_redirect_supports_kubernetes_https_and_docker_local_http_origins() {
+        assert!(is_allowed(
+            "https://app.example.com/oauth/callback",
+            "https://rise.example.com",
+            &["https://app.example.com"]
+        ));
+        assert!(is_allowed(
+            "http://app.rise.localhost/oauth/callback",
+            "http://rise.localhost:3000",
+            &["http://app.rise.localhost"]
+        ));
+        assert!(is_allowed(
+            "http://app.rise.localhost:80/oauth/callback",
+            "http://rise.localhost:3000",
+            &["http://app.rise.localhost"]
+        ));
+
+        assert!(!is_allowed(
+            "http://app.example.com/oauth/callback",
+            "https://rise.example.com",
+            &["https://app.example.com"]
+        ));
+        assert!(!is_allowed(
+            "https://app.rise.localhost/oauth/callback",
+            "http://rise.localhost:3000",
+            &["http://app.rise.localhost"]
+        ));
+    }
 }
 
 /// Resolved OAuth endpoints from spec or OIDC discovery
@@ -259,6 +388,29 @@ fn cors_headers(origin: &str) -> HeaderMap {
     headers
 }
 
+/// Decide whether a parsed OAuth redirect target is allowed.
+///
+/// Redirects may target the exact Rise origin or one of this project's exact
+/// active deployment origins. Loopback targets (including `*.localhost`) are a
+/// development exception and are accepted on any port only when Rise itself is
+/// running on a loopback origin.
+fn redirect_uri_is_allowed(redirect: &Url, public_url: &Url, app_origins: &[Url]) -> bool {
+    // This gate must run before the loopback exception: URLs such as
+    // `javascript://localhost/...` also have a parsed host.
+    if !matches!(redirect.scheme(), "http" | "https") {
+        return false;
+    }
+
+    let loopback_redirect_allowed = redirect.host_str().is_some_and(is_loopback_host)
+        && public_url.host_str().is_some_and(is_loopback_host);
+
+    loopback_redirect_allowed
+        || origins_match(redirect, public_url)
+        || app_origins
+            .iter()
+            .any(|allowed| origins_match(redirect, allowed))
+}
+
 /// Validate redirect URI against allowed origins
 async fn validate_redirect_uri(
     pool: &sqlx::PgPool,
@@ -269,18 +421,9 @@ async fn validate_redirect_uri(
 ) -> Result<(), String> {
     let redirect_url =
         Url::parse(redirect_uri).map_err(|e| format!("Invalid redirect URI: {}", e))?;
-
-    // Allow localhost for local development (any port and path)
-    if let Some(host) = redirect_url.host_str() {
-        if host == "localhost" || host == "127.0.0.1" {
-            return Ok(());
-        }
-    }
-
-    // Allow any redirect URL beginning with the Rise public URL
-    if redirect_uri.starts_with(rise_public_url) {
-        return Ok(());
-    }
+    let public_url = Url::parse(rise_public_url)
+        .map_err(|e| format!("Invalid configured Rise public URL: {}", e))?;
+    let mut app_origins = Vec::new();
 
     // Get project's deployment URLs from the deployment backend
     // Check all active deployments (including staging/non-default groups)
@@ -296,22 +439,35 @@ async fn validate_redirect_uri(
             }
         };
 
-    // Check if redirect URI starts with any deployment URL (primary or custom domain)
+    // Resolve all configured deployment origins. Invalid backend-provided URLs
+    // are ignored rather than treated as trusted string prefixes.
     for deployment in &all_deployments {
         match deployment_backend
             .get_deployment_urls(deployment, project)
             .await
         {
             Ok(urls) => {
-                // Check default URL
-                if !urls.default_url.is_empty() && redirect_uri.starts_with(&urls.default_url) {
-                    return Ok(());
+                if !urls.default_url.is_empty() {
+                    match Url::parse(&urls.default_url) {
+                        Ok(url) => app_origins.push(url),
+                        Err(error) => warn!(
+                            url = %urls.default_url,
+                            deployment_id = %deployment.deployment_id,
+                            %error,
+                            "Ignoring invalid deployment URL while validating OAuth redirect"
+                        ),
+                    }
                 }
 
-                // Check custom domain URLs
                 for custom_url in &urls.custom_domain_urls {
-                    if redirect_uri.starts_with(custom_url) {
-                        return Ok(());
+                    match Url::parse(custom_url) {
+                        Ok(url) => app_origins.push(url),
+                        Err(error) => warn!(
+                            url = %custom_url,
+                            deployment_id = %deployment.deployment_id,
+                            %error,
+                            "Ignoring invalid custom domain URL while validating OAuth redirect"
+                        ),
                     }
                 }
             }
@@ -324,8 +480,12 @@ async fn validate_redirect_uri(
         }
     }
 
+    if redirect_uri_is_allowed(&redirect_url, &public_url, &app_origins) {
+        return Ok(());
+    }
+
     Err(format!(
-        "Invalid redirect URI: not authorized for this project. Allowed: localhost, URLs starting with Rise public URL ({}), or any active deployment URL",
+        "Invalid redirect URI: origin is not authorized for this project. Allowed: the Rise public origin ({}), any active deployment origin, or loopback when Rise is running locally",
         rise_public_url
     ))
 }

--- a/src/server/extensions/providers/oauth/handlers.rs
+++ b/src/server/extensions/providers/oauth/handlers.rs
@@ -401,7 +401,8 @@ fn redirect_uri_is_allowed(redirect: &Url, public_url: &Url, app_origins: &[Url]
         return false;
     }
 
-    let loopback_redirect_allowed = redirect.host_str().is_some_and(is_loopback_host)
+    let loopback_redirect_allowed = redirect.scheme() == public_url.scheme()
+        && redirect.host_str().is_some_and(is_loopback_host)
         && public_url.host_str().is_some_and(is_loopback_host);
 
     loopback_redirect_allowed


### PR DESCRIPTION
## Summary
Replace raw redirect-URI prefix checks with parsed HTTP(S) origin validation. Redirects now require an exact trusted scheme, host, and effective port, while the loopback exception is limited to local Rise installations. Shared hostname helpers also keep ingress redirect checks dot-anchored and cover IPv4, IPv6, and the reserved `.localhost` namespace.

Closes #366.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] Added unit coverage for lookalike hosts, userinfo, scheme and port mismatches, trailing root dots, Docker-local HTTP, Kubernetes HTTPS, and IPv4/IPv6 loopback
- [ ] Full backend Rust test run: fresh-worktree compilation timed out, and the existing `develop` lockfile currently prevents a clean `--locked` run
