### PR TITLE
Fix ECS controller class propagation

### DIFF
--- a/modules/rise-ecs/locals.tf
+++ b/modules/rise-ecs/locals.tf
@@ -123,6 +123,7 @@ module "control_plane_env" {
   allow_private_ssrf = false
 
   resource_prefix         = var.resource_prefix
+  controller_class_name   = var.controller_class_name
   ssm_parameter_prefix    = var.ssm_parameter_prefix
   ssm_kms_key_arn         = var.ssm_kms_key_arn
   cpu_architecture        = var.cpu_architecture

--- a/modules/rise-ecs/tests/plan.tftest.hcl
+++ b/modules/rise-ecs/tests/plan.tftest.hcl
@@ -237,15 +237,26 @@ run "traefik_discovery_can_be_confined_to_one_install" {
   command = plan
 
   variables {
-    traefik_constraints = "Label(`rise.dev/controller-class`, `pr-457`)"
+    controller_class_name = "pr-462"
+    traefik_constraints   = "Label(`rise.dev/controller-class`, `pr-462`)"
   }
 
   assert {
     condition = contains(
       local.traefik_command,
-      "--providers.ecs.constraints=Label(`rise.dev/controller-class`, `pr-457`)"
+      "--providers.ecs.constraints=Label(`rise.dev/controller-class`, `pr-462`)"
     )
     error_message = "traefik_constraints must reach Traefik as a provider flag"
+  }
+
+  assert {
+    condition     = module.control_plane_env.docker_labels["rise.dev/controller-class"] == "pr-462"
+    error_message = "controller_class_name must label the control plane matched by Traefik"
+  }
+
+  assert {
+    condition     = module.control_plane_env.environment.RISE_CONTROLLER_CLASS_NAME == "pr-462"
+    error_message = "controller_class_name must reach the controller's orphan-reconciliation scope"
   }
 }
 


### PR DESCRIPTION
## Summary

- pass controller_class_name from rise-ecs into the control-plane environment module
- verify the control-plane label and controller environment match a non-default Traefik constraint

Follow-up to the review on #462.

## Validation

- terraform test in modules/rise-ecs: 18 passed
- terraform fmt -check -recursive modules/rise-ecs
- cargo fmt --all
- cargo clippy --workspace --all-features --all-targets -- -D warnings was run and remains blocked by six pre-existing warnings outside this Terraform diff

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rise-deploy/codesmith/rise/pr/463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790500819&installation_model_id=432987&pr_number=463&repository=rise-deploy%2Frise&return_to=https%3A%2F%2Fgithub.com%2Frise-deploy%2Frise%2Fpull%2F463&signature=92892db7bb107cccffe9d8b5a09e292a8aa8cd4af733acea3371d4d0c51a8fd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->