### PR TITLE
Allow custom IdP group claim mapping

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -33,6 +33,8 @@ auth:
   issuer: "http://rise-dex:5556/dex"
   client_id: "rise-backend"
   client_secret: "rise-backend-secret"
+  # ID-token claim containing group names (default: "groups").
+  # idp_group_claim: "cognito:groups"
   admin_users:
     - "admin@example.com"
   # Grant the admin role by IdP group instead of listing every email. A user

--- a/config/docker.yaml
+++ b/config/docker.yaml
@@ -67,6 +67,8 @@ auth:
   issuer: "${DEX_ISSUER:-http://rise-dex:5556/dex}"
   client_id: "${OIDC_CLIENT_ID:-rise-backend}"
   client_secret: "${OIDC_CLIENT_SECRET:-rise-backend-secret}"
+  # ID-token claim containing group names. AWS Cognito uses "cognito:groups".
+  idp_group_claim: "${OIDC_GROUP_CLAIM:-groups}"
   admin_users: ["${ADMIN_EMAIL:-admin@example.com}"]
   # Grant the admin role to everyone in an IdP group instead of listing emails.
   # Blank entries are filtered out, so an unset var collapses to an empty list.

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -26,6 +26,8 @@ auth:
   issuer: "${OIDC_ISSUER}"
   client_id: "${OIDC_CLIENT_ID:-rise-backend}"
   client_secret: "${OIDC_CLIENT_SECRET}"
+  # ID-token claim containing group names. AWS Cognito uses "cognito:groups".
+  idp_group_claim: "${OIDC_GROUP_CLAIM:-groups}"
   admin_users:
     - "${ADMIN_EMAIL:-admin@example.com}"
   # Optional: enable active sync to pull users/groups from Entra ID.

--- a/docker-compose.standalone.yaml
+++ b/docker-compose.standalone.yaml
@@ -295,6 +295,9 @@ services:
       - RISE_JWT_SIGNING_SECRET
       - RISE_ENCRYPTION_KEY
       - OIDC_CLIENT_SECRET
+      # Optional ID-token claim containing group names. Defaults to `groups`;
+      # AWS Cognito users can set OIDC_GROUP_CLAIM=cognito:groups.
+      - OIDC_GROUP_CLAIM
       - ADMIN_EMAIL
       # Operator access to the generic resource API (/api/v1/resources). Defaults
       # to none — set RISE_OPERATOR_EMAIL to grant a single operator (mount a

--- a/docs/engineering/public/schemas/backend-settings.schema.json
+++ b/docs/engineering/public/schemas/backend-settings.schema.json
@@ -139,9 +139,14 @@
           },
           "type": "array"
         },
+        "idp_group_claim": {
+          "default": "groups",
+          "description": "Claim in the IdP ID token that contains group names (default: \"groups\").\nFor example, AWS Cognito commonly exposes groups as \"cognito:groups\".",
+          "type": "string"
+        },
         "idp_group_sync_enabled": {
           "default": true,
-          "description": "Enable IdP group synchronization (default: true)\nWhen enabled, user team memberships are automatically synced from IdP groups claim on login",
+          "description": "Enable IdP group synchronization (default: true).\nWhen enabled, user team memberships are synchronized from the configured\nIdP group claim on login.",
           "type": "boolean"
         },
         "issuer": {

--- a/docs/engineering/src/content/docs/configuration.md
+++ b/docs/engineering/src/content/docs/configuration.md
@@ -223,6 +223,8 @@ auth:
                                 # offline_access is omitted by default (the CLI
                                 # does not use refresh tokens, and some providers
                                 # such as Google reject it); add it here if needed.
+  idp_group_claim: "groups"     # ID-token claim containing group names (default shown)
+                                # Use "cognito:groups" for AWS Cognito.
   admin_users: ["email@..."]    # Default-organization admin emails (array)
   admin_idp_groups: ["..."]     # IdP groups whose members are admins (array, optional)
   operator_users: ["ops@..."]   # Operator role allowlist (array, optional)
@@ -251,10 +253,11 @@ A user holds the role if their email is on the allowlist **or** they are in one
 of the listed groups. Group names match case-insensitively. Users granted a role
 by group bypass `platform_access` exactly as email-listed users do.
 
-**How group membership is resolved.** Rise sees the IdP's `groups` claim at
-login and mirrors it into IdP-managed teams (`sync_user_groups`, and the Entra
-active sync when enabled); those teams are what the group checks read. Two
-consequences:
+**How group membership is resolved.** Rise reads the ID-token claim configured
+by `auth.idp_group_claim` (default: `groups`) at login and mirrors it into
+IdP-managed teams (`sync_user_groups`, and the Entra active sync when enabled).
+For AWS Cognito, set `idp_group_claim: "cognito:groups"`. Those teams are what
+the group checks read. Two consequences:
 
 - Only **IdP-managed** teams count. A team a user creates themselves never
   grants a role, even if its name matches a configured group — otherwise

--- a/docs/engineering/src/content/docs/docker/production.md
+++ b/docs/engineering/src/content/docs/docker/production.md
@@ -87,6 +87,7 @@ export ACME_CA_SERVER=https://acme-staging-v02.api.letsencrypt.org/directory
 | `RISE_JWT_SIGNING_SECRET` | insecure repo placeholder | **Set it.** Overrides the demo secret baked into `config/docker.yaml`. `openssl rand -base64 32`. |
 | `RISE_ENCRYPTION_KEY` | insecure repo placeholder | **Set it.** Overrides the demo AES key. `openssl rand -base64 32`. |
 | `OIDC_CLIENT_SECRET` | `rise-backend-secret` | **Set it.** Keep in sync with the Dex client secret in `dev/dex/config.yaml`. |
+| `OIDC_GROUP_CLAIM` | `groups` | ID-token claim containing group names. Set to `cognito:groups` for AWS Cognito. |
 | `ADMIN_EMAIL` | `admin@example.com` | Initial admin user. |
 | `RISE_PLATFORM_ACCESS_POLICY` | `allow_all` | Who may use the CLI/API/dashboard. `allow_all` = any authenticated user; `restrictive` = allowlist only (see [Platform access](#platform-access)). |
 | `RISE_PLATFORM_ALLOWED_EMAIL` | empty | A single email granted platform access when the policy is `restrictive`. For several users, mount a config override. |
@@ -153,6 +154,7 @@ env var.
 
 Group-based grants — `allowed_idp_groups`, `admin_idp_groups`,
 `operator_idp_groups` — match against the IdP-managed teams Rise syncs from the
-IdP's `groups` claim at login. Teams users create themselves never match, and a
-group removal in the IdP takes effect on the user's next login. See
+ID-token claim selected by `auth.idp_group_claim` (`OIDC_GROUP_CLAIM`, default
+`groups`) at login. Teams users create themselves never match, and a group
+removal in the IdP takes effect on the user's next login. See
 [Roles](/operator-docs/configuration/#authentication-auth) for details.

--- a/docs/engineering/src/content/docs/upgrade-notes.md
+++ b/docs/engineering/src/content/docs/upgrade-notes.md
@@ -67,8 +67,9 @@ Merged to `develop`:
   the groups; group names match case-insensitively.
 
   All group matching — including the existing `auth.platform_access.allowed_idp_groups`
-  — now resolves against the **IdP-managed** teams Rise syncs from the IdP's
-  `groups` claim, rather than against every team the user belongs to. **Action
+  — now resolves against the **IdP-managed** teams Rise syncs from the configured
+  group claim (`auth.idp_group_claim`, default `groups`), rather than against
+  every team the user belongs to. **Action
   required only if** you granted platform access through `allowed_idp_groups`
   naming a team that Rise did not create from the IdP (i.e. `idp_managed = false`);
   those users lose platform access until the group comes from the IdP. This closes
@@ -76,6 +77,11 @@ Merged to `develop`:
   allowed group and grant themselves access. Group membership refreshes at login,
   so revoking a group in the IdP takes effect on the user's next login (or the next
   Entra active sync).
+- **Config change — custom IdP group claim**. `auth.idp_group_claim` selects the
+  ID-token claim Rise uses for IdP-managed team synchronization. It defaults to
+  `groups`, preserving existing behavior. AWS Cognito operators can set it to
+  `cognito:groups` (or set `OIDC_GROUP_CLAIM=cognito:groups` in the standalone
+  Docker deployment).
 - **Action required if conflicts exist — policy resource activation** ([#430](https://github.com/rise-deploy/rise/pull/430)).
   Rise activates the four reserved `rise.dev/v1alpha1` policy resource kinds —
   `Role` and `RoleBinding` under an Organization, `PlatformRole` and

--- a/helm/rise/values.yaml
+++ b/helm/rise/values.yaml
@@ -254,6 +254,8 @@ config:
     issuer: "http://dex:5556/dex"
     client_id: "rise-backend"
     client_secret: ""  # Override with Secret or environment variable
+    # ID-token claim containing group names. AWS Cognito uses "cognito:groups".
+    idp_group_claim: "groups"
     # admin_users: []  # Optional: List of admin user emails with full permissions
     # admin_idp_groups: []  # Optional: IdP groups whose members are admins
     # operator_idp_groups: []  # Optional: IdP groups whose members hold the Operator role

--- a/src/server/auth/group_sync.rs
+++ b/src/server/auth/group_sync.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 
 use crate::db::{models::TeamRole, teams};
 
-/// Synchronize user's team memberships based on IdP groups claim
+/// Synchronize a user's team memberships from the configured IdP group claim.
 ///
 /// This function implements the complete IdP group synchronization algorithm:
 /// 1. Creates teams that don't exist in Rise
@@ -19,7 +19,7 @@ use crate::db::{models::TeamRole, teams};
 /// # Arguments
 /// * `pool` - Database connection pool
 /// * `user_id` - UUID of the user logging in
-/// * `idp_groups` - List of group names from the IdP's "groups" claim
+/// * `idp_groups` - List of group names from the configured IdP group claim
 ///
 /// # Errors
 /// Returns an error if database operations fail. The transaction will be rolled back.
@@ -107,7 +107,7 @@ pub async fn sync_user_groups(pool: &PgPool, user_id: Uuid, idp_groups: &[String
         .context("Failed to list IdP-managed teams")?;
 
     for team in all_idp_teams {
-        // Case-insensitive check if team is in IdP groups claim
+        // Case-insensitive check if team is in the IdP group claim
         let in_claim = idp_groups
             .iter()
             .any(|g| g.eq_ignore_ascii_case(&team.name));
@@ -120,7 +120,7 @@ pub async fn sync_user_groups(pool: &PgPool, user_id: Uuid, idp_groups: &[String
 
             if is_member {
                 tracing::info!(
-                    "Removing user from IdP-managed team '{}' (not in groups claim)",
+                    "Removing user from IdP-managed team '{}' (not in IdP group claim)",
                     team.name
                 );
                 teams::remove_all_user_roles(&mut *tx, team.id, user_id)

--- a/src/server/auth/handlers.rs
+++ b/src/server/auth/handlers.rs
@@ -281,14 +281,17 @@ async fn sync_groups_after_login(
         })?;
 
     // Parse claims
-    let claims: crate::server::auth::jwt::Claims =
-        serde_json::from_value(claims_value).map_err(|e| {
-            tracing::warn!("Failed to parse claims for group sync: {:#}", e);
-            (
-                StatusCode::UNAUTHORIZED,
-                format!("Invalid token claims: {}", e),
-            )
-        })?;
+    let claims = crate::server::auth::jwt::Claims::from_value_with_group_claim(
+        claims_value,
+        &state.auth_settings.idp_group_claim,
+    )
+    .map_err(|e| {
+        tracing::warn!("Failed to parse claims for group sync: {:#}", e);
+        (
+            StatusCode::UNAUTHORIZED,
+            format!("Invalid token claims: {}", e),
+        )
+    })?;
 
     // Get or create user. Always pairs the user row with a default-Org
     // membership so bootstrap validation never observes a half-created user.

--- a/src/server/auth/jwt.rs
+++ b/src/server/auth/jwt.rs
@@ -26,6 +26,29 @@ pub struct Claims {
     pub groups: Option<Vec<String>>,
 }
 
+impl Claims {
+    /// Deserialize validated ID-token claims while mapping the configured IdP
+    /// group claim onto Rise's internal `groups` field.
+    pub fn from_value_with_group_claim(
+        mut value: serde_json::Value,
+        group_claim: &str,
+    ) -> serde_json::Result<Self> {
+        if group_claim != "groups" {
+            if let Some(claims) = value.as_object_mut() {
+                let configured_groups = claims.remove(group_claim);
+                // Selecting a custom claim must not silently fall back to the
+                // provider's conventional `groups` claim.
+                claims.remove("groups");
+                if let Some(groups) = configured_groups {
+                    claims.insert("groups".to_string(), groups);
+                }
+            }
+        }
+
+        serde_json::from_value(value)
+    }
+}
+
 /// JWKS (JSON Web Key Set) response from OIDC provider
 #[derive(Debug, Deserialize)]
 struct JwksResponse {
@@ -306,6 +329,61 @@ mod tests {
         assert_eq!(claims.email, "test@example.com");
         assert_eq!(claims.iss, "https://issuer.example.com");
         assert_eq!(claims.aud, "my-client-id");
+    }
+
+    #[test]
+    fn test_claims_deserialization_with_custom_group_claim() {
+        let value = serde_json::json!({
+            "sub": "user123",
+            "email": "test@example.com",
+            "iss": "https://issuer.example.com",
+            "aud": "my-client-id",
+            "exp": 1234567890,
+            "iat": 1234567800,
+            "groups": ["wrong-group"],
+            "cognito:groups": ["developers", "operators"]
+        });
+
+        let claims = Claims::from_value_with_group_claim(value, "cognito:groups").unwrap();
+
+        assert_eq!(
+            claims.groups,
+            Some(vec!["developers".to_string(), "operators".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_claims_deserialization_with_default_group_claim() {
+        let value = serde_json::json!({
+            "sub": "user123",
+            "email": "test@example.com",
+            "iss": "https://issuer.example.com",
+            "aud": "my-client-id",
+            "exp": 1234567890,
+            "iat": 1234567800,
+            "groups": ["developers"]
+        });
+
+        let claims = Claims::from_value_with_group_claim(value, "groups").unwrap();
+
+        assert_eq!(claims.groups, Some(vec!["developers".to_string()]));
+    }
+
+    #[test]
+    fn test_custom_group_claim_does_not_fall_back_to_groups() {
+        let value = serde_json::json!({
+            "sub": "user123",
+            "email": "test@example.com",
+            "iss": "https://issuer.example.com",
+            "aud": "my-client-id",
+            "exp": 1234567890,
+            "iat": 1234567800,
+            "groups": ["wrong-group"]
+        });
+
+        let claims = Claims::from_value_with_group_claim(value, "cognito:groups").unwrap();
+
+        assert_eq!(claims.groups, None);
     }
 
     #[test]

--- a/src/server/auth/roles.rs
+++ b/src/server/auth/roles.rs
@@ -7,7 +7,7 @@
 //! `auth.platform_access.allowed_idp_groups`). Both forms match
 //! case-insensitively.
 //!
-//! Rise never sees the IdP's `groups` claim outside of login: `sync_user_groups`
+//! Rise never sees the configured IdP group claim outside of login: `sync_user_groups`
 //! (and the Entra active sync) mirror it into `idp_managed` teams, which is the
 //! record consulted here. Teams a user created themselves are not IdP-managed
 //! and therefore never grant a group-derived role.

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -522,6 +522,10 @@ fn default_idp_group_sync_enabled() -> bool {
     true
 }
 
+fn default_idp_group_claim() -> String {
+    "groups".to_string()
+}
+
 fn default_active_sync_interval_secs() -> u64 {
     300 // 5 minutes
 }
@@ -625,10 +629,15 @@ pub struct AuthSettings {
     /// or default to {issuer}/token
     #[serde(default)]
     pub token_url: Option<String>,
-    /// Enable IdP group synchronization (default: true)
-    /// When enabled, user team memberships are automatically synced from IdP groups claim on login
+    /// Enable IdP group synchronization (default: true).
+    /// When enabled, user team memberships are synchronized from the configured
+    /// IdP group claim on login.
     #[serde(default = "default_idp_group_sync_enabled")]
     pub idp_group_sync_enabled: bool,
+    /// Claim in the IdP ID token that contains group names (default: "groups").
+    /// For example, AWS Cognito commonly exposes groups as "cognito:groups".
+    #[serde(default = "default_idp_group_claim")]
+    pub idp_group_claim: String,
     /// Optional active sync source for pulling users and groups from an external IdP.
     /// When configured, Rise will periodically query the IdP for users and groups
     /// assigned to the app and sync them as Rise teams.
@@ -1816,6 +1825,12 @@ impl Settings {
             ));
         }
 
+        if settings.auth.idp_group_claim.trim().is_empty() {
+            return Err(ConfigError::Message(
+                "auth.idp_group_claim must not be empty".to_string(),
+            ));
+        }
+
         // A password without a username would be silently treated by the CLI as
         // client-managed auth, while a username without a password would cause a
         // confusing login failure. Keep static registry auth explicitly paired.
@@ -2076,6 +2091,23 @@ mod tests {
         let settings: Settings = serde_json::from_value(json).unwrap();
 
         assert_eq!(settings.reserved_project_names, ["grafana", "prometheus"]);
+    }
+
+    #[test]
+    fn idp_group_claim_defaults_to_groups() {
+        let settings: Settings = serde_json::from_value(minimal_settings_json()).unwrap();
+
+        assert_eq!(settings.auth.idp_group_claim, "groups");
+    }
+
+    #[test]
+    fn idp_group_claim_can_be_customized() {
+        let mut json = minimal_settings_json();
+        json["auth"]["idp_group_claim"] = serde_json::json!("cognito:groups");
+
+        let settings: Settings = serde_json::from_value(json).unwrap();
+
+        assert_eq!(settings.auth.idp_group_claim, "cognito:groups");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Add `auth.idp_group_claim` so operators can select the ID-token claim used for IdP-managed team synchronization. The option defaults to `groups` for backward compatibility and supports provider-specific names such as AWS Cognito's `cognito:groups`; deployment configuration, generated schema, Helm values, standalone Docker passthrough, and operator documentation are updated accordingly.

## Test plan
- `cargo fmt --all -- --check`
- `cargo test --package rise-deploy --features cli,backend server::auth::jwt::tests` (8 passed)
- `cargo test --package rise-deploy --features cli,backend server::settings::tests` (40 passed)
- Regenerated the backend settings schema
- Rendered the Helm chart with `config.auth.idp_group_claim=cognito:groups`
- Validated `docker-compose.standalone.yaml` with `docker compose config`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rise-deploy/codesmith/rise/pr/447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789657840&installation_model_id=432987&pr_number=447&repository=rise-deploy%2Frise&return_to=https%3A%2F%2Fgithub.com%2Frise-deploy%2Frise%2Fpull%2F447&signature=9eda62b5ada985e66b3c64b6eb10bbc7c0aac7059b7e5717989a03f1cd58f2aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->