### PR TITLE
Ship static Docker registry credentials to trusted users

### DIFF
--- a/config/docker.yaml
+++ b/config/docker.yaml
@@ -106,8 +106,13 @@ registry:
   namespace: "rise-apps"
   # Public URL the CLI PUSHES to. Local default is the loopback-published
   # registry (localhost:5000); prod sets registry.${RISE_DOMAIN} (behind Traefik
-  # basicauth). The CLI does its own `docker login`; oci-client-auth mints none.
+  # basicauth).
   client_registry_url: "${RISE_CLIENT_REGISTRY_URL:-localhost:5000}"
+  # Optional static credentials. When set, Rise returns these through the
+  # authenticated, deployment-scoped credentials endpoint so the CLI can log in
+  # automatically. This deliberately trusts every user allowed to deploy.
+  username: "${RISE_REGISTRY_USERNAME:-}"
+  password: "${RISE_REGISTRY_PASSWORD:-}"
 deployment_controller:
   type: "docker"
   traefik_network: "rise_default"

--- a/docker-compose.standalone.yaml
+++ b/docker-compose.standalone.yaml
@@ -45,9 +45,9 @@
 #     it for real certs. The Dex client secret must stay in sync with
 #     dev/dex/config.yaml.
 #   * REGISTRY AUTH. The registry is exposed at registry.${RISE_DOMAIN} behind
-#     a Traefik basicauth middleware (htpasswd via REGISTRY_BASIC_AUTH). The CLI
-#     does its own `docker login` against that URL (oci-client-auth mints no
-#     creds). See the operator docs for the full login/push flow.
+#     a Traefik basicauth middleware (htpasswd via REGISTRY_BASIC_AUTH). Set the
+#     matching plaintext RISE_REGISTRY_USERNAME / RISE_REGISTRY_PASSWORD if Rise
+#     should log trusted users in automatically. See the operator docs.
 #   * PIN A REAL IMAGE TAG. RISE_IMAGE_TAG below is a manual pin; bump it on
 #     upgrade (there is no automatic 'latest released' resolution).
 #   * PLATFORM ACCESS. By default any authenticated IdP user may use the
@@ -143,8 +143,7 @@ services:
           - rise-dex
 
   # OCI registry for images pushed by the rise CLI. Exposed publicly via Traefik
-  # at registry.${RISE_DOMAIN} behind a basicauth middleware (the CLI does its
-  # own `docker login`; oci-client-auth mints no credentials). No host port: the
+  # at registry.${RISE_DOMAIN} behind a basicauth middleware. No host port: the
   # backend's docker daemon pulls over rise_default (rise-registry:5000); remote
   # `rise deploy` pushes go through the registry.${RISE_DOMAIN} Traefik router.
   registry:
@@ -275,6 +274,10 @@ services:
       # loopback (127.0.0.1:5000) or the public registry.${RISE_DOMAIN} per the
       # "Pull" section in docs/.../docker/index.md. Passed through only when set.
       - RISE_REGISTRY_URL
+      # Optional static registry credentials returned to authenticated users
+      # during deploy. Pass through only when explicitly set.
+      - RISE_REGISTRY_USERNAME
+      - RISE_REGISTRY_PASSWORD
       - RISE_COOKIE_SECURE=true
       # Single OIDC issuer. Defaults to dex.${RISE_DOMAIN} — which is only
       # reachable if you opt into the demo-idp overlay (the base file does NOT

--- a/docs/engineering/public/schemas/backend-settings.schema.json
+++ b/docs/engineering/public/schemas/backend-settings.schema.json
@@ -1615,11 +1615,21 @@
               "default": "",
               "type": "string"
             },
+            "password": {
+              "default": "",
+              "description": "Optional static registry password. Intended for small trusted-user setups.",
+              "type": "string"
+            },
             "registry_url": {
               "type": "string"
             },
             "type": {
               "const": "oci-client-auth",
+              "type": "string"
+            },
+            "username": {
+              "default": "",
+              "description": "Optional static registry username. When set with `password`, Rise returns\nthe credentials to authorized clients instead of relying on prior docker login.",
               "type": "string"
             }
           },

--- a/docs/engineering/src/content/docs/configuration.md
+++ b/docs/engineering/src/content/docs/configuration.md
@@ -314,7 +314,16 @@ auto_remove = true
 type = "oci-client-auth"
 registry_url = "registry.example.com"
 namespace = "rise-apps"
+# Optional: automatically authenticate trusted Rise users during deploy.
+username = "${RISE_REGISTRY_USERNAME}"
+password = "${RISE_REGISTRY_PASSWORD}"
 ```
+
+When `username` and `password` are omitted or empty, users must authenticate the
+container CLI themselves with `docker login`. When set, Rise returns these static
+credentials from the authenticated, deployment-scoped credentials endpoint and
+uses them for controller-side pulls. Anyone allowed to deploy can receive the
+credentials, so use this only where all Rise users are trusted.
 
 #### GitLab Container Registry
 

--- a/docs/engineering/src/content/docs/docker/production.md
+++ b/docs/engineering/src/content/docs/docker/production.md
@@ -78,6 +78,8 @@ export ACME_CA_SERVER=https://acme-staging-v02.api.letsencrypt.org/directory
 | `ACME_EMAIL` | — | Contact for Let's Encrypt. |
 | `ACME_CA_SERVER` | LE production | Set to LE staging while testing. |
 | `REGISTRY_BASIC_AUTH` | empty | htpasswd users for the public registry (see [Container registry](/operator-docs/docker/registry/)). |
+| `RISE_REGISTRY_USERNAME` | empty | Optional static registry username returned to trusted users during deploy. |
+| `RISE_REGISTRY_PASSWORD` | empty | Optional static registry password returned to trusted users during deploy. |
 | `DEX_ISSUER` | `https://dex.${RISE_DOMAIN}` | OIDC issuer (see [Authentication / Dex](/operator-docs/docker/authentication/)). |
 | `RISE_IMAGE_TAG` | `0.23.0` | **Manual stable image pin** — bump on upgrade; set an exact published tag for a prerelease. There is no automatic "latest released" resolution. |
 | `RISE_IMAGE_REPOSITORY` | `ghcr.io/rise-deploy/rise` | Override for a fork/mirror. |

--- a/docs/engineering/src/content/docs/docker/registry.md
+++ b/docs/engineering/src/content/docs/docker/registry.md
@@ -8,10 +8,8 @@ The registry is the part most likely to trip operators up, because the push path
 (a developer's machine) and the pull path (the Rise host's Docker daemon) can use
 **different URLs for the same registry**.
 
-The `oci-client-auth` registry provider **mints no credentials**
-(`src/server/registry/providers/docker.rs` returns empty user/pass for both push
-and pull). It assumes the relevant Docker client has already done `docker login`.
-The config carries two URLs:
+The `oci-client-auth` registry provider can either carry static credentials or
+rely on an existing `docker login`. The config carries two URLs:
 
 | Config key | Used by | Reference value |
 |------------|---------|-----------------|
@@ -30,20 +28,33 @@ htpasswd entry and pass it as `REGISTRY_BASIC_AUTH` (escape `$` as `$$` in a
 ```bash
 htpasswd -nbB ci 's3cret'
 # ci:$2y$05$....   →  REGISTRY_BASIC_AUTH='ci:$2y$05$....'  (or $$ in .env)
+export RISE_REGISTRY_USERNAME=ci
+export RISE_REGISTRY_PASSWORD=s3cret
 ```
 
 An internet-exposed registry **must** have auth — hence the basicauth
-middleware. The internal pull path can stay unauthenticated within the trusted
-host network.
+middleware. `REGISTRY_BASIC_AUTH` configures Traefik with the password hash;
+the optional plaintext `RISE_REGISTRY_USERNAME` / `RISE_REGISTRY_PASSWORD` pair
+lets Rise send the matching login to authorized users. Anyone allowed to deploy
+can retrieve this pair, so only configure it when all Rise users are trusted.
+The internal pull path can stay unauthenticated within the trusted host network.
 
 ### 2. Push (developer host, possibly remote)
 
-Log in with the basicauth credentials, then deploy. The CLI uses the stored
-`docker login` — `oci-client-auth` supplies no creds of its own.
+With `RISE_REGISTRY_USERNAME` and `RISE_REGISTRY_PASSWORD` configured, deploy
+directly; Rise returns the static pair from its authenticated, deployment-scoped
+credentials endpoint and the CLI runs `docker login` automatically.
 
 ```bash
-docker login registry.${RISE_DOMAIN}      # basicauth user/pass
 rise deploy --project myapp --image ...    # builds + pushes to client_registry_url
+```
+
+If the static pair is omitted, log in with the basicauth credentials first; the
+provider returns empty credentials and the CLI keeps using the stored login:
+
+```bash
+docker login registry.${RISE_DOMAIN}
+rise deploy --project myapp --image ...
 ```
 
 The push targets `client_registry_url` (`registry.${RISE_DOMAIN}`).

--- a/src/server/registry/models.rs
+++ b/src/server/registry/models.rs
@@ -40,11 +40,11 @@ fn default_repo_prefix() -> String {
     "rise/".to_string()
 }
 
-/// Configuration for OCI registry with client-side authentication
+/// Configuration for an OCI registry with optional static authentication
 ///
-/// This provider is for OCI-compliant registries where the client has already
-/// authenticated (e.g., via `docker login`). The backend only provides the
-/// registry URL and namespace; credentials are managed by the client's Docker config.
+/// When `username` and `password` are empty, the client must already be
+/// authenticated (e.g., via `docker login`). When configured, the backend
+/// returns the static credentials to authorized clients and uses them for pulls.
 #[derive(Debug, Clone, Deserialize)]
 pub struct OciClientAuthConfig {
     /// Registry URL (e.g., "localhost:5000", "registry.example.com")
@@ -56,6 +56,12 @@ pub struct OciClientAuthConfig {
     /// If not specified, defaults to registry_url
     #[serde(default)]
     pub client_registry_url: Option<String>,
+    /// Optional static username returned to authorized CLI clients and used for pulls
+    #[serde(default)]
+    pub username: String,
+    /// Optional static password returned to authorized CLI clients and used for pulls
+    #[serde(default)]
+    pub password: String,
 }
 
 fn default_namespace() -> String {

--- a/src/server/registry/providers/docker.rs
+++ b/src/server/registry/providers/docker.rs
@@ -6,10 +6,11 @@ use crate::server::registry::{
     ImageTagType, RegistryProvider,
 };
 
-/// OCI registry provider that relies on client-side authentication
+/// OCI registry provider with optional static authentication
 ///
-/// This provider assumes the user has already authenticated via `docker login`
-/// or equivalent. It simply returns the registry URL - no credential generation.
+/// With no configured credentials, this provider assumes the user has already
+/// authenticated via `docker login` or equivalent. Static credentials, when
+/// configured, are returned to authorized clients and used for image pulls.
 ///
 /// Works with any OCI-compliant registry (Docker Hub, Harbor, Quay, etc.)
 pub struct OciClientAuthProvider {
@@ -23,6 +24,11 @@ pub struct OciClientAuthProvider {
 impl OciClientAuthProvider {
     /// Create a new OCI client-auth registry provider
     pub fn new(config: OciClientAuthConfig) -> Result<Self> {
+        anyhow::ensure!(
+            config.username.is_empty() == config.password.is_empty(),
+            "OCI registry static credentials require both username and password"
+        );
+
         // Extract host from registry_url (remove protocol and path)
         let registry_host = config
             .registry_url
@@ -75,21 +81,19 @@ impl RegistryProvider for OciClientAuthProvider {
     ) -> Result<RegistryCredentials> {
         tracing::info!("Returning OCI registry info for repository: {}", repository);
 
-        // Return client-facing registry URL - credentials assumed to be configured via docker login
-        // The client_registry_url is used for push operations, while registry_url is used by deployment controllers
+        // The client_registry_url is used for push operations, while registry_url is used by deployment controllers.
+        // Empty credentials preserve client-managed authentication via docker login.
         Ok(RegistryCredentials {
             registry_url: self.client_registry_url.clone(),
-            username: String::new(), // Empty - docker CLI uses stored credentials
-            password: String::new(), // Empty - docker CLI uses stored credentials
+            username: self.config.username.clone(),
+            password: self.config.password.clone(),
             expires_in: None,
             auth_method: Default::default(),
         })
     }
 
     async fn get_pull_credentials(&self) -> Result<(String, String)> {
-        // Client-auth provider assumes docker login was used
-        // Return empty credentials - the docker CLI will use stored credentials
-        Ok((String::new(), String::new()))
+        Ok((self.config.username.clone(), self.config.password.clone()))
     }
 
     fn registry_host(&self) -> &str {
@@ -106,5 +110,64 @@ impl RegistryProvider for OciClientAuthProvider {
             ImageTagType::Internal => &self.registry_url,
         };
         format!("{}/{}:{}", registry_url, repository, tag)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(username: &str, password: &str) -> OciClientAuthConfig {
+        OciClientAuthConfig {
+            registry_url: "registry.internal:5000".to_string(),
+            namespace: "rise-apps".to_string(),
+            client_registry_url: Some("registry.example.com".to_string()),
+            username: username.to_string(),
+            password: password.to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn returns_static_credentials_for_push_and_pull() {
+        let provider = OciClientAuthProvider::new(config("rise", "secret")).unwrap();
+
+        let push = provider
+            .get_credentials("my-app", &["deployment-1"])
+            .await
+            .unwrap();
+        assert_eq!(push.registry_url, "registry.example.com/rise-apps");
+        assert_eq!(push.username, "rise");
+        assert_eq!(push.password, "secret");
+        assert_eq!(push.expires_in, None);
+
+        let pull = provider.get_pull_credentials().await.unwrap();
+        assert_eq!(pull, ("rise".to_string(), "secret".to_string()));
+    }
+
+    #[tokio::test]
+    async fn preserves_client_managed_auth_when_credentials_are_empty() {
+        let provider = OciClientAuthProvider::new(config("", "")).unwrap();
+
+        let push = provider
+            .get_credentials("my-app", &["deployment-1"])
+            .await
+            .unwrap();
+        assert!(push.username.is_empty());
+        assert!(push.password.is_empty());
+        assert_eq!(
+            provider.get_pull_credentials().await.unwrap(),
+            (String::new(), String::new())
+        );
+    }
+
+    #[test]
+    fn rejects_partial_static_credentials() {
+        let error = OciClientAuthProvider::new(config("rise", ""))
+            .err()
+            .expect("partial credentials must fail");
+        assert_eq!(
+            error.to_string(),
+            "OCI registry static credentials require both username and password"
+        );
     }
 }

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -1470,6 +1470,13 @@ pub enum RegistrySettings {
         /// If not specified, defaults to registry_url
         #[serde(default)]
         client_registry_url: Option<String>,
+        /// Optional static registry username. When set with `password`, Rise returns
+        /// the credentials to authorized clients instead of relying on prior docker login.
+        #[serde(default)]
+        username: String,
+        /// Optional static registry password. Intended for small trusted-user setups.
+        #[serde(default)]
+        password: String,
     },
     /// GitLab container registry — mints scoped JWTs per deployment
     #[serde(rename = "gitlab")]
@@ -1807,6 +1814,21 @@ impl Settings {
             return Err(ConfigError::Message(
                 "JWT signing secret not configured. Set RISE_SERVER__JWT_SIGNING_SECRET environment variable or [server] jwt_signing_secret in config. Generate with: openssl rand -base64 32".to_string()
             ));
+        }
+
+        // A password without a username would be silently treated by the CLI as
+        // client-managed auth, while a username without a password would cause a
+        // confusing login failure. Keep static registry auth explicitly paired.
+        if let Some(RegistrySettings::OciClientAuth {
+            username, password, ..
+        }) = &settings.registry
+        {
+            if username.is_empty() != password.is_empty() {
+                return Err(ConfigError::Message(
+                    "OCI registry static credentials require both username and password"
+                        .to_string(),
+                ));
+            }
         }
 
         // Validate deployment controller settings if configured

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -715,11 +715,15 @@ impl AppState {
                     registry_url,
                     namespace,
                     client_registry_url,
+                    username,
+                    password,
                 } => {
                     let oci_config = OciClientAuthConfig {
                         registry_url: registry_url.clone(),
                         namespace: namespace.clone(),
                         client_registry_url: client_registry_url.clone(),
+                        username: username.clone(),
+                        password: password.clone(),
                     };
                     let provider = OciClientAuthProvider::new(oci_config)
                         .context("Failed to initialize OCI client-auth registry provider")?;


### PR DESCRIPTION
## Summary

Allow the `oci-client-auth` registry provider to carry an optional static username/password pair. Authorized deploy clients receive the pair through the existing deployment-scoped credentials flow and log in automatically, while the Docker controller can reuse it for pulls. Empty credentials preserve the existing client-managed `docker login` behavior, and partial pairs fail configuration validation.

Wire the standalone Docker stack to `RISE_REGISTRY_USERNAME` and `RISE_REGISTRY_PASSWORD`, regenerate the settings schema, and document the intentional trusted-user security boundary.

Stacked on #444.

## Test plan

- [x] `cargo test --features backend server::registry::providers::docker::tests`
- [x] `cargo clippy --features backend --bin rise -- -D warnings`
- [x] Validate complete static credentials with `rise backend check-config`
- [x] Verify partial static credentials are rejected by `rise backend check-config`
- [x] `docker compose -f docker-compose.standalone.yaml config --quiet`
- [x] `cargo fmt --all -- --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rise-deploy/codesmith/rise/pr/445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789648413&installation_model_id=432987&pr_number=445&repository=rise-deploy%2Frise&return_to=https%3A%2F%2Fgithub.com%2Frise-deploy%2Frise%2Fpull%2F445&signature=361f8d6635fcda947bb19fd6403ccbfc96978fb654647de2a518abf4bb75c306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->