### PR TITLE
Add deployment JSON output

### DIFF
--- a/docs/user/src/content/docs/user-guide/deployments.md
+++ b/docs/user/src/content/docs/user-guide/deployments.md
@@ -167,6 +167,22 @@ rise deployment list -p my-app
 rise d ls -p my-app --group staging
 ```
 
+For CI and other scripts, `--json` writes the deployment data as JSON. `rise deploy`
+waits for the deployment to reach its terminal state and writes the completed deployment
+object; `rise deployment list` writes an array. `--status-file <path>` writes the same
+JSON to a file, while preserving human-readable output unless `--json` is also supplied.
+
+```bash
+# Retrieve the URL of the deployment that just completed
+rise deploy -p my-app --status-file deployment.json
+jq -r '.primary_url // empty' deployment.json
+
+# Write JSON directly to stdout
+rise deployment list -p my-app --json | jq '.[].primary_url'
+```
+
+Status files are replaced atomically after a complete JSON document is available.
+
 ### Viewing Deployment Details
 
 ```bash

--- a/docs/user/src/content/docs/user-guide/deployments.md
+++ b/docs/user/src/content/docs/user-guide/deployments.md
@@ -167,10 +167,13 @@ rise deployment list -p my-app
 rise d ls -p my-app --group staging
 ```
 
-For CI and other scripts, `--json` writes the deployment data as JSON. `rise deploy`
-waits for the deployment to reach its terminal state and writes the completed deployment
-object; `rise deployment list` writes an array. `--status-file <path>` writes the same
-JSON to a file, while preserving human-readable output unless `--json` is also supplied.
+For CI and other scripts, `--json` writes a deliberately minimal JSON payload. Each
+deployment contains `deployment_id` and `status`, plus `primary_url` when available and
+`error_message` when present. `rise deploy` waits for the deployment to reach its
+terminal state and writes one object; `rise deployment list` writes an array. Build and
+push failures also produce a failed payload after the deployment record is created.
+`--status-file <path>` writes the same JSON to a file, while preserving human-readable
+output unless `--json` is also supplied.
 
 ```bash
 # Retrieve the URL of the deployment that just completed

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -118,6 +118,8 @@ mod client_models {
         pub primary_url: Option<String>,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         pub custom_domain_urls: Vec<String>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        pub all_urls: Vec<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub image: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/build/buildkit.rs
+++ b/src/build/buildkit.rs
@@ -101,17 +101,20 @@ fn network_exists(container_cli: &str, network_name: &str) -> bool {
 }
 
 /// Create a Docker network if it doesn't exist
-fn create_network(container_cli: &str, network_name: &str) -> Result<()> {
+fn create_network(
+    container_cli: &str,
+    network_name: &str,
+    output: super::CommandOutput,
+) -> Result<()> {
     if network_exists(container_cli, network_name) {
         debug!("Network '{}' already exists", network_name);
         return Ok(());
     }
 
     info!("Creating Docker network '{}'", network_name);
-    let status = Command::new(container_cli)
-        .args(["network", "create", network_name])
-        .status()
-        .context("Failed to create network")?;
+    let mut command = Command::new(container_cli);
+    command.args(["network", "create", network_name]);
+    let status = super::run_command(command, "Failed to create network", output)?;
 
     if !status.success() {
         bail!("Failed to create network '{}'", network_name);
@@ -122,16 +125,20 @@ fn create_network(container_cli: &str, network_name: &str) -> Result<()> {
 }
 
 /// Connect a container to a Docker network
-fn connect_to_network(container_cli: &str, network_name: &str, container_name: &str) -> Result<()> {
+fn connect_to_network(
+    container_cli: &str,
+    network_name: &str,
+    container_name: &str,
+    output: super::CommandOutput,
+) -> Result<()> {
     info!(
         "Connecting container '{}' to network '{}'",
         container_name, network_name
     );
 
-    let status = Command::new(container_cli)
-        .args(["network", "connect", network_name, container_name])
-        .status()
-        .context("Failed to connect to network")?;
+    let mut command = Command::new(container_cli);
+    command.args(["network", "connect", network_name, container_name]);
+    let status = super::run_command(command, "Failed to connect to network", output)?;
 
     if !status.success() {
         bail!(
@@ -358,13 +365,16 @@ fn get_daemon_state(container_cli: &str, daemon_name: &str) -> DaemonState {
 /// Uses `rm -f` instead of `stop` because Podman does not always clean up
 /// `--rm` containers reliably on `stop`, leaving the container name in use.
 /// `rm -f` works correctly on both Docker and Podman.
-fn stop_buildkit_daemon(container_cli: &ContainerCli, daemon_name: &str) -> Result<()> {
+fn stop_buildkit_daemon(
+    container_cli: &ContainerCli,
+    daemon_name: &str,
+    output: super::CommandOutput,
+) -> Result<()> {
     info!("Stopping existing BuildKit daemon '{}'", daemon_name);
 
-    let status = Command::new(container_cli.command())
-        .args(["rm", "-f", daemon_name])
-        .status()
-        .context("Failed to remove BuildKit daemon")?;
+    let mut command = Command::new(container_cli.command());
+    command.args(["rm", "-f", daemon_name]);
+    let status = super::run_command(command, "Failed to remove BuildKit daemon", output)?;
 
     if !status.success() {
         bail!("Failed to remove BuildKit daemon");
@@ -381,6 +391,7 @@ fn create_buildkit_daemon(
     ssl_cert_file: Option<&Path>,
     network_name: Option<&str>,
     proxy_vars: &std::collections::HashMap<String, String>,
+    output: super::CommandOutput,
 ) -> Result<String> {
     if let Some(cert_path) = ssl_cert_file {
         info!(
@@ -522,7 +533,7 @@ fn create_buildkit_daemon(
 
     cmd.arg("moby/buildkit");
 
-    let status = cmd.status().context("Failed to start BuildKit daemon")?;
+    let status = super::run_command(cmd, "Failed to start BuildKit daemon", output)?;
 
     if !status.success() {
         bail!("Failed to create BuildKit daemon");
@@ -533,8 +544,8 @@ fn create_buildkit_daemon(
     // Connect to network if specified (skip when using host networking)
     if !use_host_network {
         if let Some(network) = network_name {
-            create_network(container_cli.command(), network)?;
-            connect_to_network(container_cli.command(), network, daemon_name)?;
+            create_network(container_cli.command(), network, output)?;
+            connect_to_network(container_cli.command(), network, daemon_name, output)?;
         }
     }
 
@@ -547,6 +558,7 @@ fn create_buildkit_daemon(
 pub(crate) fn ensure_managed_buildkit_daemon(
     ssl_cert_file: Option<&Path>,
     container_cli: &ContainerCli,
+    output: super::CommandOutput,
 ) -> Result<String> {
     let daemon_name = "rise-buildkit";
 
@@ -573,13 +585,14 @@ pub(crate) fn ensure_managed_buildkit_daemon(
                 "BuildKit daemon version changed ({:?} -> {}), recreating",
                 current_version, DAEMON_VERSION
             );
-            stop_buildkit_daemon(container_cli, daemon_name)?;
+            stop_buildkit_daemon(container_cli, daemon_name, output)?;
             return create_buildkit_daemon(
                 container_cli,
                 daemon_name,
                 ssl_cert_file,
                 network_name.as_deref(),
                 &proxy_vars,
+                output,
             );
         }
 
@@ -587,13 +600,14 @@ pub(crate) fn ensure_managed_buildkit_daemon(
         let current_proxy_hash = get_proxy_hash_label(container_cli.command(), daemon_name);
         if current_proxy_hash != expected_proxy_hash {
             info!("Proxy configuration has changed, recreating daemon");
-            stop_buildkit_daemon(container_cli, daemon_name)?;
+            stop_buildkit_daemon(container_cli, daemon_name, output)?;
             return create_buildkit_daemon(
                 container_cli,
                 daemon_name,
                 ssl_cert_file,
                 network_name.as_deref(),
                 &proxy_vars,
+                output,
             );
         }
 
@@ -606,13 +620,14 @@ pub(crate) fn ensure_managed_buildkit_daemon(
                 "Host networking changed (was={}, want={}), recreating daemon",
                 has_host_network, want_host_network
             );
-            stop_buildkit_daemon(container_cli, daemon_name)?;
+            stop_buildkit_daemon(container_cli, daemon_name, output)?;
             return create_buildkit_daemon(
                 container_cli,
                 daemon_name,
                 ssl_cert_file,
                 network_name.as_deref(),
                 &proxy_vars,
+                output,
             );
         }
     }
@@ -646,7 +661,7 @@ pub(crate) fn ensure_managed_buildkit_daemon(
             } else if config_changed {
                 info!("BuildKit config has changed (insecure registries), recreating daemon");
             }
-            stop_buildkit_daemon(container_cli, daemon_name)?;
+            stop_buildkit_daemon(container_cli, daemon_name, output)?;
         }
 
         // Certificate provided, but daemon has no cert label
@@ -664,7 +679,7 @@ pub(crate) fn ensure_managed_buildkit_daemon(
             } else {
                 info!("SSL certificate now available, recreating daemon with certificate");
             }
-            stop_buildkit_daemon(container_cli, daemon_name)?;
+            stop_buildkit_daemon(container_cli, daemon_name, output)?;
         }
 
         // No certificate, daemon has no cert label (matches)
@@ -685,7 +700,7 @@ pub(crate) fn ensure_managed_buildkit_daemon(
             } else if config_changed {
                 info!("BuildKit config has changed (insecure registries), recreating daemon");
             }
-            stop_buildkit_daemon(container_cli, daemon_name)?;
+            stop_buildkit_daemon(container_cli, daemon_name, output)?;
         }
 
         // No certificate, but daemon has cert (mismatch)
@@ -705,7 +720,7 @@ pub(crate) fn ensure_managed_buildkit_daemon(
             } else {
                 info!("SSL certificate removed, recreating daemon without certificate");
             }
-            stop_buildkit_daemon(container_cli, daemon_name)?;
+            stop_buildkit_daemon(container_cli, daemon_name, output)?;
         }
 
         // Daemon doesn't exist
@@ -721,12 +736,17 @@ pub(crate) fn ensure_managed_buildkit_daemon(
         ssl_cert_file,
         network_name.as_deref(),
         &proxy_vars,
+        output,
     )
 }
 
 /// Ensure buildx builder exists for the given BuildKit daemon
 /// Returns the builder name to use
-pub(crate) fn ensure_buildx_builder(container_cli: &str, buildkit_host: &str) -> Result<String> {
+pub(crate) fn ensure_buildx_builder(
+    container_cli: &str,
+    buildkit_host: &str,
+    output: super::CommandOutput,
+) -> Result<String> {
     let builder_name = "rise-buildkit";
 
     // Check if builder already exists
@@ -735,9 +755,9 @@ pub(crate) fn ensure_buildx_builder(container_cli: &str, buildkit_host: &str) ->
         .output();
 
     match inspect_status {
-        Ok(output) if output.status.success() => {
+        Ok(builder_inspect) if builder_inspect.status.success() => {
             // Builder exists, check if it's pointing to the correct endpoint
-            let inspect_output = String::from_utf8_lossy(&output.stdout);
+            let inspect_output = String::from_utf8_lossy(&builder_inspect.stdout);
 
             // Check if the buildkit_host appears in the inspect output
             // The output contains lines like "Endpoint: docker-container://rise-buildkit"
@@ -754,9 +774,9 @@ pub(crate) fn ensure_buildx_builder(container_cli: &str, buildkit_host: &str) ->
                 "Buildx builder '{}' exists but points to different endpoint, recreating",
                 builder_name
             );
-            let _ = Command::new(container_cli)
-                .args(["buildx", "rm", builder_name])
-                .status();
+            let mut command = Command::new(container_cli);
+            command.args(["buildx", "rm", builder_name]);
+            let _ = super::run_command(command, "Failed to remove buildx builder", output);
         }
         _ => {
             info!(
@@ -767,10 +787,9 @@ pub(crate) fn ensure_buildx_builder(container_cli: &str, buildkit_host: &str) ->
     }
 
     // Create new builder pointing to the BuildKit daemon
-    let status = Command::new(container_cli)
-        .args(["buildx", "create", "--name", builder_name, buildkit_host])
-        .status()
-        .context("Failed to create buildx builder")?;
+    let mut command = Command::new(container_cli);
+    command.args(["buildx", "create", "--name", builder_name, buildkit_host]);
+    let status = super::run_command(command, "Failed to create buildx builder", output)?;
 
     if !status.success() {
         bail!("Failed to create buildx builder '{}'", builder_name);

--- a/src/build/docker.rs
+++ b/src/build/docker.rs
@@ -1,6 +1,6 @@
 // Docker/Dockerfile builds
 
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 use std::path::Path;
 use std::process::Command;
 use tracing::{debug, info, warn};
@@ -8,7 +8,6 @@ use tracing::{debug, info, warn};
 use super::dockerfile_ssl::{
     preprocess_dockerfile_for_ssl, SslCertContext, SSL_CERT_BUILD_CONTEXT,
 };
-use super::registry::docker_push;
 use super::BuildPushMode;
 
 /// Configure buildx output flags (`--push` / `--load`) on a command.
@@ -62,6 +61,7 @@ pub(crate) struct DockerBuildOptions<'a> {
     pub build_contexts: &'a std::collections::HashMap<String, String>,
     pub no_cache: bool,
     pub platform: &'a str,
+    pub output: super::CommandOutput,
 }
 
 /// Build image using Docker or Podman with a Dockerfile
@@ -234,9 +234,11 @@ pub(crate) fn build_image_with_dockerfile(options: DockerBuildOptions) -> Result
 
     debug!("Executing command: {:?}", cmd);
 
-    let status = cmd
-        .status()
-        .with_context(|| format!("Failed to execute {} build", options.container_cli))?;
+    let status = super::run_command(
+        cmd,
+        &format!("Failed to execute {} build", options.container_cli),
+        options.output,
+    )?;
 
     // Note: SslCertContext cleanup is automatic via RAII when it goes out of scope
 
@@ -249,7 +251,11 @@ pub(crate) fn build_image_with_dockerfile(options: DockerBuildOptions) -> Result
     }
 
     if needs_fallback_push {
-        docker_push(options.container_cli, options.image_tag)?;
+        super::registry::docker_push_with_output(
+            options.container_cli,
+            options.image_tag,
+            options.output,
+        )?;
     }
 
     Ok(())

--- a/src/build/method.rs
+++ b/src/build/method.rs
@@ -125,6 +125,8 @@ pub(crate) struct BuildOptions {
     /// Where `platform` was sourced from (CLI / env / rise.toml / backend / host).
     /// Lets callers report or react to the precedence level that won.
     pub platform_source: crate::build::PlatformSource,
+    /// Where build command stdout is written.
+    pub output: crate::build::CommandOutput,
 }
 
 /// How the build backend should handle image push output.
@@ -293,6 +295,7 @@ impl BuildOptions {
             platform,
             platform_source,
             push_mode: BuildPushMode::Disabled,
+            output: crate::build::CommandOutput::Inherit,
         }
     }
 
@@ -309,6 +312,11 @@ impl BuildOptions {
     /// Builder method to set explicit push mode.
     pub(crate) fn with_push_mode(mut self, push_mode: BuildPushMode) -> Self {
         self.push_mode = push_mode;
+        self
+    }
+
+    pub(crate) fn with_output(mut self, output: crate::build::CommandOutput) -> Self {
+        self.output = output;
         self
     }
 }

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -15,6 +15,76 @@ mod railpack;
 mod registry;
 mod ssl;
 
+use anyhow::{bail, Context, Result};
+use std::io::{self, Write};
+use std::process::{Child, Command, ExitStatus, Stdio};
+
+/// Where a child command should write its stdout.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CommandOutput {
+    Inherit,
+    Stderr,
+}
+
+/// Run a child command while keeping its stdout out of a machine-readable
+/// command's stdout.
+pub(crate) fn run_command(
+    mut command: Command,
+    context: &str,
+    output: CommandOutput,
+) -> Result<ExitStatus> {
+    if output == CommandOutput::Inherit {
+        return command.status().with_context(|| context.to_string());
+    }
+
+    let mut child = command
+        .stdout(Stdio::piped())
+        .spawn()
+        .with_context(|| context.to_string())?;
+    forward_child_stdout(&mut child, context)?;
+    child.wait().with_context(|| context.to_string())
+}
+
+/// Run a child command with stdin while forwarding its stdout to stderr when
+/// machine-readable output is selected.
+pub(crate) fn run_command_with_stdin(
+    mut command: Command,
+    stdin: &[u8],
+    context: &str,
+    output: CommandOutput,
+) -> Result<ExitStatus> {
+    let mut child = command
+        .stdin(Stdio::piped())
+        .stdout(if output == CommandOutput::Stderr {
+            Stdio::piped()
+        } else {
+            Stdio::inherit()
+        })
+        .spawn()
+        .with_context(|| context.to_string())?;
+
+    if let Some(mut child_stdin) = child.stdin.take() {
+        child_stdin
+            .write_all(stdin)
+            .with_context(|| context.to_string())?;
+    }
+    if output == CommandOutput::Stderr {
+        forward_child_stdout(&mut child, context)?;
+    }
+    child.wait().with_context(|| context.to_string())
+}
+
+fn forward_child_stdout(child: &mut Child, context: &str) -> Result<()> {
+    let mut stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("child stdout was not piped"))?;
+    let mut stderr = io::stderr();
+    io::copy(&mut stdout, &mut stderr)
+        .map(|_| ())
+        .with_context(|| context.to_string())
+}
+
 /// Fallback target platform when nothing more specific (CLI flag, env var,
 /// rise.toml, backend hint) is provided. We default to the host architecture
 /// so local dev (e.g. ARM Mac + ARM minikube) just works; production deploys
@@ -112,10 +182,10 @@ pub use method::BuildArgs;
 pub(crate) use method::{BuildMethod, BuildOptions, BuildPushMode};
 pub(crate) use railpack::{build_with_buildctl, BuildctlFrontend, RailpackBuildOptions};
 pub(crate) use registry::{
-    docker_login, docker_pull, docker_push, docker_tag, inject_registry_auth,
+    docker_login_with_output, docker_pull_with_output, docker_push, docker_push_with_output,
+    docker_tag_with_output, inject_registry_auth,
 };
 
-use anyhow::{bail, Result};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tracing::{debug, info, warn};
@@ -234,6 +304,7 @@ pub(crate) fn build_image(options: BuildOptions) -> Result<()> {
             Some(ensure_managed_buildkit_daemon(
                 ssl_cert_path.as_deref(),
                 container_cli,
+                options.output,
             )?)
         }
     } else {
@@ -281,6 +352,7 @@ pub(crate) fn build_image(options: BuildOptions) -> Result<()> {
                 build_contexts: &resolved_build_contexts,
                 no_cache: options.no_cache,
                 platform: &options.platform,
+                output: options.output,
             })?;
         }
         BuildMethod::Pack => {
@@ -298,12 +370,17 @@ pub(crate) fn build_image(options: BuildOptions) -> Result<()> {
                 &options.env,
                 options.no_cache,
                 &options.platform,
+                options.output,
             )?;
 
             // Pack doesn't support push during build, so inline push falls back
             // to a separate push owned by the build module.
             if options.push_mode == BuildPushMode::Inline {
-                registry::docker_push(container_cli.command(), &options.image_tag)?;
+                registry::docker_push_with_output(
+                    container_cli.command(),
+                    &options.image_tag,
+                    options.output,
+                )?;
             }
         }
         BuildMethod::Railpack { use_buildctl } => {
@@ -328,6 +405,7 @@ pub(crate) fn build_image(options: BuildOptions) -> Result<()> {
                 env: &options.env,
                 no_cache: options.no_cache,
                 platform: &options.platform,
+                output: options.output,
             })?;
         }
         BuildMethod::Buildctl => {
@@ -400,6 +478,7 @@ pub(crate) fn build_image(options: BuildOptions) -> Result<()> {
                 options.no_cache,
                 container_cli.command(),
                 &options.platform,
+                options.output,
             )?;
 
             // Note: SslCertContext cleanup is automatic via RAII when it goes out of scope

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -193,7 +193,7 @@ use tracing::{debug, info, warn};
 use buildkit::{check_ssl_cert_and_warn, ensure_managed_buildkit_daemon};
 use docker::{build_image_with_dockerfile, DockerBuildOptions};
 use method::{requires_buildkit, select_build_method};
-use pack::build_image_with_buildpacks;
+use pack::{build_image_with_buildpacks, BuildpackBuildOptions};
 use railpack::build_image_with_railpacks;
 
 /// Read an environment variable, treating empty strings as if the variable is not set.
@@ -362,16 +362,16 @@ pub(crate) fn build_image(options: BuildOptions) -> Result<()> {
             if options.managed_buildkit.is_some() {
                 warn!("--managed-buildkit flag is ignored when using pack build method");
             }
-            build_image_with_buildpacks(
-                &options.app_path,
-                &options.image_tag,
-                options.builder.as_deref(),
-                &options.buildpacks,
-                &options.env,
-                options.no_cache,
-                &options.platform,
-                options.output,
-            )?;
+            build_image_with_buildpacks(BuildpackBuildOptions {
+                app_path: &options.app_path,
+                image_tag: &options.image_tag,
+                builder: options.builder.as_deref(),
+                buildpacks: &options.buildpacks,
+                env: &options.env,
+                no_cache: options.no_cache,
+                platform: &options.platform,
+                output: options.output,
+            })?;
 
             // Pack doesn't support push during build, so inline push falls back
             // to a separate push owned by the build module.

--- a/src/build/pack.rs
+++ b/src/build/pack.rs
@@ -7,17 +7,29 @@ use tracing::{debug, info};
 
 use super::ssl::{SSL_CERT_PATHS, SSL_ENV_VARS};
 
+pub(crate) struct BuildpackBuildOptions<'a> {
+    pub app_path: &'a str,
+    pub image_tag: &'a str,
+    pub builder: Option<&'a str>,
+    pub buildpacks: &'a [String],
+    pub env: &'a [String],
+    pub no_cache: bool,
+    pub platform: &'a str,
+    pub output: super::CommandOutput,
+}
+
 /// Build image using Cloud Native Buildpacks (pack CLI)
-pub(crate) fn build_image_with_buildpacks(
-    app_path: &str,
-    image_tag: &str,
-    builder: Option<&str>,
-    buildpacks: &[String],
-    env: &[String],
-    no_cache: bool,
-    platform: &str,
-    output: super::CommandOutput,
-) -> Result<()> {
+pub(crate) fn build_image_with_buildpacks(options: BuildpackBuildOptions<'_>) -> Result<()> {
+    let BuildpackBuildOptions {
+        app_path,
+        image_tag,
+        builder,
+        buildpacks,
+        env,
+        no_cache,
+        platform,
+        output,
+    } = options;
     // Check if pack CLI is available
     let pack_check = Command::new("pack").arg("version").output();
 

--- a/src/build/pack.rs
+++ b/src/build/pack.rs
@@ -16,6 +16,7 @@ pub(crate) fn build_image_with_buildpacks(
     env: &[String],
     no_cache: bool,
     platform: &str,
+    output: super::CommandOutput,
 ) -> Result<()> {
     // Check if pack CLI is available
     let pack_check = Command::new("pack").arg("version").output();
@@ -130,7 +131,7 @@ pub(crate) fn build_image_with_buildpacks(
 
     debug!("Executing command: {:?}", cmd);
 
-    let status = cmd.status().context("Failed to execute pack build")?;
+    let status = super::run_command(cmd, "Failed to execute pack build", output)?;
 
     if !status.success() {
         bail!("pack build failed with status: {}", status);

--- a/src/build/railpack.rs
+++ b/src/build/railpack.rs
@@ -9,7 +9,7 @@ use tracing::{debug, info, warn};
 
 use super::buildkit::ensure_buildx_builder;
 use super::proxy;
-use super::registry::docker_push;
+use super::registry::docker_push_with_output;
 use super::ssl::embed_ssl_cert_in_plan;
 use super::BuildPushMode;
 
@@ -34,6 +34,7 @@ pub(crate) struct RailpackBuildOptions<'a> {
     pub env: &'a [String],
     pub no_cache: bool,
     pub platform: &'a str,
+    pub output: super::CommandOutput,
 }
 
 /// RAII guard for cleaning up temp files and directories
@@ -156,7 +157,7 @@ pub(crate) fn build_image_with_railpacks(options: RailpackBuildOptions) -> Resul
         );
     }
 
-    let status = cmd.status().context("Failed to execute railpack prepare")?;
+    let status = super::run_command(cmd, "Failed to execute railpack prepare", options.output)?;
 
     if !status.success() {
         bail!("railpack prepare failed with status: {}", status);
@@ -204,6 +205,7 @@ pub(crate) fn build_image_with_railpacks(options: RailpackBuildOptions) -> Resul
             options.no_cache,
             options.container_cli,
             options.platform,
+            options.output,
         )?;
     } else {
         build_with_buildx(
@@ -217,6 +219,7 @@ pub(crate) fn build_image_with_railpacks(options: RailpackBuildOptions) -> Resul
             &all_secrets,
             options.no_cache,
             options.platform,
+            options.output,
         )?;
     }
 
@@ -236,6 +239,7 @@ fn build_with_buildx(
     secrets: &HashMap<String, String>,
     no_cache: bool,
     platform: &str,
+    output: super::CommandOutput,
 ) -> Result<()> {
     // Check buildx availability
     if !super::docker::is_buildx_available(container_cli) {
@@ -252,7 +256,7 @@ fn build_with_buildx(
 
     // If buildkit_host is provided, we need to create/use a builder pointing to it
     let builder_name = if let Some(host) = buildkit_host {
-        Some(ensure_buildx_builder(container_cli, host)?)
+        Some(ensure_buildx_builder(container_cli, host, output)?)
     } else {
         None
     };
@@ -307,9 +311,11 @@ fn build_with_buildx(
 
     debug!("Executing command: {:?}", cmd);
 
-    let status = cmd
-        .status()
-        .with_context(|| format!("Failed to execute {} buildx build", container_cli))?;
+    let status = super::run_command(
+        cmd,
+        &format!("Failed to execute {} buildx build", container_cli),
+        output,
+    )?;
 
     if !status.success() {
         bail!(
@@ -320,7 +326,7 @@ fn build_with_buildx(
     }
 
     if needs_fallback_push {
-        docker_push(container_cli, image_tag)?;
+        docker_push_with_output(container_cli, image_tag, output)?;
     }
 
     Ok(())
@@ -352,6 +358,7 @@ pub(crate) fn build_with_buildctl(
     no_cache: bool,
     container_cli: &str,
     platform: &str,
+    output: super::CommandOutput,
 ) -> Result<()> {
     // Check buildctl availability
     let buildctl_check = Command::new("buildctl").arg("--version").output();
@@ -425,7 +432,7 @@ pub(crate) fn build_with_buildctl(
 
         debug!("Executing command: {:?}", cmd);
 
-        let status = cmd.status().context("Failed to execute buildctl build")?;
+        let status = super::run_command(cmd, "Failed to execute buildctl build", output)?;
         if !status.success() {
             bail!("buildctl build failed with status: {}", status);
         }
@@ -446,11 +453,13 @@ pub(crate) fn build_with_buildctl(
             .take()
             .context("Failed to capture buildctl stdout")?;
 
-        let docker_load = Command::new(container_cli)
-            .arg("load")
-            .stdin(buildctl_stdout)
-            .status()
-            .with_context(|| format!("Failed to execute {} load", container_cli))?;
+        let mut docker_load_command = Command::new(container_cli);
+        docker_load_command.arg("load").stdin(buildctl_stdout);
+        let docker_load = super::run_command(
+            docker_load_command,
+            &format!("Failed to execute {} load", container_cli),
+            output,
+        )?;
 
         let buildctl_status = buildctl_child
             .wait()

--- a/src/build/registry.rs
+++ b/src/build/registry.rs
@@ -7,6 +7,14 @@ use tracing::{debug, info};
 
 /// Push image to container registry
 pub(crate) fn docker_push(container_cli: &str, image_tag: &str) -> Result<()> {
+    docker_push_with_output(container_cli, image_tag, super::CommandOutput::Inherit)
+}
+
+pub(crate) fn docker_push_with_output(
+    container_cli: &str,
+    image_tag: &str,
+    output: super::CommandOutput,
+) -> Result<()> {
     info!("Pushing image to registry: {}", image_tag);
 
     let mut cmd = Command::new(container_cli);
@@ -14,9 +22,11 @@ pub(crate) fn docker_push(container_cli: &str, image_tag: &str) -> Result<()> {
 
     debug!("Executing command: {:?}", cmd);
 
-    let status = cmd
-        .status()
-        .with_context(|| format!("Failed to execute {} push", container_cli))?;
+    let status = super::run_command(
+        cmd,
+        &format!("Failed to execute {} push", container_cli),
+        output,
+    )?;
 
     if !status.success() {
         bail!("{} push failed with status: {}", container_cli, status);
@@ -26,7 +36,12 @@ pub(crate) fn docker_push(container_cli: &str, image_tag: &str) -> Result<()> {
 }
 
 /// Pull image from a registry
-pub(crate) fn docker_pull(container_cli: &str, image: &str, platform: &str) -> Result<()> {
+pub(crate) fn docker_pull_with_output(
+    container_cli: &str,
+    image: &str,
+    platform: &str,
+    output: super::CommandOutput,
+) -> Result<()> {
     info!("Pulling image: {} (platform: {})", image, platform);
 
     let mut cmd = Command::new(container_cli);
@@ -34,9 +49,11 @@ pub(crate) fn docker_pull(container_cli: &str, image: &str, platform: &str) -> R
 
     debug!("Executing command: {:?}", cmd);
 
-    let status = cmd
-        .status()
-        .with_context(|| format!("Failed to execute {} pull", container_cli))?;
+    let status = super::run_command(
+        cmd,
+        &format!("Failed to execute {} pull", container_cli),
+        output,
+    )?;
 
     if !status.success() {
         bail!("{} pull failed with status: {}", container_cli, status);
@@ -46,7 +63,12 @@ pub(crate) fn docker_pull(container_cli: &str, image: &str, platform: &str) -> R
 }
 
 /// Tag a container image
-pub(crate) fn docker_tag(container_cli: &str, source: &str, target: &str) -> Result<()> {
+pub(crate) fn docker_tag_with_output(
+    container_cli: &str,
+    source: &str,
+    target: &str,
+    output: super::CommandOutput,
+) -> Result<()> {
     info!("Tagging image: {} -> {}", source, target);
 
     let mut cmd = Command::new(container_cli);
@@ -54,9 +76,11 @@ pub(crate) fn docker_tag(container_cli: &str, source: &str, target: &str) -> Res
 
     debug!("Executing command: {:?}", cmd);
 
-    let status = cmd
-        .status()
-        .with_context(|| format!("Failed to execute {} tag", container_cli))?;
+    let status = super::run_command(
+        cmd,
+        &format!("Failed to execute {} tag", container_cli),
+        output,
+    )?;
 
     if !status.success() {
         bail!("{} tag failed with status: {}", container_cli, status);
@@ -138,33 +162,31 @@ fn home_dir() -> Option<PathBuf> {
 }
 
 /// Login to container registry
-pub(crate) fn docker_login(
+pub(crate) fn docker_login_with_output(
     container_cli: &str,
     registry: &str,
     username: &str,
     password: &str,
+    output: super::CommandOutput,
 ) -> Result<()> {
     debug!(
         "Executing: {} login {} --username {} --password-stdin",
         container_cli, registry, username
     );
 
-    let status = Command::new(container_cli)
+    let mut command = Command::new(container_cli);
+    command
         .arg("login")
         .arg(registry)
         .arg("--username")
         .arg(username)
-        .arg("--password-stdin")
-        .stdin(std::process::Stdio::piped())
-        .spawn()
-        .and_then(|mut child| {
-            use std::io::Write;
-            if let Some(mut stdin) = child.stdin.take() {
-                stdin.write_all(password.as_bytes())?;
-            }
-            child.wait()
-        })
-        .with_context(|| format!("Failed to execute {} login", container_cli))?;
+        .arg("--password-stdin");
+    let status = super::run_command_with_stdin(
+        command,
+        password.as_bytes(),
+        &format!("Failed to execute {} login", container_cli),
+        output,
+    )?;
 
     if !status.success() {
         bail!("{} login failed with status: {}", container_cli, status);

--- a/src/cli/deployment/core.rs
+++ b/src/cli/deployment/core.rs
@@ -4,6 +4,7 @@ use comfy_table::{
 };
 use reqwest::Client;
 use serde::Deserialize;
+use std::path::Path;
 use std::time::{Duration, Instant};
 use tracing::{debug, info, warn};
 
@@ -296,6 +297,8 @@ pub async fn list_deployments(
     project: &str,
     group: Option<&str>,
     limit: usize,
+    json_output: bool,
+    status_file: Option<&str>,
 ) -> Result<()> {
     let token = crate::token_source::resolve_token_with_retry(http_client, config).await?;
 
@@ -338,6 +341,24 @@ pub async fn list_deployments(
 
     // Limit results
     deployments.truncate(limit);
+
+    let deployments_json = if json_output || status_file.is_some() {
+        Some(
+            serde_json::to_string_pretty(&deployments)
+                .context("Failed to serialize deployments as JSON")?,
+        )
+    } else {
+        None
+    };
+
+    if let (Some(path), Some(json)) = (status_file, deployments_json.as_deref()) {
+        write_json_status_file(path, json)?;
+    }
+
+    if json_output {
+        println!("{}", deployments_json.expect("JSON was serialized above"));
+        return Ok(());
+    }
 
     if deployments.is_empty() {
         println!("No deployments found for project '{}'", project);
@@ -491,6 +512,7 @@ pub async fn show_deployment(
             project,
             deployment_id,
             timeout_str,
+            false,
         )
         .await?;
 
@@ -805,6 +827,7 @@ async fn push_with_fresh_registry_credentials(
     project_name: &str,
     deployment_id: &str,
     image_tag: &str,
+    output: build::CommandOutput,
 ) -> Result<()> {
     let registry_credentials = fetch_deployment_registry_credentials(
         http_client,
@@ -823,9 +846,10 @@ async fn push_with_fresh_registry_credentials(
         &registry_credentials,
         project_name,
         deployment_id,
+        output,
     )
     .await?;
-    build::docker_push(container_cli, image_tag)
+    build::docker_push_with_output(container_cli, image_tag, output)
 }
 
 /// Fetch registry push credentials scoped to a specific deployment.
@@ -973,6 +997,10 @@ pub struct DeploymentOptions<'a> {
     pub cpu: Option<String>,
     /// Memory allocation (resolved from CLI flag > rise.toml > server default)
     pub memory: Option<String>,
+    /// Emit the completed deployment as JSON on stdout.
+    pub json_output: bool,
+    /// Write the completed deployment JSON to this file.
+    pub status_file: Option<String>,
 }
 
 pub async fn create_deployment(
@@ -1010,6 +1038,11 @@ pub async fn create_deployment(
     // exchanged for that service account's short-lived Rise access token;
     // otherwise it is used as-is.
     let provider = crate::token_source::resolve_token_provider(http_client, config)?;
+    let command_output = if deploy_opts.json_output {
+        build::CommandOutput::Stderr
+    } else {
+        build::CommandOutput::Inherit
+    };
     debug!("Authenticating to backend using {}", provider.describe());
     let token = token_with_retry(&provider).await?;
 
@@ -1157,7 +1190,12 @@ pub async fn create_deployment(
                 backend_platform,
             );
             log_platform_choice(&platform, source, "Pulling");
-            if let Err(e) = build::docker_pull(&container_cli, source_image, &platform) {
+            if let Err(e) = build::docker_pull_with_output(
+                &container_cli,
+                source_image,
+                &platform,
+                command_output,
+            ) {
                 report_failed_status(
                     http_client,
                     backend_url,
@@ -1171,9 +1209,12 @@ pub async fn create_deployment(
             }
 
             // Tag it with the Rise registry image tag
-            if let Err(e) =
-                build::docker_tag(&container_cli, source_image, &deployment_info.image_tag)
-            {
+            if let Err(e) = build::docker_tag_with_output(
+                &container_cli,
+                source_image,
+                &deployment_info.image_tag,
+                command_output,
+            ) {
                 report_failed_status(
                     http_client,
                     backend_url,
@@ -1209,6 +1250,7 @@ pub async fn create_deployment(
                     deploy_opts.project_name,
                     &deployment_info.deployment_id,
                     &deployment_info.image_tag,
+                    command_output,
                 )
                 .await
             } else {
@@ -1228,9 +1270,14 @@ pub async fn create_deployment(
                     &registry_credentials,
                     deploy_opts.project_name,
                     &deployment_info.deployment_id,
+                    command_output,
                 )
                 .await?;
-                build::docker_push(&container_cli, &deployment_info.image_tag)
+                build::docker_push_with_output(
+                    &container_cli,
+                    &deployment_info.image_tag,
+                    command_output,
+                )
             };
             if let Err(e) = push_result {
                 report_failed_status(
@@ -1305,7 +1352,8 @@ pub async fn create_deployment(
             deploy_opts.build_args,
             deploy_opts.toml_config,
             backend_platform,
-        );
+        )
+        .with_output(command_output);
         log_platform_choice(&options.platform, options.platform_source, "Building");
 
         if !deploy_opts.build_args.separate_push {
@@ -1326,6 +1374,7 @@ pub async fn create_deployment(
                 &registry_credentials,
                 deploy_opts.project_name,
                 &deployment_info.deployment_id,
+                command_output,
             )
             .await?;
         }
@@ -1374,6 +1423,7 @@ pub async fn create_deployment(
                 deploy_opts.project_name,
                 &deployment_info.deployment_id,
                 &deployment_info.image_tag,
+                command_output,
             )
             .await
             {
@@ -1409,20 +1459,79 @@ pub async fn create_deployment(
         );
     }
     info!("  Deployment ID: {}", deployment_info.deployment_id);
-    println!();
+
+    if !deploy_opts.json_output {
+        println!();
+    }
 
     // Step 7: Follow deployment until completion
-    show_deployment(
+    let final_deployment = super::follow_ui::follow_deployment_with_ui(
         http_client,
         backend_url,
         config,
         deploy_opts.project_name,
         &deployment_info.deployment_id,
-        true,  // follow
-        "10m", // timeout
+        "10m",
+        deploy_opts.json_output,
     )
     .await?;
 
+    let deployment_json = if deploy_opts.json_output || deploy_opts.status_file.is_some() {
+        Some(
+            serde_json::to_string_pretty(&final_deployment)
+                .context("Failed to serialize deployment as JSON")?,
+        )
+    } else {
+        None
+    };
+
+    if let (Some(path), Some(json)) = (
+        deploy_opts.status_file.as_deref(),
+        deployment_json.as_deref(),
+    ) {
+        write_json_status_file(path, json)?;
+    }
+
+    if deploy_opts.json_output {
+        println!("{}", deployment_json.expect("JSON was serialized above"));
+    }
+
+    if final_deployment.status == DeploymentStatus::Failed {
+        if let Some(error) = final_deployment.error_message {
+            bail!("Deployment failed: {error}");
+        } else {
+            bail!("Deployment failed");
+        }
+    }
+
+    Ok(())
+}
+
+/// Write a complete JSON document without exposing a partially written file to
+/// readers such as CI jobs.
+pub(crate) fn write_json_status_file(path: &str, json: &str) -> Result<()> {
+    let path = Path::new(path);
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .context("Status file path must name a valid UTF-8 file")?;
+    let temporary_path = parent.join(format!(
+        ".{file_name}.{}.{}.tmp",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    ));
+
+    std::fs::write(&temporary_path, json)
+        .with_context(|| format!("Failed to write status file {}", path.display()))?;
+    if let Err(error) = std::fs::rename(&temporary_path, path) {
+        let _ = std::fs::remove_file(&temporary_path);
+        return Err(error)
+            .with_context(|| format!("Failed to replace status file {}", path.display()));
+    }
     Ok(())
 }
 /// Multi-container build path: builds every container with `[build]` set
@@ -1466,6 +1575,11 @@ async fn build_and_push_multi_container(
     // can't outlast a short-lived CI token. See #352.
     let token = token_with_retry(provider).await?;
     let backend_platform = fetch_backend_platform_hint(http_client, backend_url, &token).await?;
+    let command_output = if deploy_opts.json_output {
+        build::CommandOutput::Stderr
+    } else {
+        build::CommandOutput::Inherit
+    };
 
     update_deployment_status_with(
         http_client,
@@ -1527,7 +1641,8 @@ async fn build_and_push_multi_container(
             BuildPushMode::Deferred
         } else {
             BuildPushMode::Inline
-        });
+        })
+        .with_output(command_output);
         let container_cli = options.container_cli.command().to_string();
         // What the project asked for. `None` means the method was auto-detected
         // from the build context, and the detected value is resolved inside
@@ -1566,6 +1681,7 @@ async fn build_and_push_multi_container(
                     &fresh_creds,
                     deploy_opts.project_name,
                     &deployment_info.deployment_id,
+                    command_output,
                 )
                 .await?;
                 cached_creds = Some(TimedRegistryCredentials::new(fresh_creds, &container_cli));
@@ -1602,6 +1718,7 @@ async fn build_and_push_multi_container(
                 deploy_opts.project_name,
                 &deployment_info.deployment_id,
                 image_tag,
+                command_output,
             )
             .await
             {
@@ -1672,6 +1789,7 @@ async fn login_to_registry(
     credentials: &RegistryCredentials,
     project_name: &str,
     deployment_id: &str,
+    output: build::CommandOutput,
 ) -> Result<()> {
     let result = match credentials.auth_method {
         RegistryAuthMethod::LoginCredentials => {
@@ -1679,11 +1797,12 @@ async fn login_to_registry(
                 return Ok(()); // OCI client-auth: credentials managed by docker login
             }
             info!("Logging into registry");
-            build::docker_login(
+            build::docker_login_with_output(
                 container_cli,
                 &credentials.registry_url,
                 &credentials.username,
                 &credentials.password,
+                output,
             )
         }
         RegistryAuthMethod::RegistryToken => {
@@ -2782,7 +2901,7 @@ pub(super) async fn open_log_stream(
 mod tests {
     use super::{
         build_multi_container_payload, extract_log_event, normalize_git_url, token_with_retry,
-        ByteLineBuffer,
+        write_json_status_file, ByteLineBuffer,
     };
     use crate::token_source::{TokenProvider, TokenSource, TokenSourceError};
     use std::sync::{
@@ -3107,6 +3226,26 @@ mod tests {
         let (containers, routes) = build_multi_container_payload(Some(&config)).unwrap();
         assert!(containers.is_none());
         assert!(routes.is_empty());
+    }
+
+    #[test]
+    fn status_file_replacement_keeps_the_document_complete() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("deployment.json");
+        let path = path.to_str().unwrap();
+
+        write_json_status_file(path, r#"{"status":"Healthy"}"#).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(path).unwrap(),
+            r#"{"status":"Healthy"}"#
+        );
+
+        write_json_status_file(path, r#"{"status":"Failed"}"#).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(path).unwrap(),
+            r#"{"status":"Failed"}"#
+        );
+        assert_eq!(std::fs::read_dir(directory.path()).unwrap().count(), 1);
     }
 
     mod registry_credential_reuse {

--- a/src/cli/deployment/core.rs
+++ b/src/cli/deployment/core.rs
@@ -3,7 +3,7 @@ use comfy_table::{
     modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, Attribute, Cell, Color, Table,
 };
 use reqwest::Client;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::time::{Duration, Instant};
 use tracing::{debug, info, warn};
@@ -16,6 +16,54 @@ use crate::token_source::token_with_retry;
 pub use crate::api::models::{Deployment, DeploymentEvent, DeploymentStatus};
 // Multi-container request wire types (serialized into the create-deployment body).
 use crate::api::models::{ContainerSpec, RouteSpec};
+
+/// Stable, deliberately small payload emitted by `deploy --json` and
+/// `deployment list --json`.
+#[derive(Debug, Serialize, PartialEq)]
+struct DeploymentOutput {
+    deployment_id: String,
+    status: DeploymentStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    primary_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error_message: Option<String>,
+}
+
+impl From<&Deployment> for DeploymentOutput {
+    fn from(deployment: &Deployment) -> Self {
+        Self {
+            deployment_id: deployment.deployment_id.clone(),
+            status: deployment.status.clone(),
+            primary_url: deployment.primary_url.clone(),
+            error_message: deployment.error_message.clone(),
+        }
+    }
+}
+
+fn deployment_json(deployment: &Deployment) -> Result<String> {
+    serde_json::to_string_pretty(&DeploymentOutput::from(deployment))
+        .context("Failed to serialize deployment as JSON")
+}
+
+fn deployments_json(deployments: &[Deployment]) -> Result<String> {
+    let output: Vec<DeploymentOutput> = deployments.iter().map(DeploymentOutput::from).collect();
+    serde_json::to_string_pretty(&output).context("Failed to serialize deployments as JSON")
+}
+
+/// Output controls shared by commands that emit deployment JSON.
+#[derive(Clone, Copy)]
+pub struct DeploymentOutputOptions<'a> {
+    pub json: bool,
+    pub status_file: Option<&'a str>,
+}
+
+struct DeploymentContext<'a> {
+    http_client: &'a Client,
+    backend_url: &'a str,
+    provider: &'a crate::token_source::TokenProvider,
+    project_name: &'a str,
+    deployment_id: &'a str,
+}
 
 /// Convert the `[containers]` section of `rise.toml` into the typed request
 /// structs expected by `POST /deployments`. Returns `(None, [])` when the
@@ -297,8 +345,7 @@ pub async fn list_deployments(
     project: &str,
     group: Option<&str>,
     limit: usize,
-    json_output: bool,
-    status_file: Option<&str>,
+    output: DeploymentOutputOptions<'_>,
 ) -> Result<()> {
     let token = crate::token_source::resolve_token_with_retry(http_client, config).await?;
 
@@ -342,20 +389,17 @@ pub async fn list_deployments(
     // Limit results
     deployments.truncate(limit);
 
-    let deployments_json = if json_output || status_file.is_some() {
-        Some(
-            serde_json::to_string_pretty(&deployments)
-                .context("Failed to serialize deployments as JSON")?,
-        )
+    let deployments_json = if output.json || output.status_file.is_some() {
+        Some(deployments_json(&deployments)?)
     } else {
         None
     };
 
-    if let (Some(path), Some(json)) = (status_file, deployments_json.as_deref()) {
+    if let (Some(path), Some(json)) = (output.status_file, deployments_json.as_deref()) {
         write_json_status_file(path, json)?;
     }
 
-    if json_output {
+    if output.json {
         println!("{}", deployments_json.expect("JSON was serialized above"));
         return Ok(());
     }
@@ -816,39 +860,83 @@ async fn report_failed_status(
     }
 }
 
+/// Emit a minimal failure payload after a deployment has been created. The
+/// deployment ID and local error are always available; the API read adds the
+/// primary URL when the deployment record can be fetched.
+async fn emit_failed_deployment_output(
+    context: DeploymentContext<'_>,
+    json_output: bool,
+    status_file: Option<&str>,
+    error_message: &str,
+) {
+    if !json_output && status_file.is_none() {
+        return;
+    }
+
+    let primary_url = match try_token_or_log(context.provider).await {
+        Some(token) => match fetch_deployment(
+            context.http_client,
+            context.backend_url,
+            &token,
+            context.project_name,
+            context.deployment_id,
+        )
+        .await
+        {
+            Ok(deployment) => deployment.primary_url,
+            Err(error) => {
+                warn!(
+                    "Failed to fetch failed deployment for JSON output: {:?}",
+                    error
+                );
+                None
+            }
+        },
+        None => None,
+    };
+
+    let output = DeploymentOutput {
+        deployment_id: context.deployment_id.to_string(),
+        status: DeploymentStatus::Failed,
+        primary_url,
+        error_message: Some(error_message.to_string()),
+    };
+    let json = match serde_json::to_string_pretty(&output) {
+        Ok(json) => json,
+        Err(error) => {
+            warn!("Failed to serialize failed deployment as JSON: {:?}", error);
+            return;
+        }
+    };
+
+    if let Some(path) = status_file {
+        if let Err(error) = write_json_status_file(path, &json) {
+            warn!("Failed to write deployment status file: {:?}", error);
+        }
+    }
+    if json_output {
+        println!("{}", json);
+    }
+}
+
 /// Fetch fresh deployment registry credentials, log in, and push an already
 /// local image. Used by `--separate-push` so short-lived registry credentials
 /// are minted immediately before the push rather than before a long build.
 async fn push_with_fresh_registry_credentials(
-    http_client: &Client,
-    backend_url: &str,
-    provider: &crate::token_source::TokenProvider,
+    context: DeploymentContext<'_>,
     container_cli: &str,
-    project_name: &str,
-    deployment_id: &str,
     image_tag: &str,
     output: build::CommandOutput,
 ) -> Result<()> {
     let registry_credentials = fetch_deployment_registry_credentials(
-        http_client,
-        backend_url,
-        provider,
-        project_name,
-        deployment_id,
+        context.http_client,
+        context.backend_url,
+        context.provider,
+        context.project_name,
+        context.deployment_id,
     )
     .await?;
-    let token = token_with_retry(provider).await?;
-    login_to_registry(
-        http_client,
-        backend_url,
-        &token,
-        container_cli,
-        &registry_credentials,
-        project_name,
-        deployment_id,
-        output,
-    )
-    .await?;
+    login_to_registry(container_cli, &registry_credentials, output).await?;
     build::docker_push_with_output(container_cli, image_tag, output)
 }
 
@@ -1160,100 +1248,164 @@ pub async fn create_deployment(
         }
     });
 
-    if let Some(source_image) = &deploy_opts.image {
-        if deploy_opts.push_image {
-            // Push-image path: pull image locally, tag it, and push to Rise registry
-            info!(
-                "Pulling and pushing image '{}' to Rise registry",
-                source_image
-            );
+    let build_result: Result<()> = async {
+        if let Some(source_image) = &deploy_opts.image {
+            if deploy_opts.push_image {
+                // Push-image path: pull image locally, tag it, and push to Rise registry
+                info!(
+                    "Pulling and pushing image '{}' to Rise registry",
+                    source_image
+                );
 
-            // Determine container CLI from config/build args
-            let container_cli = match &deploy_opts.build_args.container_cli {
-                Some(cli) => cli.clone(),
-                None => config.get_container_cli().command().to_string(),
-            };
+                // Determine container CLI from config/build args
+                let container_cli = match &deploy_opts.build_args.container_cli {
+                    Some(cli) => cli.clone(),
+                    None => config.get_container_cli().command().to_string(),
+                };
 
-            // Pull the source image for the configured platform.
-            let backend_platform =
-                fetch_backend_platform_hint(http_client, backend_url, &token).await?;
-            let toml_platform = deploy_opts
-                .toml_config
-                .as_ref()
-                .and_then(|c| c.build.as_ref())
-                .and_then(|b| b.platform.as_deref());
-            let env = build::env_var_non_empty("RISE_PLATFORM");
-            let (platform, source) = build::resolve_platform(
-                deploy_opts.build_args.platform.as_deref(),
-                env.as_deref(),
-                toml_platform,
-                backend_platform,
-            );
-            log_platform_choice(&platform, source, "Pulling");
-            if let Err(e) = build::docker_pull_with_output(
-                &container_cli,
-                source_image,
-                &platform,
-                command_output,
-            ) {
-                report_failed_status(
-                    http_client,
-                    backend_url,
-                    &provider,
-                    deploy_opts.project_name,
-                    &deployment_info.deployment_id,
-                    &e.to_string(),
-                )
-                .await;
-                return Err(e);
-            }
-
-            // Tag it with the Rise registry image tag
-            if let Err(e) = build::docker_tag_with_output(
-                &container_cli,
-                source_image,
-                &deployment_info.image_tag,
-                command_output,
-            ) {
-                report_failed_status(
-                    http_client,
-                    backend_url,
-                    &provider,
-                    deploy_opts.project_name,
-                    &deployment_info.deployment_id,
-                    &e.to_string(),
-                )
-                .await;
-                return Err(e);
-            }
-
-            // Update status to Building (reusing existing state for push phase)
-            let token = token_with_retry(&provider).await?;
-            update_deployment_status(
-                http_client,
-                backend_url,
-                &token,
-                deploy_opts.project_name,
-                &deployment_info.deployment_id,
-                "Building",
-                None,
-            )
-            .await?;
-
-            // Push to Rise registry
-            let push_result = if deploy_opts.build_args.separate_push {
-                push_with_fresh_registry_credentials(
-                    http_client,
-                    backend_url,
-                    &provider,
+                // Pull the source image for the configured platform.
+                let backend_platform =
+                    fetch_backend_platform_hint(http_client, backend_url, &token).await?;
+                let toml_platform = deploy_opts
+                    .toml_config
+                    .as_ref()
+                    .and_then(|c| c.build.as_ref())
+                    .and_then(|b| b.platform.as_deref());
+                let env = build::env_var_non_empty("RISE_PLATFORM");
+                let (platform, source) = build::resolve_platform(
+                    deploy_opts.build_args.platform.as_deref(),
+                    env.as_deref(),
+                    toml_platform,
+                    backend_platform,
+                );
+                log_platform_choice(&platform, source, "Pulling");
+                build::docker_pull_with_output(
                     &container_cli,
-                    deploy_opts.project_name,
-                    &deployment_info.deployment_id,
+                    source_image,
+                    &platform,
+                    command_output,
+                )?;
+
+                // Tag it with the Rise registry image tag
+                build::docker_tag_with_output(
+                    &container_cli,
+                    source_image,
                     &deployment_info.image_tag,
                     command_output,
+                )?;
+
+                // Update status to Building (reusing existing state for push phase)
+                let token = token_with_retry(&provider).await?;
+                update_deployment_status(
+                    http_client,
+                    backend_url,
+                    &token,
+                    deploy_opts.project_name,
+                    &deployment_info.deployment_id,
+                    "Building",
+                    None,
                 )
-                .await
+                .await?;
+
+                // Push to Rise registry
+                let push_result = if deploy_opts.build_args.separate_push {
+                    push_with_fresh_registry_credentials(
+                        DeploymentContext {
+                            http_client,
+                            backend_url,
+                            provider: &provider,
+                            project_name: deploy_opts.project_name,
+                            deployment_id: &deployment_info.deployment_id,
+                        },
+                        &container_cli,
+                        &deployment_info.image_tag,
+                        command_output,
+                    )
+                    .await
+                } else {
+                    let registry_credentials = fetch_deployment_registry_credentials(
+                        http_client,
+                        backend_url,
+                        &provider,
+                        deploy_opts.project_name,
+                        &deployment_info.deployment_id,
+                    )
+                    .await?;
+                    login_to_registry(&container_cli, &registry_credentials, command_output)
+                        .await?;
+                    build::docker_push_with_output(
+                        &container_cli,
+                        &deployment_info.image_tag,
+                        command_output,
+                    )
+                };
+                push_result?;
+
+                // Mark as pushed (controller will take over deployment)
+                let token = token_with_retry(&provider).await?;
+                update_deployment_status(
+                    http_client,
+                    backend_url,
+                    &token,
+                    deploy_opts.project_name,
+                    &deployment_info.deployment_id,
+                    "Pushed",
+                    None,
+                )
+                .await?;
+
+                info!(
+                    "✓ Successfully pushed {} to {}",
+                    source_image, deployment_info.image_tag
+                );
             } else {
+                // Pre-built image path: Skip build/push, backend already marked as Pushed
+                info!("✓ Pre-built image deployment created");
+            }
+        } else if let Some(from_deployment) = &deploy_opts.from_deployment {
+            // Redeploy from existing deployment: Skip build/push, backend already marked as Pushed
+            info!(
+                "✓ Deployment created from existing deployment '{}' with {} environment variables",
+                from_deployment,
+                if deploy_opts.use_source_env_vars {
+                    "source"
+                } else {
+                    "current project"
+                }
+            );
+        } else if deployment_info.container_images.is_some() {
+            // Multi-container build path. The backend returned the resolved
+            // image tag for every container; we build/push each one in turn
+            // using its own `[containers.X.build]` config. Pre-built containers
+            // (the ones whose rise.toml entry sets `image = "..."`) are
+            // skipped — the backend already persisted their tag verbatim.
+            build_and_push_multi_container(
+                http_client,
+                backend_url,
+                &provider,
+                config,
+                &deploy_opts,
+                &deployment_info,
+            )
+            .await?;
+        } else {
+            // Build from source path: Execute build and push.
+            //
+            // Fetch platform hint and credentials for the build-from-source path.
+            let backend_platform =
+                fetch_backend_platform_hint(http_client, backend_url, &token).await?;
+            let options = BuildOptions::from_build_args(
+                config,
+                deployment_info.image_tag.clone(),
+                deploy_opts.path.to_string(),
+                deploy_opts.build_args,
+                deploy_opts.toml_config.clone(),
+                backend_platform,
+            )
+            .with_output(command_output);
+            log_platform_choice(&options.platform, options.platform_source, "Building");
+
+            if !deploy_opts.build_args.separate_push {
                 let registry_credentials = fetch_deployment_registry_credentials(
                     http_client,
                     backend_url,
@@ -1263,36 +1415,54 @@ pub async fn create_deployment(
                 )
                 .await?;
                 login_to_registry(
-                    http_client,
-                    backend_url,
-                    &token,
-                    &container_cli,
+                    options.container_cli.command(),
                     &registry_credentials,
-                    deploy_opts.project_name,
-                    &deployment_info.deployment_id,
                     command_output,
                 )
                 .await?;
-                build::docker_push_with_output(
+            }
+
+            // Step 3: Update status to 'building'
+            let token = token_with_retry(&provider).await?;
+            update_deployment_status_with(
+                http_client,
+                backend_url,
+                &token,
+                deploy_opts.project_name,
+                &deployment_info.deployment_id,
+                "Building",
+                None,
+                detect_git_provenance(),
+            )
+            .await?;
+
+            // Step 4: Build image. In separate-push mode, the build phase only
+            // loads locally; the caller refreshes auth and pushes explicitly.
+            let options = options.with_push_mode(if deploy_opts.build_args.separate_push {
+                BuildPushMode::Deferred
+            } else {
+                BuildPushMode::Inline
+            });
+            let container_cli = options.container_cli.command().to_string();
+
+            build::build_image(options)?;
+            if deploy_opts.build_args.separate_push {
+                push_with_fresh_registry_credentials(
+                    DeploymentContext {
+                        http_client,
+                        backend_url,
+                        provider: &provider,
+                        project_name: deploy_opts.project_name,
+                        deployment_id: &deployment_info.deployment_id,
+                    },
                     &container_cli,
                     &deployment_info.image_tag,
                     command_output,
                 )
-            };
-            if let Err(e) = push_result {
-                report_failed_status(
-                    http_client,
-                    backend_url,
-                    &provider,
-                    deploy_opts.project_name,
-                    &deployment_info.deployment_id,
-                    &e.to_string(),
-                )
-                .await;
-                return Err(e);
+                .await?;
             }
 
-            // Mark as pushed (controller will take over deployment)
+            // Step 5: Mark as pushed (controller will take over deployment)
             let token = token_with_retry(&provider).await?;
             update_deployment_status(
                 http_client,
@@ -1307,156 +1477,38 @@ pub async fn create_deployment(
 
             info!(
                 "✓ Successfully pushed {} to {}",
-                source_image, deployment_info.image_tag
+                deploy_opts.project_name, deployment_info.image_tag
             );
-        } else {
-            // Pre-built image path: Skip build/push, backend already marked as Pushed
-            info!("✓ Pre-built image deployment created");
         }
-    } else if let Some(from_deployment) = &deploy_opts.from_deployment {
-        // Redeploy from existing deployment: Skip build/push, backend already marked as Pushed
-        info!(
-            "✓ Deployment created from existing deployment '{}' with {} environment variables",
-            from_deployment,
-            if deploy_opts.use_source_env_vars {
-                "source"
-            } else {
-                "current project"
-            }
-        );
-    } else if deployment_info.container_images.is_some() {
-        // Multi-container build path. The backend returned the resolved
-        // image tag for every container; we build/push each one in turn
-        // using its own `[containers.X.build]` config. Pre-built containers
-        // (the ones whose rise.toml entry sets `image = "..."`) are
-        // skipped — the backend already persisted their tag verbatim.
-        build_and_push_multi_container(
+        Ok(())
+    }
+    .await;
+
+    if let Err(error) = build_result {
+        let error_message = error.to_string();
+        report_failed_status(
             http_client,
             backend_url,
             &provider,
-            config,
-            &deploy_opts,
-            &deployment_info,
-        )
-        .await?;
-    } else {
-        // Build from source path: Execute build and push.
-        //
-        // Fetch platform hint and credentials for the build-from-source path.
-        let backend_platform =
-            fetch_backend_platform_hint(http_client, backend_url, &token).await?;
-        let options = BuildOptions::from_build_args(
-            config,
-            deployment_info.image_tag.clone(),
-            deploy_opts.path.to_string(),
-            deploy_opts.build_args,
-            deploy_opts.toml_config,
-            backend_platform,
-        )
-        .with_output(command_output);
-        log_platform_choice(&options.platform, options.platform_source, "Building");
-
-        if !deploy_opts.build_args.separate_push {
-            let registry_credentials = fetch_deployment_registry_credentials(
-                http_client,
-                backend_url,
-                &provider,
-                deploy_opts.project_name,
-                &deployment_info.deployment_id,
-            )
-            .await?;
-            let token = token_with_retry(&provider).await?;
-            login_to_registry(
-                http_client,
-                backend_url,
-                &token,
-                options.container_cli.command(),
-                &registry_credentials,
-                deploy_opts.project_name,
-                &deployment_info.deployment_id,
-                command_output,
-            )
-            .await?;
-        }
-
-        // Step 3: Update status to 'building'
-        let token = token_with_retry(&provider).await?;
-        update_deployment_status_with(
-            http_client,
-            backend_url,
-            &token,
             deploy_opts.project_name,
             &deployment_info.deployment_id,
-            "Building",
-            None,
-            detect_git_provenance(),
+            &error_message,
         )
-        .await?;
-
-        // Step 4: Build image. In separate-push mode, the build phase only
-        // loads locally; the caller refreshes auth and pushes explicitly.
-        let options = options.with_push_mode(if deploy_opts.build_args.separate_push {
-            BuildPushMode::Deferred
-        } else {
-            BuildPushMode::Inline
-        });
-        let container_cli = options.container_cli.command().to_string();
-
-        if let Err(e) = build::build_image(options) {
-            report_failed_status(
+        .await;
+        emit_failed_deployment_output(
+            DeploymentContext {
                 http_client,
                 backend_url,
-                &provider,
-                deploy_opts.project_name,
-                &deployment_info.deployment_id,
-                &e.to_string(),
-            )
-            .await;
-            return Err(e);
-        }
-        if deploy_opts.build_args.separate_push {
-            if let Err(e) = push_with_fresh_registry_credentials(
-                http_client,
-                backend_url,
-                &provider,
-                &container_cli,
-                deploy_opts.project_name,
-                &deployment_info.deployment_id,
-                &deployment_info.image_tag,
-                command_output,
-            )
-            .await
-            {
-                report_failed_status(
-                    http_client,
-                    backend_url,
-                    &provider,
-                    deploy_opts.project_name,
-                    &deployment_info.deployment_id,
-                    &e.to_string(),
-                )
-                .await;
-                return Err(e);
-            }
-        }
-
-        // Step 5: Mark as pushed (controller will take over deployment)
-        let token = token_with_retry(&provider).await?;
-        update_deployment_status(
-            http_client,
-            backend_url,
-            &token,
-            deploy_opts.project_name,
-            &deployment_info.deployment_id,
-            "Pushed",
-            None,
+                provider: &provider,
+                project_name: deploy_opts.project_name,
+                deployment_id: &deployment_info.deployment_id,
+            },
+            deploy_opts.json_output,
+            deploy_opts.status_file.as_deref(),
+            &error_message,
         )
-        .await?;
-
-        info!(
-            "✓ Successfully pushed {} to {}",
-            deploy_opts.project_name, deployment_info.image_tag
-        );
+        .await;
+        return Err(error);
     }
     info!("  Deployment ID: {}", deployment_info.deployment_id);
 
@@ -1477,10 +1529,7 @@ pub async fn create_deployment(
     .await?;
 
     let deployment_json = if deploy_opts.json_output || deploy_opts.status_file.is_some() {
-        Some(
-            serde_json::to_string_pretty(&final_deployment)
-                .context("Failed to serialize deployment as JSON")?,
-        )
+        Some(deployment_json(&final_deployment)?)
     } else {
         None
     };
@@ -1672,18 +1721,7 @@ async fn build_and_push_multi_container(
                     &deployment_info.deployment_id,
                 )
                 .await?;
-                let token = token_with_retry(provider).await?;
-                login_to_registry(
-                    http_client,
-                    backend_url,
-                    &token,
-                    &container_cli,
-                    &fresh_creds,
-                    deploy_opts.project_name,
-                    &deployment_info.deployment_id,
-                    command_output,
-                )
-                .await?;
+                login_to_registry(&container_cli, &fresh_creds, command_output).await?;
                 cached_creds = Some(TimedRegistryCredentials::new(fresh_creds, &container_cli));
             }
         }
@@ -1694,16 +1732,7 @@ async fn build_and_push_multi_container(
         let build_started = Instant::now();
         if let Err(e) = build::build_image(options) {
             let msg = format!("Build of container '{}' failed: {}", container.name, e);
-            report_failed_status(
-                http_client,
-                backend_url,
-                provider,
-                deploy_opts.project_name,
-                &deployment_info.deployment_id,
-                &msg,
-            )
-            .await;
-            return Err(e);
+            return Err(e).context(msg);
         }
         let build_ms = build_started.elapsed().as_millis() as u64;
 
@@ -1711,28 +1740,21 @@ async fn build_and_push_multi_container(
         let push_started = Instant::now();
         if deploy_opts.build_args.separate_push {
             if let Err(e) = push_with_fresh_registry_credentials(
-                http_client,
-                backend_url,
-                provider,
+                DeploymentContext {
+                    http_client,
+                    backend_url,
+                    provider,
+                    project_name: deploy_opts.project_name,
+                    deployment_id: &deployment_info.deployment_id,
+                },
                 &container_cli,
-                deploy_opts.project_name,
-                &deployment_info.deployment_id,
                 image_tag,
                 command_output,
             )
             .await
             {
                 let msg = format!("Push of container '{}' failed: {}", container.name, e);
-                report_failed_status(
-                    http_client,
-                    backend_url,
-                    provider,
-                    deploy_opts.project_name,
-                    &deployment_info.deployment_id,
-                    &msg,
-                )
-                .await;
-                return Err(e);
+                return Err(e).context(msg);
             }
             push_ms = Some(push_started.elapsed().as_millis() as u64);
         }
@@ -1780,15 +1802,10 @@ async fn build_and_push_multi_container(
     Ok(())
 }
 
-/// Login to the container registry, marking the deployment as Failed on error.
+/// Login to the container registry.
 async fn login_to_registry(
-    http_client: &Client,
-    backend_url: &str,
-    token: &str,
     container_cli: &str,
     credentials: &RegistryCredentials,
-    project_name: &str,
-    deployment_id: &str,
     output: build::CommandOutput,
 ) -> Result<()> {
     let result = match credentials.auth_method {
@@ -1819,20 +1836,7 @@ async fn login_to_registry(
         }
     };
 
-    if let Err(e) = result {
-        update_deployment_status(
-            http_client,
-            backend_url,
-            token,
-            project_name,
-            deployment_id,
-            "Failed",
-            Some(&e.to_string()),
-        )
-        .await?;
-        return Err(e);
-    }
-    Ok(())
+    result
 }
 
 /// Read an environment variable, returning `None` when it is unset or empty.
@@ -2900,8 +2904,9 @@ pub(super) async fn open_log_stream(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_multi_container_payload, extract_log_event, normalize_git_url, token_with_retry,
-        write_json_status_file, ByteLineBuffer,
+        build_multi_container_payload, deployment_json, deployments_json, extract_log_event,
+        normalize_git_url, token_with_retry, write_json_status_file, ByteLineBuffer, Deployment,
+        DeploymentStatus,
     };
     use crate::token_source::{TokenProvider, TokenSource, TokenSourceError};
     use std::sync::{
@@ -3246,6 +3251,49 @@ mod tests {
             r#"{"status":"Failed"}"#
         );
         assert_eq!(std::fs::read_dir(directory.path()).unwrap().count(), 1);
+    }
+
+    #[test]
+    fn deployment_json_contains_only_the_minimal_ci_fields() {
+        let deployment = Deployment {
+            deployment_id: "dep-123".to_string(),
+            status: DeploymentStatus::Healthy,
+            primary_url: Some("https://dep.example.com".to_string()),
+            error_message: None,
+            ..Default::default()
+        };
+
+        let json: serde_json::Value =
+            serde_json::from_str(&deployment_json(&deployment).unwrap()).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "deployment_id": "dep-123",
+                "status": "Healthy",
+                "primary_url": "https://dep.example.com"
+            })
+        );
+    }
+
+    #[test]
+    fn deployments_json_includes_failure_details_without_unrelated_fields() {
+        let deployment = Deployment {
+            deployment_id: "dep-456".to_string(),
+            status: DeploymentStatus::Failed,
+            error_message: Some("image build failed".to_string()),
+            ..Default::default()
+        };
+
+        let json: serde_json::Value =
+            serde_json::from_str(&deployments_json(&[deployment]).unwrap()).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!([{
+                "deployment_id": "dep-456",
+                "status": "Failed",
+                "error_message": "image build failed"
+            }])
+        );
     }
 
     mod registry_credential_reuse {

--- a/src/cli/deployment/follow_ui.rs
+++ b/src/cli/deployment/follow_ui.rs
@@ -638,6 +638,7 @@ pub async fn follow_deployment_with_ui(
     project: &str,
     deployment_id: &str,
     timeout_str: &str,
+    quiet: bool,
 ) -> Result<Deployment> {
     // The follow/poll loop can run for up to ~10 minutes, so resolve a fresh
     // token before each request rather than capturing one up front: in CI the
@@ -647,6 +648,19 @@ pub async fn follow_deployment_with_ui(
 
     let timeout = parse_duration(timeout_str)?;
     let start_time = Instant::now();
+
+    if quiet {
+        return follow_deployment_quiet(
+            http_client,
+            backend_url,
+            &provider,
+            project,
+            deployment_id,
+            timeout,
+            start_time,
+        )
+        .await;
+    }
 
     // Check if we're in a TTY - if not, fall back to simple mode
     if !is_tty() {
@@ -765,6 +779,36 @@ pub async fn follow_deployment_with_ui(
     }
 
     Ok(final_deployment)
+}
+
+/// Follow a deployment without writing progress to stdout.
+async fn follow_deployment_quiet(
+    http_client: &Client,
+    backend_url: &str,
+    provider: &crate::token_source::TokenProvider,
+    project: &str,
+    deployment_id: &str,
+    timeout: Duration,
+    start_time: Instant,
+) -> Result<Deployment> {
+    loop {
+        let token = token_with_retry(provider).await?;
+        let deployment =
+            fetch_deployment(http_client, backend_url, &token, project, deployment_id).await?;
+
+        if is_terminal_state(&deployment.status) {
+            return Ok(deployment);
+        }
+
+        if start_time.elapsed() >= timeout {
+            bail!(
+                "Timeout waiting for deployment to complete after {:?}",
+                timeout
+            );
+        }
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
 }
 
 /// Simple fallback for non-TTY environments (pipes, redirects)

--- a/src/cli/deployment/mod.rs
+++ b/src/cli/deployment/mod.rs
@@ -3,5 +3,5 @@ mod follow_ui;
 
 pub use core::{
     create_deployment, get_logs, list_deployments, show_deployment, stop_deployments_by_group,
-    DeploymentOptions, EnvOverride, GetLogsParams,
+    DeploymentOptions, DeploymentOutputOptions, EnvOverride, GetLogsParams,
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,6 +164,12 @@ struct DeployArgs {
     /// Memory allocation (e.g., "256Mi", "1Gi") — sets both K8s request and limit (overrides rise.toml)
     #[arg(long)]
     memory: Option<String>,
+    /// Emit the completed deployment as JSON on stdout.
+    #[arg(long)]
+    json: bool,
+    /// Write the completed deployment JSON to this file.
+    #[arg(long, value_name = "PATH")]
+    status_file: Option<String>,
     #[command(flatten)]
     build_args: build::BuildArgs,
 }
@@ -635,6 +641,12 @@ enum DeploymentCommands {
         /// Limit number of deployments to show
         #[arg(long, short, default_value = "10")]
         limit: usize,
+        /// Emit deployments as a JSON array on stdout.
+        #[arg(long)]
+        json: bool,
+        /// Write the deployments JSON array to this file.
+        #[arg(long, value_name = "PATH")]
+        status_file: Option<String>,
     },
     /// Show deployment details
     #[command(visible_alias = "s")]
@@ -1637,6 +1649,8 @@ async fn main() -> Result<()> {
                         replicas,
                         cpu,
                         memory,
+                        json_output: args.json,
+                        status_file: args.status_file.clone(),
                     },
                 )
                 .await?;
@@ -1646,6 +1660,8 @@ async fn main() -> Result<()> {
                 path,
                 group,
                 limit,
+                json,
+                status_file,
             } => {
                 let project_name = resolve_project_name(project.clone(), path)?;
                 deployment::list_deployments(
@@ -1655,6 +1671,8 @@ async fn main() -> Result<()> {
                     &project_name,
                     group.as_deref(),
                     *limit,
+                    *json,
+                    status_file.as_deref(),
                 )
                 .await?;
             }
@@ -2260,5 +2278,54 @@ mod log_color_tests {
     fn an_unrecognised_override_defers_rather_than_forcing() {
         assert!(!ansi_enabled(Some("banana"), Some("1"), true));
         assert!(ansi_enabled(Some("banana"), None, false));
+    }
+}
+
+#[cfg(all(test, feature = "cli"))]
+mod deployment_output_cli_tests {
+    use super::{Cli, Commands, DeploymentCommands};
+    use clap::Parser;
+
+    #[test]
+    fn deploy_accepts_json_and_status_file_flags() {
+        let cli = Cli::try_parse_from([
+            "rise",
+            "deploy",
+            "--json",
+            "--status-file",
+            "deployment.json",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Deploy { args } => {
+                assert!(args.json);
+                assert_eq!(args.status_file.as_deref(), Some("deployment.json"));
+            }
+            _ => panic!("expected deploy command"),
+        }
+    }
+
+    #[test]
+    fn deployment_list_accepts_json_and_status_file_flags() {
+        let cli = Cli::try_parse_from([
+            "rise",
+            "deployment",
+            "list",
+            "--json",
+            "--status-file",
+            "deployments.json",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Deployment(DeploymentCommands::List {
+                json, status_file, ..
+            }) => {
+                assert!(json);
+                assert_eq!(status_file.as_deref(), Some("deployments.json"));
+            }
+            _ => panic!("expected deployment list command"),
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1671,8 +1671,10 @@ async fn main() -> Result<()> {
                     &project_name,
                     group.as_deref(),
                     *limit,
-                    *json,
-                    status_file.as_deref(),
+                    deployment::DeploymentOutputOptions {
+                        json: *json,
+                        status_file: status_file.as_deref(),
+                    },
                 )
                 .await?;
             }


### PR DESCRIPTION
## Summary
Adds CI-friendly JSON output to `rise deploy` and `rise deployment list`, plus `--status-file <PATH>` for atomically writing deployment results. The JSON payload is deliberately minimal: `deployment_id`, `status`, optional `primary_url`, and optional `error_message`. Deploy output waits for a terminal deployment state, keeps build command output on stderr, and emits failed JSON after post-creation build or push errors.

## Test plan
- `RUSTC_WRAPPER= cargo test --features cli` — 180 passed
- `RUSTC_WRAPPER= cargo clippy --features cli --all-targets -- -D warnings`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rise-deploy/codesmith/rise/pr/481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790860101&installation_model_id=432987&pr_number=481&repository=rise-deploy%2Frise&return_to=https%3A%2F%2Fgithub.com%2Frise-deploy%2Frise%2Fpull%2F481&signature=69ad890f24b25d141409907ce23c4d9ee82b6a99a95e67e9728c725089934b95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->