### PR TITLE
Bundle AI-accessible docs in Rise images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,9 @@ COPY docs/engineering/package.json ./engineering/
 RUN npm ci
 
 COPY docs/ ./
-RUN npm run build --workspace=rise-user-docs
+COPY skills/rise-app-builder /usr/src/skills/rise-app-builder
+RUN RISE_USER_DOCS_URL=/docs node scripts/generate-llms.mjs && \
+    npm run build --workspace=rise-user-docs
 
 # Stage 3: Build dependencies (cached separately from source code)
 FROM chef AS builder


### PR DESCRIPTION
## Summary

Rise serves the built user documentation under `/docs`, but the container build bypassed the LLM artifact generator, so clean images omitted `llms.txt`, `llms-full.txt`, per-page Markdown, and the hosted app-builder skill. Run the generator before the Astro build, copy its required skill sources into the build stage, and use `/docs` as the generated user-docs base so all agent-facing links resolve through the bundled Rise documentation route.

## Test plan

- [x] Generate artifacts with `RISE_USER_DOCS_URL=/docs node docs/scripts/generate-llms.mjs` and verify expected files and links.
- [x] Build the actual documentation image stage with `docker build --target user-docs-builder --progress=plain -t rise-user-docs-llm-test .`.
- [x] Inspect the built image and verify `llms.txt`, `llms-full.txt`, per-page Markdown, and the `rise-app-builder` skill are present with `/docs` links.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rise-deploy/codesmith/rise/pr/448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789658056&installation_model_id=432987&pr_number=448&repository=rise-deploy%2Frise&return_to=https%3A%2F%2Fgithub.com%2Frise-deploy%2Frise%2Fpull%2F448&signature=7fba548f34998759b0067124bedc35fb201123745d3ece3ec4ec9bd92fa49a04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->