### PR TITLE
Allow additional control-plane secret environment variables

### DIFF
--- a/modules/rise-ecs/README.md
+++ b/modules/rise-ecs/README.md
@@ -177,6 +177,28 @@ module "rise_ecs" {
 }
 ```
 
+Use `control_plane_secret_environment` for credentials referenced through Rise
+configuration expansion. Keys are control-plane environment-variable names;
+values are full Secrets Manager ARNs in the format ECS accepts, including the
+optional JSON-key, version-stage and version-id selectors. The five built-in
+names—those four plus `RISE_LOCAL_CONFIG_YAML`—are reserved.
+
+```hcl
+module "rise_ecs" {
+  # ...
+  control_plane_secret_environment = {
+    SNOWFLAKE_OAUTH_PRIVATE_KEY = "${aws_secretsmanager_secret.snowflake_oauth.arn}:private_key::"
+  }
+}
+```
+
+The corresponding YAML can use `${SNOWFLAKE_OAUTH_PRIVATE_KEY}`. ECS resolves
+the selected secret value before Rise starts, and Rise expands the environment
+reference while loading its configuration. `rise_task_secrets` retains the
+complete `valueFrom` reference. `secret_arns_for_execution_role` strips any ECS
+selectors to the base secret ARN and deduplicates additional references to the
+same secret for IAM.
+
 **Generated source values remain in Terraform state.** The database password,
 JWT signing key and encryption key are outputs of persistent `random` resources;
 an OIDC client secret supplied as an ordinary Terraform input can also reach the

--- a/modules/rise-ecs/locals.tf
+++ b/modules/rise-ecs/locals.tf
@@ -97,13 +97,27 @@ locals {
   # plane's environment and Traefik labels look like on ECS.
   rise_environment = module.control_plane_env.environment
 
-  control_plane_secrets = concat([
-    { name = "DATABASE_URL", valueFrom = local.database_url_secret_arn },
-    { name = "RISE_JWT_SIGNING_SECRET", valueFrom = aws_secretsmanager_secret.jwt_signing_secret.arn },
-    { name = "RISE_ENCRYPTION_KEY", valueFrom = aws_secretsmanager_secret.encryption_key.arn },
-    { name = "OIDC_CLIENT_SECRET", valueFrom = aws_secretsmanager_secret.oidc_client_secret.arn },
-    ], var.control_plane_local_config_secret_arn == null ? [] : [
-    { name = "RISE_LOCAL_CONFIG_YAML", valueFrom = var.control_plane_local_config_secret_arn },
+  control_plane_builtin_secret_environment = merge({
+    DATABASE_URL            = local.database_url_secret_arn
+    RISE_JWT_SIGNING_SECRET = aws_secretsmanager_secret.jwt_signing_secret.arn
+    RISE_ENCRYPTION_KEY     = aws_secretsmanager_secret.encryption_key.arn
+    OIDC_CLIENT_SECRET      = aws_secretsmanager_secret.oidc_client_secret.arn
+    }, var.control_plane_local_config_secret_arn == null ? {} : {
+    RISE_LOCAL_CONFIG_YAML = var.control_plane_local_config_secret_arn
+  })
+  control_plane_secret_environment = merge(
+    local.control_plane_builtin_secret_environment,
+    var.control_plane_secret_environment,
+  )
+  control_plane_secrets = [
+    for name, value_from in local.control_plane_secret_environment : {
+      name      = name
+      valueFrom = value_from
+    }
+  ]
+  control_plane_additional_secret_arns = distinct([
+    for value_from in values(var.control_plane_secret_environment) :
+    join(":", slice(split(":", value_from), 0, 7))
   ])
 }
 

--- a/modules/rise-ecs/outputs.tf
+++ b/modules/rise-ecs/outputs.tf
@@ -102,15 +102,8 @@ output "rise_task_environment" {
 }
 
 output "rise_task_secrets" {
-  description = "Secrets Manager ARNs to inject as environment variables, keyed by variable name."
-  value = merge({
-    DATABASE_URL            = local.database_url_secret_arn
-    RISE_JWT_SIGNING_SECRET = aws_secretsmanager_secret.jwt_signing_secret.arn
-    RISE_ENCRYPTION_KEY     = aws_secretsmanager_secret.encryption_key.arn
-    OIDC_CLIENT_SECRET      = aws_secretsmanager_secret.oidc_client_secret.arn
-    }, var.control_plane_local_config_secret_arn == null ? {} : {
-    RISE_LOCAL_CONFIG_YAML = var.control_plane_local_config_secret_arn
-  })
+  description = "Secrets Manager valueFrom references injected as environment variables, keyed by variable name."
+  value       = local.control_plane_secret_environment
 }
 
 output "secret_arns_for_execution_role" {
@@ -119,14 +112,16 @@ output "secret_arns_for_execution_role" {
     read them. Secrets Manager appends a random suffix to every ARN, so these
     are exact ARNs rather than patterns.
   EOT
-  value = compact([
+  value = concat([
     local.database_url_secret_arn,
     aws_secretsmanager_secret.jwt_signing_secret.arn,
     aws_secretsmanager_secret.encryption_key.arn,
     aws_secretsmanager_secret.oidc_client_secret.arn,
+    ], var.repository_credentials_secret_arn == null ? [] : [
     var.repository_credentials_secret_arn,
+    ], var.control_plane_local_config_secret_arn == null ? [] : [
     var.control_plane_local_config_secret_arn,
-  ])
+  ], local.control_plane_additional_secret_arns)
 }
 
 output "database_endpoint" {

--- a/modules/rise-ecs/tests/guardrails.tftest.hcl
+++ b/modules/rise-ecs/tests/guardrails.tftest.hcl
@@ -91,6 +91,30 @@ run "rejects_noncanonical_idp_group_sync_prefixes" {
   expect_failures = [var.idp_group_sync_prefixes]
 }
 
+run "rejects_an_additional_secret_that_overrides_a_builtin" {
+  command = plan
+
+  variables {
+    control_plane_secret_environment = {
+      DATABASE_URL = "arn:aws:secretsmanager:eu-central-1:123456789012:secret:rise/database-url-abc123"
+    }
+  }
+
+  expect_failures = [var.control_plane_secret_environment]
+}
+
+run "rejects_an_additional_secret_without_a_full_arn" {
+  command = plan
+
+  variables {
+    control_plane_secret_environment = {
+      SNOWFLAKE_OAUTH_PRIVATE_KEY = "rise/snowflake-oauth"
+    }
+  }
+
+  expect_failures = [var.control_plane_secret_environment]
+}
+
 # VPC endpoints reach AWS services only. Traefik's HTTP-01 challenge needs
 # Let's Encrypt, so the certificate would silently never arrive.
 run "rejects_acme_without_internet_egress" {

--- a/modules/rise-ecs/tests/plan.tftest.hcl
+++ b/modules/rise-ecs/tests/plan.tftest.hcl
@@ -145,6 +145,39 @@ run "loads_a_secret_local_config_overlay" {
   }
 }
 
+run "injects_additional_control_plane_secrets" {
+  command = plan
+
+  variables {
+    control_plane_secret_environment = {
+      SNOWFLAKE_OAUTH_PRIVATE_KEY = "arn:aws:secretsmanager:eu-central-1:123456789012:secret:rise/snowflake-oauth-abc123:private_key:AWSCURRENT:"
+      SHARED_SECRET_COPY          = "arn:aws:secretsmanager:eu-central-1:123456789012:secret:rise/snowflake-oauth-abc123"
+    }
+  }
+
+  assert {
+    condition = one([
+      for secret in local.control_plane_secrets :
+      secret.valueFrom
+      if secret.name == "SNOWFLAKE_OAUTH_PRIVATE_KEY"
+    ]) == "arn:aws:secretsmanager:eu-central-1:123456789012:secret:rise/snowflake-oauth-abc123:private_key:AWSCURRENT:"
+    error_message = "additional secrets must reach the task with ECS selectors intact"
+  }
+
+  assert {
+    condition     = output.rise_task_secrets["SNOWFLAKE_OAUTH_PRIVATE_KEY"] == "arn:aws:secretsmanager:eu-central-1:123456789012:secret:rise/snowflake-oauth-abc123:private_key:AWSCURRENT:"
+    error_message = "module outputs must expose additional task secret references"
+  }
+
+  assert {
+    condition = (
+      length(output.secret_arns_for_execution_role) == 5
+      && output.secret_arns_for_execution_role[4] == "arn:aws:secretsmanager:eu-central-1:123456789012:secret:rise/snowflake-oauth-abc123"
+    )
+    error_message = "execution-role output must contain each base secret ARN once"
+  }
+}
+
 run "uses_an_external_traefik_role_without_creating_iam" {
   command = plan
 

--- a/modules/rise-ecs/variables.tf
+++ b/modules/rise-ecs/variables.tf
@@ -459,6 +459,43 @@ variable "control_plane_local_config_secret_arn" {
   default     = null
 }
 
+variable "control_plane_secret_environment" {
+  description = <<-EOT
+    Additional Secrets Manager values to inject into the Rise control-plane
+    container, keyed by environment-variable name. Each value must be a full
+    Secrets Manager secret ARN, optionally followed by the three ECS selector
+    segments for JSON key, version stage and version id.
+
+    The module exposes each base secret ARN through
+    secret_arns_for_execution_role. Names reserved for the module's built-in
+    secrets cannot be overridden.
+  EOT
+  type        = map(string)
+  default     = {}
+
+  validation {
+    condition = length(setintersection(
+      toset(keys(var.control_plane_secret_environment)),
+      toset([
+        "DATABASE_URL",
+        "RISE_JWT_SIGNING_SECRET",
+        "RISE_ENCRYPTION_KEY",
+        "OIDC_CLIENT_SECRET",
+        "RISE_LOCAL_CONFIG_YAML",
+      ]),
+    )) == 0
+    error_message = "control_plane_secret_environment cannot override DATABASE_URL, RISE_JWT_SIGNING_SECRET, RISE_ENCRYPTION_KEY, OIDC_CLIENT_SECRET or RISE_LOCAL_CONFIG_YAML."
+  }
+
+  validation {
+    condition = alltrue([
+      for value_from in values(var.control_plane_secret_environment) :
+      can(regex("^arn:[^:]+:secretsmanager:[^:]+:[0-9]{12}:secret:[^:]+(?::[^:]*:[^:]*:[^:]*)?$", value_from))
+    ])
+    error_message = "control_plane_secret_environment values must be full Secrets Manager secret ARNs, optionally followed by ECS JSON-key, version-stage and version-id selectors."
+  }
+}
+
 variable "rise_desired_count" {
   description = "Control-plane replicas. Safe above 1: the reconcile loop is leader-elected through rise-runtime-sync."
   type        = number


### PR DESCRIPTION
## Summary

Add a `control_plane_secret_environment` map to the `rise-ecs` module so operators can inject independently managed Secrets Manager values into the Rise control-plane container. The module preserves ECS JSON-key/version selectors in the task definition and `rise_task_secrets`, derives deduplicated base secret ARNs for `secret_arns_for_execution_role`, and rejects malformed references or collisions with built-in secret environment names. The module README documents the environment-expansion configuration pattern.

## Test plan

- [x] `terraform fmt -check -recursive modules/rise-ecs`
- [x] `terraform -chdir=modules/rise-ecs validate`
- [x] `terraform -chdir=modules/rise-ecs test` (27 passed)
- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-features --all-targets -- -D warnings` — reaches unrelated failures in `src/build/mod.rs`, `src/server/project/handlers.rs`, and dead code under `src/server/extensions/` on the current `develop` branch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rise-deploy/codesmith/rise/pr/485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790945259&installation_model_id=432987&pr_number=485&repository=rise-deploy%2Frise&return_to=https%3A%2F%2Fgithub.com%2Frise-deploy%2Frise%2Fpull%2F485&signature=f5fba7a6725026880735f9ec268867fef07a055578afffa9a84ee4d5402a0961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->