### PR TITLE
Make env export shell-safe

### DIFF
--- a/docs/user/src/content/docs/user-guide/getting-started.md
+++ b/docs/user/src/content/docs/user-guide/getting-started.md
@@ -173,13 +173,14 @@ rise run --project my-app --http-port 3000
 **Run your app directly** with Rise env vars exported to your shell (no image build needed):
 
 ```bash
+eval "$(rise env export -p my-app)"
+npm run dev
+# Or save the commands and source them later:
 rise env export -p my-app > .env.rise
-# then load with your preferred tool, e.g.:
-export $(cat .env.rise | xargs)
-# or: direnv, dotenv, etc.
+source .env.rise
 ```
 
-`rise env export` fetches the resolved set of non-secret environment variables Rise would inject into a deployment, letting you run your app natively without Docker. This is useful when your local dev workflow builds and runs the app directly (e.g. `cargo run`, `npm run dev`).
+`rise env export` fetches the resolved set of loadable environment variables Rise would inject into a deployment as shell-safe `export` commands, letting you run your app natively without Docker. Protected secrets are omitted. This is useful when your local dev workflow builds and runs the app directly (e.g. `cargo run`, `npm run dev`).
 
 Note that variables sourced from extensions (e.g., database credentials from the RDS extension) are not included — use a local database for development instead.
 

--- a/docs/user/src/content/docs/user-guide/local-development.md
+++ b/docs/user/src/content/docs/user-guide/local-development.md
@@ -177,13 +177,14 @@ rise build myapp:latest --push
 If your workflow runs the app directly (e.g. `cargo run`, `npm run dev`) rather than in a container, use `rise env export` to inject Rise's environment variables into your shell:
 
 ```bash
+eval "$(rise env export -p my-app)"
+npm run dev
+# Or save the commands and source them later:
 rise env export -p my-app > .env.rise
-# Load with your preferred tool:
-export $(cat .env.rise | xargs)
-# or: source .env.rise, direnv, dotenv, etc.
+source .env.rise
 ```
 
-`rise env export` outputs the resolved set of non-secret environment variables — `PORT`, `RISE_ISSUER`, `RISE_APP_URL`, `RISE_APP_URLS`, and any user-set project variables. No image build is required.
+`rise env export` outputs shell-safe `export` commands for the resolved set of loadable environment variables — `PORT`, `RISE_ISSUER`, `RISE_APP_URL`, `RISE_APP_URLS`, and any user-set project variables. Protected secrets are omitted. No image build is required.
 
 :::note
 Variables from extensions (e.g., RDS database credentials) are protected secrets and are not included. Use a local database instead and override `DATABASE_URL` in your shell.

--- a/skills/rise-app-builder/reference/cli-cheatsheet.md
+++ b/skills/rise-app-builder/reference/cli-cheatsheet.md
@@ -144,7 +144,7 @@ Valid colors: `green`, `blue`, `yellow`, `red`, `purple`, `orange`, `gray`.
 | `rise env get <key>` | `g` | `-p`, `--path`, `-E/--environment` |
 | `rise env delete <key>` | `unset`, `rm`, `del` | `-p`, `--path`, `-E/--environment` |
 | `rise env import <file>` | `i` | `-p`, `--path`, `-E/--environment`. Format: `KEY=value` or `KEY=secret:value` |
-| `rise env export` | `x` | `-p`, `--path`, `-E/--environment`. Outputs `KEY=value` dotfile format |
+| `rise env export` | `x` | `-p`, `--path`, `-E/--environment`. Outputs shell-safe `export KEY=value` commands |
 
 Without `-E`, variables are global (apply to all environments). With `-E`, scoped to that environment (merged on top of globals).
 

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -617,10 +617,29 @@ pub async fn list_deployment_env(
     Ok(())
 }
 
-/// Export environment variables in dotfile format (KEY=value per line).
+/// Quote a value as a POSIX shell single-quoted string.
+fn shell_quote(value: &str) -> anyhow::Result<String> {
+    if value.contains('\0') {
+        anyhow::bail!("Environment variable values cannot contain NUL bytes")
+    }
+
+    Ok(format!("'{}'", value.replace('\'', "'\\''")))
+}
+
+/// Check whether a key can be exported by a POSIX-compatible shell.
+fn is_shell_identifier(key: &str) -> bool {
+    let mut chars = key.chars();
+    matches!(
+        chars.next(),
+        Some(c) if c.is_ascii_alphabetic() || c == '_'
+    ) && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Export environment variables as shell commands (`export KEY='value'`).
 ///
-/// Output goes to stdout for clean piping (`rise env export > .env` or
-/// `eval $(rise env export)`). Warnings about protected secrets go to stderr.
+/// Output goes to stdout for clean piping (`eval "$(rise env export)"` or
+/// `rise env export > .env.rise && source .env.rise`). Warnings about protected
+/// secrets go to stderr.
 pub async fn export_env(
     http_client: &Client,
     backend_url: &str,
@@ -638,6 +657,16 @@ pub async fn export_env(
     )
     .await?;
 
+    for (key, value) in &loadable_vars {
+        if !is_shell_identifier(key) {
+            anyhow::bail!(
+                "Cannot export environment variable '{}': the key is not a valid shell identifier",
+                key
+            );
+        }
+        shell_quote(value)?;
+    }
+
     if !protected_keys.is_empty() {
         eprintln!(
             "warning: {} protected secret{} excluded (cannot be exported):",
@@ -650,7 +679,7 @@ pub async fn export_env(
     }
 
     for (key, value) in &loadable_vars {
-        println!("{}={}", key, value);
+        println!("export {}={}", key, shell_quote(value)?);
     }
 
     Ok(())
@@ -658,7 +687,36 @@ pub async fn export_env(
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_env_file, parse_env_string};
+    use super::{is_shell_identifier, parse_env_file, parse_env_string, shell_quote};
+
+    #[test]
+    fn shell_quote_preserves_shell_significant_values() {
+        assert_eq!(shell_quote("").unwrap(), "''");
+        assert_eq!(shell_quote("hello world").unwrap(), "'hello world'");
+        assert_eq!(shell_quote("it's").unwrap(), "'it'\\''s'");
+        assert_eq!(
+            shell_quote("line one\nline two").unwrap(),
+            "'line one\nline two'"
+        );
+        assert_eq!(
+            shell_quote("$(touch /tmp/pwned); *.txt").unwrap(),
+            "'$(touch /tmp/pwned); *.txt'"
+        );
+    }
+
+    #[test]
+    fn shell_quote_rejects_nul_bytes() {
+        assert!(shell_quote("before\0after").is_err());
+    }
+
+    #[test]
+    fn shell_identifier_requires_portable_variable_name() {
+        assert!(is_shell_identifier("FOO_2"));
+        assert!(is_shell_identifier("_private"));
+        assert!(!is_shell_identifier("2FOO"));
+        assert!(!is_shell_identifier("foo.bar"));
+        assert!(!is_shell_identifier("foo-bar"));
+    }
 
     #[test]
     fn parse_env_string_rejects_empty_keys() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -862,7 +862,7 @@ enum EnvCommands {
         #[arg(long, short = 'E')]
         environment: Option<String>,
     },
-    /// Export resolved environment variables in dotfile format (KEY=value)
+    /// Export resolved environment variables as shell export commands
     #[command(visible_alias = "x")]
     Export {
         /// Project name (optional if rise.toml contains [project] section)


### PR DESCRIPTION
## Summary

`rise env export` emits shell-safe `export KEY='value'` commands so values containing spaces, quotes, newlines, or shell metacharacters remain intact when loaded with `eval \"$(rise env export)\"` or sourced from a file. Shell-incompatible keys and NUL-containing values fail before any output is emitted. The CLI reference and local-development guides document the sourceable output format.

## Test plan

- [x] `RUSTC_WRAPPER= cargo test --package rise-deploy`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rise-deploy/codesmith/rise/pr/484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790867581&installation_model_id=432987&pr_number=484&repository=rise-deploy%2Frise&return_to=https%3A%2F%2Fgithub.com%2Frise-deploy%2Frise%2Fpull%2F484&signature=a68cb3effb1fcb5be04c5d22ce2642eed99790bf84d74af8c962c767657285f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->