### PR TITLE
Surface backend resource adjustments in deployment events

### DIFF
--- a/crates/rise-backend-core/src/events.rs
+++ b/crates/rise-backend-core/src/events.rs
@@ -43,9 +43,9 @@ pub enum EventKind {
     ReplicaRestarted,
     /// The desired replica count changed.
     Scaled,
-    /// A runtime-native event passed through. `attributes` carries whatever the
-    /// backend supplied, including an upstream `count` where the source already
-    /// aggregated repeats (Kubernetes `Event` does).
+    /// A backend-originated event passed through. `attributes` carries whatever
+    /// the backend supplied, including an upstream `count` where the source
+    /// already aggregated repeats (Kubernetes `Event` does).
     BackendEvent,
 }
 
@@ -92,8 +92,8 @@ impl fmt::Display for EventKind {
     }
 }
 
-/// The attribute vocabulary: what a `status_changed` event may carry, and what
-/// each key means.
+/// The attribute vocabulary: what a deployment event may carry, and what each
+/// key means.
 ///
 /// This module is the single place that decides an attribute's *meaning*. It is
 /// deliberately not an allowlist — readers render whatever an event carries, so
@@ -126,6 +126,16 @@ pub mod attributes {
     pub const REPLICAS: &str = "replicas";
     pub const CPU: &str = "cpu";
     pub const MEMORY: &str = "memory";
+    /// A backend-originated event subtype. `resource_adjusted` identifies a
+    /// requested resource shape that the backend represented with different
+    /// effective values.
+    pub const EVENT_TYPE: &str = "type";
+    pub const RESOURCE_ADJUSTED: &str = "resource_adjusted";
+    pub const REQUESTED_CPU: &str = "requested_cpu";
+    pub const REQUESTED_MEMORY: &str = "requested_memory";
+    pub const RESOLVED_CPU_UNITS: &str = "resolved_cpu_units";
+    pub const RESOLVED_MEMORY_MIB: &str = "resolved_memory_mib";
+    pub const CONTAINER: &str = "container";
     /// Declared container names, and the image the deployment was created with.
     pub const CONTAINERS: &str = "containers";
     pub const IMAGE: &str = "image";
@@ -164,17 +174,16 @@ pub mod attributes {
     pub const IMAGES: &str = "images";
 }
 
-/// A runtime-native event a backend wants forwarded into the log.
+/// A backend-originated event a backend wants forwarded into the log.
 ///
-/// The runtime's own words, carried through rather than translated: what
-/// Kubernetes calls `FailedScheduling` and what ECS phrases as prose both say
-/// something no periodic observation can, and paraphrasing them would lose the
-/// detail that makes them worth having.
+/// The backend's own words, carried through rather than translated: what
+/// Kubernetes calls `FailedScheduling`, what ECS phrases as prose, and what a
+/// controller resolves before applying all say something no periodic
+/// observation can, and paraphrasing them would lose useful detail.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ForwardedEvent {
-    /// The runtime's identifier for this occurrence. Stable for the same event
-    /// and distinct across events, so re-reading the same window cannot record
-    /// it twice.
+    /// A stable identifier for this occurrence, distinct across occurrences, so
+    /// re-reading the same backend window cannot record it twice.
     pub dedupe_key: String,
     pub occurred_at: chrono::DateTime<chrono::Utc>,
     pub severity: EventSeverity,

--- a/crates/rise-backend-core/src/store.rs
+++ b/crates/rise-backend-core/src/store.rs
@@ -179,7 +179,7 @@ pub trait DeploymentStore: Send + Sync {
         events: &[crate::observation::DerivedEvent],
     ) -> Result<()>;
 
-    /// Forward runtime-native events into the deployment's log, skipping any
+    /// Forward backend-originated events into the deployment's log, skipping any
     /// already recorded.
     ///
     /// Deduplicated on `dedupe_key`, because a backend re-reads the same window

--- a/crates/rise-backend-ecs/src/reconciler.rs
+++ b/crates/rise-backend-ecs/src/reconciler.rs
@@ -236,6 +236,39 @@ fn forwarded_from_ecs(n: &crate::service::ServiceNarrative) -> Option<ForwardedE
     })
 }
 
+/// Describe a resource representation that differs from the user's request.
+///
+/// The event is emitted from desired-state computation, after the task
+/// definition has a valid Fargate size. Its key includes both sides of the
+/// representation so a later, different resolution remains visible while
+/// repeated reconcile ticks remain idempotent.
+fn resource_adjustment_event(
+    container: &str,
+    requested_cpu: &str,
+    requested_memory: &str,
+    size: crate::sizing::FargateSize,
+) -> ForwardedEvent {
+    ForwardedEvent {
+        dedupe_key: format!(
+            "resource-adjusted:{container}:{requested_cpu}:{requested_memory}:{}:{}",
+            size.cpu_units, size.memory_mib
+        ),
+        occurred_at: chrono::Utc::now(),
+        severity: EventSeverity::Warning,
+        message: "Resources were rounded up to satisfy Fargate task-size limits".to_string(),
+        subject: Some(container.to_string()),
+        attributes: serde_json::json!({
+            rise_backend_core::events::attributes::EVENT_TYPE:
+                rise_backend_core::events::attributes::RESOURCE_ADJUSTED,
+            rise_backend_core::events::attributes::CONTAINER: container,
+            rise_backend_core::events::attributes::REQUESTED_CPU: requested_cpu,
+            rise_backend_core::events::attributes::REQUESTED_MEMORY: requested_memory,
+            rise_backend_core::events::attributes::RESOLVED_CPU_UNITS: size.cpu_units,
+            rise_backend_core::events::attributes::RESOLVED_MEMORY_MIB: size.memory_mib,
+        }),
+    }
+}
+
 /// Project an ECS service's event list onto the shape the reconciler keeps.
 ///
 /// ECS returns roughly the last hour, newest first, and caps the list — so this
@@ -826,7 +859,29 @@ impl EcsReconciler {
                 .compute_desired_for_deployment(project, deployment)
                 .await
             {
-                Ok(mut entries) => desired.append(&mut entries),
+                Ok((mut entries, events)) => {
+                    desired.append(&mut entries);
+                    if !events.is_empty() {
+                        match self
+                            .store
+                            .forward_backend_events(deployment.id, EventSource::Ecs, &events)
+                            .await
+                        {
+                            Ok(n) if n > 0 => {
+                                debug!(
+                                    deployment = %deployment.deployment_id,
+                                    "Forwarded {n} new ECS deployment event(s)"
+                                );
+                            }
+                            Ok(_) => {}
+                            Err(e) => warn!(
+                                deployment = %deployment.deployment_id,
+                                "Failed to forward ECS deployment events: {:?}",
+                                e
+                            ),
+                        }
+                    }
+                }
                 Err(e) if e.downcast_ref::<PermanentDeployError>().is_some() => {
                     let message = rejection_message(&e);
                     if rejection_fails_deployment(&deployment.status) {
@@ -975,7 +1030,10 @@ impl EcsReconciler {
         &self,
         project: &Project,
         deployment: &Deployment,
-    ) -> Result<Vec<(DesiredService, TaskDefinitionSpec, DesiredContainer)>> {
+    ) -> Result<(
+        Vec<(DesiredService, TaskDefinitionSpec, DesiredContainer)>,
+        Vec<ForwardedEvent>,
+    )> {
         let (container_specs, route_specs) = resolve_runtime_containers(deployment)?;
 
         // Fail closed on the features v1 does not implement, rather than
@@ -1042,6 +1100,7 @@ impl EcsReconciler {
                 .resolve_image(project, deployment, source_deployment_id.as_deref());
 
         let mut out = Vec::new();
+        let mut events = Vec::new();
         for spec in &container_specs {
             let entry = self
                 .desired_for_spec(
@@ -1057,9 +1116,13 @@ impl EcsReconciler {
                     &base_image,
                 )
                 .await?;
-            out.push(entry);
+            let (service, task_definition, desired_container, event) = entry;
+            out.push((service, task_definition, desired_container));
+            if let Some(event) = event {
+                events.push(event);
+            }
         }
-        Ok(out)
+        Ok((out, events))
     }
 
     /// Reject deployments that request a capability this backend does not yet
@@ -1114,7 +1177,12 @@ impl EcsReconciler {
         secret_env: &ResolvedDeploymentEnvVars,
         env_name: Option<&str>,
         base_image: &str,
-    ) -> Result<(DesiredService, TaskDefinitionSpec, DesiredContainer)> {
+    ) -> Result<(
+        DesiredService,
+        TaskDefinitionSpec,
+        DesiredContainer,
+        Option<ForwardedEvent>,
+    )> {
         let replica_count = clamp_replicas(spec.replicas);
         if let Some(requested) = spec.replicas {
             if requested > MAX_REPLICAS {
@@ -1243,7 +1311,7 @@ impl EcsReconciler {
             },
         ))?;
 
-        if task_def.size.rounded_up {
+        let resource_adjustment = if task_def.size.rounded_up {
             info!(
                 project = %project.name,
                 container = %spec.name,
@@ -1253,7 +1321,15 @@ impl EcsReconciler {
                 resolved_memory_mib = %task_def.memory,
                 "Rounded the requested resources up to the nearest valid Fargate task size"
             );
-        }
+            Some(resource_adjustment_event(
+                &spec.name,
+                &desired_container.cpu,
+                &desired_container.memory,
+                task_def.size,
+            ))
+        } else {
+            None
+        };
 
         let desired_service = DesiredService {
             name: service::service_name(
@@ -1285,7 +1361,12 @@ impl EcsReconciler {
                 route_hash: desired_container.route_hash.clone(),
             },
         };
-        Ok((desired_service, task_def, desired_container))
+        Ok((
+            desired_service,
+            task_def,
+            desired_container,
+            resource_adjustment,
+        ))
     }
 
     // ── observing the cluster ─────────────────────────────────────────────
@@ -2566,7 +2647,35 @@ pub(crate) fn clamp_replicas(requested: Option<u32>) -> u32 {
 
 #[cfg(test)]
 mod tests {
-    use super::{persisted_td_hash, tasks_or_indeterminate, with_persisted_td_hash, TaskView};
+    use super::{
+        persisted_td_hash, resource_adjustment_event, tasks_or_indeterminate,
+        with_persisted_td_hash, TaskView,
+    };
+
+    #[test]
+    fn resource_adjustment_event_preserves_request_and_effective_size() {
+        let event = resource_adjustment_event(
+            "app",
+            "128m-500m",
+            "192Mi-512Mi",
+            crate::sizing::FargateSize {
+                cpu_units: 512,
+                memory_mib: 1024,
+                rounded_up: true,
+            },
+        );
+
+        assert_eq!(
+            event.severity,
+            rise_backend_core::events::EventSeverity::Warning
+        );
+        assert_eq!(event.subject.as_deref(), Some("app"));
+        assert_eq!(event.attributes["type"], "resource_adjusted");
+        assert_eq!(event.attributes["requested_cpu"], "128m-500m");
+        assert_eq!(event.attributes["requested_memory"], "192Mi-512Mi");
+        assert_eq!(event.attributes["resolved_cpu_units"], 512);
+        assert_eq!(event.attributes["resolved_memory_mib"], 1024);
+    }
 
     fn task_view(name: &str) -> TaskView {
         TaskView {

--- a/frontend/src/features/deployments.tsx
+++ b/frontend/src/features/deployments.tsx
@@ -13,6 +13,7 @@ import { EmptyState, ErrorState, LoadingState } from '../components/states';
 import { LogConsole } from './logs/log-console';
 import { ContainerStatusPanel } from './logs/container-status';
 import { EventTimeline } from './logs/event-timeline';
+import { fetchDeploymentEvents, type DeploymentEvent } from './logs/api';
 
 const STATUS_TONES = {
     Healthy: 'ok',
@@ -794,6 +795,81 @@ export function DeploymentsList({ projectName }) {
 }
 
 
+/**
+ * Shows the latest backend resource representation for each container.
+ *
+ * This is keyed by the event contract rather than a backend name: any backend
+ * that reports `type: resource_adjusted` gets the same notice. The event log is
+ * the source of this fact because the deployment row retains the requested
+ * resources and controller metadata is private bookkeeping.
+ */
+function ResourceAdjustmentNotice({
+    projectName,
+    deploymentId,
+    deploymentStatus,
+}: {
+    projectName: string;
+    deploymentId: string;
+    deploymentStatus: string;
+}) {
+    const [events, setEvents] = useState<DeploymentEvent[]>([]);
+
+    useEffect(() => {
+        const controller = new AbortController();
+        void fetchDeploymentEvents({
+            projectName,
+            deploymentId,
+            kinds: ['backend_event'],
+            minSeverity: 'all',
+            limit: 500,
+            signal: controller.signal,
+        })
+            .then((page) => setEvents(page.events))
+            .catch((error) => {
+                if (error instanceof Error && error.name === 'AbortError') return;
+                setEvents([]);
+            });
+        return () => controller.abort();
+    }, [projectName, deploymentId, deploymentStatus]);
+
+    const latestByContainer = new Map<string, DeploymentEvent>();
+    for (const event of events) {
+        if (event.attributes?.type !== 'resource_adjusted') continue;
+        const container = typeof event.attributes.container === 'string'
+            ? event.attributes.container
+            : event.subject || 'deployment';
+        if (!latestByContainer.has(container)) latestByContainer.set(container, event);
+    }
+
+    if (latestByContainer.size === 0) return null;
+
+    return (
+        <div className="r-alert warn" style={{ marginBottom: 16, fontSize: 12.5 }}>
+            <Icon name="info" size={14} />
+            <div style={{ flex: 1 }}>
+                <div style={{ fontWeight: 600, marginBottom: 4 }}>Resources adjusted by the backend</div>
+                {[...latestByContainer.entries()].map(([container, event]) => (
+                    <div key={`${container}-${event.id}`}>
+                        <span className="mono">{container}</span>{': '}
+                        CPU <span className="mono">{attributeText(event, 'requested_cpu')}</span>
+                        {' → '}
+                        <span className="mono">{attributeText(event, 'resolved_cpu_units')} units</span>
+                        {', memory '}
+                        <span className="mono">{attributeText(event, 'requested_memory')}</span>
+                        {' → '}
+                        <span className="mono">{attributeText(event, 'resolved_memory_mib')} MiB</span>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}
+
+function attributeText(event: DeploymentEvent, key: string): string {
+    const value = event.attributes?.[key];
+    return value === undefined || value === null ? '-' : String(value);
+}
+
 function formatDurationDelta(fromTs?: string | null, toTs?: string | null) {
     if (!fromTs || !toTs) return '--';
     const from = new Date(fromTs).getTime();
@@ -1108,6 +1184,11 @@ export function DeploymentDetail({ projectName, deploymentId }) {
                 }
             />
             <PanelBody>
+                <ResourceAdjustmentNotice
+                    projectName={projectName}
+                    deploymentId={deploymentId}
+                    deploymentStatus={deployment.status}
+                />
                 <KV>
                     <KVRow k="Replicas">
                         {totals.replicas}

--- a/frontend/src/features/logs/api.ts
+++ b/frontend/src/features/logs/api.ts
@@ -190,7 +190,7 @@ export async function fetchLogVolume(request: LogVolumeRequest): Promise<LogVolu
 export interface DeploymentEvent {
     id: number;
     deployment_id: string;
-    /** When it happened, per the runtime's clock. What the rail plots. */
+    /** When it happened, according to the event source. What the rail plots. */
     occurred_at: string;
     /** When Rise recorded it. What pages are cut on. */
     recorded_at: string;

--- a/frontend/src/features/logs/event-timeline.tsx
+++ b/frontend/src/features/logs/event-timeline.tsx
@@ -139,6 +139,7 @@ const RESERVED_KEYS = new Set(['from', 'to', 'reason']);
  * single place that decides what an attribute *means*.
  */
 const LABELS: Record<string, string> = {
+    type: 'type',
     created_by: 'by',
     build_method: 'build',
     image_size_bytes: 'size',
@@ -149,6 +150,10 @@ const LABELS: Record<string, string> = {
     git_revision: 'revision',
     git_branch: 'branch',
     git_dirty: 'uncommitted changes',
+    requested_cpu: 'requested CPU',
+    requested_memory: 'requested memory',
+    resolved_cpu_units: 'effective CPU units',
+    resolved_memory_mib: 'effective memory (MiB)',
 };
 
 /**
@@ -161,6 +166,7 @@ const ORDER = [
     // Who and what, before how much.
     'created_by', 'superseded_by', 'rolled_back_from', 'stopped_by',
     'container', 'containers', 'replicas', 'cpu', 'memory',
+    'requested_cpu', 'requested_memory', 'resolved_cpu_units', 'resolved_memory_mib',
     // Then what was built, and from what.
     'git_branch', 'git_revision', 'git_dirty',
     'build_method', 'build_ms', 'push_ms', 'registry',

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -125,6 +125,25 @@ mod client_models {
         pub updated: String,
     }
 
+    /// One event recorded in a deployment's append-only history.
+    #[derive(Debug, Deserialize, Clone)]
+    pub struct DeploymentEvent {
+        pub id: i64,
+        pub occurred_at: String,
+        pub kind: String,
+        pub severity: String,
+        pub source: String,
+        pub subject: Option<String>,
+        pub message: Option<String>,
+        pub attributes: serde_json::Value,
+    }
+
+    #[derive(Debug, Deserialize)]
+    pub struct DeploymentEventPage {
+        pub events: Vec<DeploymentEvent>,
+        pub next_cursor: Option<String>,
+    }
+
     fn default_group() -> String {
         DEFAULT_DEPLOYMENT_GROUP.to_string()
     }

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -11,6 +11,25 @@ pub use crate::server::deployment::models::*;
 #[cfg(not(feature = "backend"))]
 pub use self::client_models::*;
 
+/// One event recorded in a deployment's append-only history.
+#[derive(Debug, serde::Deserialize, Clone)]
+pub struct DeploymentEvent {
+    pub id: i64,
+    pub occurred_at: String,
+    pub kind: String,
+    pub severity: String,
+    pub source: String,
+    pub subject: Option<String>,
+    pub message: Option<String>,
+    pub attributes: serde_json::Value,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct DeploymentEventPage {
+    pub events: Vec<DeploymentEvent>,
+    pub next_cursor: Option<String>,
+}
+
 #[cfg(not(feature = "backend"))]
 mod client_models {
     use serde::{Deserialize, Serialize};
@@ -123,25 +142,6 @@ mod client_models {
         pub created: String,
         #[serde(default)]
         pub updated: String,
-    }
-
-    /// One event recorded in a deployment's append-only history.
-    #[derive(Debug, Deserialize, Clone)]
-    pub struct DeploymentEvent {
-        pub id: i64,
-        pub occurred_at: String,
-        pub kind: String,
-        pub severity: String,
-        pub source: String,
-        pub subject: Option<String>,
-        pub message: Option<String>,
-        pub attributes: serde_json::Value,
-    }
-
-    #[derive(Debug, Deserialize)]
-    pub struct DeploymentEventPage {
-        pub events: Vec<DeploymentEvent>,
-        pub next_cursor: Option<String>,
     }
 
     fn default_group() -> String {

--- a/src/cli/deployment/core.rs
+++ b/src/cli/deployment/core.rs
@@ -12,7 +12,7 @@ use crate::config::Config;
 use crate::token_source::token_with_retry;
 
 // Re-export models from API module (always available)
-pub use crate::api::models::{Deployment, DeploymentStatus};
+pub use crate::api::models::{Deployment, DeploymentEvent, DeploymentStatus};
 // Multi-container request wire types (serialized into the create-deployment body).
 use crate::api::models::{ContainerSpec, RouteSpec};
 
@@ -182,6 +182,110 @@ pub async fn fetch_deployment(
         .context("Failed to parse deployment response")?;
 
     Ok(deployment)
+}
+
+/// Fetch the complete recorded event history for a deployment.
+///
+/// Events are read newest-first by the API and paged on the server's write
+/// order. The caller decides how to display them, so this helper preserves the
+/// API order and follows every page.
+pub async fn fetch_deployment_events(
+    http_client: &Client,
+    backend_url: &str,
+    token: &str,
+    project: &str,
+    deployment_id: &str,
+) -> Result<Vec<DeploymentEvent>> {
+    let base = format!(
+        "{}/api/v1/projects/{}/deployments/{}/events",
+        backend_url, project, deployment_id
+    );
+    let mut events = Vec::new();
+    let mut cursor = None;
+
+    loop {
+        let mut url = format!("{}?limit=500&min_severity=all", base);
+        if let Some(cursor) = cursor.as_deref() {
+            url.push_str("&cursor=");
+            url.push_str(&urlencoding::encode(cursor));
+        }
+
+        let response = http_client
+            .get(&url)
+            .bearer_auth(token)
+            .send()
+            .await
+            .context("Failed to fetch deployment events")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            bail!(
+                "Failed to fetch deployment events ({}): {}",
+                status,
+                error_text
+            );
+        }
+
+        let page: crate::api::models::DeploymentEventPage = response
+            .json()
+            .await
+            .context("Failed to parse deployment events response")?;
+        events.extend(page.events);
+
+        let Some(next) = page.next_cursor else {
+            break;
+        };
+        cursor = Some(next);
+    }
+
+    Ok(events)
+}
+
+/// Fetch the newest page of a deployment's event history.
+///
+/// Follow mode uses this after its initial complete read. Re-reading one page
+/// keeps the polling path bounded while the reporter's event-id set prevents
+/// already printed events from appearing again.
+pub async fn fetch_latest_deployment_events(
+    http_client: &Client,
+    backend_url: &str,
+    token: &str,
+    project: &str,
+    deployment_id: &str,
+) -> Result<Vec<DeploymentEvent>> {
+    let url = format!(
+        "{}/api/v1/projects/{}/deployments/{}/events?limit=500&min_severity=all",
+        backend_url, project, deployment_id
+    );
+    let response = http_client
+        .get(&url)
+        .bearer_auth(token)
+        .send()
+        .await
+        .context("Failed to fetch deployment events")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let error_text = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "Unknown error".to_string());
+        bail!(
+            "Failed to fetch deployment events ({}): {}",
+            status,
+            error_text
+        );
+    }
+
+    let page: crate::api::models::DeploymentEventPage = response
+        .json()
+        .await
+        .context("Failed to parse deployment events response")?;
+    Ok(page.events)
 }
 
 /// List deployments for a project

--- a/src/cli/deployment/follow_ui.rs
+++ b/src/cli/deployment/follow_ui.rs
@@ -422,6 +422,7 @@ fn should_stream_logs(status: &DeploymentStatus) -> bool {
 ///
 /// Opens an SSE log stream and polls deployment status every 3 seconds.
 /// Returns the final deployment when a terminal state is reached.
+#[allow(clippy::too_many_arguments)]
 async fn stream_logs_with_status_polling(
     http_client: &Client,
     backend_url: &str,
@@ -595,6 +596,7 @@ async fn drain_log_stream(stream: &mut super::core::LogStream) {
 }
 
 /// Fall back to status-only polling when log streaming is unavailable.
+#[allow(clippy::too_many_arguments)]
 async fn status_only_polling(
     http_client: &Client,
     backend_url: &str,

--- a/src/cli/deployment/follow_ui.rs
+++ b/src/cli/deployment/follow_ui.rs
@@ -1,14 +1,19 @@
 use anyhow::{bail, Result};
 use reqwest::Client;
 use serde::Deserialize;
+use serde_json::Value;
+use std::collections::HashSet;
 use std::io::{self, IsTerminal, Write as _};
 use std::time::{Duration, Instant};
-use tracing::{debug, info};
+use tracing::debug;
 
-use crate::api::models::{Deployment, DeploymentStatus};
+use crate::api::models::{Deployment, DeploymentEvent, DeploymentStatus};
 use crate::config::Config;
 
-use super::core::{fetch_deployment, open_log_stream, parse_duration, LogStreamError};
+use super::core::{
+    fetch_deployment, fetch_deployment_events, fetch_latest_deployment_events, open_log_stream,
+    parse_duration, LogStreamError,
+};
 use crate::token_source::token_with_retry;
 
 // Project info for fetching project URL
@@ -39,33 +44,139 @@ const SPINNER_FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦
 
 /// State tracking between polls
 struct FollowState {
-    last_status: DeploymentStatus,
-    last_error: Option<String>,
-    last_url: Option<String>,
     spinner_frame: usize,
-    is_first_poll: bool,
 }
 
 impl FollowState {
     fn new() -> Self {
+        Self { spinner_frame: 0 }
+    }
+}
+
+/// Keeps the deployment event log visible while the deploy command follows a
+/// deployment. The initial read includes the complete history; later reads use
+/// only the newest page and the event id set makes the output idempotent.
+struct EventReporter {
+    seen: HashSet<i64>,
+    initialized: bool,
+}
+
+impl EventReporter {
+    fn new() -> Self {
         Self {
-            last_status: DeploymentStatus::Pending,
-            last_error: None,
-            last_url: None,
-            spinner_frame: 0,
-            is_first_poll: true,
+            seen: HashSet::new(),
+            initialized: false,
         }
     }
 
-    fn should_log_state_change(&self, deployment: &Deployment) -> bool {
-        self.is_first_poll || self.last_status != deployment.status
+    async fn poll(
+        &mut self,
+        http_client: &Client,
+        backend_url: &str,
+        provider: &crate::token_source::TokenProvider,
+        project: &str,
+        deployment_id: &str,
+    ) -> Vec<DeploymentEvent> {
+        let token = match token_with_retry(provider).await {
+            Ok(token) => token,
+            Err(error) => {
+                debug!(
+                    "Could not resolve a token for deployment events: {:?}",
+                    error
+                );
+                return Vec::new();
+            }
+        };
+
+        let result = if self.initialized {
+            fetch_latest_deployment_events(http_client, backend_url, &token, project, deployment_id)
+                .await
+        } else {
+            fetch_deployment_events(http_client, backend_url, &token, project, deployment_id).await
+        };
+
+        let events = match result {
+            Ok(events) => events,
+            Err(error) => {
+                debug!("Could not read deployment events: {:?}", error);
+                return Vec::new();
+            }
+        };
+        self.initialized = true;
+
+        unseen_events(&mut self.seen, events)
+    }
+}
+
+fn unseen_events(seen: &mut HashSet<i64>, events: Vec<DeploymentEvent>) -> Vec<DeploymentEvent> {
+    let mut new_events: Vec<_> = events
+        .into_iter()
+        .filter(|event| seen.insert(event.id))
+        .collect();
+    // The API returns newest-first; command output follows the order in which
+    // the server recorded events.
+    new_events.reverse();
+    new_events
+}
+
+fn print_deployment_events(events: &[DeploymentEvent]) {
+    for event in events {
+        let subject = event
+            .subject
+            .as_deref()
+            .map(|value| format!(" {value}:"))
+            .unwrap_or_default();
+        let description = event_description(event);
+        let attributes = if event.attributes.is_object()
+            && event
+                .attributes
+                .as_object()
+                .is_some_and(|attrs| !attrs.is_empty())
+        {
+            format!(
+                " {}",
+                serde_json::to_string(&event.attributes).unwrap_or_else(|_| "{}".to_string())
+            )
+        } else {
+            String::new()
+        };
+
+        println!(
+            "{} [{}] {}{} {}{}",
+            event.occurred_at,
+            event.severity.to_uppercase(),
+            event.source,
+            subject,
+            description,
+            attributes
+        );
+    }
+}
+
+fn event_description(event: &DeploymentEvent) -> String {
+    if event.kind == "status_changed" {
+        let from = event.attributes.get("from").and_then(event_scalar);
+        let to = event.attributes.get("to").and_then(event_scalar);
+        if let Some(to) = to {
+            return match from {
+                Some(from) => format!("status changed: {from} → {to}"),
+                None => format!("status: {to}"),
+            };
+        }
     }
 
-    fn update(&mut self, deployment: &Deployment) {
-        self.last_status = deployment.status.clone();
-        self.last_error = deployment.error_message.clone();
-        self.last_url = deployment.primary_url.clone();
-        self.is_first_poll = false;
+    event
+        .message
+        .clone()
+        .unwrap_or_else(|| event.kind.replace('_', " "))
+}
+
+fn event_scalar(value: &Value) -> Option<String> {
+    match value {
+        Value::String(value) => Some(value.clone()),
+        Value::Number(value) => Some(value.to_string()),
+        Value::Bool(value) => Some(value.to_string()),
+        _ => None,
     }
 }
 
@@ -212,13 +323,6 @@ fn is_terminal_state(status: &DeploymentStatus) -> bool {
     )
 }
 
-/// Log state change to tracing (appears in history)
-fn log_state_change(project: &str, deployment_id: &str, status: &DeploymentStatus) {
-    let status_text = format!("{}", status);
-
-    info!("Deployment {}:{} → {}", project, deployment_id, status_text);
-}
-
 /// Check if stdout is a TTY
 fn is_tty() -> bool {
     io::stdout().is_terminal()
@@ -326,6 +430,7 @@ async fn stream_logs_with_status_polling(
     deployment_id: &str,
     timeout: Duration,
     start_time: Instant,
+    event_reporter: &mut EventReporter,
 ) -> Result<Deployment> {
     let mut log_stream = None;
     let mut retry_count: usize = 0;
@@ -391,6 +496,16 @@ async fn stream_logs_with_status_polling(
                     let deployment = fetch_deployment(
                         http_client, backend_url, &token, project, deployment_id,
                     ).await?;
+                    let events = event_reporter
+                        .poll(
+                            http_client,
+                            backend_url,
+                            provider,
+                            project,
+                            deployment_id,
+                        )
+                        .await;
+                    print_deployment_events(&events);
                     if is_terminal_state(&deployment.status) {
                         drain_log_stream(stream).await;
                         return Ok(deployment);
@@ -409,6 +524,7 @@ async fn stream_logs_with_status_polling(
                     deployment_id,
                     timeout,
                     start_time,
+                    event_reporter,
                 )
                 .await;
             }
@@ -443,6 +559,16 @@ async fn stream_logs_with_status_polling(
                     let deployment = fetch_deployment(
                         http_client, backend_url, &token, project, deployment_id,
                     ).await?;
+                    let events = event_reporter
+                        .poll(
+                            http_client,
+                            backend_url,
+                            provider,
+                            project,
+                            deployment_id,
+                        )
+                        .await;
+                    print_deployment_events(&events);
                     if is_terminal_state(&deployment.status) {
                         return Ok(deployment);
                     }
@@ -477,6 +603,7 @@ async fn status_only_polling(
     deployment_id: &str,
     timeout: Duration,
     start_time: Instant,
+    event_reporter: &mut EventReporter,
 ) -> Result<Deployment> {
     loop {
         // Resolve a fresh token per poll so a long wait doesn't outlast a
@@ -484,6 +611,10 @@ async fn status_only_polling(
         let token = token_with_retry(provider).await?;
         let deployment =
             fetch_deployment(http_client, backend_url, &token, project, deployment_id).await?;
+        let events = event_reporter
+            .poll(http_client, backend_url, provider, project, deployment_id)
+            .await;
+        print_deployment_events(&events);
         if is_terminal_state(&deployment.status) {
             return Ok(deployment);
         }
@@ -530,6 +661,7 @@ pub async fn follow_deployment_with_ui(
 
     let mut state = FollowState::new();
     let mut live_section = LiveStatusSection::new();
+    let mut event_reporter = EventReporter::new();
 
     // Hide cursor for cleaner output
     print!("{}", ansi::HIDE_CURSOR);
@@ -543,17 +675,19 @@ pub async fn follow_deployment_with_ui(
             let deployment =
                 fetch_deployment(http_client, backend_url, &token, project, deployment_id).await?;
 
-            if state.should_log_state_change(&deployment) {
+            let events = event_reporter
+                .poll(http_client, backend_url, &provider, project, deployment_id)
+                .await;
+            if !events.is_empty() {
                 live_section.clear_previous();
-                log_state_change(project, deployment_id, &deployment.status);
                 live_section.last_line_count = 0;
-            } else {
-                let output = live_section.render(&deployment, &state);
-                print!("{}", output);
-                io::stdout().flush().unwrap();
+                print_deployment_events(&events);
             }
 
-            state.update(&deployment);
+            let output = live_section.render(&deployment, &state);
+            print!("{}", output);
+            io::stdout().flush().unwrap();
+
             state.spinner_frame = (state.spinner_frame + 1) % SPINNER_FRAMES.len();
 
             // Terminal state reached before Deploying - skip to Phase 3
@@ -604,6 +738,7 @@ pub async fn follow_deployment_with_ui(
             deployment_id,
             timeout,
             start_time,
+            &mut event_reporter,
         )
         .await?
     } else {
@@ -640,19 +775,18 @@ async fn follow_deployment_simple(
     timeout: Duration,
 ) -> Result<Deployment> {
     let start_time = Instant::now();
-    let mut state = FollowState::new();
+    let mut event_reporter = EventReporter::new();
 
-    // Phase 1: Status polling (print state changes as text lines)
+    // Phase 1: Status polling with the event log as the permanent output.
     let deployment = loop {
         let token = token_with_retry(provider).await?;
         let deployment =
             fetch_deployment(http_client, backend_url, &token, project, deployment_id).await?;
 
-        if state.should_log_state_change(&deployment) {
-            log_state_change(project, deployment_id, &deployment.status);
-        }
-
-        state.update(&deployment);
+        let events = event_reporter
+            .poll(http_client, backend_url, provider, project, deployment_id)
+            .await;
+        print_deployment_events(&events);
 
         if is_terminal_state(&deployment.status) {
             break deployment;
@@ -681,6 +815,7 @@ async fn follow_deployment_simple(
             deployment_id,
             timeout,
             start_time,
+            &mut event_reporter,
         )
         .await?
     } else {
@@ -703,4 +838,64 @@ async fn follow_deployment_simple(
     }
 
     Ok(final_deployment)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event(id: i64, kind: &str, message: Option<&str>, attributes: Value) -> DeploymentEvent {
+        DeploymentEvent {
+            id,
+            occurred_at: "2026-09-01T09:11:03.969119Z".to_string(),
+            kind: kind.to_string(),
+            severity: "info".to_string(),
+            source: "control-plane".to_string(),
+            subject: None,
+            message: message.map(str::to_string),
+            attributes,
+        }
+    }
+
+    #[test]
+    fn unseen_events_are_returned_in_recorded_order_once() {
+        let mut seen = HashSet::from([2]);
+        let events = vec![
+            event(3, "backend_event", Some("third"), Value::Null),
+            event(2, "backend_event", Some("second"), Value::Null),
+            event(1, "backend_event", Some("first"), Value::Null),
+        ];
+
+        let fresh = unseen_events(&mut seen, events);
+        assert_eq!(
+            fresh.iter().map(|event| event.id).collect::<Vec<_>>(),
+            [1, 3]
+        );
+        assert!(unseen_events(&mut seen, fresh).is_empty());
+    }
+
+    #[test]
+    fn status_events_get_a_readable_transition_description() {
+        let status = event(
+            1,
+            "status_changed",
+            None,
+            serde_json::json!({ "from": "Pending", "to": "Building" }),
+        );
+        assert_eq!(
+            event_description(&status),
+            "status changed: Pending → Building"
+        );
+    }
+
+    #[test]
+    fn backend_events_keep_their_message_as_the_description() {
+        let backend = event(
+            1,
+            "backend_event",
+            Some("Resources were rounded up"),
+            serde_json::json!({ "type": "resource_adjusted" }),
+        );
+        assert_eq!(event_description(&backend), "Resources were rounded up");
+    }
 }

--- a/src/db/backend_events.rs
+++ b/src/db/backend_events.rs
@@ -1,10 +1,10 @@
-//! Runtime-native events, forwarded from a backend into the deployment log.
+//! Backend-originated events, forwarded into the deployment log.
 //!
-//! These are the runtime's own words about a deployment — an ECS service saying
-//! it cannot place a task, Kubernetes saying a pod will not schedule. They
-//! explain things the periodic observation cannot: a replica stuck `pending`
-//! looks identical whether the image is missing or the cluster is full, and only
-//! the runtime knows which.
+//! These are backend-owned details about a deployment — an ECS service saying it
+//! cannot place a task, Kubernetes saying a pod will not schedule, or a
+//! controller explaining that it represented a requested resource with a
+//! different effective value. They explain things the periodic observation
+//! cannot.
 //!
 //! Forwarded rather than trusted as the source of truth. A stream can drop and a
 //! poll can overlap, so these enrich the level-triggered observations rather


### PR DESCRIPTION
## Summary
ECS now records Fargate resource adjustments as structured backend events containing the requested and effective CPU and memory values, using the existing generic deployment-event pathway. `rise deploy` reads and prints every event type, while Deployment details show the adjustment in both the generic Resources panel and event Timeline without backend-specific UI logic.

## Test plan
- `env SQLX_OFFLINE=true RUSTC_WRAPPER= cargo check`
- `env SQLX_OFFLINE=true RUSTC_WRAPPER= cargo test -p rise-backend-ecs --lib` — 70 passed
- `env SQLX_OFFLINE=true RUSTC_WRAPPER= cargo test --bin rise` — 175 passed
- `env SQLX_OFFLINE=true RUSTC_WRAPPER= cargo clippy -p rise-backend-ecs --lib -- -D warnings`
- Frontend typecheck reaches an existing missing `@tanstack/react-virtual` dependency in the checkout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rise-deploy/codesmith/rise/pr/479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790849216&installation_model_id=432987&pr_number=479&repository=rise-deploy%2Frise&return_to=https%3A%2F%2Fgithub.com%2Frise-deploy%2Frise%2Fpull%2F479&signature=384456b2e7e2f43ff566e09c9bc0d26a24b8265fd4c6f358328d22e3b4777579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->