### PR TITLE
Support secret control-plane config overlays on ECS

### DIFF
--- a/modules/rise-ecs/README.md
+++ b/modules/rise-ecs/README.md
@@ -146,6 +146,26 @@ $ htpasswd -bnBC 10 "" 'your-password' | tr -d ':\n'
 secret live in Secrets Manager and reach the task through the task definition's
 `secrets` block, so they never appear in a `DescribeTaskDefinition` response.
 
+Set `control_plane_local_config_secret_arn` when the control plane needs an
+operator-specific YAML overlay, for example extension-provider configuration.
+The secret value becomes `local.yaml`, which Rise loads after its shipped
+`default.yaml` and `ecs.yaml`. The task bootstrap writes the file with mode 0600
+and removes the secret from the environment before starting Rise. Include the
+secret ARN in `modules/rise-aws`'s `ecs_secret_arns` so the task execution role
+can resolve it:
+
+```hcl
+module "rise_aws" {
+  # ...
+  ecs_secret_arns = [aws_secretsmanager_secret.rise_local_config.arn]
+}
+
+module "rise_ecs" {
+  # ...
+  control_plane_local_config_secret_arn = aws_secretsmanager_secret.rise_local_config.arn
+}
+```
+
 **The generated database password is in Terraform state.** Use an encrypted
 remote backend with restricted access. To keep it out entirely, create the
 secret yourself and pass `database_url_secret_arn` — the module then creates no

--- a/modules/rise-ecs/locals.tf
+++ b/modules/rise-ecs/locals.tf
@@ -88,6 +88,31 @@ locals {
   # the two cannot drift on the one contract that matters: what the control
   # plane's environment and Traefik labels look like on ECS.
   rise_environment = module.control_plane_env.environment
+
+  control_plane_command = var.control_plane_local_config_secret_arn == null ? ["backend", "server"] : [<<-SH
+    set -eu
+    umask 077
+    mkdir -p /tmp/rise-config
+    cp /etc/rise/default.yaml /etc/rise/ecs.yaml /tmp/rise-config/
+    printf '%s' "$RISE_LOCAL_CONFIG_YAML" > /tmp/rise-config/local.yaml
+    unset RISE_LOCAL_CONFIG_YAML
+    export RISE_CONFIG_DIR=/tmp/rise-config
+    exec /usr/local/bin/rise backend server
+  SH
+  ]
+
+  control_plane_entry_point = var.control_plane_local_config_secret_arn == null ? {} : {
+    entryPoint = ["/bin/sh", "-c"]
+  }
+
+  control_plane_secrets = concat([
+    { name = "DATABASE_URL", valueFrom = local.database_url_secret_arn },
+    { name = "RISE_JWT_SIGNING_SECRET", valueFrom = aws_secretsmanager_secret.jwt_signing_secret.arn },
+    { name = "RISE_ENCRYPTION_KEY", valueFrom = aws_secretsmanager_secret.encryption_key.arn },
+    { name = "OIDC_CLIENT_SECRET", valueFrom = aws_secretsmanager_secret.oidc_client_secret.arn },
+    ], var.control_plane_local_config_secret_arn == null ? [] : [
+    { name = "RISE_LOCAL_CONFIG_YAML", valueFrom = var.control_plane_local_config_secret_arn },
+  ])
 }
 
 module "control_plane_env" {

--- a/modules/rise-ecs/outputs.tf
+++ b/modules/rise-ecs/outputs.tf
@@ -103,12 +103,14 @@ output "rise_task_environment" {
 
 output "rise_task_secrets" {
   description = "Secrets Manager ARNs to inject as environment variables, keyed by variable name."
-  value = {
+  value = merge({
     DATABASE_URL            = local.database_url_secret_arn
     RISE_JWT_SIGNING_SECRET = aws_secretsmanager_secret.jwt_signing_secret.arn
     RISE_ENCRYPTION_KEY     = aws_secretsmanager_secret.encryption_key.arn
     OIDC_CLIENT_SECRET      = aws_secretsmanager_secret.oidc_client_secret.arn
-  }
+    }, var.control_plane_local_config_secret_arn == null ? {} : {
+    RISE_LOCAL_CONFIG_YAML = var.control_plane_local_config_secret_arn
+  })
 }
 
 output "secret_arns_for_execution_role" {
@@ -123,6 +125,7 @@ output "secret_arns_for_execution_role" {
     aws_secretsmanager_secret.encryption_key.arn,
     aws_secretsmanager_secret.oidc_client_secret.arn,
     var.repository_credentials_secret_arn,
+    var.control_plane_local_config_secret_arn,
   ])
 }
 

--- a/modules/rise-ecs/rise.tf
+++ b/modules/rise-ecs/rise.tf
@@ -19,11 +19,11 @@ resource "aws_ecs_task_definition" "rise" {
   }
 
   container_definitions = jsonencode([
-    {
+    merge({
       name      = "rise"
       image     = local.rise_image_ref
       essential = true
-      command   = ["backend", "server"]
+      command   = local.control_plane_command
 
       portMappings = [{ containerPort = 3000 }]
 
@@ -33,12 +33,7 @@ resource "aws_ecs_task_definition" "rise" {
 
       # Resolved by ECS at task start under the execution role, so none of these
       # appear in a DescribeTaskDefinition response.
-      secrets = [
-        { name = "DATABASE_URL", valueFrom = local.database_url_secret_arn },
-        { name = "RISE_JWT_SIGNING_SECRET", valueFrom = aws_secretsmanager_secret.jwt_signing_secret.arn },
-        { name = "RISE_ENCRYPTION_KEY", valueFrom = aws_secretsmanager_secret.encryption_key.arn },
-        { name = "OIDC_CLIENT_SECRET", valueFrom = aws_secretsmanager_secret.oidc_client_secret.arn },
-      ]
+      secrets = local.control_plane_secrets
 
       healthCheck = {
         # `rise backend health` rather than curl: an ECS health check runs
@@ -62,7 +57,7 @@ resource "aws_ecs_task_definition" "rise" {
           "awslogs-stream-prefix" = "rise"
         }
       }
-    }
+    }, local.control_plane_entry_point)
   ])
 
   tags = local.tags

--- a/modules/rise-ecs/tests/plan.tftest.hcl
+++ b/modules/rise-ecs/tests/plan.tftest.hcl
@@ -74,6 +74,49 @@ run "creates_a_whole_install" {
     condition     = local.rise_environment["RISE_ECS_ASSIGN_PUBLIC_IP"] == "false"
     error_message = "workloads must run in private subnets without public IPs"
   }
+
+  assert {
+    condition = alltrue([
+      join(" ", local.control_plane_command) == "backend server",
+      length(local.control_plane_entry_point) == 0,
+    ])
+    error_message = "the control plane must start directly when no local config overlay is configured"
+  }
+}
+
+run "loads_a_secret_local_config_overlay" {
+  command = plan
+
+  variables {
+    control_plane_local_config_secret_arn = "arn:aws:secretsmanager:eu-central-1:123456789012:secret:rise/local-config-abc123"
+  }
+
+  assert {
+    condition     = local.control_plane_entry_point.entryPoint == ["/bin/sh", "-c"]
+    error_message = "a local config overlay must use the shell bootstrap entrypoint"
+  }
+
+  assert {
+    condition = alltrue([
+      strcontains(one(local.control_plane_command), "local.yaml"),
+      strcontains(one(local.control_plane_command), "unset RISE_LOCAL_CONFIG_YAML"),
+    ])
+    error_message = "the bootstrap must write the overlay with restrictive permissions and remove it from the Rise process environment"
+  }
+
+  assert {
+    condition = one([
+      for secret in local.control_plane_secrets :
+      secret.valueFrom
+      if secret.name == "RISE_LOCAL_CONFIG_YAML"
+    ]) == "arn:aws:secretsmanager:eu-central-1:123456789012:secret:rise/local-config-abc123"
+    error_message = "the overlay must reach the task through ECS secret injection"
+  }
+
+  assert {
+    condition     = output.rise_task_secrets["RISE_LOCAL_CONFIG_YAML"] == "arn:aws:secretsmanager:eu-central-1:123456789012:secret:rise/local-config-abc123"
+    error_message = "module outputs must expose the overlay secret to external task-definition wiring"
+  }
 }
 
 run "alb_uses_https_and_group_restricted_auth" {

--- a/modules/rise-ecs/variables.tf
+++ b/modules/rise-ecs/variables.tf
@@ -423,6 +423,20 @@ variable "rise_memory" {
   default     = "2048"
 }
 
+variable "control_plane_local_config_secret_arn" {
+  description = <<-EOT
+    Secrets Manager secret whose value is a Rise YAML overlay. The control
+    plane writes it to a mode-0600 local.yaml before startup, after which Rise
+    layers it over the shipped default.yaml and ecs.yaml. Null loads no overlay.
+
+    The task execution role must be allowed to read this ARN. Use the secret
+    for operator-specific configuration and credentials that must not appear in
+    the task definition, such as extension-provider settings.
+  EOT
+  type        = string
+  default     = null
+}
+
 variable "rise_desired_count" {
   description = "Control-plane replicas. Safe above 1: the reconcile loop is leader-elected through rise-runtime-sync."
   type        = number


### PR DESCRIPTION
## Summary

Allow `modules/rise-ecs` callers to supply a Secrets Manager ARN whose value is an operator-specific Rise YAML overlay. ECS injects the value only at task startup; the bootstrap writes a mode-0600 `local.yaml`, removes the secret from the process environment, and starts Rise with the shipped defaults and ECS configuration underneath it.

The default task command is unchanged when no overlay is configured. The input is generic rather than extension-specific, so operators can supply provider configuration or other settings that the shipped environment-variable surface does not expose without vendoring the module or publishing secrets in the task definition.

The task execution role must be allowed to read the secret; the module exposes the ARN through its existing secret outputs and documents the corresponding `rise-aws.ecs_secret_arns` wiring.

## Test plan

- `terraform fmt -check -recursive modules tests/e2e/bootstrap tests/e2e/run`
- `terraform validate` for both modules and both ECS e2e workspaces
- `terraform test`
  - `modules/rise-aws`: 6 passed
  - `modules/rise-ecs`: 19 passed
  - `tests/e2e/bootstrap`: 3 passed
  - `tests/e2e/run`: 6 passed

No merge or release is included in this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rise-deploy/codesmith/rise/pr/465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790518841&installation_model_id=432987&pr_number=465&repository=rise-deploy%2Frise&return_to=https%3A%2F%2Fgithub.com%2Frise-deploy%2Frise%2Fpull%2F465&signature=e02450ab307a618a3fb0a4a5702da6a19c8dad3009b12130c579b2aa60994275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->