### PR TITLE
Support bounded ECS platform deployments

### DIFF
--- a/config/ecs.yaml
+++ b/config/ecs.yaml
@@ -35,10 +35,17 @@ auth:
   issuer: "${DEX_ISSUER:-http://rise-dex:5556/dex}"
   client_id: "${OIDC_CLIENT_ID:-rise-backend}"
   client_secret: "${OIDC_CLIENT_SECRET:-rise-backend-secret}"
+  idp_group_claim: "${OIDC_GROUP_CLAIM:-groups}"
   admin_users:
     - "${ADMIN_EMAIL:-admin@example.com}"
+  admin_idp_groups:
+    - "${RISE_ADMIN_IDP_GROUP:-}"
   allow_team_creation: true
   allow_list_all_teams: true
+  platform_access:
+    policy: "${RISE_PLATFORM_ACCESS_POLICY:-allow_all}"
+    allowed_idp_groups:
+      - "${RISE_PLATFORM_ALLOWED_IDP_GROUP:-}"
 
 registry:
   # ECR is the recommended registry for this backend: ECS pulls with the task

--- a/modules/rise-aws/README.md
+++ b/modules/rise-aws/README.md
@@ -1,11 +1,14 @@
 # Rise AWS Terraform Module
 
-This module creates the AWS IAM resources required for the Rise backend to manage AWS services (ECR for container registries and RDS for database instances).
+This module creates the AWS IAM resources required for the Rise backend to manage AWS services and deploy applications onto ECS.
 
 ## Features
 
-- **Controller role**: Manages ECR repository lifecycle (create, delete, tag) and RDS instances
+- **Controller role**: Manages the enabled providers and ECS deployment controller
 - **Push role**: Separate role for generating scoped image push credentials
+- Separate ECS execution, application, and Traefik discovery roles
+- Optional common permissions boundary on every generated role
+- Inline policy mode for deployers that may create roles but not customer-managed policies
 - Supports IAM role (for AWS deployments with IRSA or instance profiles)
 - Supports IAM user with access keys (for non-AWS deployments)
 - Configurable repository prefix for multi-tenant isolation
@@ -15,7 +18,7 @@ This module creates the AWS IAM resources required for the Rise backend to manag
 
 ## Architecture
 
-The module creates two separate IAM roles with distinct permissions:
+The module creates distinct identities for each responsibility:
 
 1. **Backend Role** (e.g., `rise-backend`): Used by the Rise backend to manage AWS resources
    - ECR repositories: Create/delete, tag, list for discovery
@@ -26,6 +29,12 @@ The module creates two separate IAM roles with distinct permissions:
 2. **Push Role** (e.g., `rise-backend-ecr-push`): Assumed by the backend to generate scoped credentials
    - Push images to ECR
    - The backend uses STS AssumeRole with an inline session policy to scope credentials to specific repositories
+
+3. **ECS execution role**: ECS image pulls, logs, and task secret resolution
+
+4. **Application task role**: The identity applications run as; it has no controller policy
+
+5. **Traefik task role**: Read-only ECS, EC2, and SSM discovery calls
 
 ## Usage
 
@@ -42,6 +51,29 @@ module "rise_aws" {
   tags = {
     Environment = "production"
   }
+}
+```
+
+### Delegated ECS installation
+
+```hcl
+module "rise_aws" {
+  source = "./modules/rise-aws"
+
+  name                     = "rise-prod-controller"
+  enable_ecr               = true
+  enable_ecs               = true
+  enable_rds               = false
+  iam_policy_mode          = "inline"
+  permissions_boundary_arn = var.runtime_boundary_arn
+
+  ecr_repository_prefix  = "rise-prod/"
+  ecr_push_role_name     = "rise-prod-ecr-push"
+  ecs_cluster_name       = "platform"
+  ecs_execution_role_name = "rise-prod-execution"
+  ecs_workload_role_name  = "rise-prod-app"
+  ecs_traefik_role_name   = "rise-prod-traefik"
+  ssm_parameter_prefix    = "rise-prod"
 }
 ```
 
@@ -168,8 +200,12 @@ This makes it easy to reference in your configuration management tool (e.g., usi
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | name | Name for the IAM role and policy | `string` | `"rise-backend"` | no |
+| permissions_boundary_arn | Boundary attached to every generated role | `string` | `null` | no |
+| iam_policy_mode | `managed` or `inline` generated policies | `string` | `"managed"` | no |
 | tags | Tags to apply to all resources | `map(string)` | `{}` | no |
 | enable_ecr | Enable ECR permissions | `bool` | `true` | no |
+| ecr_repository_prefix | Repository path prefix | `string` | `<name>/` | no |
+| ecr_push_role_name | ECR publisher role name | `string` | `<name>-ecr-push` | no |
 | enable_rds | Enable RDS permissions | `bool` | `false` | no |
 | rds_vpc_id | VPC ID for RDS resources | `string` | `null` | no |
 | rds_subnet_ids | Subnet IDs for RDS DB subnet group | `list(string)` | `[]` | no |
@@ -184,6 +220,11 @@ This makes it easy to reference in your configuration management tool (e.g., usi
 | image_tag_mutability | Tag mutability for repositories | `string` | `"MUTABLE"` | no |
 | scan_on_push | Enable image scanning on push | `bool` | `true` | no |
 | max_image_count | Max images to retain per repository | `number` | `100` | no |
+| enable_ecs | Enable ECS controller identities and policies | `bool` | `false` | no |
+| ecs_cluster_name | Existing cluster Rise reconciles | `string` | `<name>` | no |
+| ecs_execution_role_name | ECS execution role name | `string` | `<name>-ecs-execution` | no |
+| ecs_workload_role_name | Application task role name | `string` | `<name>-app` | no |
+| ecs_traefik_role_name | Traefik discovery role name | `string` | `<name>-traefik` | no |
 
 ## Outputs
 
@@ -201,12 +242,15 @@ This makes it easy to reference in your configuration management tool (e.g., usi
 | role_name | Name of the controller IAM role |
 | push_role_arn | ARN of the push IAM role (ECR only) |
 | push_role_name | Name of the push IAM role (ECR only) |
+| ecs_execution_role_arn | ECS execution role ARN |
+| ecs_task_role_arn | Application task role ARN |
+| ecs_traefik_role_arn | Traefik discovery role ARN |
 | user_arn | ARN of the IAM user (if created) |
 | user_name | Name of the IAM user (if created) |
 | access_key_id | Access key ID (sensitive, if IAM user created) |
 | secret_access_key | Secret access key (sensitive, if IAM user created) |
-| controller_policy_arn | ARN of the controller IAM policy |
-| push_policy_arn | ARN of the push IAM policy (ECR only) |
+| controller_policy_arn | ARN of the controller IAM policy in managed mode; otherwise null |
+| push_policy_arn | ARN of the push IAM policy in managed mode; otherwise null |
 | policy_document | The controller IAM policy document JSON |
 | lifecycle_policy | ECR lifecycle policy JSON |
 | kms_key_arn | ARN of the KMS key (if KMS enabled) |

--- a/modules/rise-aws/main.tf
+++ b/modules/rise-aws/main.tf
@@ -1,6 +1,6 @@
 locals {
   name        = var.name
-  repo_prefix = "${var.name}/"
+  repo_prefix = coalesce(var.ecr_repository_prefix, "${var.name}/")
 
   # KMS key alias name - defaults to just the name, but can be overridden for backwards compatibility
   kms_key_alias = var.kms_key_alias != null ? var.kms_key_alias : var.name
@@ -41,6 +41,9 @@ locals {
 
   ecs_cluster_name        = coalesce(var.ecs_cluster_name, var.name)
   ecs_execution_role_name = coalesce(var.ecs_execution_role_name, "${var.name}-ecs-execution")
+  ecs_workload_role_name  = coalesce(var.ecs_workload_role_name, "${var.name}-app")
+  ecs_traefik_role_name   = coalesce(var.ecs_traefik_role_name, "${var.name}-traefik")
+  ecr_push_role_name      = coalesce(var.ecr_push_role_name, "${var.name}-ecr-push")
   ecs_cluster_arn         = "arn:${local.partition}:ecs:${local.region}:${local.account_id}:cluster/${local.ecs_cluster_name}"
 
   # Trailing slashes in the configured prefix would produce `parameter//rise//*`,
@@ -427,7 +430,7 @@ data "aws_iam_policy_document" "backend" {
       # should see the two ARNs, not "(known after apply)".
       resources = [
         "arn:${local.partition}:iam::${local.account_id}:role/${local.ecs_execution_role_name}",
-        "arn:${local.partition}:iam::${local.account_id}:role/${local.name}"
+        "arn:${local.partition}:iam::${local.account_id}:role/${local.ecs_workload_role_name}"
       ]
       condition {
         test     = "StringEquals"
@@ -480,6 +483,8 @@ data "aws_iam_policy_document" "backend" {
 }
 
 resource "aws_iam_policy" "backend" {
+  count = var.iam_policy_mode == "managed" ? 1 : 0
+
   name        = local.name
   description = "IAM policy for Rise backend to manage ECR repositories, RDS instances, and S3 buckets"
   policy      = data.aws_iam_policy_document.backend.json
@@ -556,15 +561,26 @@ locals {
 }
 
 resource "aws_iam_role" "backend" {
-  name               = local.name
-  description        = "IAM role for Rise backend"
-  assume_role_policy = local.assume_role_policy
-  tags               = local.tags
+  name                 = local.name
+  description          = "IAM role for Rise backend"
+  assume_role_policy   = local.assume_role_policy
+  permissions_boundary = var.permissions_boundary_arn
+  tags                 = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "backend" {
+  count = var.iam_policy_mode == "managed" ? 1 : 0
+
   role       = aws_iam_role.backend.name
-  policy_arn = aws_iam_policy.backend.arn
+  policy_arn = aws_iam_policy.backend[0].arn
+}
+
+resource "aws_iam_role_policy" "backend" {
+  count = var.iam_policy_mode == "inline" ? 1 : 0
+
+  name   = "controller"
+  role   = aws_iam_role.backend.id
+  policy = data.aws_iam_policy_document.backend.json
 }
 
 # -----------------------------------------------------------------------------
@@ -579,10 +595,18 @@ resource "aws_iam_user" "backend" {
 }
 
 resource "aws_iam_user_policy_attachment" "backend" {
-  count = var.create_iam_user ? 1 : 0
+  count = var.create_iam_user && var.iam_policy_mode == "managed" ? 1 : 0
 
   user       = aws_iam_user.backend[0].name
-  policy_arn = aws_iam_policy.backend.arn
+  policy_arn = aws_iam_policy.backend[0].arn
+}
+
+resource "aws_iam_user_policy" "backend" {
+  count = var.create_iam_user && var.iam_policy_mode == "inline" ? 1 : 0
+
+  name   = "controller"
+  user   = aws_iam_user.backend[0].name
+  policy = data.aws_iam_policy_document.backend.json
 }
 
 resource "aws_iam_access_key" "backend" {
@@ -632,9 +656,9 @@ data "aws_iam_policy_document" "push_role" {
 }
 
 resource "aws_iam_policy" "push_role" {
-  count = var.enable_ecr ? 1 : 0
+  count = var.enable_ecr && var.iam_policy_mode == "managed" ? 1 : 0
 
-  name        = "${var.name}-ecr-push"
+  name        = local.ecr_push_role_name
   description = "IAM policy for Rise ECR push operations"
   policy      = data.aws_iam_policy_document.push_role[0].json
   tags        = local.tags
@@ -671,17 +695,26 @@ data "aws_iam_policy_document" "push_role_assume" {
 resource "aws_iam_role" "push_role" {
   count = var.enable_ecr ? 1 : 0
 
-  name               = "${var.name}-ecr-push"
-  description        = "IAM role for Rise ECR push operations (assumed to generate scoped credentials)"
-  assume_role_policy = data.aws_iam_policy_document.push_role_assume[0].json
-  tags               = local.tags
+  name                 = local.ecr_push_role_name
+  description          = "IAM role for Rise ECR push operations (assumed to generate scoped credentials)"
+  assume_role_policy   = data.aws_iam_policy_document.push_role_assume[0].json
+  permissions_boundary = var.permissions_boundary_arn
+  tags                 = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "push_role" {
-  count = var.enable_ecr ? 1 : 0
+  count = var.enable_ecr && var.iam_policy_mode == "managed" ? 1 : 0
 
   role       = aws_iam_role.push_role[0].name
   policy_arn = aws_iam_policy.push_role[0].arn
+}
+
+resource "aws_iam_role_policy" "push_role" {
+  count = var.enable_ecr && var.iam_policy_mode == "inline" ? 1 : 0
+
+  name   = "push"
+  role   = aws_iam_role.push_role[0].id
+  policy = data.aws_iam_policy_document.push_role[0].json
 }
 
 # The controller also needs permission to assume the push role
@@ -699,7 +732,7 @@ data "aws_iam_policy_document" "assume_push_role" {
 }
 
 resource "aws_iam_policy" "assume_push_role" {
-  count = var.enable_ecr ? 1 : 0
+  count = var.enable_ecr && var.iam_policy_mode == "managed" ? 1 : 0
 
   name        = "${var.name}-ecr-assume-push"
   description = "Allow assuming the ECR push role"
@@ -708,17 +741,33 @@ resource "aws_iam_policy" "assume_push_role" {
 }
 
 resource "aws_iam_role_policy_attachment" "controller_assume_push" {
-  count = var.enable_ecr ? 1 : 0
+  count = var.enable_ecr && var.iam_policy_mode == "managed" ? 1 : 0
 
   role       = aws_iam_role.backend.name
   policy_arn = aws_iam_policy.assume_push_role[0].arn
 }
 
+resource "aws_iam_role_policy" "controller_assume_push" {
+  count = var.enable_ecr && var.iam_policy_mode == "inline" ? 1 : 0
+
+  name   = "assume-ecr-push"
+  role   = aws_iam_role.backend.id
+  policy = data.aws_iam_policy_document.assume_push_role[0].json
+}
+
 resource "aws_iam_user_policy_attachment" "controller_assume_push" {
-  count = var.create_iam_user && var.enable_ecr ? 1 : 0
+  count = var.create_iam_user && var.enable_ecr && var.iam_policy_mode == "managed" ? 1 : 0
 
   user       = aws_iam_user.backend[0].name
   policy_arn = aws_iam_policy.assume_push_role[0].arn
+}
+
+resource "aws_iam_user_policy" "controller_assume_push" {
+  count = var.create_iam_user && var.enable_ecr && var.iam_policy_mode == "inline" ? 1 : 0
+
+  name   = "assume-ecr-push"
+  user   = aws_iam_user.backend[0].name
+  policy = data.aws_iam_policy_document.assume_push_role[0].json
 }
 
 # -----------------------------------------------------------------------------
@@ -755,10 +804,11 @@ data "aws_iam_policy_document" "ecs_execution_assume" {
 resource "aws_iam_role" "ecs_execution" {
   count = var.enable_ecs ? 1 : 0
 
-  name               = local.ecs_execution_role_name
-  description        = "ECS task execution role for Rise workloads (image pull + secret resolution)"
-  assume_role_policy = data.aws_iam_policy_document.ecs_execution_assume[0].json
-  tags               = local.tags
+  name                 = local.ecs_execution_role_name
+  description          = "ECS task execution role for Rise workloads (image pull + secret resolution)"
+  assume_role_policy   = data.aws_iam_policy_document.ecs_execution_assume[0].json
+  permissions_boundary = var.permissions_boundary_arn
+  tags                 = local.tags
 }
 
 # ECR pull and CloudWatch Logs. This is the managed policy AWS maintains for
@@ -816,7 +866,7 @@ data "aws_iam_policy_document" "ecs_execution" {
 }
 
 resource "aws_iam_policy" "ecs_execution" {
-  count = var.enable_ecs ? 1 : 0
+  count = var.enable_ecs && var.iam_policy_mode == "managed" ? 1 : 0
 
   name        = "${local.ecs_execution_role_name}-secrets"
   description = "Secret resolution for the Rise ECS task execution role"
@@ -825,10 +875,73 @@ resource "aws_iam_policy" "ecs_execution" {
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_execution" {
-  count = var.enable_ecs ? 1 : 0
+  count = var.enable_ecs && var.iam_policy_mode == "managed" ? 1 : 0
 
   role       = aws_iam_role.ecs_execution[0].name
   policy_arn = aws_iam_policy.ecs_execution[0].arn
+}
+
+resource "aws_iam_role_policy" "ecs_execution" {
+  count = var.enable_ecs && var.iam_policy_mode == "inline" ? 1 : 0
+
+  name   = "secrets"
+  role   = aws_iam_role.ecs_execution[0].id
+  policy = data.aws_iam_policy_document.ecs_execution[0].json
+}
+
+# -----------------------------------------------------------------------------
+# Application and Traefik task roles
+#
+# These identities are deliberately separate from the controller. The module
+# supplies only Traefik's discovery policy; applications start with an empty
+# role and receive whatever their operator adds within the common boundary.
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "ecs_workload" {
+  count = var.enable_ecs ? 1 : 0
+
+  name                 = local.ecs_workload_role_name
+  description          = "Task role for applications deployed by Rise"
+  assume_role_policy   = data.aws_iam_policy_document.ecs_execution_assume[0].json
+  permissions_boundary = var.permissions_boundary_arn
+  tags                 = local.tags
+}
+
+data "aws_iam_policy_document" "ecs_traefik" {
+  count = var.enable_ecs ? 1 : 0
+
+  statement {
+    sid = "DiscoverTasks"
+    actions = [
+      "ec2:DescribeInstances",
+      "ecs:DescribeClusters",
+      "ecs:DescribeContainerInstances",
+      "ecs:DescribeTaskDefinition",
+      "ecs:DescribeTasks",
+      "ecs:ListClusters",
+      "ecs:ListTasks",
+      "ssm:DescribeInstanceInformation",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role" "ecs_traefik" {
+  count = var.enable_ecs ? 1 : 0
+
+  name                 = local.ecs_traefik_role_name
+  description          = "Traefik ECS provider discovery"
+  assume_role_policy   = data.aws_iam_policy_document.ecs_execution_assume[0].json
+  permissions_boundary = var.permissions_boundary_arn
+  tags                 = local.tags
+}
+
+resource "aws_iam_role_policy" "ecs_traefik" {
+  count = var.enable_ecs ? 1 : 0
+
+  name   = "discovery"
+  role   = aws_iam_role.ecs_traefik[0].id
+  policy = data.aws_iam_policy_document.ecs_traefik[0].json
 }
 
 # -----------------------------------------------------------------------------

--- a/modules/rise-aws/outputs.tf
+++ b/modules/rise-aws/outputs.tf
@@ -58,12 +58,12 @@ output "push_role_name" {
 
 output "controller_policy_arn" {
   description = "ARN of the IAM policy for the Rise backend"
-  value       = aws_iam_policy.backend.arn
+  value       = var.iam_policy_mode == "managed" ? aws_iam_policy.backend[0].arn : null
 }
 
 output "push_policy_arn" {
   description = "ARN of the IAM policy for push operations (null if ECR not enabled)"
-  value       = var.enable_ecr ? aws_iam_policy.push_role[0].arn : null
+  value       = var.enable_ecr && var.iam_policy_mode == "managed" ? aws_iam_policy.push_role[0].arn : null
 }
 
 output "policy_document" {
@@ -105,11 +105,25 @@ output "ecs_execution_role_name" {
 
 output "ecs_task_role_arn" {
   description = <<-EOT
-    ARN of the role deployed workloads run as. This is the backend role: on ECS
-    the control plane and the workloads it launches share one identity, since
-    per-project task roles are not implemented (ADR-0005 D14).
+    ARN of the role deployed workloads run as. It is separate from the backend
+    role so application policies cannot grant the controller's permissions.
   EOT
-  value       = var.enable_ecs ? aws_iam_role.backend.arn : null
+  value       = var.enable_ecs ? aws_iam_role.ecs_workload[0].arn : null
+}
+
+output "ecs_task_role_name" {
+  description = "Name of the role deployed workloads run as."
+  value       = var.enable_ecs ? aws_iam_role.ecs_workload[0].name : null
+}
+
+output "ecs_traefik_role_arn" {
+  description = "ARN of the discovery-only Traefik task role."
+  value       = var.enable_ecs ? aws_iam_role.ecs_traefik[0].arn : null
+}
+
+output "ecs_traefik_role_name" {
+  description = "Name of the discovery-only Traefik task role."
+  value       = var.enable_ecs ? aws_iam_role.ecs_traefik[0].name : null
 }
 
 output "rise_config" {
@@ -152,7 +166,7 @@ output "rise_config" {
         cluster              = local.ecs_cluster_name
         region               = local.region
         execution_role_arn   = aws_iam_role.ecs_execution[0].arn
-        task_role_arn        = aws_iam_role.backend.arn
+        task_role_arn        = aws_iam_role.ecs_workload[0].arn
         ssm_parameter_prefix = local.ssm_prefix
         ssm_kms_key_id       = var.ssm_kms_key_arn
       }

--- a/modules/rise-aws/tests/ecs.tftest.hcl
+++ b/modules/rise-aws/tests/ecs.tftest.hcl
@@ -146,3 +146,46 @@ run "disabling_ecs_emits_no_ecs_statements" {
     error_message = "ECS statements leak into the policy when enable_ecs is false"
   }
 }
+
+run "inline_roles_share_the_supplied_boundary" {
+  command = plan
+
+  variables {
+    iam_policy_mode          = "inline"
+    permissions_boundary_arn = "arn:aws:iam::123456789012:policy/rise-boundary"
+    ecs_execution_role_name  = "rise-execution"
+    ecs_workload_role_name   = "rise-app"
+    ecs_traefik_role_name    = "rise-traefik"
+    ecr_push_role_name       = "rise-ecr-push"
+  }
+
+  assert {
+    condition = alltrue([
+      aws_iam_role.backend.permissions_boundary == "arn:aws:iam::123456789012:policy/rise-boundary",
+      aws_iam_role.push_role[0].permissions_boundary == "arn:aws:iam::123456789012:policy/rise-boundary",
+      aws_iam_role.ecs_execution[0].permissions_boundary == "arn:aws:iam::123456789012:policy/rise-boundary",
+      aws_iam_role.ecs_workload[0].permissions_boundary == "arn:aws:iam::123456789012:policy/rise-boundary",
+      aws_iam_role.ecs_traefik[0].permissions_boundary == "arn:aws:iam::123456789012:policy/rise-boundary",
+    ])
+    error_message = "every ECS runtime role must carry the supplied permissions boundary"
+  }
+
+  assert {
+    condition = (
+      length(aws_iam_policy.backend) == 0
+      && length(aws_iam_policy.push_role) == 0
+      && length(aws_iam_policy.assume_push_role) == 0
+      && length(aws_iam_policy.ecs_execution) == 0
+    )
+    error_message = "inline mode must not create customer-managed policies"
+  }
+
+  assert {
+    condition = (
+      output.ecs_task_role_name == "rise-app"
+      && output.ecs_traefik_role_name == "rise-traefik"
+      && aws_iam_role.backend.name == "rise-backend"
+    )
+    error_message = "applications and Traefik must use identities distinct from the controller"
+  }
+}

--- a/modules/rise-aws/variables.tf
+++ b/modules/rise-aws/variables.tf
@@ -4,6 +4,23 @@ variable "name" {
   default     = "rise-backend"
 }
 
+variable "permissions_boundary_arn" {
+  description = "Optional permissions boundary attached to every IAM role this module creates."
+  type        = string
+  default     = null
+}
+
+variable "iam_policy_mode" {
+  description = "How this module attaches its generated policies. inline avoids iam:CreatePolicy in delegated installations; managed preserves the existing resource shape."
+  type        = string
+  default     = "managed"
+
+  validation {
+    condition     = contains(["inline", "managed"], var.iam_policy_mode)
+    error_message = "iam_policy_mode must be inline or managed."
+  }
+}
+
 variable "tags" {
   description = "Tags to apply to all resources"
   type        = map(string)
@@ -54,6 +71,23 @@ variable "enable_ecr" {
   description = "Enable ECR permissions for the Rise backend. Set to true if using ECR for container registry."
   type        = bool
   default     = true
+}
+
+variable "ecr_repository_prefix" {
+  description = "Repository path prefix managed by Rise. Defaults to <name>/."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.ecr_repository_prefix == null || endswith(var.ecr_repository_prefix, "/")
+    error_message = "ecr_repository_prefix must end in /."
+  }
+}
+
+variable "ecr_push_role_name" {
+  description = "Name for the scoped ECR publisher role. Defaults to <name>-ecr-push."
+  type        = string
+  default     = null
 }
 
 variable "enable_rds" {
@@ -162,6 +196,18 @@ variable "ecs_cluster_name" {
 
 variable "ecs_execution_role_name" {
   description = "Name for the ECS task execution role this module creates. Defaults to \"<name>-ecs-execution\"."
+  type        = string
+  default     = null
+}
+
+variable "ecs_workload_role_name" {
+  description = "Name for the task role used by applications Rise deploys. Defaults to <name>-app."
+  type        = string
+  default     = null
+}
+
+variable "ecs_traefik_role_name" {
+  description = "Name for the discovery-only Traefik task role. Defaults to <name>-traefik."
   type        = string
   default     = null
 }

--- a/modules/rise-ecs/README.md
+++ b/modules/rise-ecs/README.md
@@ -2,7 +2,7 @@
 
 Terraform for a working Rise install on Amazon ECS (Fargate), in the shape
 [ADR-0005](../../docs/engineering/src/content/docs/adr/0005-ecs-deployment-backend.md)
-describes: an NLB fronting Traefik, Traefik terminating TLS with ACME, the Rise
+describes: a public load balancer fronting Traefik, the Rise
 control plane and every deployed workload in private subnets, RDS for the
 control-plane store, and ECR for images.
 
@@ -24,8 +24,9 @@ module "rise_aws" {
   ecs_cluster_name     = "rise"
   ssm_parameter_prefix = "rise"
 
-  # Lets the execution role read the secrets rise-ecs creates.
-  ecs_secret_arns = module.rise_ecs.secret_arns_for_execution_role
+  # Names are deterministic, which avoids a module dependency cycle while
+  # still confining task-secret reads to this install.
+  ecs_secret_arns = ["arn:aws:secretsmanager:eu-west-1:123456789012:secret:rise/*"]
 }
 
 module "rise_ecs" {
@@ -39,6 +40,8 @@ module "rise_ecs" {
 
   controller_role_arn = module.rise_aws.role_arn
   execution_role_arn  = module.rise_aws.ecs_execution_role_arn
+  workload_task_role_arn = module.rise_aws.ecs_task_role_arn
+  traefik_task_role_arn  = module.rise_aws.ecs_traefik_role_arn
   ecr_push_role_arn   = module.rise_aws.push_role_arn
 
   oidc_issuer        = "https://id.example.com"
@@ -46,6 +49,10 @@ module "rise_ecs" {
   oidc_client_secret = var.oidc_client_secret
 }
 ```
+
+`rise_image_ref` accepts a digest-pinned public image directly, for example
+`ghcr.io/rise-deploy/rise@sha256:…`. Set exactly one of `rise_image_ref` and
+`rise_image_tag`.
 
 Then create the DNS records from the `dns_records_required` output, or pass
 `route53_zone_id` and let the module make them. **The wildcard is required**:
@@ -107,8 +114,8 @@ step.
 `edge_mode = "alb-acm"` terminates at an ALB instead, buying L7 access logs and
 WAF. It costs custom domains their automatic certificates: ACM has no HTTP-01,
 so each one gains a DNS-validated certificate an operator has to create, against
-a default limit of 25 per listener. Traefik still routes and still enforces
-access classes in both modes.
+a default limit of 25 per listener. Port 80 redirects permanently to HTTPS;
+Traefik still routes and still enforces access classes in both modes.
 
 **Traefik runs one replica, and that is not configurable.** Its ACME file store
 is not multi-writer safe. In ACME mode the deployment configuration also stops
@@ -121,6 +128,11 @@ Point `oidc_issuer` at a real provider. `deploy_dex = true` runs Dex as an ECS
 service instead, so the install is usable end to end without one — **a demo**:
 storage is in-memory, so sessions and refresh tokens are lost whenever the task
 is replaced, and there is no HA.
+
+For an IdP that publishes groups, set `oidc_group_claim`, `admin_idp_group`,
+`platform_access_policy = "restrictive"`, and `platform_allowed_idp_group`.
+These values are rendered through the ECS environment into the shipped
+configuration; no mounted override file is required.
 
 Dex needs a bcrypt hash, since Terraform has no bcrypt function:
 

--- a/modules/rise-ecs/edge.tf
+++ b/modules/rise-ecs/edge.tf
@@ -83,8 +83,18 @@ resource "aws_lb_listener" "http" {
   protocol          = local.is_nlb ? "TCP" : "HTTP"
 
   default_action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.traefik["80"].arn
+    type             = local.is_nlb ? "forward" : "redirect"
+    target_group_arn = local.is_nlb ? aws_lb_target_group.traefik["80"].arn : null
+
+    dynamic "redirect" {
+      for_each = local.is_nlb ? [] : [1]
+
+      content {
+        port        = "443"
+        protocol    = "HTTPS"
+        status_code = "HTTP_301"
+      }
+    }
   }
 }
 

--- a/modules/rise-ecs/locals.tf
+++ b/modules/rise-ecs/locals.tf
@@ -78,7 +78,10 @@ locals {
   workload_task_role_arn = coalesce(var.workload_task_role_arn, var.controller_role_arn)
   traefik_task_role_arn  = coalesce(var.traefik_task_role_arn, try(aws_iam_role.traefik[0].arn, null))
 
-  log_group_name = "/${local.name}"
+  log_group_name = coalesce(var.log_group_name, "/${local.name}")
+  rise_image_ref = var.rise_image_ref != null ? var.rise_image_ref : (
+    var.rise_image_tag != null ? "${var.rise_image}:${var.rise_image_tag}" : ""
+  )
 
   # --- Control-plane environment -------------------------------------------
   # Built by modules/control-plane-env, which the e2e test root also consumes so
@@ -109,8 +112,12 @@ module "control_plane_env" {
   traefik_entrypoint   = local.traefik_entrypoint
   traefik_certresolver = local.acme_enabled ? "letsencrypt" : null
 
-  oidc_issuer    = local.oidc_issuer
-  oidc_client_id = var.oidc_client_id
+  oidc_issuer                = local.oidc_issuer
+  oidc_client_id             = var.oidc_client_id
+  oidc_group_claim           = var.oidc_group_claim
+  admin_idp_group            = var.admin_idp_group
+  platform_access_policy     = var.platform_access_policy
+  platform_allowed_idp_group = var.platform_allowed_idp_group
   # The issuer is public here (Traefik-fronted, or an operator's own IdP), so
   # the SSRF defaults stay closed.
   allow_private_ssrf = false

--- a/modules/rise-ecs/modules/control-plane-env/main.tf
+++ b/modules/rise-ecs/modules/control-plane-env/main.tf
@@ -19,8 +19,12 @@ locals {
       AWS_REGION          = var.region
       ADMIN_EMAIL         = var.admin_email
 
-      DEX_ISSUER     = var.oidc_issuer
-      OIDC_CLIENT_ID = var.oidc_client_id
+      DEX_ISSUER                      = var.oidc_issuer
+      OIDC_CLIENT_ID                  = var.oidc_client_id
+      OIDC_GROUP_CLAIM                = var.oidc_group_claim
+      RISE_ADMIN_IDP_GROUP            = var.admin_idp_group != null ? var.admin_idp_group : ""
+      RISE_PLATFORM_ACCESS_POLICY     = var.platform_access_policy
+      RISE_PLATFORM_ALLOWED_IDP_GROUP = var.platform_allowed_idp_group != null ? var.platform_allowed_idp_group : ""
 
       RISE_SSRF_ALLOW_PRIVATE = tostring(var.allow_private_ssrf)
       RISE_SSRF_ALLOW_HTTP    = tostring(var.allow_private_ssrf)

--- a/modules/rise-ecs/modules/control-plane-env/variables.tf
+++ b/modules/rise-ecs/modules/control-plane-env/variables.tf
@@ -103,7 +103,8 @@ variable "oidc_client_id" {
 }
 
 variable "oidc_group_claim" {
-  type = string
+  type    = string
+  default = "groups"
 }
 
 variable "admin_idp_group" {
@@ -112,7 +113,8 @@ variable "admin_idp_group" {
 }
 
 variable "platform_access_policy" {
-  type = string
+  type    = string
+  default = "allow_all"
 }
 
 variable "platform_allowed_idp_group" {

--- a/modules/rise-ecs/modules/control-plane-env/variables.tf
+++ b/modules/rise-ecs/modules/control-plane-env/variables.tf
@@ -102,6 +102,24 @@ variable "oidc_client_id" {
   type = string
 }
 
+variable "oidc_group_claim" {
+  type = string
+}
+
+variable "admin_idp_group" {
+  type    = string
+  default = null
+}
+
+variable "platform_access_policy" {
+  type = string
+}
+
+variable "platform_allowed_idp_group" {
+  type    = string
+  default = null
+}
+
 variable "allow_private_ssrf" {
   description = <<-EOT
     Let Rise make outbound requests to private addresses and over plain HTTP.

--- a/modules/rise-ecs/rise.tf
+++ b/modules/rise-ecs/rise.tf
@@ -21,7 +21,7 @@ resource "aws_ecs_task_definition" "rise" {
   container_definitions = jsonencode([
     {
       name      = "rise"
-      image     = "${var.rise_image}:${var.rise_image_tag}"
+      image     = local.rise_image_ref
       essential = true
       command   = ["backend", "server"]
 
@@ -105,6 +105,11 @@ resource "aws_ecs_service" "rise" {
     precondition {
       condition     = length(local.private_subnet_ids) <= 16
       error_message = "At most 16 subnets: an awsvpc network configuration accepts no more, and the backend rejects the setting at startup."
+    }
+
+    precondition {
+      condition     = (var.rise_image_ref == null) != (var.rise_image_tag == null)
+      error_message = "Set exactly one of rise_image_ref or rise_image_tag."
     }
   }
 

--- a/modules/rise-ecs/tests/plan.tftest.hcl
+++ b/modules/rise-ecs/tests/plan.tftest.hcl
@@ -76,6 +76,42 @@ run "creates_a_whole_install" {
   }
 }
 
+run "alb_uses_https_and_group_restricted_auth" {
+  command = plan
+
+  variables {
+    edge_mode                  = "alb-acm"
+    acme_email                 = null
+    acm_certificate_arn        = "arn:aws:acm:eu-central-1:123456789012:certificate/abc"
+    rise_image_tag             = null
+    rise_image_ref             = "ghcr.io/rise-deploy/rise@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    oidc_group_claim           = "cognito:groups"
+    admin_idp_group            = "rise-admins"
+    platform_access_policy     = "restrictive"
+    platform_allowed_idp_group = "rise-platform-users"
+  }
+
+  assert {
+    condition = (
+      aws_lb_listener.http.default_action[0].type == "redirect"
+      && aws_lb_listener.http.default_action[0].redirect[0].protocol == "HTTPS"
+      && aws_lb_listener.http.default_action[0].redirect[0].status_code == "HTTP_301"
+    )
+    error_message = "ALB mode must redirect HTTP to HTTPS"
+  }
+
+  assert {
+    condition = alltrue([
+      local.rise_image_ref == "ghcr.io/rise-deploy/rise@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      local.rise_environment["OIDC_GROUP_CLAIM"] == "cognito:groups",
+      local.rise_environment["RISE_ADMIN_IDP_GROUP"] == "rise-admins",
+      local.rise_environment["RISE_PLATFORM_ACCESS_POLICY"] == "restrictive",
+      local.rise_environment["RISE_PLATFORM_ALLOWED_IDP_GROUP"] == "rise-platform-users",
+    ])
+    error_message = "digest and group-based authorization settings must reach the control-plane task"
+  }
+}
+
 # The database /24s must stay clear of the private /20s at the maximum four AZs.
 # The private subnets are /20s at netnum `index + 1`, so the fourth AZ's is
 # 10.42.64.0/20 (covering /24-netnums 64..79). A database range starting at

--- a/modules/rise-ecs/variables.tf
+++ b/modules/rise-ecs/variables.tf
@@ -244,6 +244,12 @@ variable "log_retention_days" {
   default     = 30
 }
 
+variable "log_group_name" {
+  description = "CloudWatch log group for the control plane, rise-traefik and deployed applications. Defaults to /<name>."
+  type        = string
+  default     = null
+}
+
 # -----------------------------------------------------------------------------
 # Ingress and edge
 # -----------------------------------------------------------------------------
@@ -389,8 +395,20 @@ variable "rise_image" {
 }
 
 variable "rise_image_tag" {
-  description = "Image tag. No default on purpose — a floating tag makes the running version unknowable."
+  description = "Image tag. Set this or rise_image_ref, but not both."
   type        = string
+  default     = null
+}
+
+variable "rise_image_ref" {
+  description = "Complete immutable control-plane image reference, such as ghcr.io/rise-deploy/rise@sha256:…. Set this or rise_image_tag, but not both."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.rise_image_ref == null || strcontains(var.rise_image_ref, "@sha256:")
+    error_message = "rise_image_ref must be an OCI digest reference containing @sha256:."
+  }
 }
 
 variable "rise_cpu" {
@@ -434,6 +452,12 @@ variable "resource_prefix" {
   default     = "rise"
 }
 
+variable "controller_class_name" {
+  description = "Controller identity stamped onto every managed service and used to isolate multiple Rise installations sharing one cluster."
+  type        = string
+  default     = "default"
+}
+
 variable "ssm_parameter_prefix" {
   description = "SSM path for secret environment variables. Must match the value given to modules/rise-aws."
   type        = string
@@ -455,6 +479,40 @@ variable "max_replicas" {
 variable "admin_email" {
   description = "Bootstrap admin user (auth.admin_users)."
   type        = string
+}
+
+variable "oidc_group_claim" {
+  description = "ID-token claim containing identity-provider group names."
+  type        = string
+  default     = "groups"
+}
+
+variable "admin_idp_group" {
+  description = "Identity-provider group whose members are Rise administrators. Null grants no group administrative access."
+  type        = string
+  default     = null
+}
+
+variable "platform_access_policy" {
+  description = "Who may use the Rise platform: allow_all or restrictive."
+  type        = string
+  default     = "allow_all"
+
+  validation {
+    condition     = contains(["allow_all", "restrictive"], var.platform_access_policy)
+    error_message = "platform_access_policy must be allow_all or restrictive."
+  }
+}
+
+variable "platform_allowed_idp_group" {
+  description = "Identity-provider group allowed to use Rise when platform_access_policy is restrictive."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.platform_access_policy != "restrictive" || try(trimspace(var.platform_allowed_idp_group), "") != ""
+    error_message = "restrictive platform access requires platform_allowed_idp_group."
+  }
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Make the ECS Terraform modules composable inside an IAM-delegated platform namespace. Every generated ECS role can carry one platform permissions boundary, inline policy mode avoids requiring `iam:CreatePolicy`, and applications plus Traefik receive identities separate from the Rise controller.

The ECS module also accepts digest-pinned control-plane images, redirects ALB HTTP traffic to HTTPS, exposes the controller class and log group, and passes group-based OIDC access settings through the shipped ECS configuration. These are generic module inputs; existing defaults remain valid.

## Test plan

- `terraform validate` in `modules/rise-aws`
- `terraform test -test-directory=tests` in `modules/rise-aws` (6 passed)
- `terraform validate` in `modules/rise-ecs`
- `terraform test -test-directory=tests` in `modules/rise-ecs` (18 passed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rise-deploy/codesmith/rise/pr/462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790454674&installation_model_id=432987&pr_number=462&repository=rise-deploy%2Frise&return_to=https%3A%2F%2Fgithub.com%2Frise-deploy%2Frise%2Fpull%2F462&signature=5185a6eeb6172fb731a50b1a078f7e1ac897d2e8e90343fb2f3f0f0ddf617417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->