### PR TITLE
Require explicit env types and add profile defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4481,6 +4481,7 @@ dependencies = [
  "rise-resource-api",
  "rise-resource-store-postgres",
  "rise-runtime-sync",
+ "rpassword",
  "rsa",
  "rustls",
  "schemars 1.2.2",
@@ -4571,6 +4572,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4588,6 +4600,16 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a1efe12a1469752d0e6ff5ebec0b6ef4924cc5c4c71046b0ec730040535819d"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ cli = [
     "dep:clap",
     "dep:comfy-table",
     "dep:dirs",
+    "dep:rpassword",
     "dep:tempfile",
     "dep:toml",
     "dep:url",
@@ -178,6 +179,7 @@ urlencoding = "2.1"
 clap = { version = "4.5.53", features = ["derive"], optional = true }
 comfy-table = { version = "7.1", optional = true }
 dirs = { version = "6.0", optional = true }
+rpassword = { version = "7.4", optional = true }
 tempfile = { version = "3.0", optional = true }
 toml = { version = "1", optional = true }
 url = { workspace = true, optional = true }

--- a/docs/user/src/content/docs/user-guide/cli-reference.md
+++ b/docs/user/src/content/docs/user-guide/cli-reference.md
@@ -9,7 +9,7 @@ The Rise CLI (`rise`) provides commands for managing projects, deployments, team
 | Command | Alias | Subcommands | Details |
 |---------|-------|-------------|---------|
 | `rise login` | | | [Authentication](../authentication) |
-| `rise profile` | | `list` (`ls`), `remove` (`rm`) | [Login Profiles](../configuration#login-profiles) |
+| `rise profile` | | `list` (`ls`), `use`, `remove` (`rm`) | [Login Profiles](../configuration#login-profiles) |
 | `rise deploy` | | | [Deployments](../deployments) |
 | `rise build` | | | [Building Images](../builds) |
 | `rise run` | | | [Local Development](../local-development) |
@@ -86,4 +86,4 @@ For token sources that can mint new tokens, the CLI refreshes proactively so lon
 
 CLI settings are stored in `~/.config/rise/config.json`, created on first `rise login`. See [Project Configuration](../configuration#global-cli-config) for details.
 
-Multiple accounts/backends can be managed side by side with named login profiles (`--profile` / `RISE_PROFILE`, `rise profile list`/`remove`). See [Login Profiles](../configuration#login-profiles).
+Multiple accounts/backends can be managed side by side with named login profiles (`--profile` / `RISE_PROFILE`, `rise profile list`/`use`/`remove`). See [Login Profiles](../configuration#login-profiles).

--- a/docs/user/src/content/docs/user-guide/configuration.mdx
+++ b/docs/user/src/content/docs/user-guide/configuration.mdx
@@ -162,6 +162,9 @@ rise project list --profile work
 export RISE_PROFILE=work
 rise project list
 
+# Make it the default for future commands
+rise profile use work
+
 # See every registered profile and which one is active
 rise profile list
 
@@ -169,10 +172,11 @@ rise profile list
 rise profile remove work
 ```
 
-`--profile` takes precedence over the `RISE_PROFILE` environment variable;
-passing `--profile default` (or unsetting `RISE_PROFILE`) switches back to the
-default profile. A named profile's config is stored separately, at
-`~/.config/rise/profiles/<name>.json`.
+Profile selection follows `--profile`, then `RISE_PROFILE`, then the profile
+selected by `rise profile use`. `rise profile use default` selects the default
+profile for future commands. A named profile's config is stored separately at
+`~/.config/rise/profiles/<name>.json`; the default selection is stored at
+`~/.config/rise/default-profile`.
 
 ## Backend Configuration Schema
 

--- a/docs/user/src/content/docs/user-guide/environment-variables.md
+++ b/docs/user/src/content/docs/user-guide/environment-variables.md
@@ -13,20 +13,21 @@ Rise manages environment variables at the project level. Variables are injected 
 rise env set -p my-app LOG_LEVEL info --plain
 
 # Retrievable secret (encrypted at rest, masked in listings)
-rise env set -p my-app DATABASE_URL postgres://user:pass@db/mydb --secret --protected=false
+rise env set -p my-app DATABASE_URL postgres://user:pass@db/mydb --secret
 
 # Protected secret (encrypted, cannot be retrieved via API)
-rise env set -p my-app JWT_SECRET supersecret --secret
+rise env set -p my-app JWT_SECRET supersecret --protected
 ```
 
-Every value requires an explicit `--plain` or `--secret` type. Secrets are
-protected by default; pass `--protected=false` when the value must be
-retrievable through the API. Omit the value to enter it interactively; input
-for both secret forms is hidden:
+Every value requires exactly one type: `--plain`, `--secret`, or `--protected`.
+Secret values are encrypted at rest; protected secrets cannot be retrieved
+through the API. Omit the value to enter it interactively; input for both
+secret forms is hidden:
 
 ```bash
 rise env set -p my-app LOG_LEVEL --plain
 rise env set -p my-app DATABASE_URL --secret
+rise env set -p my-app JWT_SECRET --protected
 ```
 
 With a `rise.toml` in your directory, you can omit `-p`:
@@ -209,4 +210,4 @@ When deploying, variables are merged in this order (later overrides earlier):
 2. `[environments.<target>.env]` variables for the target environment (source: `toml`)
 3. CLI deploy-time overrides (`-e`, `--secret-env`, `--protected-env`, `--env-file`) (source: `cli`)
 
-Only plain-text variables can be managed in `rise.toml`. Secrets must be set via the CLI (`rise env set --secret`) or passed at deploy time (`--secret-env`, `--protected-env`).
+Only plain-text variables can be managed in `rise.toml`. Secrets must be set via the CLI (`rise env set --secret` or `rise env set --protected`) or passed at deploy time (`--secret-env`, `--protected-env`).

--- a/docs/user/src/content/docs/user-guide/environment-variables.md
+++ b/docs/user/src/content/docs/user-guide/environment-variables.md
@@ -10,19 +10,29 @@ Rise manages environment variables at the project level. Variables are injected 
 
 ```bash
 # Plain text variable
-rise env set -p my-app LOG_LEVEL info
+rise env set -p my-app LOG_LEVEL info --plain
 
-# Secret variable (encrypted at rest, masked in listings)
-rise env set -p my-app DATABASE_URL postgres://user:pass@db/mydb --secret
+# Retrievable secret (encrypted at rest, masked in listings)
+rise env set -p my-app DATABASE_URL postgres://user:pass@db/mydb --secret --protected=false
 
 # Protected secret (encrypted, cannot be retrieved via API)
-rise env set -p my-app JWT_SECRET supersecret --secret --protected
+rise env set -p my-app JWT_SECRET supersecret --secret
+```
+
+Every value requires an explicit `--plain` or `--secret` type. Secrets are
+protected by default; pass `--protected=false` when the value must be
+retrievable through the API. Omit the value to enter it interactively; input
+for both secret forms is hidden:
+
+```bash
+rise env set -p my-app LOG_LEVEL --plain
+rise env set -p my-app DATABASE_URL --secret
 ```
 
 With a `rise.toml` in your directory, you can omit `-p`:
 
 ```bash
-rise env set LOG_LEVEL info
+rise env set LOG_LEVEL info --plain
 ```
 
 ### Listing Variables
@@ -75,7 +85,7 @@ Variables can be scoped to a specific [environment](../environments) using the `
 
 ```bash
 # Set a variable only for staging
-rise env set DATABASE_URL postgres://staging-db/mydb -E staging
+rise env set DATABASE_URL postgres://staging-db/mydb --plain -E staging
 
 # Get a scoped variable
 rise env get -p my-app DATABASE_URL -E staging
@@ -114,7 +124,7 @@ Rise automatically injects these variables into every deployment:
 | `RISE_ENVIRONMENT` | Environment name (if the deployment has an associated environment) | `staging` |
 | `RISE_CONTAINER_HOST__<NAME>` | Resolvable address (`<host>:<port>`) of each sibling container in a [multi-container deployment](../deployments#multi-container-deployments) that exposes a `port` — one entry per such container, whether or not it is routed (a port-having database like Redis is included). `<NAME>` is the uppercase container name (dashes mapped to underscores). Workers (containers without a `port`) are excluded. Injected only when the deployment has two or more containers. Each container also sees its own entry. | `default-api:8080` |
 
-`PORT` defaults to 8080. Override it per-deployment with `--http-port` on `rise deploy`, or set it permanently with `rise env set -p my-app PORT 3000`.
+`PORT` defaults to 8080. Override it per-deployment with `--http-port` on `rise deploy`, or set it permanently with `rise env set -p my-app PORT 3000 --plain`.
 
 `RISE_CONTAINER_HOST__<NAME>` values are `<host>:<port>` (no scheme). Always address siblings through this variable rather than hardcoding a hostname — the exact host string depends on the deployment backend, but the variable resolves correctly on both:
 

--- a/docs/user/src/content/docs/user-guide/environments.md
+++ b/docs/user/src/content/docs/user-guide/environments.md
@@ -142,7 +142,7 @@ Scope environment variables to a specific environment with the `-E` flag:
 
 ```bash
 # Set a variable only for staging
-rise env set DATABASE_URL postgres://staging-db/mydb -E staging
+rise env set DATABASE_URL postgres://staging-db/mydb --plain -E staging
 
 # List variables for staging (shows merged global + scoped)
 rise env list -p my-app -E staging

--- a/docs/user/src/content/docs/user-guide/getting-started.md
+++ b/docs/user/src/content/docs/user-guide/getting-started.md
@@ -110,7 +110,7 @@ See [Deployments](../deployments) for the full lifecycle and [Environments](../e
 Set runtime environment variables for your project:
 
 ```bash
-rise env set -p my-app DATABASE_URL postgres://db.example.com/mydb
+rise env set -p my-app DATABASE_URL postgres://db.example.com/mydb --plain
 rise env set -p my-app API_KEY s3cret --secret
 ```
 

--- a/skills/rise-app-builder/SKILL.md
+++ b/skills/rise-app-builder/SKILL.md
@@ -133,8 +133,8 @@ Then reference `$ENCRYPTED` in the `--spec` JSON.
 | Flag / option | Encrypted at rest | Retrievable via API |
 |---------------|:-:|:-:|
 | `-e KEY=VALUE` (plain env) | | n/a |
-| `--secret-env KEY=VALUE` / `rise env set --secret --protected=false` | ✅ | ✅ |
-| `--protected-env KEY=VALUE` / `rise env set --secret` | ✅ | ❌ |
+| `--secret-env KEY=VALUE` / `rise env set --secret` | ✅ | ✅ |
+| `--protected-env KEY=VALUE` / `rise env set --protected` | ✅ | ❌ |
 
 ## Condensed Patterns
 

--- a/skills/rise-app-builder/reference/cli-cheatsheet.md
+++ b/skills/rise-app-builder/reference/cli-cheatsheet.md
@@ -139,7 +139,7 @@ Valid colors: `green`, `blue`, `yellow`, `red`, `purple`, `orange`, `gray`.
 
 | Command | Aliases | Key Flags |
 |---------|---------|-----------|
-| `rise env set <key> [value]` | `s` | `--plain` or `--secret` (required), `-p`, `--path`, `--protected <bool>`, `-E/--environment` |
+| `rise env set <key> [value]` | `s` | `--plain`, `--secret`, or `--protected` (exactly one required), `-p`, `--path`, `-E/--environment` |
 | `rise env list` | `ls`, `l` | `-p`, `--path`, `-E/--environment` |
 | `rise env get <key>` | `g` | `-p`, `--path`, `-E/--environment` |
 | `rise env delete <key>` | `unset`, `rm`, `del` | `-p`, `--path`, `-E/--environment` |

--- a/skills/rise-app-builder/reference/cli-cheatsheet.md
+++ b/skills/rise-app-builder/reference/cli-cheatsheet.md
@@ -139,7 +139,7 @@ Valid colors: `green`, `blue`, `yellow`, `red`, `purple`, `orange`, `gray`.
 
 | Command | Aliases | Key Flags |
 |---------|---------|-----------|
-| `rise env set <key> <value>` | `s` | `-p`, `--path`, `--secret`, `--protected [bool]`, `-E/--environment` |
+| `rise env set <key> [value]` | `s` | `--plain` or `--secret` (required), `-p`, `--path`, `--protected <bool>`, `-E/--environment` |
 | `rise env list` | `ls`, `l` | `-p`, `--path`, `-E/--environment` |
 | `rise env get <key>` | `g` | `-p`, `--path`, `-E/--environment` |
 | `rise env delete <key>` | `unset`, `rm`, `del` | `-p`, `--path`, `-E/--environment` |

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -193,6 +193,8 @@ pub struct Config {
 /// is unsound if anything else reads the environment concurrently.
 static PROFILE_OVERRIDE: OnceLock<Option<String>> = OnceLock::new();
 
+const DEFAULT_PROFILE_FILE: &str = "default-profile";
+
 /// Set the process-wide profile override. Must be called at most once, before
 /// any other profile resolution — `main()` does this immediately after
 /// parsing CLI args, when `--profile` was passed.
@@ -202,13 +204,13 @@ pub fn set_profile_override(profile: Option<String>) {
 
 impl Config {
     /// The active login profile, i.e. the one selected via `--profile` /
-    /// `RISE_PROFILE` for the lifetime of this process, or `None` for the
+    /// `RISE_PROFILE` for the lifetime of this process, or the configured
     /// default profile.
     ///
     /// `--profile` is resolved once in `main()` into [`set_profile_override`],
     /// so every independent config load in the process — not just the one in
     /// `main()` — agrees on the same active profile. Absent that override,
-    /// falls back to the `RISE_PROFILE` environment variable.
+    /// falls back to `RISE_PROFILE`, then the persisted default selection.
     pub fn active_profile() -> Result<Option<String>> {
         if let Some(overridden) = PROFILE_OVERRIDE.get() {
             return Ok(overridden.clone());
@@ -222,12 +224,59 @@ impl Config {
             validate_profile_name(trimmed)?;
             return Ok(Some(trimmed.to_string()));
         }
+        #[cfg(not(test))]
+        return Self::default_profile();
+
+        #[cfg(test)]
         Ok(None)
     }
 
     /// The active profile's name for display purposes (`"default"` when unset).
     pub fn active_profile_label() -> Result<String> {
         Ok(Self::active_profile()?.unwrap_or_else(|| "default".to_string()))
+    }
+
+    /// The profile selected by `rise profile use`, independent of overrides.
+    pub fn default_profile() -> Result<Option<String>> {
+        let path = Self::config_dir()?.join(DEFAULT_PROFILE_FILE);
+        Self::read_default_profile_file(&path)
+    }
+
+    /// Select the profile used when neither `--profile` nor `RISE_PROFILE` is set.
+    pub fn set_default_profile(name: &str) -> Result<()> {
+        validate_profile_name(name)?;
+
+        if name != "default" && !Self::path_for(Some(name))?.exists() {
+            anyhow::bail!(
+                "Profile '{}' does not exist; register it with 'rise login --profile {}' first",
+                name,
+                name
+            );
+        }
+
+        let path = Self::config_dir()?.join(DEFAULT_PROFILE_FILE);
+        Self::write_private_file(&path, format!("{name}\n").as_bytes())
+    }
+
+    fn read_default_profile_file(path: &std::path::Path) -> Result<Option<String>> {
+        if !path.exists() {
+            return Ok(None);
+        }
+
+        let contents = fs::read_to_string(path).context("Failed to read default profile")?;
+        let name = contents.trim();
+        if name.is_empty() || name == "default" {
+            return Ok(None);
+        }
+        validate_profile_name(name).context("Invalid default profile")?;
+        Ok(Some(name.to_string()))
+    }
+
+    fn config_dir() -> Result<PathBuf> {
+        let home = dirs::home_dir().context("Failed to get home directory")?;
+        let config_dir = home.join(".config").join("rise");
+        ensure_config_dir(&config_dir)?;
+        Ok(config_dir)
     }
 
     /// List the names of all registered non-default profiles, i.e. every
@@ -266,14 +315,15 @@ impl Config {
         }
 
         fs::remove_file(&path).context("Failed to remove profile config file")?;
+        if Self::default_profile()?.as_deref() == Some(name) {
+            Self::set_default_profile("default")?;
+        }
         Ok(())
     }
 
     /// The config file path for a given profile (`None` = default profile).
     pub fn path_for(profile: Option<&str>) -> Result<PathBuf> {
-        let home = dirs::home_dir().context("Failed to get home directory")?;
-        let config_dir = home.join(".config").join("rise");
-        ensure_config_dir(&config_dir)?;
+        let config_dir = Self::config_dir()?;
 
         match profile {
             None => Ok(config_dir.join("config.json")),
@@ -323,8 +373,11 @@ impl Config {
     /// Write configuration to a specific path with restrictive permissions on Unix
     fn write_config_file(config_path: &std::path::Path, config: &Config) -> Result<()> {
         let json = serde_json::to_string_pretty(config).context("Failed to serialize config")?;
+        Self::write_private_file(config_path, json.as_bytes())
+    }
 
-        // On Unix, create/write the file with 0600 permissions atomically
+    fn write_private_file(path: &std::path::Path, contents: &[u8]) -> Result<()> {
+        // On Unix, create/write the file with 0600 permissions
         #[cfg(unix)]
         {
             use std::io::Write;
@@ -334,15 +387,15 @@ impl Config {
                 .create(true)
                 .truncate(true)
                 .mode(0o600)
-                .open(config_path)
+                .open(path)
                 .context("Failed to create config file")?;
-            file.write_all(json.as_bytes())
+            file.write_all(contents)
                 .context("Failed to write config file")?;
         }
 
         #[cfg(not(unix))]
         {
-            fs::write(config_path, json).context("Failed to write config file")?;
+            fs::write(path, contents).context("Failed to write config file")?;
         }
 
         Ok(())
@@ -502,10 +555,32 @@ mod tests {
 
     #[test]
     fn test_active_profile_is_default_in_tests() {
-        // RISE_PROFILE reads are disabled under #[cfg(test)] (like the other
-        // env-checking getters), so this only exercises the "unset" path.
         assert_eq!(Config::active_profile().unwrap(), None);
         assert_eq!(Config::active_profile_label().unwrap(), "default");
+    }
+
+    #[test]
+    fn test_read_default_profile_file() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let path = tmp_dir.path().join(DEFAULT_PROFILE_FILE);
+
+        assert_eq!(Config::read_default_profile_file(&path).unwrap(), None);
+        fs::write(&path, "default\n").unwrap();
+        assert_eq!(Config::read_default_profile_file(&path).unwrap(), None);
+        fs::write(&path, "work\n").unwrap();
+        assert_eq!(
+            Config::read_default_profile_file(&path).unwrap(),
+            Some("work".to_string())
+        );
+    }
+
+    #[test]
+    fn test_read_default_profile_file_rejects_invalid_name() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let path = tmp_dir.path().join(DEFAULT_PROFILE_FILE);
+        fs::write(&path, "../work\n").unwrap();
+
+        assert!(Config::read_default_profile_file(&path).is_err());
     }
 
     #[test]

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use comfy_table::{modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, Attribute, Cell, Table};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
+use std::io::{BufRead, Write};
 use std::path::PathBuf;
 
 #[derive(Debug, Deserialize)]
@@ -27,6 +28,34 @@ struct SetEnvVarRequest {
     is_secret: bool,
     #[serde(default)]
     is_protected: bool,
+}
+
+/// Return a supplied value or prompt for one when it is omitted.
+pub fn resolve_env_value(value: Option<&str>, is_secret: bool) -> Result<String> {
+    if let Some(value) = value {
+        return Ok(value.to_string());
+    }
+
+    if is_secret {
+        return rpassword::prompt_password("Value: ")
+            .context("Failed to read environment variable value");
+    }
+
+    read_plain_env_value(&mut std::io::stdin().lock(), &mut std::io::stderr())
+}
+
+fn read_plain_env_value(reader: &mut impl BufRead, writer: &mut impl Write) -> Result<String> {
+    write!(writer, "Value: ").context("Failed to write environment variable prompt")?;
+    writer
+        .flush()
+        .context("Failed to write environment variable prompt")?;
+
+    let mut value = String::new();
+    reader
+        .read_line(&mut value)
+        .context("Failed to read environment variable value")?;
+    value.truncate(value.trim_end_matches(['\r', '\n']).len());
+    Ok(value)
 }
 
 /// Build a URL with an optional `?environment=` query parameter
@@ -687,7 +716,30 @@ pub async fn export_env(
 
 #[cfg(test)]
 mod tests {
-    use super::{is_shell_identifier, parse_env_file, parse_env_string, shell_quote};
+    use super::{
+        is_shell_identifier, parse_env_file, parse_env_string, read_plain_env_value,
+        resolve_env_value, shell_quote,
+    };
+
+    #[test]
+    fn supplied_env_value_does_not_prompt() {
+        assert_eq!(
+            resolve_env_value(Some("  value  "), false).unwrap(),
+            "  value  "
+        );
+    }
+
+    #[test]
+    fn plain_env_prompt_removes_only_the_line_ending() {
+        let mut input = &b"  value  \r\n"[..];
+        let mut output = Vec::new();
+
+        assert_eq!(
+            read_plain_env_value(&mut input, &mut output).unwrap(),
+            "  value  "
+        );
+        assert_eq!(output, b"Value: ");
+    }
 
     #[test]
     fn shell_quote_preserves_shell_significant_values() {

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -333,8 +333,9 @@ pub async fn get_env(
     if env_var.is_secret && env_var.is_protected {
         anyhow::bail!(
             "Cannot retrieve value: '{}' is a protected secret.\n\
-             To make it unprotected, update it with: rise env set {} <value> --secret --protected=false",
-            key, key
+             To make it retrievable, update it with: rise env set {} <value> --secret",
+            key,
+            key
         );
     }
 

--- a/src/cli/profile.rs
+++ b/src/cli/profile.rs
@@ -1,5 +1,6 @@
 //! `rise profile` — inspect and manage the login profiles selected via the
-//! global `--profile` flag / `RISE_PROFILE` environment variable.
+//! global `--profile` flag, `RISE_PROFILE` environment variable, or persisted
+//! default selection.
 //!
 //! A profile is "registered" simply by having a saved config file: `rise
 //! login --profile <name>` creates one on first use, so there is nothing to
@@ -51,11 +52,15 @@ pub fn list_profiles() -> Result<()> {
     }
 
     println!("{}", table);
-    println!(
-        "\nActive profile: {} (RISE_PROFILE env var / --profile flag; \"default\" if unset)",
-        active
-    );
+    println!("\nActive profile: {}", active);
 
+    Ok(())
+}
+
+/// Select the profile used when no per-command or environment override exists.
+pub fn use_profile(name: &str) -> Result<()> {
+    Config::set_default_profile(name)?;
+    println!("✓ Default profile set to '{}'", name);
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,8 +83,8 @@ fn resolve_project_name_with_config(
 pub struct Cli {
     /// Login profile to use, letting you manage multiple Rise accounts or
     /// backends side by side. Falls back to the RISE_PROFILE environment
-    /// variable, then the default profile. `rise login --profile <name>`
-    /// registers a new profile if it doesn't already exist.
+    /// variable, then the profile selected by `rise profile use`.
+    /// `rise login --profile <name>` registers a new profile if needed.
     #[arg(long, global = true)]
     profile: Option<String>,
     #[command(subcommand)]
@@ -440,6 +440,11 @@ enum ProfileCommands {
     /// List registered login profiles
     #[command(visible_alias = "ls")]
     List,
+    /// Select the profile used when --profile and RISE_PROFILE are unset
+    Use {
+        /// Registered profile name (or "default")
+        name: String,
+    },
     /// Remove a profile's saved login/config
     #[command(visible_alias = "rm")]
     Remove {
@@ -778,6 +783,12 @@ enum ServiceAccountCommands {
 enum EnvCommands {
     /// Set an environment variable for a project
     #[command(visible_alias = "s")]
+    #[command(group(
+        clap::ArgGroup::new("env_type")
+            .required(true)
+            .multiple(false)
+            .args(["plain", "secret"])
+    ))]
     Set {
         /// Project name (optional if rise.toml contains [project] section)
         #[arg(long, short = 'p')]
@@ -787,13 +798,16 @@ enum EnvCommands {
         path: String,
         /// Variable name (e.g., DATABASE_URL)
         key: String,
-        /// Variable value
-        value: String,
-        /// Mark as secret (encrypted at rest)
+        /// Variable value (prompted for when omitted)
+        value: Option<String>,
+        /// Store the value as plain text
+        #[arg(long)]
+        plain: bool,
+        /// Store the value as an encrypted, protected secret
         #[arg(long)]
         secret: bool,
-        /// Mark secret as protected (cannot be decrypted via API). Only applies to secrets. Defaults to true for secrets, must be false for non-secrets.
-        #[arg(long)]
+        /// Whether the secret is protected from API retrieval (defaults to true)
+        #[arg(long, requires = "secret", conflicts_with = "plain")]
         protected: Option<bool>,
         /// Scope variable to a specific environment (e.g., 'staging'). Without this, the variable is global.
         #[arg(long, short = 'E')]
@@ -1192,11 +1206,20 @@ async fn main() -> Result<()> {
         other => other,
     };
 
-    // Backend commands don't need CLI config (they use Settings from TOML/env vars)
-    // Only client commands (login, project, team, deployment, service-account) need it
+    // Backend commands use Settings from TOML/environment variables.
     #[cfg(feature = "backend")]
     if let Commands::Backend(backend_cmd) = &cli_command {
         return backend::handle_backend_command(backend_cmd.clone()).await;
+    }
+
+    // Profile management only reads and writes local profile files.
+    if let Commands::Profile(profile_cmd) = &cli_command {
+        match profile_cmd {
+            ProfileCommands::List => profile::list_profiles()?,
+            ProfileCommands::Use { name } => profile::use_profile(name)?,
+            ProfileCommands::Remove { name } => profile::remove_profile(name)?,
+        }
+        return Ok(());
     }
 
     // Load CLI config for client commands
@@ -1204,8 +1227,7 @@ async fn main() -> Result<()> {
     let mut config = config::Config::load()?;
     let backend_url = config.get_backend_url();
 
-    // Check version compatibility for all commands except Login
-    // (Backend commands are handled above and don't use the HTTP API; Login might use a custom URL)
+    // Commands that call the backend warn when the CLI and server versions differ.
     if !matches!(&cli_command, Commands::Login { .. }) {
         // Non-fatal version check - just warns user
         let _ = version::check_version_compatibility(&http_client, &backend_url).await;
@@ -1246,10 +1268,7 @@ async fn main() -> Result<()> {
         Commands::Encrypt { plaintext } => {
             cli::encrypt::encrypt_command(&config, plaintext.clone()).await?;
         }
-        Commands::Profile(profile_cmd) => match profile_cmd {
-            ProfileCommands::List => profile::list_profiles()?,
-            ProfileCommands::Remove { name } => profile::remove_profile(name)?,
-        },
+        Commands::Profile(_) => unreachable!("Profile commands are handled before config loading"),
         Commands::Project(project_cmd) => match project_cmd {
             ProjectCommands::Create {
                 name,
@@ -1869,11 +1888,16 @@ async fn main() -> Result<()> {
                 | EnvCommands::ShowDeployment { project, path, .. } => (project, path),
             };
             let project_name = resolve_project_name(project.clone(), path)?;
+            let prompted_value = match env_cmd {
+                EnvCommands::Set { value, secret, .. } => {
+                    Some(env::resolve_env_value(value.as_deref(), *secret)?)
+                }
+                _ => None,
+            };
             let token = cli::token_source::resolve_token_with_retry(&http_client, &config).await?;
             match env_cmd {
                 EnvCommands::Set {
                     key,
-                    value,
                     secret,
                     protected,
                     environment,
@@ -1888,7 +1912,9 @@ async fn main() -> Result<()> {
                         &token,
                         &project_name,
                         key,
-                        value,
+                        prompted_value
+                            .as_deref()
+                            .expect("set commands resolve an environment variable value"),
                         *secret,
                         is_protected,
                         environment.as_deref(),
@@ -2285,7 +2311,7 @@ mod log_color_tests {
 
 #[cfg(all(test, feature = "cli"))]
 mod deployment_output_cli_tests {
-    use super::{Cli, Commands, DeploymentCommands};
+    use super::{Cli, Commands, DeploymentCommands, EnvCommands, ProfileCommands};
     use clap::Parser;
 
     #[test]
@@ -2328,6 +2354,104 @@ mod deployment_output_cli_tests {
                 assert_eq!(status_file.as_deref(), Some("deployments.json"));
             }
             _ => panic!("expected deployment list command"),
+        }
+    }
+
+    #[test]
+    fn env_set_requires_an_explicit_type() {
+        let error = Cli::try_parse_from(["rise", "env", "set", "KEY", "value"]).unwrap_err();
+        let message = error.to_string();
+
+        assert!(message.contains("--plain"));
+        assert!(message.contains("--secret"));
+    }
+
+    #[test]
+    fn env_set_accepts_an_omitted_plain_value() {
+        let cli = Cli::try_parse_from(["rise", "env", "set", "KEY", "--plain"]).unwrap();
+
+        match cli.command {
+            Commands::Env(EnvCommands::Set {
+                key,
+                value,
+                plain,
+                secret,
+                ..
+            }) => {
+                assert_eq!(key, "KEY");
+                assert_eq!(value, None);
+                assert!(plain);
+                assert!(!secret);
+            }
+            _ => panic!("expected env set command"),
+        }
+    }
+
+    #[test]
+    fn env_set_rejects_plain_and_secret_together() {
+        assert!(
+            Cli::try_parse_from(["rise", "env", "set", "KEY", "value", "--plain", "--secret"])
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn env_set_accepts_an_omitted_secret_value() {
+        let cli = Cli::try_parse_from(["rise", "env", "set", "KEY", "--secret"]).unwrap();
+
+        match cli.command {
+            Commands::Env(EnvCommands::Set {
+                value,
+                secret,
+                protected,
+                ..
+            }) => {
+                assert_eq!(value, None);
+                assert!(secret);
+                assert_eq!(protected, None);
+            }
+            _ => panic!("expected env set command"),
+        }
+    }
+
+    #[test]
+    fn env_set_requires_secret_when_setting_protection() {
+        assert!(Cli::try_parse_from([
+            "rise",
+            "env",
+            "set",
+            "KEY",
+            "value",
+            "--plain",
+            "--protected=false"
+        ])
+        .is_err());
+
+        let cli = Cli::try_parse_from([
+            "rise",
+            "env",
+            "set",
+            "KEY",
+            "value",
+            "--secret",
+            "--protected=false",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Env(EnvCommands::Set { protected, .. }) => {
+                assert_eq!(protected, Some(false));
+            }
+            _ => panic!("expected env set command"),
+        }
+    }
+
+    #[test]
+    fn profile_use_accepts_a_profile_name() {
+        let cli = Cli::try_parse_from(["rise", "profile", "use", "work"]).unwrap();
+
+        match cli.command {
+            Commands::Profile(ProfileCommands::Use { name }) => assert_eq!(name, "work"),
+            _ => panic!("expected profile use command"),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -787,7 +787,7 @@ enum EnvCommands {
         clap::ArgGroup::new("env_type")
             .required(true)
             .multiple(false)
-            .args(["plain", "secret"])
+            .args(["plain", "secret", "protected"])
     ))]
     Set {
         /// Project name (optional if rise.toml contains [project] section)
@@ -803,12 +803,12 @@ enum EnvCommands {
         /// Store the value as plain text
         #[arg(long)]
         plain: bool,
-        /// Store the value as an encrypted, protected secret
+        /// Store the value as an encrypted secret retrievable through the API
         #[arg(long)]
         secret: bool,
-        /// Whether the secret is protected from API retrieval (defaults to true)
-        #[arg(long, requires = "secret", conflicts_with = "plain")]
-        protected: Option<bool>,
+        /// Store the value as an encrypted secret that cannot be retrieved
+        #[arg(long)]
+        protected: bool,
         /// Scope variable to a specific environment (e.g., 'staging'). Without this, the variable is global.
         #[arg(long, short = 'E')]
         environment: Option<String>,
@@ -1889,9 +1889,15 @@ async fn main() -> Result<()> {
             };
             let project_name = resolve_project_name(project.clone(), path)?;
             let prompted_value = match env_cmd {
-                EnvCommands::Set { value, secret, .. } => {
-                    Some(env::resolve_env_value(value.as_deref(), *secret)?)
-                }
+                EnvCommands::Set {
+                    value,
+                    secret,
+                    protected,
+                    ..
+                } => Some(env::resolve_env_value(
+                    value.as_deref(),
+                    *secret || *protected,
+                )?),
                 _ => None,
             };
             let token = cli::token_source::resolve_token_with_retry(&http_client, &config).await?;
@@ -1903,9 +1909,7 @@ async fn main() -> Result<()> {
                     environment,
                     ..
                 } => {
-                    // Protected defaults to true for secrets, false for non-secrets
-                    // Can be explicitly overridden with --protected flag
-                    let is_protected = protected.unwrap_or(*secret);
+                    let is_secret = *secret || *protected;
                     env::set_env(
                         &http_client,
                         &backend_url,
@@ -1915,8 +1919,8 @@ async fn main() -> Result<()> {
                         prompted_value
                             .as_deref()
                             .expect("set commands resolve an environment variable value"),
-                        *secret,
-                        is_protected,
+                        is_secret,
+                        *protected,
                         environment.as_deref(),
                     )
                     .await?;
@@ -2364,6 +2368,7 @@ mod deployment_output_cli_tests {
 
         assert!(message.contains("--plain"));
         assert!(message.contains("--secret"));
+        assert!(message.contains("--protected"));
     }
 
     #[test]
@@ -2388,14 +2393,6 @@ mod deployment_output_cli_tests {
     }
 
     #[test]
-    fn env_set_rejects_plain_and_secret_together() {
-        assert!(
-            Cli::try_parse_from(["rise", "env", "set", "KEY", "value", "--plain", "--secret"])
-                .is_err()
-        );
-    }
-
-    #[test]
     fn env_set_accepts_an_omitted_secret_value() {
         let cli = Cli::try_parse_from(["rise", "env", "set", "KEY", "--secret"]).unwrap();
 
@@ -2408,40 +2405,42 @@ mod deployment_output_cli_tests {
             }) => {
                 assert_eq!(value, None);
                 assert!(secret);
-                assert_eq!(protected, None);
+                assert!(!protected);
             }
             _ => panic!("expected env set command"),
         }
     }
 
     #[test]
-    fn env_set_requires_secret_when_setting_protection() {
-        assert!(Cli::try_parse_from([
-            "rise",
-            "env",
-            "set",
-            "KEY",
-            "value",
-            "--plain",
-            "--protected=false"
-        ])
-        .is_err());
+    fn env_set_accepts_an_omitted_protected_value() {
+        let cli = Cli::try_parse_from(["rise", "env", "set", "KEY", "--protected"]).unwrap();
 
-        let cli = Cli::try_parse_from([
-            "rise",
-            "env",
-            "set",
-            "KEY",
-            "value",
-            "--secret",
-            "--protected=false",
-        ])
-        .unwrap();
         match cli.command {
-            Commands::Env(EnvCommands::Set { protected, .. }) => {
-                assert_eq!(protected, Some(false));
+            Commands::Env(EnvCommands::Set {
+                value,
+                secret,
+                protected,
+                ..
+            }) => {
+                assert_eq!(value, None);
+                assert!(!secret);
+                assert!(protected);
             }
             _ => panic!("expected env set command"),
+        }
+    }
+
+    #[test]
+    fn env_set_rejects_multiple_types() {
+        for types in [
+            ["--plain", "--secret"],
+            ["--plain", "--protected"],
+            ["--secret", "--protected"],
+        ] {
+            assert!(Cli::try_parse_from([
+                "rise", "env", "set", "KEY", "value", types[0], types[1],
+            ])
+            .is_err());
         }
     }
 

--- a/src/server/env_vars/handlers.rs
+++ b/src/server/env_vars/handlers.rs
@@ -535,7 +535,7 @@ pub async fn get_project_env_var_value(
     if !env_var.is_secret || env_var.is_protected {
         return Err(ServerError::bad_request(format!(
             "Environment variable '{}' is a protected secret and cannot be retrieved. \
-             Update it with --protected=false to allow retrieval.",
+             Update it with --secret to allow retrieval.",
             key
         )));
     }
@@ -605,7 +605,7 @@ pub async fn get_deployment_env_var_value(
     if !env_var.is_secret || env_var.is_protected {
         return Err(ServerError::bad_request(format!(
             "Environment variable '{}' is a protected secret and cannot be retrieved. \
-             Update it with --protected=false to allow retrieval.",
+             Update it with --secret to allow retrieval.",
             key
         )));
     }


### PR DESCRIPTION
## Summary

- require `rise env set` callers to choose exactly one of `--plain`, `--secret`, or `--protected`, mapped directly to plain text, retrievable encrypted secrets, and non-retrievable encrypted secrets
- prompt for omitted values, with terminal echo disabled for both secret modes
- add `rise profile use` with persisted default selection below `--profile` and `RISE_PROFILE` in precedence
- update CLI/server guidance, user documentation, and the bundled Rise skill for the resulting commands

## Test plan

- `cargo test --features cli`
- `cargo clippy --features cli -- -D warnings`
- `cargo check --all-features --locked`
- `cargo fmt --all -- --check`
- `git diff --check`
