### PR TITLE
Add multiple CLI login profiles

### DIFF
--- a/docs/user/src/content/docs/user-guide/authentication.md
+++ b/docs/user/src/content/docs/user-guide/authentication.md
@@ -24,9 +24,25 @@ rise login
 
 Tokens are stored in `~/.config/rise/config.json` (plain JSON).
 
+### Multiple Profiles
+
+To manage more than one Rise account or backend side by side, log in with a
+named `--profile`:
+
+```bash
+rise login --profile work --url https://rise.work.example.com
+```
+
+`rise login --profile <name>` registers the profile automatically if it
+doesn't already exist. Subsequent commands pick it up via `--profile <name>`
+or the `RISE_PROFILE` environment variable; `rise profile list` shows every
+registered profile. See [Login Profiles](../configuration#login-profiles) for
+details.
+
 ### Environment Variables
 
 - `RISE_URL` — default backend URL
+- `RISE_PROFILE` — login profile to use (see [Login Profiles](../configuration#login-profiles))
 - `RISE_TOKEN` — authentication token (bypasses interactive login)
 
 ### API Usage

--- a/docs/user/src/content/docs/user-guide/cli-reference.md
+++ b/docs/user/src/content/docs/user-guide/cli-reference.md
@@ -9,6 +9,7 @@ The Rise CLI (`rise`) provides commands for managing projects, deployments, team
 | Command | Alias | Subcommands | Details |
 |---------|-------|-------------|---------|
 | `rise login` | | | [Authentication](../authentication) |
+| `rise profile` | | `list` (`ls`), `remove` (`rm`) | [Login Profiles](../configuration#login-profiles) |
 | `rise deploy` | | | [Deployments](../deployments) |
 | `rise build` | | | [Building Images](../builds) |
 | `rise run` | | | [Local Development](../local-development) |
@@ -44,6 +45,7 @@ rise project show
 | Variable | Description |
 |----------|-------------|
 | `RISE_URL` | Default backend URL |
+| `RISE_PROFILE` | Login profile to use, equivalent to the global `--profile` flag. See [Login Profiles](../configuration#login-profiles). |
 | `RISE_TOKEN` | Authentication token (skips interactive login) |
 | `RISE_TOKEN_COMMAND` | Shell command whose stdout is used as the bearer token. JWT output uses the embedded `exp` claim; opaque output uses `RISE_TOKEN_COMMAND_TTL` as its assumed lifetime. |
 | `RISE_TOKEN_COMMAND_TTL` | Assumed lifetime (seconds) for opaque tokens produced by `RISE_TOKEN_COMMAND`. The command is re-run after two thirds of this TTL has elapsed. JWT tokens ignore this setting and use their `exp` claim instead. Default: `600` (10 minutes). |
@@ -83,3 +85,5 @@ For token sources that can mint new tokens, the CLI refreshes proactively so lon
 ## Global Configuration
 
 CLI settings are stored in `~/.config/rise/config.json`, created on first `rise login`. See [Project Configuration](../configuration#global-cli-config) for details.
+
+Multiple accounts/backends can be managed side by side with named login profiles (`--profile` / `RISE_PROFILE`, `rise profile list`/`remove`). See [Login Profiles](../configuration#login-profiles).

--- a/docs/user/src/content/docs/user-guide/configuration.mdx
+++ b/docs/user/src/content/docs/user-guide/configuration.mdx
@@ -145,6 +145,35 @@ The CLI stores global configuration in `~/.config/rise/config.json`, including:
 
 This file is created automatically on first `rise login`.
 
+## Login Profiles
+
+By default, `rise login` stores credentials in the config file above (the
+**default profile**). To manage more than one Rise account or backend side by
+side — e.g. a personal account and a work account — use a named profile:
+
+```bash
+# Log in and register a new profile named "work" (created if it doesn't exist)
+rise login --profile work --url https://rise.work.example.com
+
+# Use it for a single command
+rise project list --profile work
+
+# ...or for a whole shell session
+export RISE_PROFILE=work
+rise project list
+
+# See every registered profile and which one is active
+rise profile list
+
+# Remove a profile's stored credentials
+rise profile remove work
+```
+
+`--profile` takes precedence over the `RISE_PROFILE` environment variable;
+passing `--profile default` (or unsetting `RISE_PROFILE`) switches back to the
+default profile. A named profile's config is stored separately, at
+`~/.config/rise/profiles/<name>.json`.
+
 ## Backend Configuration Schema
 
 If you're operating a Rise deployment, a JSON Schema for backend configuration (`rise.yaml`) is available at [`backend-settings.schema.json`](/docs/schemas/backend-settings.schema.json). See the [Operator Configuration guide](https://rise-deploy.github.io/rise/operator/configuration/) for details.

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -126,6 +126,51 @@ fn probe_runtime(command: &str) -> Option<ContainerRuntime> {
 // - Linux: Secret Service API / libsecret
 // - Windows: Credential Manager
 
+/// Only ASCII letters, digits, `-` and `_` are allowed in a profile name — it
+/// is used verbatim as a file name under `~/.config/rise/profiles/`.
+pub fn validate_profile_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        anyhow::bail!("Profile name cannot be empty");
+    }
+    if name.len() > 63 {
+        anyhow::bail!("Profile name '{}' is too long (max 63 characters)", name);
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        anyhow::bail!(
+            "Invalid profile name '{}': only ASCII letters, digits, '-' and '_' are allowed",
+            name
+        );
+    }
+    Ok(())
+}
+
+/// Create `dir` with `0700` permissions on Unix if it doesn't already exist.
+fn ensure_config_dir(dir: &std::path::Path) -> Result<()> {
+    if !dir.exists() {
+        #[cfg(unix)]
+        {
+            // Create parent directories with default permissions
+            if let Some(parent) = dir.parent() {
+                fs::create_dir_all(parent).context("Failed to create config parent directory")?;
+            }
+            // Create the target directory with 0700 atomically
+            use std::os::unix::fs::DirBuilderExt;
+            fs::DirBuilder::new()
+                .mode(0o700)
+                .create(dir)
+                .context("Failed to create config directory")?;
+        }
+        #[cfg(not(unix))]
+        {
+            fs::create_dir_all(dir).context("Failed to create config directory")?;
+        }
+    }
+    Ok(())
+}
+
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct Config {
     pub token: Option<String>,
@@ -135,40 +180,103 @@ pub struct Config {
 }
 
 impl Config {
-    /// Get the path to the config file
-    pub fn config_path() -> Result<PathBuf> {
-        let home = dirs::home_dir().context("Failed to get home directory")?;
-
-        let config_dir = home.join(".config").join("rise");
-
-        // Create directory if it doesn't exist, with restrictive permissions on Unix
-        if !config_dir.exists() {
-            #[cfg(unix)]
-            {
-                // Create parent directories with default permissions
-                if let Some(parent) = config_dir.parent() {
-                    fs::create_dir_all(parent)
-                        .context("Failed to create config parent directory")?;
-                }
-                // Create the rise config directory with 0700 atomically
-                use std::os::unix::fs::DirBuilderExt;
-                fs::DirBuilder::new()
-                    .mode(0o700)
-                    .create(&config_dir)
-                    .context("Failed to create config directory")?;
+    /// The active login profile, i.e. the one selected via `--profile` /
+    /// `RISE_PROFILE` for the lifetime of this process, or `None` for the
+    /// default profile.
+    ///
+    /// `--profile` is resolved once in `main()`, which normalizes it into the
+    /// `RISE_PROFILE` environment variable (removing it for the literal value
+    /// `"default"`) so every independent config load in the process — not
+    /// just the one in `main()` — agrees on the same active profile.
+    pub fn active_profile() -> Result<Option<String>> {
+        #[cfg(not(test))]
+        if let Ok(val) = std::env::var("RISE_PROFILE") {
+            let trimmed = val.trim();
+            if trimmed.is_empty() || trimmed == "default" {
+                return Ok(None);
             }
-            #[cfg(not(unix))]
-            {
-                fs::create_dir_all(&config_dir).context("Failed to create config directory")?;
-            }
+            validate_profile_name(trimmed)?;
+            return Ok(Some(trimmed.to_string()));
         }
-
-        Ok(config_dir.join("config.json"))
+        Ok(None)
     }
 
-    /// Load configuration from disk
+    /// The active profile's name for display purposes (`"default"` when unset).
+    pub fn active_profile_label() -> Result<String> {
+        Ok(Self::active_profile()?.unwrap_or_else(|| "default".to_string()))
+    }
+
+    /// List the names of all registered non-default profiles, i.e. every
+    /// profile a `rise login --profile <name>` has ever saved.
+    pub fn list_profiles() -> Result<Vec<String>> {
+        let home = dirs::home_dir().context("Failed to get home directory")?;
+        let profiles_dir = home.join(".config").join("rise").join("profiles");
+
+        let mut names = Vec::new();
+        if profiles_dir.exists() {
+            for entry in fs::read_dir(&profiles_dir).context("Failed to read profiles directory")? {
+                let entry = entry.context("Failed to read profile directory entry")?;
+                let path = entry.path();
+                if path.extension().and_then(|e| e.to_str()) == Some("json") {
+                    if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                        names.push(stem.to_string());
+                    }
+                }
+            }
+        }
+        names.sort();
+        Ok(names)
+    }
+
+    /// Remove a profile's saved configuration file. `"default"` removes the
+    /// base `config.json`.
+    pub fn remove_profile(name: &str) -> Result<()> {
+        let path = if name == "default" {
+            Self::path_for(None)?
+        } else {
+            Self::path_for(Some(name))?
+        };
+
+        if !path.exists() {
+            anyhow::bail!("Profile '{}' does not exist", name);
+        }
+
+        fs::remove_file(&path).context("Failed to remove profile config file")?;
+        Ok(())
+    }
+
+    /// The config file path for a given profile (`None` = default profile).
+    pub fn path_for(profile: Option<&str>) -> Result<PathBuf> {
+        let home = dirs::home_dir().context("Failed to get home directory")?;
+        let config_dir = home.join(".config").join("rise");
+        ensure_config_dir(&config_dir)?;
+
+        match profile {
+            None => Ok(config_dir.join("config.json")),
+            Some(name) => {
+                validate_profile_name(name)?;
+                let profiles_dir = config_dir.join("profiles");
+                ensure_config_dir(&profiles_dir)?;
+                Ok(profiles_dir.join(format!("{name}.json")))
+            }
+        }
+    }
+
+    /// Get the path to the active profile's config file
+    pub fn config_path() -> Result<PathBuf> {
+        Self::path_for(Self::active_profile()?.as_deref())
+    }
+
+    /// Load the active profile's configuration from disk
     pub fn load() -> Result<Self> {
-        let config_path = Self::config_path()?;
+        Self::load_named(Self::active_profile()?.as_deref())
+    }
+
+    /// Load a specific profile's configuration from disk, independent of the
+    /// active profile. Used to inspect other profiles (e.g. `rise profile list`)
+    /// without switching the active one.
+    pub fn load_named(profile: Option<&str>) -> Result<Self> {
+        let config_path = Self::path_for(profile)?;
 
         if !config_path.exists() {
             return Ok(Config::default());
@@ -366,6 +474,41 @@ mod tests {
     fn test_token_from_config() {
         let c = config(|c| c.token = Some("config-token".to_string()));
         assert_eq!(c.stored_token(), Some("config-token".to_string()));
+    }
+
+    #[test]
+    fn test_active_profile_is_default_in_tests() {
+        // RISE_PROFILE reads are disabled under #[cfg(test)] (like the other
+        // env-checking getters), so this only exercises the "unset" path.
+        assert_eq!(Config::active_profile().unwrap(), None);
+        assert_eq!(Config::active_profile_label().unwrap(), "default");
+    }
+
+    #[test]
+    fn test_validate_profile_name_accepts_alnum_dash_underscore() {
+        assert!(validate_profile_name("work").is_ok());
+        assert!(validate_profile_name("work-2").is_ok());
+        assert!(validate_profile_name("work_2").is_ok());
+        assert!(validate_profile_name("default").is_ok());
+    }
+
+    #[test]
+    fn test_validate_profile_name_rejects_empty() {
+        assert!(validate_profile_name("").is_err());
+    }
+
+    #[test]
+    fn test_validate_profile_name_rejects_path_separators() {
+        assert!(validate_profile_name("../escape").is_err());
+        assert!(validate_profile_name("a/b").is_err());
+    }
+
+    #[test]
+    fn test_validate_profile_name_rejects_too_long() {
+        let long_name = "a".repeat(64);
+        assert!(validate_profile_name(&long_name).is_err());
+        let ok_name = "a".repeat(63);
+        assert!(validate_profile_name(&ok_name).is_ok());
     }
 
     #[test]

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
+use std::sync::OnceLock;
 
 pub fn normalize_backend_url(url: &str) -> String {
     url.trim_end_matches('/').to_string()
@@ -179,16 +180,39 @@ pub struct Config {
     pub managed_buildkit: Option<bool>,
 }
 
+/// Process-wide override for the active profile, set at most once by `main()`
+/// from an explicit `--profile` flag. The outer `Option` tracks whether an
+/// override was set at all (unset = no `--profile` flag was given, so
+/// `RISE_PROFILE` should be consulted instead); the inner `Option` is the
+/// resolved profile itself (`None` = the default profile, i.e. `--profile
+/// default`).
+///
+/// Using a `OnceLock` here — rather than round-tripping through
+/// `std::env::set_var`/`remove_var` — avoids mutating the process
+/// environment after the async runtime's worker threads are running, which
+/// is unsound if anything else reads the environment concurrently.
+static PROFILE_OVERRIDE: OnceLock<Option<String>> = OnceLock::new();
+
+/// Set the process-wide profile override. Must be called at most once, before
+/// any other profile resolution — `main()` does this immediately after
+/// parsing CLI args, when `--profile` was passed.
+pub fn set_profile_override(profile: Option<String>) {
+    let _ = PROFILE_OVERRIDE.set(profile);
+}
+
 impl Config {
     /// The active login profile, i.e. the one selected via `--profile` /
     /// `RISE_PROFILE` for the lifetime of this process, or `None` for the
     /// default profile.
     ///
-    /// `--profile` is resolved once in `main()`, which normalizes it into the
-    /// `RISE_PROFILE` environment variable (removing it for the literal value
-    /// `"default"`) so every independent config load in the process — not
-    /// just the one in `main()` — agrees on the same active profile.
+    /// `--profile` is resolved once in `main()` into [`set_profile_override`],
+    /// so every independent config load in the process — not just the one in
+    /// `main()` — agrees on the same active profile. Absent that override,
+    /// falls back to the `RISE_PROFILE` environment variable.
     pub fn active_profile() -> Result<Option<String>> {
+        if let Some(overridden) = PROFILE_OVERRIDE.get() {
+            return Ok(overridden.clone());
+        }
         #[cfg(not(test))]
         if let Ok(val) = std::env::var("RISE_PROFILE") {
             let trimmed = val.trim();

--- a/src/cli/login/device_flow.rs
+++ b/src/cli/login/device_flow.rs
@@ -174,6 +174,7 @@ pub async fn handle_device_flow(
                     .context("Failed to save authentication token")?;
 
                 println!("\n✓ Login successful!");
+                println!("  Profile: {}", Config::active_profile_label()?);
                 println!("  Token saved to: {}", Config::config_path()?.display());
 
                 // Display token expiration

--- a/src/cli/login/oauth_code.rs
+++ b/src/cli/login/oauth_code.rs
@@ -329,6 +329,7 @@ pub async fn handle_authorization_code_flow(
         .context("Failed to save authentication token")?;
 
     println!("✓ Login successful!");
+    println!("  Profile: {}", Config::active_profile_label()?);
     println!("  Token saved to: {}", Config::config_path()?.display());
 
     // Display token expiration

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -10,6 +10,7 @@ pub mod environment;
 pub mod extension;
 pub mod identity;
 pub mod login;
+pub mod profile;
 pub mod project;
 pub mod run;
 pub mod service_account;

--- a/src/cli/profile.rs
+++ b/src/cli/profile.rs
@@ -1,0 +1,67 @@
+//! `rise profile` — inspect and manage the login profiles selected via the
+//! global `--profile` flag / `RISE_PROFILE` environment variable.
+//!
+//! A profile is "registered" simply by having a saved config file: `rise
+//! login --profile <name>` creates one on first use, so there is nothing to
+//! create explicitly ahead of time.
+
+use crate::config::Config;
+use anyhow::Result;
+use comfy_table::{modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, Attribute, Cell, Table};
+
+/// List all registered profiles, marking which one is currently active.
+pub fn list_profiles() -> Result<()> {
+    let active = Config::active_profile_label()?;
+
+    let mut names = vec!["default".to_string()];
+    names.extend(Config::list_profiles()?);
+
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header(vec![
+            Cell::new("").add_attribute(Attribute::Bold),
+            Cell::new("NAME").add_attribute(Attribute::Bold),
+            Cell::new("BACKEND URL").add_attribute(Attribute::Bold),
+            Cell::new("LOGGED IN").add_attribute(Attribute::Bold),
+            Cell::new("CONFIG FILE").add_attribute(Attribute::Bold),
+        ]);
+
+    for name in &names {
+        let key = if name == "default" {
+            None
+        } else {
+            Some(name.as_str())
+        };
+        let cfg = Config::load_named(key)?;
+        let path = Config::path_for(key)?;
+
+        table.add_row(vec![
+            Cell::new(if *name == active { "*" } else { "" }),
+            Cell::new(name),
+            Cell::new(cfg.backend_url.as_deref().unwrap_or("-")),
+            Cell::new(if cfg.stored_token().is_some() {
+                "yes"
+            } else {
+                "no"
+            }),
+            Cell::new(path.display()),
+        ]);
+    }
+
+    println!("{}", table);
+    println!(
+        "\nActive profile: {} (RISE_PROFILE env var / --profile flag; \"default\" if unset)",
+        active
+    );
+
+    Ok(())
+}
+
+/// Remove a profile's saved config file.
+pub fn remove_profile(name: &str) -> Result<()> {
+    Config::remove_profile(name)?;
+    println!("✓ Removed profile '{}'", name);
+    Ok(())
+}

--- a/src/cli/token_source.rs
+++ b/src/cli/token_source.rs
@@ -740,10 +740,13 @@ pub fn select_token_provider(
         Arc::new(StaticToken::new(token, "stored login token"))
     } else {
         // 5. Nothing.
-        return Err(TokenSourceError::NoSource(
-            "Not authenticated. Run 'rise login' first.".to_string(),
-        )
-        .into());
+        let message = match Config::active_profile().ok().flatten() {
+            Some(profile) => format!(
+                "Not authenticated for profile '{profile}'. Run 'rise login --profile {profile}' first."
+            ),
+            None => "Not authenticated. Run 'rise login' first.".to_string(),
+        };
+        return Err(TokenSourceError::NoSource(message).into());
     };
 
     // `RISE_IDENTITY` set → exchange the resolved token for that identity,

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,12 @@ fn resolve_project_name_with_config(
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Cli {
+    /// Login profile to use, letting you manage multiple Rise accounts or
+    /// backends side by side. Falls back to the RISE_PROFILE environment
+    /// variable, then the default profile. `rise login --profile <name>`
+    /// registers a new profile if it doesn't already exist.
+    #[arg(long, global = true)]
+    profile: Option<String>,
     #[command(subcommand)]
     command: Commands,
 }
@@ -223,6 +229,9 @@ enum Commands {
         #[arg(long, conflicts_with = "browser")]
         device: bool,
     },
+    /// Manage CLI login profiles (see the global --profile flag / RISE_PROFILE)
+    #[command(subcommand)]
+    Profile(ProfileCommands),
     /// Project management commands
     #[command(subcommand)]
     #[command(visible_alias = "p")]
@@ -417,6 +426,19 @@ enum SkillCommands {
         /// Directory to remove from. Defaults to ~/.claude/skills
         #[arg(long)]
         target: Option<std::path::PathBuf>,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum ProfileCommands {
+    /// List registered login profiles
+    #[command(visible_alias = "ls")]
+    List,
+    /// Remove a profile's saved login/config
+    #[command(visible_alias = "rm")]
+    Remove {
+        /// Profile name to remove ("default" removes the default profile)
+        name: String,
     },
 }
 
@@ -1137,6 +1159,19 @@ async fn main() -> Result<()> {
 
     let cli = Cli::parse();
 
+    // Resolve the active login profile once, up front: an explicit --profile
+    // normalizes into the RISE_PROFILE environment variable (or clears it, for
+    // the literal value "default") so every independent config load later in
+    // the process — not just the one below — agrees on the same profile.
+    if let Some(profile) = &cli.profile {
+        config::validate_profile_name(profile).context("Invalid --profile value")?;
+        if profile == "default" {
+            std::env::remove_var("RISE_PROFILE");
+        } else {
+            std::env::set_var("RISE_PROFILE", profile);
+        }
+    }
+
     // Transform Deploy command to Deployment::Create for zero-duplication aliasing
     let cli_command = match cli.command {
         Commands::Deploy { args } => Commands::Deployment(DeploymentCommands::Create { args }),
@@ -1197,6 +1232,10 @@ async fn main() -> Result<()> {
         Commands::Encrypt { plaintext } => {
             cli::encrypt::encrypt_command(&config, plaintext.clone()).await?;
         }
+        Commands::Profile(profile_cmd) => match profile_cmd {
+            ProfileCommands::List => profile::list_profiles()?,
+            ProfileCommands::Remove { name } => profile::remove_profile(name)?,
+        },
         Commands::Project(project_cmd) => match project_cmd {
             ProjectCommands::Create {
                 name,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1160,15 +1160,17 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     // Resolve the active login profile once, up front: an explicit --profile
-    // normalizes into the RISE_PROFILE environment variable (or clears it, for
-    // the literal value "default") so every independent config load later in
-    // the process — not just the one below — agrees on the same profile.
+    // sets a process-wide override (cleared for the literal value "default")
+    // so every independent config load later in the process — not just the
+    // one below — agrees on the same profile. This deliberately avoids
+    // std::env::set_var, which is unsound to mutate concurrently with reads
+    // from other threads once the async runtime's workers are running.
     if let Some(profile) = &cli.profile {
         config::validate_profile_name(profile).context("Invalid --profile value")?;
         if profile == "default" {
-            std::env::remove_var("RISE_PROFILE");
+            config::set_profile_override(None);
         } else {
-            std::env::set_var("RISE_PROFILE", profile);
+            config::set_profile_override(Some(profile.clone()));
         }
     }
 


### PR DESCRIPTION
Supports managing several Rise accounts/backends side by side via a
global --profile flag or RISE_PROFILE env var (flag wins; --profile
default clears it). A named profile is stored separately under
~/.config/rise/profiles/<name>.json and is registered automatically
the first time `rise login --profile <name>` saves to it; the
unqualified default profile keeps using ~/.config/rise/config.json.

Adds `rise profile list`/`rise profile remove <name>` to inspect and
manage registered profiles, and threads the active profile into the
login success message and the "not authenticated" error hint.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rise-deploy/codesmith/rise/pr/473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790772800&installation_model_id=432987&pr_number=473&repository=rise-deploy%2Frise&return_to=https%3A%2F%2Fgithub.com%2Frise-deploy%2Frise%2Fpull%2F473&signature=1f90afd31b7c23ea3468b42895c2774ac99e60890d8758bdfef31067bf20006a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->