### PR TITLE
Allow external Traefik roles from resource outputs

### DIFF
--- a/modules/rise-ecs/README.md
+++ b/modules/rise-ecs/README.md
@@ -38,11 +38,12 @@ module "rise_ecs" {
   admin_email    = "ops@example.com"
   acme_email     = "ops@example.com"
 
-  controller_role_arn = module.rise_aws.role_arn
-  execution_role_arn  = module.rise_aws.ecs_execution_role_arn
-  workload_task_role_arn = module.rise_aws.ecs_task_role_arn
-  traefik_task_role_arn  = module.rise_aws.ecs_traefik_role_arn
-  ecr_push_role_arn   = module.rise_aws.push_role_arn
+  controller_role_arn      = module.rise_aws.role_arn
+  execution_role_arn       = module.rise_aws.ecs_execution_role_arn
+  workload_task_role_arn   = module.rise_aws.ecs_task_role_arn
+  traefik_task_role_arn    = module.rise_aws.ecs_traefik_role_arn
+  create_traefik_task_role = false
+  ecr_push_role_arn        = module.rise_aws.push_role_arn
 
   oidc_issuer        = "https://id.example.com"
   oidc_client_id     = "rise"

--- a/modules/rise-ecs/locals.tf
+++ b/modules/rise-ecs/locals.tf
@@ -76,7 +76,11 @@ locals {
   oidc_issuer = var.deploy_dex ? "https://dex.${var.ingress_domain}/dex" : var.oidc_issuer
 
   workload_task_role_arn = coalesce(var.workload_task_role_arn, var.controller_role_arn)
-  traefik_task_role_arn  = coalesce(var.traefik_task_role_arn, try(aws_iam_role.traefik[0].arn, null))
+  create_traefik_task_role = coalesce(
+    var.create_traefik_task_role,
+    var.traefik_task_role_arn == null,
+  )
+  traefik_task_role_arn = coalesce(var.traefik_task_role_arn, try(aws_iam_role.traefik[0].arn, null))
 
   log_group_name = coalesce(var.log_group_name, "/${local.name}")
   rise_image_ref = var.rise_image_ref != null ? var.rise_image_ref : (

--- a/modules/rise-ecs/tests/external-traefik-role.tftest.hcl
+++ b/modules/rise-ecs/tests/external-traefik-role.tftest.hcl
@@ -1,0 +1,37 @@
+provider "aws" {
+  region                      = "eu-central-1"
+  access_key                  = "AKIAIOSFODNN7EXAMPLE"
+  secret_key                  = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  skip_metadata_api_check     = true
+  skip_region_validation      = true
+}
+
+run "accepts_an_external_traefik_role_that_is_unknown_during_planning" {
+  command = plan
+
+  module {
+    source = "./tests/fixtures/external-traefik-role"
+  }
+
+  override_data {
+    target = module.rise.data.aws_caller_identity.current
+    values = { account_id = "123456789012" }
+  }
+
+  override_data {
+    target = module.rise.data.aws_region.current
+    values = { id = "eu-central-1", region = "eu-central-1" }
+  }
+
+  override_data {
+    target = module.rise.data.aws_partition.current
+    values = { partition = "aws" }
+  }
+
+  override_data {
+    target = module.rise.data.aws_availability_zones.available
+    values = { names = ["eu-central-1a", "eu-central-1b", "eu-central-1c"] }
+  }
+}

--- a/modules/rise-ecs/tests/fixtures/external-traefik-role/main.tf
+++ b/modules/rise-ecs/tests/fixtures/external-traefik-role/main.tf
@@ -1,0 +1,28 @@
+resource "aws_iam_role" "traefik" {
+  name = "rise-traefik"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+module "rise" {
+  source = "../../.."
+
+  name                     = "rise"
+  ingress_domain           = "rise.example.com"
+  admin_email              = "ops@example.com"
+  rise_image_tag           = "0.23.0"
+  acme_email               = "ops@example.com"
+  controller_role_arn      = "arn:aws:iam::123456789012:role/rise"
+  execution_role_arn       = "arn:aws:iam::123456789012:role/rise-ecs-execution"
+  ecr_push_role_arn        = "arn:aws:iam::123456789012:role/rise-ecr-push"
+  oidc_issuer              = "https://id.example.com"
+  oidc_client_secret       = "s3cret"
+  create_traefik_task_role = false
+  traefik_task_role_arn    = aws_iam_role.traefik.arn
+}

--- a/modules/rise-ecs/tests/guardrails.tftest.hcl
+++ b/modules/rise-ecs/tests/guardrails.tftest.hcl
@@ -104,6 +104,28 @@ run "rejects_ecr_without_a_push_role" {
   expect_failures = [aws_lb.this]
 }
 
+run "rejects_external_traefik_mode_without_an_arn" {
+  command = plan
+
+  variables {
+    create_traefik_task_role = false
+    traefik_task_role_arn    = null
+  }
+
+  expect_failures = [var.create_traefik_task_role]
+}
+
+run "rejects_module_owned_traefik_mode_with_an_external_arn" {
+  command = plan
+
+  variables {
+    create_traefik_task_role = true
+    traefik_task_role_arn    = "arn:aws:iam::123456789012:role/rise-traefik"
+  }
+
+  expect_failures = [var.create_traefik_task_role]
+}
+
 run "rejects_an_install_with_no_identity_provider" {
   command = plan
 

--- a/modules/rise-ecs/tests/plan.tftest.hcl
+++ b/modules/rise-ecs/tests/plan.tftest.hcl
@@ -76,6 +76,25 @@ run "creates_a_whole_install" {
   }
 }
 
+run "uses_an_external_traefik_role_without_creating_iam" {
+  command = plan
+
+  variables {
+    create_traefik_task_role = false
+    traefik_task_role_arn    = "arn:aws:iam::123456789012:role/rise-traefik"
+  }
+
+  assert {
+    condition     = length(aws_iam_role.traefik) == 0
+    error_message = "an external Traefik role must disable module-owned IAM"
+  }
+
+  assert {
+    condition     = aws_ecs_task_definition.traefik.task_role_arn == "arn:aws:iam::123456789012:role/rise-traefik"
+    error_message = "the external Traefik role must reach the task definition"
+  }
+}
+
 run "alb_uses_https_and_group_restricted_auth" {
   command = plan
 

--- a/modules/rise-ecs/traefik.tf
+++ b/modules/rise-ecs/traefik.tf
@@ -4,7 +4,7 @@
 # behind an unauthenticated dashboard.
 
 data "aws_iam_policy_document" "traefik_assume" {
-  count = var.traefik_task_role_arn == null ? 1 : 0
+  count = local.create_traefik_task_role ? 1 : 0
 
   statement {
     effect = "Allow"
@@ -22,7 +22,7 @@ data "aws_iam_policy_document" "traefik_assume" {
 }
 
 resource "aws_iam_role" "traefik" {
-  count = var.traefik_task_role_arn == null ? 1 : 0
+  count = local.create_traefik_task_role ? 1 : 0
 
   name               = "${local.name}-traefik"
   description        = "Traefik ECS provider discovery"
@@ -49,7 +49,7 @@ locals {
 }
 
 data "aws_iam_policy_document" "traefik" {
-  count = var.traefik_task_role_arn == null ? 1 : 0
+  count = local.create_traefik_task_role ? 1 : 0
 
   statement {
     sid       = "DiscoverTasks"
@@ -73,7 +73,7 @@ data "aws_iam_policy_document" "traefik" {
 }
 
 resource "aws_iam_role_policy" "traefik" {
-  count = var.traefik_task_role_arn == null ? 1 : 0
+  count = local.create_traefik_task_role ? 1 : 0
 
   name   = "discovery"
   role   = aws_iam_role.traefik[0].id

--- a/modules/rise-ecs/variables.tf
+++ b/modules/rise-ecs/variables.tf
@@ -50,10 +50,32 @@ variable "traefik_task_role_arn" {
     Pre-created task role for Traefik. Leave null and the module creates one.
 
     Set it where the applying identity has no IAM-write -- the e2e harness runs
-    that way, with IAM pre-created in a bootstrap apply.
+    that way, with IAM pre-created in a bootstrap apply. When the ARN comes
+    from another module's resource output, also set create_traefik_task_role to
+    false so resource counts stay known during the first plan.
   EOT
   type        = string
   default     = null
+}
+
+variable "create_traefik_task_role" {
+  description = <<-EOT
+    Whether this module creates Traefik's task role. Null infers the decision
+    from traefik_task_role_arn for compatibility with plan-known ARNs. Set
+    false explicitly when the external ARN is unknown until apply; Terraform
+    requires resource count decisions to be known during planning.
+  EOT
+  type        = bool
+  default     = null
+
+  validation {
+    condition = var.create_traefik_task_role == null || (
+      var.create_traefik_task_role
+      ? var.traefik_task_role_arn == null
+      : var.traefik_task_role_arn != null
+    )
+    error_message = "create_traefik_task_role must be true with no traefik_task_role_arn, or false with an external ARN."
+  }
 }
 
 variable "registry_type" {


### PR DESCRIPTION
## Summary

- add an explicit `create_traefik_task_role` input to `modules/rise-ecs`
- keep the current ARN-based inference as the default for plan-known values
- validate contradictory create/bring combinations
- test an external role ARN that is genuinely unknown during the first plan

## Why

A root module can compose `rise-aws` and `rise-ecs` in one apply:

```hcl
traefik_task_role_arn    = module.rise_aws.ecs_traefik_role_arn
create_traefik_task_role = false
```

The ARN is unknown during the first plan because it comes from a resource. Deriving `count` from `traefik_task_role_arn == null` therefore makes the number of Traefik IAM resources unknown and Terraform rejects the plan. The explicit lifecycle input keeps those counts plan-known while allowing the task definition to receive the ARN at apply time.

Leaving `create_traefik_task_role` null preserves the existing interface for callers that pass a literal ARN or let `rise-ecs` create the role.

## Validation

- `terraform fmt -check -recursive modules tests/e2e/bootstrap tests/e2e/run`
- `terraform validate` for `modules/rise-aws`, `modules/rise-ecs`, `tests/e2e/bootstrap`, and `tests/e2e/run`
- `terraform test`:
  - `modules/rise-aws`: 6 passed
  - `modules/rise-ecs`: 22 passed
  - `tests/e2e/bootstrap`: 3 passed
  - `tests/e2e/run`: 6 passed

No merge or release is included in this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rise-deploy/codesmith/rise/pr/464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790512591&installation_model_id=432987&pr_number=464&repository=rise-deploy%2Frise&return_to=https%3A%2F%2Fgithub.com%2Frise-deploy%2Frise%2Fpull%2F464&signature=2d6f19661ccfd79ca7c39a2766cf4be8b2b09e363e80e54eb7bdfa18874d4128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->