### PR TITLE
Document exact-tag Docker RC validation

### DIFF
--- a/docker-compose.standalone.local.yaml
+++ b/docker-compose.standalone.local.yaml
@@ -5,9 +5,12 @@
 #   docker compose -f docker-compose.standalone.yaml \
 #                  -f docker-compose.standalone.local.yaml up -d
 #
+# To validate a tagged release candidate, set RISE_IMAGE_TAG to its exact GHCR
+# tag (the Git release tag without its leading `v`) before running this command.
+#
 # Effect: plain HTTP on *.rise.localhost, no TLS, no Let's Encrypt. This is what
-# the e2e (scripts/ci/e2e-docker.sh) and a quick local try use. No RISE_DOMAIN /
-# ACME_EMAIL needed.
+# the tests/e2e Docker backend harness and a quick local try use. No RISE_DOMAIN
+# / ACME_EMAIL needed.
 #
 #   * Traefik: single `web` (:80) entrypoint — NO websecure, NO ACME, NO HTTP->
 #     HTTPS redirect. The label-based routers in the base file that target the
@@ -53,6 +56,8 @@ services:
       - "127.0.0.1:5000:5000"
 
   rise:
+    # Mirrors the base file's stable default while honoring an exact
+    # RISE_IMAGE_TAG override for CI/e2e and release-candidate validation.
     image: ${RISE_IMAGE_REPOSITORY:-ghcr.io/rise-deploy/rise}:${RISE_IMAGE_TAG:-0.23.0}
     # Re-publish the backend on loopback so the CLI/e2e reach the control plane
     # directly at http://rise.localhost:3000 (prod goes through Traefik instead).

--- a/docker-compose.standalone.yaml
+++ b/docker-compose.standalone.yaml
@@ -10,6 +10,11 @@
 #   docker compose -f docker-compose.standalone.yaml \
 #                  -f docker-compose.standalone.local.yaml up -d
 #
+#   # Tagged release candidate — use its exact published GHCR tag (without `v`):
+#   export RISE_IMAGE_TAG="$(git describe --tags --exact-match --match 'v*' HEAD | sed 's/^v//')"
+#   docker compose -f docker-compose.standalone.yaml \
+#                  -f docker-compose.standalone.local.yaml up -d
+#
 # This file is fully self-contained — it does NOT layer on top of the dev
 # docker-compose.yml. It brings up everything Rise needs to deploy apps through
 # the `docker` deployment controller: Postgres for state, Dex as the OIDC
@@ -60,7 +65,8 @@
 #     goes through Traefik. (The local overlay re-publishes them on 127.0.0.1 for
 #     direct dev access.)
 #
-# Image tag is overridable for CI via RISE_IMAGE_REPOSITORY / RISE_IMAGE_TAG.
+# Image source is overridable for CI and prerelease validation via
+# RISE_IMAGE_REPOSITORY / RISE_IMAGE_TAG.
 # =============================================================================
 
 # Fixed project name so the network is always "rise_default", regardless of the
@@ -221,9 +227,10 @@ services:
   # the real domain. The host Docker socket is mounted so it can create/route app
   # containers.
   rise:
-    # RISE_IMAGE_TAG is MANUALLY PINNED to a known-good released version; bump on
+    # RISE_IMAGE_TAG is MANUALLY PINNED to a known-good stable version; bump on
     # upgrade — there is no automatic 'latest released' resolution. Override with
-    # RISE_IMAGE_TAG (CI/e2e does this) or RISE_IMAGE_REPOSITORY for a fork/mirror.
+    # the exact published tag for CI/e2e or prerelease validation (release tags
+    # drop their leading `v` on GHCR), or use RISE_IMAGE_REPOSITORY for a mirror.
     image: ${RISE_IMAGE_REPOSITORY:-ghcr.io/rise-deploy/rise}:${RISE_IMAGE_TAG:-0.23.0}
     container_name: rise-backend
     restart: unless-stopped

--- a/docs/engineering/src/content/docs/docker/production.md
+++ b/docs/engineering/src/content/docs/docker/production.md
@@ -51,6 +51,15 @@ export RISE_DOMAIN=rise.example.com ACME_EMAIL=ops@example.com
 docker compose -f docker-compose.standalone.yaml up -d
 ```
 
+This uses the Compose file's pinned stable image. For a release candidate, set
+`RISE_IMAGE_TAG` to its exact published GHCR tag (without the Git tag's leading
+`v`) before bringing up the stack. From an exact tagged checkout:
+
+```bash
+export RISE_IMAGE_TAG="$(git describe --tags --exact-match --match 'v*' HEAD | sed 's/^v//')"
+docker compose -f docker-compose.standalone.yaml up -d
+```
+
 Traefik requests certificates via the HTTP-01 challenge on the `web` entrypoint
 (`certificatesresolvers.le`); all plain HTTP is redirected to HTTPS.
 
@@ -70,7 +79,7 @@ export ACME_CA_SERVER=https://acme-staging-v02.api.letsencrypt.org/directory
 | `ACME_CA_SERVER` | LE production | Set to LE staging while testing. |
 | `REGISTRY_BASIC_AUTH` | empty | htpasswd users for the public registry (see [Container registry](/operator-docs/docker/registry/)). |
 | `DEX_ISSUER` | `https://dex.${RISE_DOMAIN}` | OIDC issuer (see [Authentication / Dex](/operator-docs/docker/authentication/)). |
-| `RISE_IMAGE_TAG` | `0.23.0` | **Manual** image pin — bump on upgrade. There is no automatic "latest released" resolution. |
+| `RISE_IMAGE_TAG` | `0.23.0` | **Manual stable image pin** — bump on upgrade; set an exact published tag for a prerelease. There is no automatic "latest released" resolution. |
 | `RISE_IMAGE_REPOSITORY` | `ghcr.io/rise-deploy/rise` | Override for a fork/mirror. |
 | `POSTGRES_PASSWORD` | `rise123` | Change it. |
 | `RISE_JWT_SIGNING_SECRET` | insecure repo placeholder | **Set it.** Overrides the demo secret baked into `config/docker.yaml`. `openssl rand -base64 32`. |

--- a/docs/engineering/src/content/docs/docker/quick-start.md
+++ b/docs/engineering/src/content/docs/docker/quick-start.md
@@ -12,6 +12,20 @@ docker compose -f docker-compose.standalone.yaml \
                -f docker-compose.standalone.local.yaml up -d
 ```
 
+The command above uses the Compose file's pinned stable image by default. To
+validate a release candidate, first check out its Git tag and derive the exact
+published GHCR tag (the release workflow removes the leading `v`):
+
+```bash
+export RISE_IMAGE_TAG="$(git describe --tags --exact-match --match 'v*' HEAD | sed 's/^v//')"
+docker compose -f docker-compose.standalone.yaml \
+               -f docker-compose.standalone.local.yaml up -d
+```
+
+`git describe --exact-match` deliberately fails on an untagged checkout instead
+of silently running a different image. Run this only after that tag's CI has
+published `ghcr.io/rise-deploy/rise:${RISE_IMAGE_TAG}`.
+
 This serves the control plane on `http://rise.localhost:3000` and apps on
 `http://{project}.rise.localhost` over plain HTTP. The `.localhost` suffix
 resolves to `127.0.0.1` in most browsers, so no `/etc/hosts` edits are needed


### PR DESCRIPTION
## Summary
Keep the standalone Compose stack pinned to the known-good stable image by default while documenting a fail-closed release-candidate workflow. An exact tagged checkout now derives the published GHCR tag without the leading `v`, and untagged checkouts fail instead of silently validating a different image.

## Test plan
- [x] `git diff --check`
- [x] Validate the base and local-overlay Compose configurations
- [x] Verify an exact image-tag override resolves correctly
- [x] Verify tag derivation with `v0.23.0-rc4`
- [x] Engineering documentation check and build (49 pages, zero diagnostics)
