### PR TITLE
Harden login group sync and Snowflake private keys

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -35,6 +35,8 @@ auth:
   client_secret: "rise-backend-secret"
   # ID-token claim containing group names (default: "groups").
   # idp_group_claim: "cognito:groups"
+  # Optional prefixes limiting which canonical groups become Rise teams.
+  # idp_group_sync_prefixes: ["rise-"]
   admin_users:
     - "admin@example.com"
   # Grant the admin role by IdP group instead of listing every email. A user

--- a/config/docker.yaml
+++ b/config/docker.yaml
@@ -69,6 +69,9 @@ auth:
   client_secret: "${OIDC_CLIENT_SECRET:-rise-backend-secret}"
   # ID-token claim containing group names. AWS Cognito uses "cognito:groups".
   idp_group_claim: "${OIDC_GROUP_CLAIM:-groups}"
+  # Optional comma-separated prefixes limiting which canonical group names are
+  # mirrored into Rise teams during login. Empty accepts every canonical name.
+  idp_group_sync_prefixes: "${RISE_IDP_GROUP_SYNC_PREFIXES:-}"
   admin_users: ["${ADMIN_EMAIL:-admin@example.com}"]
   # Grant the admin role to everyone in an IdP group instead of listing emails.
   # Blank entries are filtered out, so an unset var collapses to an empty list.

--- a/config/ecs.yaml
+++ b/config/ecs.yaml
@@ -36,6 +36,7 @@ auth:
   client_id: "${OIDC_CLIENT_ID:-rise-backend}"
   client_secret: "${OIDC_CLIENT_SECRET:-rise-backend-secret}"
   idp_group_claim: "${OIDC_GROUP_CLAIM:-groups}"
+  idp_group_sync_prefixes: "${RISE_IDP_GROUP_SYNC_PREFIXES:-}"
   admin_users:
     - "${ADMIN_EMAIL:-admin@example.com}"
   admin_idp_groups:

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -28,6 +28,7 @@ auth:
   client_secret: "${OIDC_CLIENT_SECRET}"
   # ID-token claim containing group names. AWS Cognito uses "cognito:groups".
   idp_group_claim: "${OIDC_GROUP_CLAIM:-groups}"
+  idp_group_sync_prefixes: "${RISE_IDP_GROUP_SYNC_PREFIXES:-}"
   admin_users:
     - "${ADMIN_EMAIL:-admin@example.com}"
   # Optional: enable active sync to pull users/groups from Entra ID.

--- a/docs/engineering/public/schemas/backend-settings.schema.json
+++ b/docs/engineering/public/schemas/backend-settings.schema.json
@@ -149,6 +149,14 @@
           "description": "Enable IdP group synchronization (default: true).\nWhen enabled, user team memberships are synchronized from the configured\nIdP group claim on login.",
           "type": "boolean"
         },
+        "idp_group_sync_prefixes": {
+          "default": [],
+          "description": "Optional prefixes limiting which canonical IdP group names are mirrored\ninto Rise teams during login. An empty list accepts every canonical\ngroup name.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "issuer": {
           "type": "string"
         },

--- a/docs/engineering/src/content/docs/configuration.md
+++ b/docs/engineering/src/content/docs/configuration.md
@@ -228,6 +228,7 @@ auth:
                                 # such as Google reject it); add it here if needed.
   idp_group_claim: "groups"     # ID-token claim containing group names (default shown)
                                 # Use "cognito:groups" for AWS Cognito.
+  idp_group_sync_prefixes: []   # Optional prefixes limiting groups mirrored as teams.
   admin_users: ["email@..."]    # Default-organization admin emails (array)
   admin_idp_groups: ["..."]     # IdP groups whose members are admins (array, optional)
   operator_users: ["ops@..."]   # Operator role allowlist (array, optional)
@@ -260,7 +261,11 @@ by group bypass `platform_access` exactly as email-listed users do.
 by `auth.idp_group_claim` (default: `groups`) at login and mirrors it into
 IdP-managed teams (`sync_user_groups`, and the Entra active sync when enabled).
 For AWS Cognito, set `idp_group_claim: "cognito:groups"`. Those teams are what
-the group checks read. Two consequences:
+the group checks read. Login sync accepts only canonical team names containing
+lowercase ASCII letters, digits, and hyphens. Set `idp_group_sync_prefixes`
+(for example, `["rise-"]`) to mirror only matching groups; an empty list accepts
+every canonical name. The prefix filter does not apply to Entra active sync.
+Three consequences:
 
 - Only **IdP-managed** teams count. A team a user creates themselves never
   grants a role, even if its name matches a configured group — otherwise
@@ -268,6 +273,8 @@ the group checks read. Two consequences:
 - Membership refreshes at login. Removing a user from a group in the IdP takes
   effect on their next login (or on the next Entra active sync), not
   immediately. Revoke access that must take effect at once in the IdP itself.
+- Invalid or prefix-excluded claim values never create teams. Existing
+  memberships outside the filtered claim are removed at the next login.
 
 The same resolution backs `platform_access.allowed_idp_groups`.
 

--- a/docs/engineering/src/content/docs/docker/production.md
+++ b/docs/engineering/src/content/docs/docker/production.md
@@ -88,6 +88,7 @@ export ACME_CA_SERVER=https://acme-staging-v02.api.letsencrypt.org/directory
 | `RISE_ENCRYPTION_KEY` | insecure repo placeholder | **Set it.** Overrides the demo AES key. `openssl rand -base64 32`. |
 | `OIDC_CLIENT_SECRET` | `rise-backend-secret` | **Set it.** Keep in sync with the Dex client secret in `dev/dex/config.yaml`. |
 | `OIDC_GROUP_CLAIM` | `groups` | ID-token claim containing group names. Set to `cognito:groups` for AWS Cognito. |
+| `RISE_IDP_GROUP_SYNC_PREFIXES` | empty | Optional comma-separated prefixes limiting which canonical IdP groups become Rise teams. |
 | `ADMIN_EMAIL` | `admin@example.com` | Initial admin user. |
 | `RISE_PLATFORM_ACCESS_POLICY` | `allow_all` | Who may use the CLI/API/dashboard. `allow_all` = any authenticated user; `restrictive` = allowlist only (see [Platform access](#platform-access)). |
 | `RISE_PLATFORM_ALLOWED_EMAIL` | empty | A single email granted platform access when the policy is `restrictive`. For several users, mount a config override. |
@@ -155,6 +156,7 @@ env var.
 Group-based grants — `allowed_idp_groups`, `admin_idp_groups`,
 `operator_idp_groups` — match against the IdP-managed teams Rise syncs from the
 ID-token claim selected by `auth.idp_group_claim` (`OIDC_GROUP_CLAIM`, default
-`groups`) at login. Teams users create themselves never match, and a group
-removal in the IdP takes effect on the user's next login. See
+`groups`) at login. `RISE_IDP_GROUP_SYNC_PREFIXES` can limit synchronization to
+canonical names under one or more prefixes. Teams users create themselves never
+match, and a group removal in the IdP takes effect on the user's next login. See
 [Roles](/operator-docs/configuration/#authentication-auth) for details.

--- a/docs/engineering/src/content/docs/extensions/snowflake-oauth-provisioner.md
+++ b/docs/engineering/src/content/docs/extensions/snowflake-oauth-provisioner.md
@@ -27,12 +27,17 @@ extensions:
       # For private key auth:
       # auth_type: private_key
       # private_key_path: "/etc/rise/snowflake_rsa_key.p8"
-      # private_key_password: "${SNOWFLAKE_KEY_PASSWORD}"  # optional
+      # private_key_password: "${SNOWFLAKE_KEY_PASSWORD}"  # optional; omit for unencrypted keys
       integration_name_prefix: "rise"   # prefix for SECURITY INTEGRATION names
       # default_blocked_roles: ["ACCOUNTADMIN", "ORGADMIN", "SECURITYADMIN"]
       # default_scopes: ["refresh_token"]
       # refresh_token_validity_seconds: 7776000  # 90 days
 ```
+
+Private-key authentication accepts encrypted PKCS#8, unencrypted PKCS#8, and
+unencrypted RSA PKCS#1 PEM keys. Rise converts unencrypted keys to encrypted
+PKCS#8 in memory for the Snowflake connector; the generated passphrase is not
+persisted.
 
 ## Project Extension Spec
 

--- a/docs/engineering/src/content/docs/upgrade-notes.md
+++ b/docs/engineering/src/content/docs/upgrade-notes.md
@@ -31,6 +31,17 @@ version section at tag time._
 
 Merged to `develop`:
 
+- **Config change — login-time IdP group prefixes.**
+  `auth.idp_group_sync_prefixes` optionally limits which canonical group names
+  are mirrored into Rise teams. An empty list preserves synchronization of all
+  canonical names. Invalid claim values are skipped, and excluded memberships
+  are removed on the user's next login. ECS and Docker installs can supply the
+  prefixes as a comma-separated `RISE_IDP_GROUP_SYNC_PREFIXES` value.
+
+- **Snowflake private-key authentication accepts unencrypted PEM keys.** Rise
+  converts unencrypted PKCS#8 and RSA PKCS#1 keys to encrypted PKCS#8 in memory
+  for the connector. The generated passphrase is not persisted.
+
 - **The Pods tab is gone, and a deployment's history is now an event log.**
   Every backend used to write a Kubernetes-shaped `pod_status` snapshot into
   `controller_metadata` on each reconcile, and the UI read into its keys. That

--- a/modules/rise-ecs/README.md
+++ b/modules/rise-ecs/README.md
@@ -132,8 +132,10 @@ is replaced, and there is no HA.
 
 For an IdP that publishes groups, set `oidc_group_claim`, `admin_idp_group`,
 `platform_access_policy = "restrictive"`, and `platform_allowed_idp_group`.
-These values are rendered through the ECS environment into the shipped
-configuration; no mounted override file is required.
+Set `idp_group_sync_prefixes` to limit which canonical group names are mirrored
+into Rise teams; an empty list accepts every canonical name. These values are
+rendered through the ECS environment into the shipped configuration; no mounted
+override file is required.
 
 Dex needs a bcrypt hash, since Terraform has no bcrypt function:
 

--- a/modules/rise-ecs/locals.tf
+++ b/modules/rise-ecs/locals.tf
@@ -133,6 +133,7 @@ module "control_plane_env" {
   oidc_issuer                = local.oidc_issuer
   oidc_client_id             = var.oidc_client_id
   oidc_group_claim           = var.oidc_group_claim
+  idp_group_sync_prefixes    = var.idp_group_sync_prefixes
   admin_idp_group            = var.admin_idp_group
   platform_access_policy     = var.platform_access_policy
   platform_allowed_idp_group = var.platform_allowed_idp_group

--- a/modules/rise-ecs/modules/control-plane-env/main.tf
+++ b/modules/rise-ecs/modules/control-plane-env/main.tf
@@ -22,6 +22,7 @@ locals {
       DEX_ISSUER                      = var.oidc_issuer
       OIDC_CLIENT_ID                  = var.oidc_client_id
       OIDC_GROUP_CLAIM                = var.oidc_group_claim
+      RISE_IDP_GROUP_SYNC_PREFIXES    = join(",", var.idp_group_sync_prefixes)
       RISE_ADMIN_IDP_GROUP            = var.admin_idp_group != null ? var.admin_idp_group : ""
       RISE_PLATFORM_ACCESS_POLICY     = var.platform_access_policy
       RISE_PLATFORM_ALLOWED_IDP_GROUP = var.platform_allowed_idp_group != null ? var.platform_allowed_idp_group : ""

--- a/modules/rise-ecs/modules/control-plane-env/variables.tf
+++ b/modules/rise-ecs/modules/control-plane-env/variables.tf
@@ -111,6 +111,11 @@ variable "oidc_group_claim" {
   default = "groups"
 }
 
+variable "idp_group_sync_prefixes" {
+  type    = list(string)
+  default = []
+}
+
 variable "admin_idp_group" {
   type    = string
   default = null

--- a/modules/rise-ecs/tests/guardrails.tftest.hcl
+++ b/modules/rise-ecs/tests/guardrails.tftest.hcl
@@ -81,6 +81,16 @@ run "rejects_a_repo_prefix_without_a_trailing_slash" {
   expect_failures = [var.ecr_repo_prefix]
 }
 
+run "rejects_noncanonical_idp_group_sync_prefixes" {
+  command = plan
+
+  variables {
+    idp_group_sync_prefixes = ["Rise_"]
+  }
+
+  expect_failures = [var.idp_group_sync_prefixes]
+}
+
 # VPC endpoints reach AWS services only. Traefik's HTTP-01 challenge needs
 # Let's Encrypt, so the certificate would silently never arrive.
 run "rejects_acme_without_internet_egress" {

--- a/modules/rise-ecs/tests/plan.tftest.hcl
+++ b/modules/rise-ecs/tests/plan.tftest.hcl
@@ -148,9 +148,15 @@ run "alb_uses_https_and_group_restricted_auth" {
     rise_image_tag             = null
     rise_image_ref             = "ghcr.io/rise-deploy/rise@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     oidc_group_claim           = "cognito:groups"
+    idp_group_sync_prefixes    = ["rise-"]
     admin_idp_group            = "rise-admins"
     platform_access_policy     = "restrictive"
     platform_allowed_idp_group = "rise-platform-users"
+  }
+
+  assert {
+    condition     = local.rise_environment["RISE_IDP_GROUP_SYNC_PREFIXES"] == "rise-"
+    error_message = "IdP group sync prefixes must reach the shipped ECS configuration"
   }
 
   assert {

--- a/modules/rise-ecs/variables.tf
+++ b/modules/rise-ecs/variables.tf
@@ -523,6 +523,19 @@ variable "oidc_group_claim" {
   default     = "groups"
 }
 
+variable "idp_group_sync_prefixes" {
+  description = "Optional lowercase prefixes limiting which canonical IdP group names are mirrored into Rise teams during login. Empty accepts every canonical name."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for prefix in var.idp_group_sync_prefixes : can(regex("^[a-z0-9-]+$", prefix))
+    ])
+    error_message = "idp_group_sync_prefixes entries must contain only lowercase ASCII letters, digits, and hyphens."
+  }
+}
+
 variable "admin_idp_group" {
   description = "Identity-provider group whose members are Rise administrators. Null grants no group administrative access."
   type        = string

--- a/src/db/teams.rs
+++ b/src/db/teams.rs
@@ -4,6 +4,18 @@ use uuid::Uuid;
 
 use crate::db::models::{Team, TeamMember, TeamRole, User};
 
+/// Whether a name satisfies the database constraint carried by `teams.name`.
+///
+/// Keep claim-derived names on the same side of the boundary before opening a
+/// transaction: one malformed IdP group must not roll back every valid group in
+/// the same token.
+pub fn is_valid_team_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+}
+
 /// List all teams
 pub async fn list(pool: &PgPool) -> Result<Vec<Team>> {
     let teams = sqlx::query_as!(

--- a/src/server/auth/group_sync.rs
+++ b/src/server/auth/group_sync.rs
@@ -1,18 +1,47 @@
 use anyhow::{Context, Result};
 use sqlx::PgPool;
+use std::collections::HashSet;
 use uuid::Uuid;
 
 use crate::db::{models::TeamRole, teams};
+
+fn filter_idp_groups<'a>(idp_groups: &'a [String], allowed_prefixes: &[String]) -> Vec<&'a str> {
+    let mut seen = HashSet::new();
+    idp_groups
+        .iter()
+        .filter_map(|group_name| {
+            if !teams::is_valid_team_name(group_name) {
+                tracing::warn!(
+                    group = %group_name,
+                    "Skipping IdP group whose name cannot be represented as a Rise team"
+                );
+                return None;
+            }
+            if !allowed_prefixes.is_empty()
+                && !allowed_prefixes
+                    .iter()
+                    .any(|prefix| group_name.starts_with(prefix))
+            {
+                tracing::debug!(
+                    group = %group_name,
+                    "Skipping IdP group outside the configured sync prefixes"
+                );
+                return None;
+            }
+            seen.insert(group_name.as_str())
+                .then_some(group_name.as_str())
+        })
+        .collect()
+}
 
 /// Synchronize a user's team memberships from the configured IdP group claim.
 ///
 /// This function implements the complete IdP group synchronization algorithm:
 /// 1. Creates teams that don't exist in Rise
 /// 2. Marks teams as IdP-managed
-/// 3. Updates team names to match IdP case (IdP is source of truth)
-/// 4. Removes every pre-existing membership when a team becomes IdP-managed
-/// 5. Adds user to all groups in the IdP claim
-/// 6. Removes user from IdP-managed teams NOT in the claim
+/// 3. Removes every pre-existing membership when a team becomes IdP-managed
+/// 4. Adds the user to canonical groups admitted by the configured prefixes
+/// 5. Removes the user from IdP-managed teams outside that filtered claim
 ///
 /// All operations are performed within a database transaction for atomicity.
 ///
@@ -20,10 +49,18 @@ use crate::db::{models::TeamRole, teams};
 /// * `pool` - Database connection pool
 /// * `user_id` - UUID of the user logging in
 /// * `idp_groups` - List of group names from the configured IdP group claim
+/// * `allowed_prefixes` - Optional prefixes limiting which canonical names sync
 ///
 /// # Errors
 /// Returns an error if database operations fail. The transaction will be rolled back.
-pub async fn sync_user_groups(pool: &PgPool, user_id: Uuid, idp_groups: &[String]) -> Result<()> {
+pub async fn sync_user_groups(
+    pool: &PgPool,
+    user_id: Uuid,
+    idp_groups: &[String],
+    allowed_prefixes: &[String],
+) -> Result<()> {
+    let idp_groups = filter_idp_groups(idp_groups, allowed_prefixes);
+
     // Start transaction for atomicity - all operations succeed or all fail
     let mut tx = pool.begin().await.context("Failed to start transaction")?;
 
@@ -34,7 +71,7 @@ pub async fn sync_user_groups(pool: &PgPool, user_id: Uuid, idp_groups: &[String
     );
 
     // Phase 1: Process each group in the IdP claim
-    for group_name in idp_groups {
+    for group_name in &idp_groups {
         // Locked for the rest of the transaction: the membership API decides
         // whether a caller may write to a team by reading `idp_managed`, and at
         // `READ COMMITTED` that read can land between this takeover's purge and
@@ -44,20 +81,6 @@ pub async fn sync_user_groups(pool: &PgPool, user_id: Uuid, idp_groups: &[String
             .context("Failed to find team by name")?;
 
         let team_id = if let Some(team) = existing_team {
-            // Team exists - update if needed
-
-            // Update name if case differs (IdP is authoritative source for casing)
-            if team.name != *group_name {
-                tracing::info!(
-                    "Updating team name from '{}' to '{}' (IdP case correction)",
-                    team.name,
-                    group_name
-                );
-                teams::update_name(&mut *tx, team.id, group_name)
-                    .await
-                    .context("Failed to update team name")?;
-            }
-
             // If team wasn't IdP-managed before, convert it.
             //
             // Every existing membership goes, not just the owners. An
@@ -123,10 +146,7 @@ pub async fn sync_user_groups(pool: &PgPool, user_id: Uuid, idp_groups: &[String
         .context("Failed to list IdP-managed teams")?;
 
     for team in all_idp_teams {
-        // Case-insensitive check if team is in the IdP group claim
-        let in_claim = idp_groups
-            .iter()
-            .any(|g| g.eq_ignore_ascii_case(&team.name));
+        let in_claim = idp_groups.iter().any(|group| team.name == *group);
 
         if !in_claim {
             // User should not be in this IdP-managed team
@@ -159,6 +179,84 @@ mod tests {
     use super::*;
     use crate::db::users;
 
+    #[test]
+    fn claim_filter_keeps_only_unique_canonical_groups_under_allowed_prefixes() {
+        let groups = [
+            "eu-west-1_uV3yhZdtV_baliohq-google-workspace".to_string(),
+            "other-valid-group".to_string(),
+            "rise-users".to_string(),
+            "rise-users".to_string(),
+        ];
+        let prefixes = ["rise-".to_string()];
+
+        assert_eq!(filter_idp_groups(&groups, &prefixes), ["rise-users"]);
+    }
+
+    #[sqlx::test]
+    async fn login_sync_keeps_only_canonical_groups_with_an_allowed_prefix(pool: PgPool) {
+        let user = users::create(&pool, "member@example.com").await.unwrap();
+
+        sync_user_groups(
+            &pool,
+            user.id,
+            &["rise-stale".to_string()],
+            &["rise-".to_string()],
+        )
+        .await
+        .unwrap();
+
+        sync_user_groups(
+            &pool,
+            user.id,
+            &[
+                "eu-west-1_uV3yhZdtV_baliohq-google-workspace".to_string(),
+                "other-valid-group".to_string(),
+                "rise-users".to_string(),
+                "rise-users".to_string(),
+            ],
+            &["rise-".to_string()],
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            teams::list_idp_group_names_for_user(&pool, user.id)
+                .await
+                .unwrap(),
+            vec!["rise-users".to_string()]
+        );
+    }
+
+    #[sqlx::test]
+    async fn invalid_group_casing_cannot_claim_a_privileged_team(pool: PgPool) {
+        let user = users::create(&pool, "member@example.com").await.unwrap();
+
+        sync_user_groups(
+            &pool,
+            user.id,
+            &["rise-admins".to_string()],
+            &["rise-".to_string()],
+        )
+        .await
+        .unwrap();
+        sync_user_groups(
+            &pool,
+            user.id,
+            &["Rise-Admins".to_string()],
+            &["rise-".to_string()],
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            teams::list_idp_group_names_for_user(&pool, user.id)
+                .await
+                .unwrap()
+                .is_empty(),
+            "an invalid group must remove stale access, not normalize into it"
+        );
+    }
+
     /// Taking over a self-service team must not leave its members behind.
     ///
     /// Team names are first-come, first-served while `allow_team_creation` is
@@ -190,7 +288,7 @@ mod tests {
         );
 
         // A real member of the IdP group logs in, and the team is taken over.
-        sync_user_groups(&pool, genuine.id, &["rise-operators".to_string()])
+        sync_user_groups(&pool, genuine.id, &["rise-operators".to_string()], &[])
             .await
             .unwrap();
 

--- a/src/server/auth/handlers.rs
+++ b/src/server/auth/handlers.rs
@@ -317,8 +317,13 @@ async fn sync_groups_after_login(
             user.email
         );
 
-        if let Err(e) =
-            crate::server::auth::group_sync::sync_user_groups(&state.db_pool, user.id, groups).await
+        if let Err(e) = crate::server::auth::group_sync::sync_user_groups(
+            &state.db_pool,
+            user.id,
+            groups,
+            &state.auth_settings.idp_group_sync_prefixes,
+        )
+        .await
         {
             // Log error but don't fail login
             tracing::error!(

--- a/src/server/extensions/providers/snowflake_oauth.rs
+++ b/src/server/extensions/providers/snowflake_oauth.rs
@@ -4,7 +4,9 @@ use crate::server::extensions::{Extension, InjectedEnvVar};
 use crate::server::settings::{PrivateKeySource, SnowflakeAuth};
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use chrono::{DateTime, Duration, Utc};
+use openssl::{pkey::PKey, rand::rand_bytes, symm::Cipher};
 use rise_runtime_sync::{with_leader_election, LeaderElection};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -17,6 +19,47 @@ use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use snowflake_connector_rs::{SnowflakeAuthMethod, SnowflakeClient, SnowflakeClientConfig};
+
+fn prepare_snowflake_private_key(
+    private_key_pem: String,
+    configured_password: Option<&str>,
+) -> Result<(String, Vec<u8>)> {
+    if private_key_pem.contains("BEGIN ENCRYPTED PRIVATE KEY") {
+        return Ok((
+            private_key_pem,
+            configured_password.unwrap_or_default().as_bytes().to_vec(),
+        ));
+    }
+
+    let is_unencrypted = private_key_pem.contains("BEGIN PRIVATE KEY")
+        || private_key_pem.contains("BEGIN RSA PRIVATE KEY");
+    if !is_unencrypted {
+        return Err(anyhow!(
+            "Unsupported private key format. Expected encrypted PKCS#8, unencrypted PKCS#8, or an RSA PKCS#1 PEM key"
+        ));
+    }
+
+    let private_key = PKey::private_key_from_pem(private_key_pem.as_bytes())
+        .context("Failed to parse unencrypted Snowflake private key")?;
+    private_key
+        .rsa()
+        .context("Snowflake private key must use RSA")?;
+    let password = match configured_password.filter(|password| !password.is_empty()) {
+        Some(password) => password.as_bytes().to_vec(),
+        None => {
+            let mut random = [0_u8; 32];
+            rand_bytes(&mut random).context("Failed to generate temporary private-key password")?;
+            URL_SAFE_NO_PAD.encode(random).into_bytes()
+        }
+    };
+    let encrypted = private_key
+        .private_key_to_pem_pkcs8_passphrase(Cipher::aes_256_cbc(), &password)
+        .context("Failed to encrypt Snowflake private key in memory")?;
+    let encrypted = String::from_utf8(encrypted)
+        .context("OpenSSL returned a non-UTF-8 encrypted private key")?;
+
+    Ok((encrypted, password))
+}
 
 /// User-facing extension spec - minimal configuration
 /// Backend connection credentials are configured in config/{RISE_CONFIG_RUN_MODE}.yaml
@@ -387,44 +430,10 @@ impl SnowflakeOAuthProvisioner {
                     PrivateKeySource::Inline { private_key } => private_key.clone(),
                 };
 
-                // Detect if key is encrypted or unencrypted based on PEM header
-                let is_encrypted = private_key_pem.contains("BEGIN ENCRYPTED PRIVATE KEY");
-                let is_unencrypted_pkcs8 = private_key_pem.contains("BEGIN PRIVATE KEY");
-                let is_rsa_key = private_key_pem.contains("BEGIN RSA PRIVATE KEY");
-
-                // For unencrypted keys, we need to convert to encrypted PKCS#8 format
-                // because the Snowflake connector library only supports encrypted keys
-                let password_bytes = if is_encrypted {
-                    // Key is already encrypted, use provided password
-                    private_key_password
-                        .as_ref()
-                        .map(|p| p.as_bytes().to_vec())
-                        .unwrap_or_default()
-                } else if is_unencrypted_pkcs8 || is_rsa_key {
-                    // Key is unencrypted - the library doesn't support this
-                    // We need to return a clear error
-                    return Err(anyhow!(
-                        "Unencrypted private keys are not supported by the Snowflake connector. \n\
-                         \n\
-                         Please encrypt your private key using:\n\
-                         openssl pkcs8 -topk8 -v2 aes256 -in unencrypted_key.pem -out encrypted_key.p8\n\
-                         \n\
-                         Then update your config/{{RISE_CONFIG_RUN_MODE}}.yaml:\n\
-                         auth_type: private_key\n\
-                         private_key: \"$${{SNOWFLAKE_PRIVATE_KEY}}\"  # encrypted key\n\
-                         private_key_password: \"$${{SNOWFLAKE_PRIVATE_KEY_PASSWORD}}\"\n\
-                         \n\
-                         Alternatively, use password authentication instead of private key."
-                    ));
-                } else {
-                    // Unknown key format
-                    return Err(anyhow!(
-                        "Unsupported private key format. Expected PEM format with one of:\n\
-                         - BEGIN ENCRYPTED PRIVATE KEY (PKCS#8 encrypted)\n\
-                         - BEGIN PRIVATE KEY (PKCS#8 unencrypted - not supported, must be encrypted)\n\
-                         - BEGIN RSA PRIVATE KEY (PKCS#1 - not supported, must be PKCS#8 encrypted)"
-                    ));
-                };
+                let (private_key_pem, password_bytes) = prepare_snowflake_private_key(
+                    private_key_pem,
+                    private_key_password.as_deref(),
+                )?;
 
                 SnowflakeAuthMethod::KeyPair {
                     encrypted_pem: private_key_pem,
@@ -456,33 +465,8 @@ impl SnowflakeOAuthProvisioner {
             config.warehouse = Some(warehouse.clone());
         }
 
-        let client = SnowflakeClient::new(&self.user, auth_method, config).map_err(|e| {
-            // Provide helpful error messages for common issues
-            let error_str = format!("{:?}", e);
-            if error_str.contains("ENCRYPTED PRIVATE KEY") {
-                anyhow!(
-                    "Failed to create Snowflake client: {}. \n\
-                     \n\
-                     The snowflake-connector-rs library expects private keys in PKCS#8 encrypted format.\n\
-                     \n\
-                     If you have an unencrypted private key, you can encrypt it with:\n\
-                     openssl pkcs8 -topk8 -v2 aes256 -in rsa_key.p8 -out rsa_key_encrypted.p8\n\
-                     \n\
-                     Or generate a new encrypted key pair:\n\
-                     openssl genrsa 2048 | openssl pkcs8 -topk8 -v2 aes256 -out rsa_key.p8\n\
-                     \n\
-                     Then configure the encrypted key and password in config/{{RISE_CONFIG_RUN_MODE}}.yaml:\n\
-                     auth_type: private_key\n\
-                     private_key: \"$${{SNOWFLAKE_PRIVATE_KEY}}\"\n\
-                     private_key_password: \"$${{SNOWFLAKE_PRIVATE_KEY_PASSWORD}}\"\n\
-                     \n\
-                     Alternatively, use password authentication instead.",
-                    e
-                )
-            } else {
-                anyhow!("Failed to create Snowflake client: {}", e)
-            }
-        })?;
+        let client = SnowflakeClient::new(&self.user, auth_method, config)
+            .map_err(|e| anyhow!("Failed to create Snowflake client: {}", e))?;
 
         Ok(client)
     }
@@ -1600,8 +1584,63 @@ fn oauth_spec_with_synced_scopes(
 
 #[cfg(test)]
 mod tests {
-    use super::oauth_spec_with_synced_scopes;
+    use super::{oauth_spec_with_synced_scopes, prepare_snowflake_private_key};
+    use openssl::{pkey::PKey, rsa::Rsa, symm::Cipher};
+    use rsa::{pkcs8::DecodePrivateKey, traits::PublicKeyParts, RsaPrivateKey};
     use serde_json::json;
+
+    fn assert_unencrypted_key_is_prepared(pem: Vec<u8>) {
+        let original = PKey::private_key_from_pem(&pem).unwrap();
+        let (encrypted, password) =
+            prepare_snowflake_private_key(String::from_utf8(pem).unwrap(), None).unwrap();
+
+        assert!(encrypted.contains("BEGIN ENCRYPTED PRIVATE KEY"));
+        let prepared = RsaPrivateKey::from_pkcs8_encrypted_pem(&encrypted, &password).unwrap();
+        let original = original.rsa().unwrap();
+        assert_eq!(original.n().to_vec(), prepared.n().to_bytes_be());
+        assert_eq!(original.e().to_vec(), prepared.e().to_bytes_be());
+    }
+
+    #[test]
+    fn unencrypted_pkcs8_private_key_is_encrypted_in_memory() {
+        let key = PKey::from_rsa(Rsa::generate(2048).unwrap()).unwrap();
+        assert_unencrypted_key_is_prepared(key.private_key_to_pem_pkcs8().unwrap());
+    }
+
+    #[test]
+    fn unencrypted_pkcs1_private_key_is_encrypted_in_memory() {
+        let key = Rsa::generate(2048).unwrap();
+        assert_unencrypted_key_is_prepared(key.private_key_to_pem().unwrap());
+    }
+
+    #[test]
+    fn encrypted_pkcs8_private_key_and_password_pass_through() {
+        let key = PKey::from_rsa(Rsa::generate(2048).unwrap()).unwrap();
+        let pem = String::from_utf8(
+            key.private_key_to_pem_pkcs8_passphrase(Cipher::aes_256_cbc(), b"known-password")
+                .unwrap(),
+        )
+        .unwrap();
+
+        let (prepared, password) =
+            prepare_snowflake_private_key(pem.clone(), Some("known-password")).unwrap();
+
+        assert_eq!(prepared, pem);
+        assert_eq!(password, b"known-password");
+    }
+
+    #[test]
+    fn malformed_unencrypted_private_key_is_rejected() {
+        let error = prepare_snowflake_private_key(
+            "-----BEGIN PRIVATE KEY-----\nnot-a-key\n-----END PRIVATE KEY-----".to_string(),
+            None,
+        )
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("Failed to parse unencrypted Snowflake private key"));
+    }
 
     #[test]
     fn oauth_scope_sync_updates_scopes_and_preserves_other_fields() {

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -786,6 +786,11 @@ pub struct AuthSettings {
     /// For example, AWS Cognito commonly exposes groups as "cognito:groups".
     #[serde(default = "default_idp_group_claim")]
     pub idp_group_claim: String,
+    /// Optional prefixes limiting which canonical IdP group names are mirrored
+    /// into Rise teams during login. An empty list accepts every canonical
+    /// group name.
+    #[serde(default, deserialize_with = "deserialize_string_list_flexible")]
+    pub idp_group_sync_prefixes: Vec<String>,
     /// Optional active sync source for pulling users and groups from an external IdP.
     /// When configured, Rise will periodically query the IdP for users and groups
     /// assigned to the app and sync them as Rise teams.
@@ -2253,6 +2258,43 @@ impl Settings {
             ));
         }
 
+        if let Some(prefix) = settings
+            .auth
+            .idp_group_sync_prefixes
+            .iter()
+            .find(|prefix| !crate::db::teams::is_valid_team_name(prefix))
+        {
+            return Err(ConfigError::Message(format!(
+                "auth.idp_group_sync_prefixes contains invalid prefix {prefix:?}; use only lowercase ASCII letters, digits, and hyphens"
+            )));
+        }
+
+        for access_group in settings
+            .auth
+            .admin_idp_groups
+            .iter()
+            .chain(settings.auth.operator_idp_groups.iter())
+            .chain(settings.auth.platform_access.allowed_idp_groups.iter())
+        {
+            let canonical = access_group.to_ascii_lowercase();
+            if !crate::db::teams::is_valid_team_name(&canonical) {
+                return Err(ConfigError::Message(format!(
+                    "IdP access group {access_group:?} cannot be represented as a Rise team; use only ASCII letters, digits, and hyphens"
+                )));
+            }
+            if !settings.auth.idp_group_sync_prefixes.is_empty()
+                && !settings
+                    .auth
+                    .idp_group_sync_prefixes
+                    .iter()
+                    .any(|prefix| canonical.starts_with(prefix))
+            {
+                return Err(ConfigError::Message(format!(
+                    "IdP access group {access_group:?} cannot be synchronized by auth.idp_group_sync_prefixes"
+                )));
+            }
+        }
+
         // A password without a username would be silently treated by the CLI as
         // client-managed auth, while a username without a password would cause a
         // confusing login failure. Keep static registry auth explicitly paired.
@@ -2728,6 +2770,25 @@ mod tests {
         let settings: Settings = serde_json::from_value(json).unwrap();
 
         assert_eq!(settings.auth.idp_group_claim, "cognito:groups");
+    }
+
+    #[test]
+    fn idp_group_sync_prefixes_accept_a_sequence_or_comma_separated_string() {
+        let mut sequence = minimal_settings_json();
+        sequence["auth"]["idp_group_sync_prefixes"] = serde_json::json!(["rise-", "platform-"]);
+        let settings: Settings = serde_json::from_value(sequence).unwrap();
+        assert_eq!(
+            settings.auth.idp_group_sync_prefixes,
+            ["rise-", "platform-"]
+        );
+
+        let mut scalar = minimal_settings_json();
+        scalar["auth"]["idp_group_sync_prefixes"] = serde_json::json!("rise-, platform-");
+        let settings: Settings = serde_json::from_value(scalar).unwrap();
+        assert_eq!(
+            settings.auth.idp_group_sync_prefixes,
+            ["rise-", "platform-"]
+        );
     }
 
     #[test]
@@ -3474,6 +3535,7 @@ auth:
         env.insert("RISE_ECS_SUBNETS", "subnet-abc,subnet-def");
         env.insert("RISE_ECS_SECURITY_GROUPS", "sg-abc");
         env.insert("RISE_ECS_LOG_GROUP", "/rise-e2e");
+        env.insert("RISE_IDP_GROUP_SYNC_PREFIXES", "rise-,platform-");
 
         let settings = load_shipped_ecs_config(&env).expect("shipped ecs.yaml must load");
 
@@ -3502,6 +3564,10 @@ auth:
         assert_eq!(resource_prefix, "rise");
         assert!(access_classes.contains_key("public"));
         assert!(access_classes.contains_key("private"));
+        assert_eq!(
+            settings.auth.idp_group_sync_prefixes,
+            ["rise-", "platform-"]
+        );
 
         assert!(matches!(
             settings.deployment_logs,
@@ -3589,6 +3655,47 @@ server:
         let err = load_shipped_ecs_config(&env).expect_err("must reject");
         assert!(
             err.to_string().contains("at least one subnet"),
+            "unhelpful message: {err}"
+        );
+    }
+
+    #[test]
+    fn ecs_config_rejects_a_noncanonical_group_sync_prefix() {
+        let mut env = ecs_base_env();
+        env.insert("RISE_IDP_GROUP_SYNC_PREFIXES", "Rise_");
+
+        let err = load_shipped_ecs_config(&env).expect_err("must reject invalid prefix");
+        assert!(
+            err.to_string()
+                .contains("auth.idp_group_sync_prefixes contains invalid prefix"),
+            "unhelpful message: {err}"
+        );
+    }
+
+    #[test]
+    fn ecs_config_rejects_an_access_group_outside_the_sync_prefixes() {
+        let mut env = ecs_base_env();
+        env.insert("RISE_IDP_GROUP_SYNC_PREFIXES", "rise-");
+        env.insert("RISE_ADMIN_IDP_GROUP", "platform-admins");
+
+        let err = load_shipped_ecs_config(&env).expect_err("must reject unreachable access group");
+        assert!(
+            err.to_string().contains(
+                "IdP access group \"platform-admins\" cannot be synchronized by auth.idp_group_sync_prefixes"
+            ),
+            "unhelpful message: {err}"
+        );
+    }
+
+    #[test]
+    fn ecs_config_rejects_an_access_group_that_cannot_be_a_team() {
+        let mut env = ecs_base_env();
+        env.insert("RISE_ADMIN_IDP_GROUP", "rise_admins");
+
+        let err = load_shipped_ecs_config(&env).expect_err("must reject invalid access group");
+        assert!(
+            err.to_string()
+                .contains("cannot be represented as a Rise team"),
             "unhelpful message: {err}"
         );
     }


### PR DESCRIPTION
## Summary

Login-time IdP group synchronization now admits only names that can be represented by Rise teams, optionally restricts them with `auth.idp_group_sync_prefixes`, and removes stale memberships against that filtered claim. Startup validation rejects role-bearing groups that the filter cannot synchronize, while the empty-prefix default continues to accept every canonical group. The filter is intentionally limited to token-claim login sync and does not alter Entra active sync.

Snowflake private-key authentication now accepts unencrypted PKCS#8 and RSA PKCS#1 PEM keys. Rise converts them to encrypted PKCS#8 in memory with a generated passphrase before calling the connector; already encrypted PKCS#8 keys pass through unchanged. The ECS module, shipped configurations, generated schema, and operator documentation expose both behaviors.

## Test plan

- `mise exec -- env RUSTC_WRAPPER= SQLX_OFFLINE=true cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise exec -- env RUSTC_WRAPPER= DATABASE_URL=postgres://rise:rise123@localhost:5432/rise cargo test --workspace --all-features`
- `env RUSTC_WRAPPER= mise run config:schema:generate`
- `terraform test -no-color` in `modules/rise-ecs` (24 passed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rise-deploy/codesmith/rise/pr/475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790794296&installation_model_id=432987&pr_number=475&repository=rise-deploy%2Frise&return_to=https%3A%2F%2Fgithub.com%2Frise-deploy%2Frise%2Fpull%2F475&signature=2cdbeb56abb33674be55df572c24b0f738964ddd39fd8d7555e58c6022ce3d5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->