### PR TITLE
Keep ECS Cloud Map registration stable

### DIFF
--- a/docs/engineering/src/content/docs/ecs/terraform.md
+++ b/docs/engineering/src/content/docs/ecs/terraform.md
@@ -160,12 +160,13 @@ The Rise container runs the `config/ecs.yaml` that ships in the image
 environment interpolations. Two of them are the difference between a working
 install and a puzzling one, and the module derives both from Cloud Map:
 
-- `RISE_AUTH_BACKEND_URL` — `http://rise.<namespace>:3000`. Traefik calls it for
-  every forwardAuth subrequest, so it must be reachable *from inside the
-  cluster* and must never be the public URL.
-- `RISE_TRAEFIK_API_URL` — `http://traefik.<namespace>:8080`. Readiness comes
-  from Traefik's `serverStatus` with no fallback, so without it a project with a
-  `health_check` never becomes Healthy.
+- `RISE_AUTH_BACKEND_URL` —
+  `http://<name>-control-plane.<namespace>:3000`. Traefik calls it for every
+  forwardAuth subrequest, so it must be reachable *from inside the cluster* and
+  must never be the public URL.
+- `RISE_TRAEFIK_API_URL` — `http://<name>-traefik.<namespace>:8080`. Readiness
+  comes from Traefik's `serverStatus` with no fallback, so without it a project
+  with a `health_check` never becomes Healthy.
 
 Subnets and security groups are passed as comma-separated strings. The settings
 loader accepts a YAML list or a comma-separated string precisely so a Terraform

--- a/modules/rise-ecs/README.md
+++ b/modules/rise-ecs/README.md
@@ -184,7 +184,10 @@ failing closed at deploy time rather than half-working:
 
 - **Multi-container deployments.** Cross-container discovery needs Cloud Map
   registration for workloads, which is unimplemented. The namespace here exists
-  for the control plane's own services.
+  for the control plane's own services. Their names are scoped to the module
+  name: `<name>-control-plane`, `<name>-traefik` and, when enabled,
+  `<name>-dex`. This keeps multiple installs distinct when they bring the same
+  Cloud Map namespace.
 - **Workload identity tokens.** There is no way to write files into a running
   Fargate task; a sidecar on a shared volume is the intended mechanism.
 - **Runtime logs.** `deployment_logs` is `none`. Installs running Loki can use

--- a/modules/rise-ecs/cluster.tf
+++ b/modules/rise-ecs/cluster.tf
@@ -51,7 +51,7 @@ resource "aws_service_discovery_private_dns_namespace" "this" {
 }
 
 resource "aws_service_discovery_service" "rise" {
-  name = "rise"
+  name = local.control_plane_discovery_name
 
   dns_config {
     namespace_id   = local.namespace_id
@@ -62,9 +62,6 @@ resource "aws_service_discovery_service" "rise" {
       ttl  = 10
     }
   }
-
-  # Registration is ECS's job, not a Cloud Map health check's.
-  health_check_custom_config {}
 
   # Instances must be deregistered before a Cloud Map service will delete, and
   # ECS deregisters them only as its own tasks drain. `terraform destroy` hits
@@ -75,7 +72,7 @@ resource "aws_service_discovery_service" "rise" {
 }
 
 resource "aws_service_discovery_service" "traefik" {
-  name = "traefik"
+  name = local.traefik_discovery_name
 
   dns_config {
     namespace_id   = local.namespace_id
@@ -86,9 +83,6 @@ resource "aws_service_discovery_service" "traefik" {
       ttl  = 10
     }
   }
-
-  # Registration is ECS's job, not a Cloud Map health check's.
-  health_check_custom_config {}
 
   force_destroy = true
   tags          = local.tags
@@ -97,7 +91,7 @@ resource "aws_service_discovery_service" "traefik" {
 resource "aws_service_discovery_service" "dex" {
   count = var.deploy_dex ? 1 : 0
 
-  name = "dex"
+  name = local.dex_discovery_name
 
   dns_config {
     namespace_id   = local.namespace_id
@@ -108,9 +102,6 @@ resource "aws_service_discovery_service" "dex" {
       ttl  = 10
     }
   }
-
-  # Registration is ECS's job, not a Cloud Map health check's.
-  health_check_custom_config {}
 
   force_destroy = true
   tags          = local.tags

--- a/modules/rise-ecs/dex.tf
+++ b/modules/rise-ecs/dex.tf
@@ -114,5 +114,9 @@ resource "aws_ecs_service" "dex" {
   propagate_tags = "SERVICE"
   tags           = local.tags
 
+  lifecycle {
+    replace_triggered_by = [aws_service_discovery_service.dex[count.index]]
+  }
+
   depends_on = [aws_ecs_service.traefik]
 }

--- a/modules/rise-ecs/locals.tf
+++ b/modules/rise-ecs/locals.tf
@@ -51,13 +51,17 @@ locals {
   namespace_name   = coalesce(var.cloud_map_namespace_name, "${local.name}.internal")
   namespace_id     = local.create_namespace ? aws_service_discovery_private_dns_namespace.this[0].id : var.cloud_map_namespace_id
 
+  control_plane_discovery_name = "${local.name}-control-plane"
+  traefik_discovery_name       = "${local.name}-traefik"
+  dex_discovery_name           = "${local.name}-dex"
+
   # The two internal URLs the install turns on. auth_backend_url must be
   # reachable from inside the cluster — Traefik calls it for every forwardAuth
   # subrequest — and must never be the public URL. traefik_api_url is where
   # readiness comes from: serverStatus, with no fallback, so a project with a
   # health_check never becomes Healthy without it.
-  auth_backend_url = "http://rise.${local.namespace_name}:3000"
-  traefik_api_url  = "http://traefik.${local.namespace_name}:8080"
+  auth_backend_url = "http://${local.control_plane_discovery_name}.${local.namespace_name}:3000"
+  traefik_api_url  = "http://${local.traefik_discovery_name}.${local.namespace_name}:8080"
 
   # --- Edge -----------------------------------------------------------------
   acme_enabled       = var.edge_mode == "nlb-traefik-acme"

--- a/modules/rise-ecs/rise.tf
+++ b/modules/rise-ecs/rise.tf
@@ -97,6 +97,11 @@ resource "aws_ecs_service" "rise" {
   tags           = local.tags
 
   lifecycle {
+    # Cloud Map derives service ids from the namespace and name, so recreating a
+    # service can produce the same ARN after deregistering every task. Replace
+    # the ECS service with it so ECS registers the new tasks against that ARN.
+    replace_triggered_by = [aws_service_discovery_service.rise]
+
     precondition {
       condition     = length(local.private_subnet_ids) <= 16
       error_message = "At most 16 subnets: an awsvpc network configuration accepts no more, and the backend rejects the setting at startup."

--- a/modules/rise-ecs/tests/guardrails.tftest.hcl
+++ b/modules/rise-ecs/tests/guardrails.tftest.hcl
@@ -165,4 +165,12 @@ run "deploy_dex_uses_a_browser_reachable_issuer" {
     condition     = local.rise_environment["DEX_ISSUER"] == "https://dex.rise.example.com/dex"
     error_message = "the demo issuer must be publicly reachable, not the Cloud Map address"
   }
+
+  assert {
+    condition = alltrue([
+      aws_service_discovery_service.dex[0].name == "rise-dex",
+      length(aws_service_discovery_service.dex[0].health_check_custom_config) == 0,
+    ])
+    error_message = "Dex discovery must be install-scoped without an empty custom health check"
+  }
 }

--- a/modules/rise-ecs/tests/plan.tftest.hcl
+++ b/modules/rise-ecs/tests/plan.tftest.hcl
@@ -66,8 +66,25 @@ run "creates_a_whole_install" {
   # Never the public URL. Traefik calls it for every forwardAuth subrequest, and
   # the backend refuses to start when it is empty.
   assert {
-    condition     = local.rise_environment["RISE_AUTH_BACKEND_URL"] == "http://rise.rise.internal:3000"
+    condition     = local.rise_environment["RISE_AUTH_BACKEND_URL"] == "http://rise-control-plane.rise.internal:3000"
     error_message = "auth_backend_url must be the internal Cloud Map address"
+  }
+
+  assert {
+    condition = alltrue([
+      aws_service_discovery_service.rise.name == "rise-control-plane",
+      aws_service_discovery_service.traefik.name == "rise-traefik",
+      local.rise_environment["RISE_TRAEFIK_API_URL"] == "http://rise-traefik.rise.internal:8080",
+    ])
+    error_message = "Cloud Map names must be scoped to the Rise installation"
+  }
+
+  assert {
+    condition = alltrue([
+      length(aws_service_discovery_service.rise.health_check_custom_config) == 0,
+      length(aws_service_discovery_service.traefik.health_check_custom_config) == 0,
+    ])
+    error_message = "empty custom health checks cause perpetual Cloud Map service replacement"
   }
 
   assert {

--- a/modules/rise-ecs/traefik.tf
+++ b/modules/rise-ecs/traefik.tf
@@ -236,6 +236,12 @@ resource "aws_ecs_service" "traefik" {
   propagate_tags = "SERVICE"
   tags           = local.tags
 
+  lifecycle {
+    # Replacing the discovery service removes its instances even when its ARN
+    # remains stable. A fresh ECS service registers its tasks again.
+    replace_triggered_by = [aws_service_discovery_service.traefik]
+  }
+
   depends_on = [
     aws_lb_listener.http,
     aws_efs_mount_target.acme,

--- a/tests/e2e/run/services.tf
+++ b/tests/e2e/run/services.tf
@@ -11,7 +11,6 @@ resource "aws_service_discovery_service" "postgres" {
     }
   }
 
-  health_check_custom_config {}
   force_destroy = true
   tags          = local.tags
 }
@@ -29,7 +28,6 @@ resource "aws_service_discovery_service" "rise" {
     }
   }
 
-  health_check_custom_config {}
   force_destroy = true
   tags          = local.tags
 }
@@ -105,6 +103,10 @@ resource "aws_ecs_service" "postgres" {
 
   propagate_tags = "SERVICE"
   tags           = local.tags
+
+  lifecycle {
+    replace_triggered_by = [aws_service_discovery_service.postgres]
+  }
 }
 
 # -----------------------------------------------------------------------------
@@ -201,6 +203,10 @@ resource "aws_ecs_service" "rise" {
   propagate_tags = "SERVICE"
   tags           = local.tags
 
+  lifecycle {
+    replace_triggered_by = [aws_service_discovery_service.rise]
+  }
+
   depends_on = [aws_ecs_service.postgres]
 }
 
@@ -228,7 +234,6 @@ resource "aws_service_discovery_service" "traefik" {
     }
   }
 
-  health_check_custom_config {}
   force_destroy = true
   tags          = local.tags
 }
@@ -324,6 +329,10 @@ resource "aws_ecs_service" "traefik" {
   }
 
   tags = local.tags
+
+  lifecycle {
+    replace_triggered_by = [aws_service_discovery_service.traefik]
+  }
 }
 
 # -----------------------------------------------------------------------------
@@ -348,7 +357,6 @@ resource "aws_service_discovery_service" "dex" {
     }
   }
 
-  health_check_custom_config {}
   force_destroy = true
   tags          = local.tags
 }
@@ -428,4 +436,8 @@ resource "aws_ecs_service" "dex" {
   }
 
   tags = local.tags
+
+  lifecycle {
+    replace_triggered_by = [aws_service_discovery_service.dex]
+  }
 }

--- a/tests/e2e/run/tests/plan.tftest.hcl
+++ b/tests/e2e/run/tests/plan.tftest.hcl
@@ -53,6 +53,16 @@ variables {
 run "per_run_stack_plans" {
   command = plan
 
+  assert {
+    condition = alltrue([
+      length(aws_service_discovery_service.postgres.health_check_custom_config) == 0,
+      length(aws_service_discovery_service.rise.health_check_custom_config) == 0,
+      length(aws_service_discovery_service.traefik.health_check_custom_config) == 0,
+      length(aws_service_discovery_service.dex.health_check_custom_config) == 0,
+    ])
+    error_message = "empty custom health checks cause perpetual Cloud Map service replacement"
+  }
+
   # Plain HTTP: no load balancer to terminate at, no ACME. A Secure cookie is
   # never sent over HTTP, so this must follow the scheme.
   assert {


### PR DESCRIPTION
## Summary

Keep ECS-backed Rise installations registered in Cloud Map across repeated Terraform applies and legitimate discovery-service replacement.

- Scope the module's discovery names to the installation: `<name>-control-plane`, `<name>-traefik`, and `<name>-dex`.
- Remove empty `health_check_custom_config` blocks. The AWS provider does not persist an empty block, so it otherwise plans a forced replacement on every subsequent apply.
- Make each ECS service replacement follow its Cloud Map service replacement. Cloud Map can recreate a service with the same ARN after deregistering its tasks, which leaves an unchanged ECS service with no DNS instances.
- Apply the same stable lifecycle to the ECS e2e infrastructure and document the generated internal URLs.

This addresses the provider behaviours described in hashicorp/terraform-provider-aws#44285 and #46930. Existing module installations will replace their control-plane discovery services and ECS services once when adopting the scoped names; expect a brief control-plane and ingress interruption during that apply.

## Test plan

Using the repository-pinned Terraform 1.16.0:

- `terraform fmt -check -recursive modules/ tests/e2e/bootstrap tests/e2e/run`
- `terraform validate` for `modules/rise-aws`, `modules/rise-ecs`, `tests/e2e/bootstrap`, and `tests/e2e/run`
- `terraform test`
  - `modules/rise-aws`: 6 passed
  - `modules/rise-ecs`: 23 passed
  - `tests/e2e/bootstrap`: 3 passed
  - `tests/e2e/run`: 6 passed

No merge or release is included in this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rise-deploy/codesmith/rise/pr/469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790612839&installation_model_id=432987&pr_number=469&repository=rise-deploy%2Frise&return_to=https%3A%2F%2Fgithub.com%2Frise-deploy%2Frise%2Fpull%2F469&signature=c4975fabf46393e9e51466fef5774edd3c5f7362413ad49b466daff8db8bcb3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->