### PR TITLE
Load ECS config overlays directly from the environment

### DIFF
--- a/docs/engineering/public/schemas/backend-settings.schema.json
+++ b/docs/engineering/public/schemas/backend-settings.schema.json
@@ -2411,7 +2411,7 @@
           "type": "null"
         }
       ],
-      "description": "Curated catalog of stateless container images surfaced as one-click\n\"quickstart\" deploys in the UI. The catalog is layered: `default.yaml`\nships the built-in selection and any `quickstart.templates` list in a\nlater layer (run-mode or `local.yaml`) *replaces* it entirely. Operators\nwho want to add to the defaults must re-include them."
+      "description": "Curated catalog of stateless container images surfaced as one-click\n\"quickstart\" deploys in the UI. The catalog is layered: `default.yaml`\nships the built-in selection and any `quickstart.templates` list in a\nlater layer (run-mode or the local configuration layer) *replaces* it\nentirely. Operators who want to add to the defaults must re-include\nthem."
     },
     "registry": {
       "anyOf": [

--- a/docs/engineering/src/content/docs/configuration.md
+++ b/docs/engineering/src/content/docs/configuration.md
@@ -12,9 +12,12 @@ Configuration files are located in `config/` and loaded in this order:
 2. `{RISE_CONFIG_RUN_MODE}.yaml` - Environment-specific config (**required**)
    - `development.yaml` when `RISE_CONFIG_RUN_MODE=development`
    - `production.yaml` when `RISE_CONFIG_RUN_MODE=production`
-3. `local.yaml` - Local overrides (not checked into git, optional)
+3. The local configuration layer (optional):
+   - `RISE_LOCAL_CONFIG_YAML` when the environment variable is present
+   - `local.yaml` otherwise (not checked into git)
 
-Later files override earlier ones.
+Later layers override earlier ones. `RISE_LOCAL_CONFIG_YAML` is parsed as YAML
+and replaces the `local.yaml` source; Rise does not load both.
 
 In container deployments, `RISE_CONFIG_DIR` is typically `/etc/rise`.
 
@@ -666,11 +669,11 @@ The `icon` field accepts either:
 ### Defaults and overrides
 
 Rise ships a `default.yaml` config layer with four curated templates. The
-config loader (`default.yaml` → `<run_mode>.yaml` → `local.yaml`) merges maps
+config loader (`default.yaml` → `<run_mode>.yaml` → local layer) merges maps
 but **replaces arrays**, so any `quickstart.templates` list in a later layer
 replaces the defaults entirely. To extend the shipped catalog, copy
-`/etc/rise/default.yaml`'s `quickstart.templates` into your override file and
-add to the list.
+`/etc/rise/default.yaml`'s `quickstart.templates` into your local layer and add
+to the list.
 
 ### Validation
 

--- a/modules/rise-ecs/README.md
+++ b/modules/rise-ecs/README.md
@@ -149,11 +149,13 @@ secret live in Secrets Manager and reach the task through the task definition's
 
 Set `control_plane_local_config_secret_arn` when the control plane needs an
 operator-specific YAML overlay, for example extension-provider configuration.
-The secret value becomes `local.yaml`, which Rise loads after its shipped
-`default.yaml` and `ecs.yaml`. The task bootstrap writes the file with mode 0600
-and removes the secret from the environment before starting Rise. Include the
-secret ARN in `modules/rise-aws`'s `ecs_secret_arns` so the task execution role
-can resolve it:
+ECS injects the secret value as `RISE_LOCAL_CONFIG_YAML`, which supplies the
+local configuration layer that Rise loads after its shipped `default.yaml` and
+`ecs.yaml`. The ECS module owns the control-plane address `0.0.0.0:3000`; the
+overlay must not set `server.host` or `server.port` because task networking,
+security groups, internal URLs and Traefik use that address. Include the secret
+ARN in `modules/rise-aws`'s `ecs_secret_arns` so the task execution role can
+resolve it:
 
 ```hcl
 module "rise_aws" {

--- a/modules/rise-ecs/locals.tf
+++ b/modules/rise-ecs/locals.tf
@@ -93,22 +93,6 @@ locals {
   # plane's environment and Traefik labels look like on ECS.
   rise_environment = module.control_plane_env.environment
 
-  control_plane_command = var.control_plane_local_config_secret_arn == null ? ["backend", "server"] : [<<-SH
-    set -eu
-    umask 077
-    mkdir -p /tmp/rise-config
-    cp /etc/rise/default.yaml /etc/rise/ecs.yaml /tmp/rise-config/
-    printf '%s' "$RISE_LOCAL_CONFIG_YAML" > /tmp/rise-config/local.yaml
-    unset RISE_LOCAL_CONFIG_YAML
-    export RISE_CONFIG_DIR=/tmp/rise-config
-    exec /usr/local/bin/rise backend server
-  SH
-  ]
-
-  control_plane_entry_point = var.control_plane_local_config_secret_arn == null ? {} : {
-    entryPoint = ["/bin/sh", "-c"]
-  }
-
   control_plane_secrets = concat([
     { name = "DATABASE_URL", valueFrom = local.database_url_secret_arn },
     { name = "RISE_JWT_SIGNING_SECRET", valueFrom = aws_secretsmanager_secret.jwt_signing_secret.arn },

--- a/modules/rise-ecs/rise.tf
+++ b/modules/rise-ecs/rise.tf
@@ -19,11 +19,11 @@ resource "aws_ecs_task_definition" "rise" {
   }
 
   container_definitions = jsonencode([
-    merge({
+    {
       name      = "rise"
       image     = local.rise_image_ref
       essential = true
-      command   = local.control_plane_command
+      command   = ["backend", "server"]
 
       portMappings = [{ containerPort = 3000 }]
 
@@ -57,7 +57,7 @@ resource "aws_ecs_task_definition" "rise" {
           "awslogs-stream-prefix" = "rise"
         }
       }
-    }, local.control_plane_entry_point)
+    }
   ])
 
   tags = local.tags

--- a/modules/rise-ecs/tests/plan.tftest.hcl
+++ b/modules/rise-ecs/tests/plan.tftest.hcl
@@ -74,14 +74,6 @@ run "creates_a_whole_install" {
     condition     = local.rise_environment["RISE_ECS_ASSIGN_PUBLIC_IP"] == "false"
     error_message = "workloads must run in private subnets without public IPs"
   }
-
-  assert {
-    condition = alltrue([
-      join(" ", local.control_plane_command) == "backend server",
-      length(local.control_plane_entry_point) == 0,
-    ])
-    error_message = "the control plane must start directly when no local config overlay is configured"
-  }
 }
 
 run "loads_a_secret_local_config_overlay" {
@@ -89,19 +81,6 @@ run "loads_a_secret_local_config_overlay" {
 
   variables {
     control_plane_local_config_secret_arn = "arn:aws:secretsmanager:eu-central-1:123456789012:secret:rise/local-config-abc123"
-  }
-
-  assert {
-    condition     = local.control_plane_entry_point.entryPoint == ["/bin/sh", "-c"]
-    error_message = "a local config overlay must use the shell bootstrap entrypoint"
-  }
-
-  assert {
-    condition = alltrue([
-      strcontains(one(local.control_plane_command), "local.yaml"),
-      strcontains(one(local.control_plane_command), "unset RISE_LOCAL_CONFIG_YAML"),
-    ])
-    error_message = "the bootstrap must write the overlay with restrictive permissions and remove it from the Rise process environment"
   }
 
   assert {

--- a/modules/rise-ecs/variables.tf
+++ b/modules/rise-ecs/variables.tf
@@ -447,13 +447,13 @@ variable "rise_memory" {
 
 variable "control_plane_local_config_secret_arn" {
   description = <<-EOT
-    Secrets Manager secret whose value is a Rise YAML overlay. The control
-    plane writes it to a mode-0600 local.yaml before startup, after which Rise
-    layers it over the shipped default.yaml and ecs.yaml. Null loads no overlay.
+    Secrets Manager secret whose value supplies Rise's local YAML configuration
+    layer over the shipped default.yaml and ecs.yaml. Null loads no overlay.
 
     The task execution role must be allowed to read this ARN. Use the secret
     for operator-specific configuration and credentials that must not appear in
-    the task definition, such as extension-provider settings.
+    the task definition, such as extension-provider settings. The ECS module
+    owns server.host and server.port; the overlay must not set them.
   EOT
   type        = string
   default     = null

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -46,8 +46,9 @@ pub struct Settings {
     /// Curated catalog of stateless container images surfaced as one-click
     /// "quickstart" deploys in the UI. The catalog is layered: `default.yaml`
     /// ships the built-in selection and any `quickstart.templates` list in a
-    /// later layer (run-mode or `local.yaml`) *replaces* it entirely. Operators
-    /// who want to add to the defaults must re-include them.
+    /// later layer (run-mode or the local configuration layer) *replaces* it
+    /// entirely. Operators who want to add to the defaults must re-include
+    /// them.
     #[serde(default)]
     pub quickstart: Option<QuickstartSettings>,
 }
@@ -2106,8 +2107,17 @@ impl Settings {
         // 2. Load environment-specific config (required)
         Self::try_add_config_file(&mut builder, config_dir, run_mode, true)?;
 
-        // 3. Load local config (optional, not checked into git)
-        Self::try_add_config_file(&mut builder, config_dir, "local", false)?;
+        // 3. Load the local config layer from the environment when supplied,
+        //    otherwise from the optional file that is not checked into git.
+        if let Some(local_yaml) = env_lookup("RISE_LOCAL_CONFIG_YAML") {
+            tracing::info!("Loading local config from RISE_LOCAL_CONFIG_YAML");
+            builder = builder.add_source(config::File::from_str(
+                &local_yaml,
+                config::FileFormat::Yaml,
+            ));
+        } else {
+            Self::try_add_config_file(&mut builder, config_dir, "local", false)?;
+        }
 
         // Build config and substitute environment variables
         let config = builder.build()?;
@@ -3314,9 +3324,9 @@ auth:
         load_shipped_ecs_config_with_overlay(env, None)
     }
 
-    /// As above, with an optional `local.yaml` layered over the shipped file —
-    /// the way an operator overrides a section they cannot express through the
-    /// file's env vars (a different registry type, say).
+    /// As above, with an optional environment-backed local layer over the
+    /// shipped file — the way ECS supplies settings that do not belong in its
+    /// task definition (a registry credential, say).
     fn load_shipped_ecs_config_with_overlay(
         env: &std::collections::HashMap<&'static str, &'static str>,
         overlay: Option<&str>,
@@ -3331,14 +3341,14 @@ auth:
         let temp_dir = TempDir::new().unwrap();
         fs::write(temp_dir.path().join("default.yaml"), "{}\n").unwrap();
         fs::write(temp_dir.path().join("ecs.yaml"), ecs_yaml).unwrap();
-        if let Some(overlay) = overlay {
-            fs::write(temp_dir.path().join("local.yaml"), overlay).unwrap();
-        }
 
-        let owned: std::collections::HashMap<String, String> = env
+        let mut owned: std::collections::HashMap<String, String> = env
             .iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
+        if let Some(overlay) = overlay {
+            owned.insert("RISE_LOCAL_CONFIG_YAML".to_string(), overlay.to_string());
+        }
         let env_lookup = move |name: &str| owned.get(name).cloned();
 
         Settings::new_with_env(temp_dir.path().to_str().unwrap(), "ecs", &env_lookup)
@@ -3386,6 +3396,26 @@ auth:
             settings.deployment_logs,
             DeploymentLogsSettings::None { .. }
         ));
+    }
+
+    #[test]
+    fn ecs_local_config_yaml_supplies_the_local_layer() {
+        let mut env = ecs_base_env();
+        env.insert("OVERLAY_PUBLIC_URL", "https://control.example.com");
+
+        let settings = load_shipped_ecs_config_with_overlay(
+            &env,
+            Some(
+                r#"
+server:
+  public_url: "${OVERLAY_PUBLIC_URL}"
+"#,
+            ),
+        )
+        .expect("environment-backed local YAML must load");
+
+        assert_eq!(settings.server.public_url, "https://control.example.com");
+        assert_eq!(settings.server.port, 3000);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Load `RISE_LOCAL_CONFIG_YAML` as the local configuration layer inside the settings loader so the control-plane server and health command resolve identical settings. The file-backed `local.yaml` remains the fallback when the environment variable is absent, and environment substitution continues to apply inside the YAML overlay.

The ECS task now uses the image entrypoint directly without a shell bootstrap or temporary configuration directory. The module documentation also records that `server.host` and `server.port` belong to the fixed ECS networking contract and must not be overridden by the overlay.

## Test plan
- `SQLX_OFFLINE=true RUSTC_WRAPPER= cargo test --offline --all-features server::settings::tests` (49 passed)
- `terraform -chdir=modules/rise-ecs test -no-color` (23 passed)
- Rust and Terraform formatting checks
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rise-deploy/codesmith/rise/pr/466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790545372&installation_model_id=432987&pr_number=466&repository=rise-deploy%2Frise&return_to=https%3A%2F%2Fgithub.com%2Frise-deploy%2Frise%2Fpull%2F466&signature=39a8e8237f560c8d425abf6839ed22ed3609ab1e0d92b54b8cdf67729de37b00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->