### PR TITLE
Implement token subresource for ServiceAccount and Controller

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -71,7 +71,9 @@ Status legend: `[x]` shipped · `[~]` in progress · `[ ]` planned.
   `require_operator`. The choke point is live on the generic resource API, with
   per-item list filtering, the allowlisted list-only projection, and
   `metadata.effectiveLabels` on every response. Controllers are ordinary
-  `controller:<name>` principals evaluated by the same choke point; the
+  `controller:<name>` principals evaluated by the same choke point, whether
+  they authenticate with a JWT matched against their trust policies or with
+  an identity token from their `/token` subresource; the
   `ResourceDefinition.allowedStatusControllerIds` allowlist is removed.
 - [~] Add Role/policy audit and explain diagnostics for semantically inert
   configuration: no-op recipient or membership constraints, owners with no
@@ -174,27 +176,33 @@ Status legend: `[x]` shipped · `[~]` in progress · `[ ]` planned.
 - [ ] Issue User sessions with canonical `sub` plus immutable `rise_uid`
   after exact live, active `UserIdentity (issuer, subject)` and active parent
   User resolution.
-- [ ] Move workload token exchange to each ServiceAccount or Controller `/token`
+- [x] Move workload token exchange to each ServiceAccount or Controller `/token`
   subresource, introduced additively per kind: a resource-API-backed identity
   gains its `/token` route without touching any other, not-yet-migrated identity
   of the same kind still on the legacy exchange endpoint. Validate external
   assertions only against trust-policy children of that URL target; do not
   perform a global source-identity search, and mask target/assertion/policy
   failures behind the same coarse authentication error.
-- [ ] Support delegated issuance on the same `/token` route for an already
+  The route is live on `rise.dev/ServiceAccount` and `rise.dev/Controller`;
+  the minted identity token (`typ: rise-identity+jwt`, canonical `sub` plus
+  `rise_uid`) is a principal of the generic resource API, re-resolved to one
+  live resource on every request.
+- [x] Support delegated issuance on the same `/token` route for an already
   Rise-authenticated principal holding `(create, qualified ResourceKind,
   token)`. Workload exchange and delegated request modes are disjoint.
-- [ ] Add a canonical RFC 9396 `authorization_details` claim with
+- [x] Add a canonical RFC 9396 `authorization_details` claim with
   `type: rise.dev/rbac`, one qualified `scope` per entry, and multiple entries
   whose permissions union. Reject empty permission axes, carry the parsed cap
   on `AuthenticatedPrincipal`, and enforce live RBAC intersected with that cap
   on every primary and secondary decision.
-- [ ] Add bounded nested `act` attribution. Delegation chains are allowed only
+- [x] Add bounded nested `act` attribution. Delegation chains are allowed only
   across explicit live token-create grants; there is no token-class/one-hop
   bypass rule.
-- [ ] Reject stale UID tokens, inactive/deleted principals, Group subjects as
+- [~] Reject stale UID tokens, inactive/deleted principals, Group subjects as
   principals, malformed subjects/scopes, and external workload JWTs on every
-  non-token endpoint.
+  non-token endpoint. Identity tokens are rejected on every one of those
+  grounds; raw external JWTs on ordinary endpoints remain governed by the
+  transitional `auth.allow_raw_external_tokens` above.
 - [ ] Retire the typed `service_accounts` table, its synthetic users/emails, and
   the transitional identity-selection contract — gated on every service account
   having migrated to a resource-API `ServiceAccount` and that legacy path's
@@ -204,8 +212,12 @@ Status legend: `[x]` shipped · `[~]` in progress · `[ ]` planned.
   shipped `ControllerTrustPolicy` (§1), the typed ServiceAccount table is in
   production use today and needs the same measure-then-drain-then-remove
   discipline as `auth.allow_raw_external_tokens`.
-- [ ] Keep the platform-global maximum token TTL and add negative tests for
+- [~] Keep the platform-global maximum token TTL and add negative tests for
   audience, cap, target trust, mode-confusion, and name-recreation behavior.
+  The maximum is `server.auth_token_max_ttl_seconds` for both token kinds,
+  and cap, target-trust, mode-confusion, and name-recreation behavior are
+  tested through the route; audience-mismatch coverage waits on the
+  middleware-level test harness.
 
 ## 3. Subresource execution
 
@@ -214,9 +226,11 @@ Status legend: `[x]` shipped · `[~]` in progress · `[ ]` planned.
 - [ ] Register generic `status` and `finalizers` mutation strategies once in
   the resource layer; individual resource handlers must not reimplement their
   field separation.
-- [ ] Register `token` as a generated finite response with the two typed
+- [~] Register `token` as a generated finite response with the two typed
   authentication outcomes from ADR-0001. Raw assertions are consumed before
-  handler invocation.
+  handler invocation. Both outcomes are served today on the two built-in
+  identity kinds; moving that fixed registration onto the declared registry
+  seam waits on ADR-0002.
 - [ ] Make discovery report each kind's supported subresources, verbs, media
   types, and execution shape.
 - [ ] Design Deployment `logs` as the first streaming product subresource,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -154,8 +154,14 @@ Status legend: `[x]` shipped · `[~]` in progress · `[ ]` planned.
   subresources.
 - [ ] Add a resumable Watch API with explicit backpressure, connection limits,
   and observability.
-- [ ] Build `rise-resource-client` with Rise-issued credential providers,
-  watch resume, and generic finalizer/subresource helpers.
+- [ ] Build `rise-resource-client` in the shape of Kubernetes' dynamic client:
+  `(group, version, plural)` plus ancestor-name addressing over untyped
+  envelopes, verbs and named subresources that line up one-to-one with the
+  authorization tuples, Rise-issued credential providers (a session bearer,
+  and a `/token`-refreshed identity token from an external assertion or a
+  delegating principal), watch resume, and generic finalizer/subresource
+  helpers. The e2e harness and the CLI's token source become its first
+  consumers; typed wrappers for built-in kinds layer on top later.
 - [ ] Add built-in version conversion and define external
   `ResourceDefinition` schema-evolution behavior.
 - [ ] Close built-in `(group, kind)` shadowing and finish audit coverage for
@@ -184,9 +190,10 @@ Status legend: `[x]` shipped · `[~]` in progress · `[ ]` planned.
   perform a global source-identity search, and mask target/assertion/policy
   failures behind the same coarse authentication error.
   The route is live on `rise.dev/ServiceAccount` and `rise.dev/Controller`;
-  the minted identity token (`typ: rise-identity+jwt`, canonical `sub` plus
-  `rise_uid`) is a principal of the generic resource API, re-resolved to one
-  live resource on every request.
+  the minted identity token (RS256, `typ: rise-identity+jwt`, canonical `sub`
+  plus `rise_uid`) is a principal of the generic resource API, re-resolved to
+  one live resource on every request, and the same token minted for a
+  requested `audience` is verifiable by that party against Rise's JWKS.
 - [x] Support delegated issuance on the same `/token` route for an already
   Rise-authenticated principal holding `(create, qualified ResourceKind,
   token)`. Workload exchange and delegated request modes are disjoint.

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -62,11 +62,14 @@ scope and avoiding dead-end compatibility layers.
    list projection — plus the live `MembershipResolver`, pulled forward from
    increment 10 so the choke point has a real principal to build a snapshot
    from.
-10. **Planned — identity authentication and token convergence.** Add live
-   User/UserIdentity resolution, operator selection/JIT, target-bound workload
-   exchange, delegated `/token`, UID checks, caps, and actor-chain handling.
-   The live `MembershipResolver` moved to 9b; `authorization_details` parsing
-   stays here.
+10. **Split into 10a and 10b — identity authentication and token
+   convergence.** 10a (implemented) is the target-bound `/token` subresource
+   on ServiceAccount and Controller: workload exchange against the target's
+   trust policies, delegated issuance under `(create, <kind>, token)`, the
+   identity token with `rise_uid`, `authorization_details` parsing into the
+   engine's cap, UID-bound re-resolution on every request, and the bounded
+   `act` chain. 10b (planned) is live User/UserIdentity resolution, operator
+   selection, and JIT login.
 11. **Planned — full conformance and finalization.** Close every applicable
    ADR-0001 acceptance scenario, update documentation/status, and audit the
    implementation requirement by requirement.
@@ -1839,3 +1842,70 @@ idempotent when a read-modify-write client replays the stored spec.
     which only affects their own resource. The owner-reference half of this —
     holding another resource's deletion open with `blockOwnerDeletion` — is
     closed by the `use` requirement on both attaching and detaching an edge.
+
+## Increment 10a — the `token` subresource and resource principals
+
+- State: implemented on branch `claude/adr-001-token-cutover-6kjopq`.
+- Acceptance criteria:
+  - `POST …/serviceaccounts/{org}/{name}/token` and `POST …/controllers/{name}/token`
+    issue a Rise identity token for exactly the addressed resource; `/token` on
+    any other kind is the ordinary route-not-found before authentication, and
+    every other method on it is `405`.
+  - Workload exchange consults only the target's `ServiceAccountTrustPolicy` /
+    `ControllerTrustPolicy` children, narrowed by issuer before JWKS work,
+    requires exactly one claim match, and answers every post-route failure —
+    absent, wrong-kind, or draining target; unaccepted issuer; failed
+    verification; zero or several matches — with one byte-identical `401`.
+  - Delegated issuance needs `(create, <kind>, token)` on the exact target
+    under the caller's own cap; `get` on the target, `create` on the main
+    resource, and `get` on the subresource each grant nothing. A caller who
+    cannot `get` the target is masked to `404`.
+  - The two modes never mix; a Rise-issued assertion is never exchanged; a
+    trust policy may not name Rise's issuer.
+  - The identity token carries canonical `sub` and `rise_uid`, optional
+    `rise.dev/rbac` `authorization_details`, and a bounded `act` chain; it is
+    accepted only by the generic resource API, where the middleware re-resolves
+    `(sub, rise_uid)` to one live resource on every request and parses the
+    ceiling fail-closed.
+  - Delegation chains only across live token-create grants; actor data never
+    grants; a chain past `MAX_DELEGATION_DEPTH` is refused at both the handler
+    and the signer.
+- Decisions:
+  - The claim types, signer, verifier variant (`RiseToken::Identity`), `act`
+    chain, and TTL enforcement live in `rise-backend-auth`; the
+    `authorization_details` wire form and its parsing into `AuthorizationCap`
+    live in `rise-authz`; `rise-deploy` owns target resolution, trust-policy
+    lookup, and the route. `rise-backend-auth` therefore carries the details as
+    opaque JSON and stays free of the resource API crate.
+  - The generic resource API router carries its own authentication layers,
+    identical to the platform-wide ones except that a credential-less `POST`
+    to a `/token` path reaches the handler. The handler, not the middleware,
+    decides whether that path really is a registered token route; anything
+    else without a credential is `401`, and an unknown collection is `401`
+    rather than `404` so the registry stays invisible to unauthenticated
+    callers.
+  - Token issuance is not a serializable write: it persists nothing and runs
+    on a read-path authorization context.
+  - `server.auth_token_max_ttl_seconds` is the platform-global maximum for
+    identity tokens as well as access tokens; `expires_in` is clamped to it.
+  - The membership resolver holds an optional `User`: a resource principal has
+    no Group ties and no operator standing by construction, and the engine
+    rejects a resolver that claims otherwise.
+  - Built on PR #491's controller principals. A Controller resolved per
+    request from its trust policies and one holding an identity token from
+    its `/token` subresource are the same `controller:<name>` principal to
+    the engine; delegated issuance records either as the delegator, and the
+    resource API's `AnyAuth` is the one credential type both arrive through.
+  - The transitional `POST /api/v1/auth/token` and its typed-table principals
+    are untouched; they retire with the typed-object migration.
+- Verification:
+  - `rise-backend-auth`: identity round trip, rejection by both legacy
+    adapters, the `rise_uid` payload guard on the ingress path, the
+    disambiguation matrix, and the chain limit.
+  - `rise-authz`: scenarios 49–52 over `AuthorizationCap::from_details`,
+    including a checked list of malformed shapes.
+  - `rise-deploy` against Postgres: exchange by name and by UID for both
+    kinds; the coarse-401 matrix; delegated issuance across the grant
+    variants; a minted token authenticating as the target, gaining a live
+    grant, and dying with its UID; a two-hop delegation chain; caps applied to
+    `get` and `list`; create-only enforcement; the Rise-issuer guard.

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -1888,6 +1888,16 @@ idempotent when a read-modify-write client replays the stored spec.
     on a read-path authorization context.
   - `server.auth_token_max_ttl_seconds` is the platform-global maximum for
     identity tokens as well as access tokens; `expires_in` is clamped to it.
+  - Identity tokens are always RS256, signed with the JWKS key, whatever their
+    audience. The request may name an `audience`; omitted means Rise's own
+    API, which is the only audience the middleware accepts, and any other
+    value hands the same token to an external verifier. One token kind and
+    one verification path beat a symmetric internal variant beside an
+    asymmetric external one; the cost is that `rs256_private_key_pem` is now
+    load-bearing for the resource API too, which the upgrade notes say.
+    `authorization_details` is refused with an external audience, and the
+    audience check lives in `resolve_identity` so it is tested with the rest
+    of resolution rather than in the middleware alone.
   - The membership resolver holds an optional `User`: a resource principal has
     no Group ties and no operator standing by construction, and the engine
     rejects a resolver that claims otherwise.

--- a/crates/rise-authz/src/engine/mod.rs
+++ b/crates/rise-authz/src/engine/mod.rs
@@ -39,7 +39,9 @@ pub use gate::{
     RoleBodyChange,
 };
 pub use membership::{MembershipResolver, PrincipalMembership};
-pub use principal::{AuthenticatedPrincipal, AuthorizationCap, CapEntry, CapPermission};
+pub use principal::{
+    AuthenticatedPrincipal, AuthorizationCap, CapEntry, CapPermission, RBAC_DETAIL_TYPE,
+};
 pub use tree::{ResourceNode, ResourceTree};
 
 use bindings::{load_organization_bindings, load_platform_bindings, BindingFact};

--- a/crates/rise-authz/src/engine/principal.rs
+++ b/crates/rise-authz/src/engine/principal.rs
@@ -1,20 +1,81 @@
 use rise_resource_api::{
     Effect, KindMatcher, PolicyStatement, Scope, SubjectId, SubresourceMatcher, VerbMatcher,
 };
+use serde::{Deserialize, Deserializer, Serialize};
 use uuid::Uuid;
 
 use crate::engine::{AuthorizationError, ResourceTree};
 
+/// The RFC 9396 `type` of every Rise authorization-detail entry (ADR-0001 §7).
+pub const RBAC_DETAIL_TYPE: &str = "rise.dev/rbac";
+
 /// One `rise.dev/rbac` authorization-detail permission (ADR-0001 §7).
 ///
 /// The grammar is a Role statement's without an effect: a ceiling only ever
-/// removes authority, so every entry is implicitly an Allow.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// removes authority, so every entry is implicitly an Allow. The serialized
+/// form is the wire shape of one `permissions` element; the matchers reject an
+/// empty axis, a non-`*` wildcard, and duplicates exactly as a Role does.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct CapPermission {
     pub verbs: VerbMatcher,
     pub kinds: KindMatcher,
     /// Omission covers the main resource only, exactly as in a Role statement.
+    /// An explicit `null` is rejected rather than read as omission.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_non_null"
+    )]
     pub subresources: Option<SubresourceMatcher>,
+}
+
+fn deserialize_optional_non_null<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    T::deserialize(deserializer).map(Some)
+}
+
+/// The wire shape of one `authorization_details` entry.
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AuthorizationDetail {
+    #[serde(rename = "type")]
+    detail_type: String,
+    scope: Scope,
+    permissions: Vec<CapPermission>,
+}
+
+impl TryFrom<AuthorizationDetail> for CapEntry {
+    type Error = String;
+
+    fn try_from(detail: AuthorizationDetail) -> Result<Self, Self::Error> {
+        if detail.detail_type != RBAC_DETAIL_TYPE {
+            return Err(format!(
+                "authorization detail type must be '{RBAC_DETAIL_TYPE}', got '{}'",
+                detail.detail_type
+            ));
+        }
+        if detail.permissions.is_empty() {
+            return Err("authorization detail permissions must not be empty".into());
+        }
+        Ok(Self {
+            scope: detail.scope,
+            permissions: detail.permissions,
+        })
+    }
+}
+
+impl From<CapEntry> for AuthorizationDetail {
+    fn from(entry: CapEntry) -> Self {
+        Self {
+            detail_type: RBAC_DETAIL_TYPE.to_owned(),
+            scope: entry.scope,
+            permissions: entry.permissions,
+        }
+    }
 }
 
 impl CapPermission {
@@ -30,7 +91,11 @@ impl CapPermission {
 
 /// One authorization-detail entry: a single qualified Scope and the permissions
 /// the token retains within it.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// Serializes as an RFC 9396 entry of type [`RBAC_DETAIL_TYPE`]; deserializing
+/// rejects any other type and an empty permission list.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "AuthorizationDetail", into = "AuthorizationDetail")]
 pub struct CapEntry {
     pub scope: Scope,
     pub permissions: Vec<CapPermission>,
@@ -49,6 +114,53 @@ pub enum AuthorizationCap {
 }
 
 impl AuthorizationCap {
+    /// Parse a credential's `authorization_details` claim, or a `/token`
+    /// request's narrowing, into a ceiling (ADR-0001 §7).
+    ///
+    /// `None` is the omitted claim and means the full live policy. A present
+    /// value must be a non-empty array of well-formed `rise.dev/rbac` entries:
+    /// an empty array, a non-array, an unknown type, or a malformed entry is an
+    /// error rather than a fallback to full access, and the caller treats that
+    /// error as an invalid credential.
+    pub fn from_details(details: Option<&[serde_json::Value]>) -> Result<Self, AuthorizationError> {
+        let Some(details) = details else {
+            return Ok(Self::Unrestricted);
+        };
+        if details.is_empty() {
+            return Err(AuthorizationError::invalid_input(
+                "authorization_details must not be an empty list",
+            ));
+        }
+        details
+            .iter()
+            .enumerate()
+            .map(|(index, entry)| {
+                serde_json::from_value::<CapEntry>(entry.clone()).map_err(|error| {
+                    AuthorizationError::invalid_input(format!(
+                        "authorization_details[{index}] is invalid: {error}"
+                    ))
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map(Self::Restricted)
+    }
+
+    /// The canonical claim value for this ceiling: `None` for an unrestricted
+    /// credential, otherwise the entries in wire form.
+    pub fn to_details(&self) -> Option<Vec<serde_json::Value>> {
+        match self {
+            Self::Unrestricted => None,
+            Self::Restricted(entries) => Some(
+                entries
+                    .iter()
+                    .map(|entry| {
+                        serde_json::to_value(entry).expect("a CapEntry serializes to JSON")
+                    })
+                    .collect(),
+            ),
+        }
+    }
+
     /// The ceiling that applies to one resource: the union of every entry whose
     /// Scope covers it. `None` means unrestricted.
     pub(crate) fn ceiling_for(&self, target: &ResourceTree) -> Option<Vec<PolicyStatement>> {

--- a/crates/rise-authz/tests/engine.rs
+++ b/crates/rise-authz/tests/engine.rs
@@ -1660,3 +1660,124 @@ async fn an_org_binding_replaces_the_platform_ownership_default_for_its_own_org(
         "replacement is confined to the organization that authored the override"
     );
 }
+
+/// ADR-0001 §7, scenarios 49–52: the `authorization_details` claim parses into
+/// the same ceiling the engine evaluates, and every malformed shape fails
+/// closed instead of falling back to full policy.
+#[tokio::test]
+async fn authorization_details_parse_into_a_ceiling_and_fail_closed() {
+    let mut builder = StoreBuilder::new();
+    let acme = builder.resource(ORGANIZATION, "acme", None);
+    let app = builder.resource(PROJECT, "app", Some(acme));
+    let deployment = builder.resource(DEPLOYMENT, "foo", Some(app));
+    let catalog = builder.resource(PROJECT, "catalog", Some(acme));
+    let other_deployment = builder.resource(DEPLOYMENT, "bar", Some(catalog));
+    let store = builder.build();
+
+    // Omitted details are the full live policy.
+    assert_eq!(
+        AuthorizationCap::from_details(None).unwrap(),
+        AuthorizationCap::Unrestricted
+    );
+
+    // Two entries at different Scopes union without a Cartesian product
+    // (scenario 51); a main-resource detail excludes subresources (49); a
+    // subresource detail is separate from the main resource (50).
+    let details = vec![
+        json!({
+            "type": "rise.dev/rbac",
+            "scope": "rise.dev/Project/acme/app",
+            "permissions": [{ "verbs": ["get", "list"], "kinds": ["rise.dev/Deployment"] }]
+        }),
+        json!({
+            "type": "rise.dev/rbac",
+            "scope": "rise.dev/Project/acme/catalog",
+            "permissions": [{
+                "verbs": ["get"],
+                "kinds": ["rise.dev/Deployment"],
+                "subresources": ["status"]
+            }]
+        }),
+    ];
+    let cap = AuthorizationCap::from_details(Some(&details)).unwrap();
+    assert_eq!(
+        cap.to_details().as_deref(),
+        Some(details.as_slice()),
+        "a parsed ceiling round-trips to its canonical wire form"
+    );
+
+    let capped =
+        AuthenticatedPrincipal::new("user:u-root".parse().unwrap(), Uuid::new_v4(), cap).unwrap();
+    let engine = engine(store.clone(), FakeMemberships::operator());
+    let snapshot = engine.snapshot(capped).await.unwrap();
+    let status = |verb| PermissionTuple {
+        verb,
+        kind: "rise.dev/Deployment".parse().unwrap(),
+        subresource: Some("status".parse().unwrap()),
+    };
+
+    let app_target = engine.resource_tree(deployment).await.unwrap();
+    let app_policy = engine
+        .effective_policy(&snapshot, &app_target)
+        .await
+        .unwrap();
+    assert_eq!(
+        app_policy.decide(&tuple(Verb::Get, "rise.dev/Deployment")),
+        Decision::Allow
+    );
+    assert_eq!(
+        app_policy.decide(&status(Verb::Get)),
+        Decision::Deny,
+        "a main-resource detail omits every subresource"
+    );
+
+    let catalog_target = engine.resource_tree(other_deployment).await.unwrap();
+    let catalog_policy = engine
+        .effective_policy(&snapshot, &catalog_target)
+        .await
+        .unwrap();
+    assert_eq!(catalog_policy.decide(&status(Verb::Get)), Decision::Allow);
+    assert_eq!(
+        catalog_policy.decide(&tuple(Verb::Get, "rise.dev/Deployment")),
+        Decision::Deny,
+        "a subresource detail never reaches the main resource"
+    );
+    assert_eq!(
+        catalog_policy.decide(&tuple(Verb::List, "rise.dev/Deployment")),
+        Decision::Deny,
+        "entries union by their own Scope, never across Scopes"
+    );
+
+    // Scenario 52: malformed details fail token validation.
+    let permission = json!({ "verbs": ["get"], "kinds": ["rise.dev/Deployment"] });
+    let rejected: Vec<serde_json::Value> = vec![
+        // A present empty detail set.
+        json!([]),
+        // Unknown type.
+        json!([{ "type": "rise.dev/other", "scope": "rise.dev/Project/acme/app", "permissions": [permission] }]),
+        // Missing type.
+        json!([{ "scope": "rise.dev/Project/acme/app", "permissions": [permission] }]),
+        // Empty permissions.
+        json!([{ "type": "rise.dev/rbac", "scope": "rise.dev/Project/acme/app", "permissions": [] }]),
+        // Empty axes.
+        json!([{ "type": "rise.dev/rbac", "scope": "rise.dev/Project/acme/app", "permissions": [{ "verbs": [], "kinds": ["rise.dev/Deployment"] }] }]),
+        json!([{ "type": "rise.dev/rbac", "scope": "rise.dev/Project/acme/app", "permissions": [{ "verbs": ["get"], "kinds": [] }] }]),
+        json!([{ "type": "rise.dev/rbac", "scope": "rise.dev/Project/acme/app", "permissions": [{ "verbs": ["get"], "kinds": ["rise.dev/Deployment"], "subresources": [] }] }]),
+        json!([{ "type": "rise.dev/rbac", "scope": "rise.dev/Project/acme/app", "permissions": [{ "verbs": ["get"], "kinds": ["rise.dev/Deployment"], "subresources": null }] }]),
+        // Unqualified kind and Scope; empty Scope.
+        json!([{ "type": "rise.dev/rbac", "scope": "rise.dev/Project/acme/app", "permissions": [{ "verbs": ["get"], "kinds": ["Deployment"] }] }]),
+        json!([{ "type": "rise.dev/rbac", "scope": "Project/acme/app", "permissions": [permission] }]),
+        json!([{ "type": "rise.dev/rbac", "scope": "", "permissions": [permission] }]),
+        // Malformed entries.
+        json!([{ "type": "rise.dev/rbac", "scope": "rise.dev/Project/acme/app", "permissions": [permission], "extra": 1 }]),
+        json!(["not-an-object"]),
+        json!([{ "type": "rise.dev/rbac", "scope": "rise.dev/Project/acme/app", "permissions": [{ "verbs": ["get"], "kinds": ["rise.dev/Deployment"], "effect": "Allow" }] }]),
+    ];
+    for details in rejected {
+        let entries = details.as_array().expect("test details are arrays");
+        assert!(
+            AuthorizationCap::from_details(Some(entries)).is_err(),
+            "{details} must fail closed"
+        );
+    }
+}

--- a/crates/rise-backend-auth/README.md
+++ b/crates/rise-backend-auth/README.md
@@ -37,14 +37,16 @@ verifier; callers enforce audience per context).
 | Alg | header `typ` | Verifier output | Notes |
 |---|---|---|---|
 | HS256 | `"rise-access+jwt"` | `RiseToken::Access(AccessClaims)` | exchanged SA / controller principal (RFC 8693), `aud = public_url` (checked by the API middleware, not here) |
+| HS256 | `"rise-identity+jwt"` | `RiseToken::Identity(IdentityClaims)` | ServiceAccount / Controller *resource* principal minted by a `/token` subresource (ADR-0001 §7); `aud = public_url` and the `(sub, rise_uid)` liveness check are the API middleware's |
 | HS256 | any other (incl. default `"JWT"`, missing, unknown) | `RiseToken::Session(RiseClaims)` | UI / CLI user login, `aud = public_url` (checked by the API middleware, not here) |
 | RS256 | any (incl. default `"JWT"`) | `RiseToken::Ingress(RiseClaims)` | deployed-app ingress auth, `aud = project_url` (not checked here) |
 | anything else | — | **rejected** (`InvalidAlgorithm`) | only HS256 / RS256 are accepted |
 
 **Dispatch:** RS256 → `Ingress`. HS256 branches on the header `typ` **first** — the
-access `typ` (`rise-access+jwt`) → `Access`; anything else → `Session`. The access
-`typ` is matched *exclusively*; legacy session tokens carry the default `"JWT"`, so a
-session is never required to set a specific `typ`. The
+access `typ` (`rise-access+jwt`) → `Access`, the identity `typ` (`rise-identity+jwt`)
+→ `Identity`; anything else → `Session`. The special `typ`s are matched
+*exclusively*; legacy session tokens carry the default `"JWT"`, so a session is
+never required to set a specific `typ`. The
 `rise_token_disambiguation_matrix` unit test pins this table against the real
 `verify_rise_jwt`.
 
@@ -53,9 +55,10 @@ Two notes on the RS256 / HS256 boundaries:
 - **Session vs. Access (HS256).** Both are HS256, and `RiseClaims` has no
   `#[serde(deny_unknown_fields)]`, so they are not serde-distinguishable — the
   `header.typ` discriminator is what keeps them apart. `AccessClaims` *does* use
-  `deny_unknown_fields`. The ingress adapter (`verify_jwt_skip_aud`) additionally
-  rejects any token carrying a `principal` claim, so an access-shaped payload can
-  never be honored on the ingress path.
+  `deny_unknown_fields`, as does `IdentityClaims`. The ingress adapter
+  (`verify_jwt_skip_aud`) additionally rejects any token carrying a `principal` or
+  `rise_uid` claim, so an access- or identity-shaped payload can never be honored
+  on the ingress path.
 - **Workload vs. Ingress (RS256).** Rise also mints **Workload** tokens (RS256,
   same key, default `typ:"JWT"`), but they are **sign-only** — `verify_rise_jwt`
   never returns a `Workload` variant. The *only* thing currently keeping a Workload
@@ -71,9 +74,11 @@ Two notes on the RS256 / HS256 boundaries:
 |---|---|---|---|---|
 | Workload (`WorkloadClaims`) | RS256 | `"JWT"` | n/a — sign-only; verified **externally** via the published JWKS (AWS STS / GCP WIF / Vault), never by Rise | outbound federation |
 
-The signer (`RiseTokenSigner`) mints all four kinds — `sign_user_jwt` (Session),
-`sign_access_jwt` (Access), `sign_ingress_jwt` (Ingress), `sign_workload_jwt`
-(Workload) — but the verifier classifies only the three inbound kinds above.
+The signer (`RiseTokenSigner`) mints all five kinds — `sign_user_jwt` (Session),
+`sign_access_jwt` (Access), `sign_identity_jwt` (Identity), `sign_ingress_jwt`
+(Ingress), `sign_workload_jwt` (Workload) — but the verifier classifies only the
+four inbound kinds above. `sign_identity_jwt` also enforces `MAX_DELEGATION_DEPTH`
+on the `act` chain, so no signing path can emit a token the platform limit forbids.
 
 ### External tokens — `verify_external_jwt` (Path A)
 
@@ -102,13 +107,15 @@ enforces `iss` + `exp`. Audience and any custom-claim constraints are validated
 ## Public surface (selected)
 
 - Verify: [`verify_external_jwt`], [`RiseTokenSigner::verify_rise_jwt`].
-- Sign: [`RiseTokenSigner`] (`sign_user_jwt`, `sign_access_jwt`, `sign_ingress_jwt`,
-  `sign_workload_jwt`, `generate_jwks`), [`compute_key_id`], `RISE_ACCESS_TYP`.
+- Sign: [`RiseTokenSigner`] (`sign_user_jwt`, `sign_access_jwt`, `sign_identity_jwt`,
+  `sign_ingress_jwt`, `sign_workload_jwt`, `generate_jwks`), [`compute_key_id`],
+  `RISE_ACCESS_TYP`, `RISE_IDENTITY_TYP`, `IdentityTokenSpec`.
 - Adapters (legacy, thin wrappers over `verify_rise_jwt`): `verify_user_jwt`
   (HS256 + `aud`), `verify_jwt_skip_aud` (HS256 **or** RS256, `aud` skipped; rejects
   access tokens / `principal`-carrying tokens).
 - Claims: [`RiseClaims`], [`AccessClaims`], [`PrincipalClaims`], [`Scope`],
-  [`WorkloadClaims`], [`WorkloadSubjectInfo`], [`ExternalClaims`].
+  `IdentityClaims`, `ActorClaim`, `MAX_DELEGATION_DEPTH`, [`WorkloadClaims`],
+  [`WorkloadSubjectInfo`], [`ExternalClaims`].
 - Matchers: [`TrustCandidate`], [`TrustMatch`], [`match_trust_candidates`]
   (shape-agnostic claim matching a caller builds from its own trust-policy
   resources — Controller, ServiceAccount — since this crate cannot depend on

--- a/crates/rise-backend-auth/README.md
+++ b/crates/rise-backend-auth/README.md
@@ -37,16 +37,18 @@ verifier; callers enforce audience per context).
 | Alg | header `typ` | Verifier output | Notes |
 |---|---|---|---|
 | HS256 | `"rise-access+jwt"` | `RiseToken::Access(AccessClaims)` | exchanged SA / controller principal (RFC 8693), `aud = public_url` (checked by the API middleware, not here) |
-| HS256 | `"rise-identity+jwt"` | `RiseToken::Identity(IdentityClaims)` | ServiceAccount / Controller *resource* principal minted by a `/token` subresource (ADR-0001 §7); `aud = public_url` and the `(sub, rise_uid)` liveness check are the API middleware's |
+| HS256 | `"rise-identity+jwt"` | **rejected** (`InvalidAlgorithm`) | identity tokens are never HS256 |
 | HS256 | any other (incl. default `"JWT"`, missing, unknown) | `RiseToken::Session(RiseClaims)` | UI / CLI user login, `aud = public_url` (checked by the API middleware, not here) |
-| RS256 | any (incl. default `"JWT"`) | `RiseToken::Ingress(RiseClaims)` | deployed-app ingress auth, `aud = project_url` (not checked here) |
+| RS256 | `"rise-identity+jwt"` | `RiseToken::Identity(IdentityClaims)` | ServiceAccount / Controller *resource* principal minted by a `/token` subresource (ADR-0001 §7), for Rise's own audience or an external one; `aud = public_url` and the `(sub, rise_uid)` liveness check are the API middleware's, an external audience verifies via the JWKS |
+| RS256 | any other (incl. default `"JWT"`) | `RiseToken::Ingress(RiseClaims)` | deployed-app ingress auth, `aud = project_url` (not checked here) |
 | anything else | — | **rejected** (`InvalidAlgorithm`) | only HS256 / RS256 are accepted |
 
-**Dispatch:** RS256 → `Ingress`. HS256 branches on the header `typ` **first** — the
-access `typ` (`rise-access+jwt`) → `Access`, the identity `typ` (`rise-identity+jwt`)
-→ `Identity`; anything else → `Session`. The special `typ`s are matched
-*exclusively*; legacy session tokens carry the default `"JWT"`, so a session is
-never required to set a specific `typ`. The
+**Dispatch:** both branches read the header `typ` **first**. RS256: the identity
+`typ` (`rise-identity+jwt`) → `Identity`; anything else → `Ingress`. HS256: the
+access `typ` (`rise-access+jwt`) → `Access`; the identity `typ` is rejected;
+anything else → `Session`. The special `typ`s are matched *exclusively*; legacy
+session and ingress tokens carry the default `"JWT"`, so neither is ever
+required to set a specific `typ`. The
 `rise_token_disambiguation_matrix` unit test pins this table against the real
 `verify_rise_jwt`.
 
@@ -77,8 +79,10 @@ Two notes on the RS256 / HS256 boundaries:
 The signer (`RiseTokenSigner`) mints all five kinds — `sign_user_jwt` (Session),
 `sign_access_jwt` (Access), `sign_identity_jwt` (Identity), `sign_ingress_jwt`
 (Ingress), `sign_workload_jwt` (Workload) — but the verifier classifies only the
-four inbound kinds above. `sign_identity_jwt` also enforces `MAX_DELEGATION_DEPTH`
-on the `act` chain, so no signing path can emit a token the platform limit forbids.
+four inbound kinds above. `sign_identity_jwt` signs with the RS256 key whatever
+the audience — a token for Rise's API and one for an external verifier are the
+same kind, and the JWKS serves both — and enforces `MAX_DELEGATION_DEPTH` on
+the `act` chain, so no signing path can emit a token the platform limit forbids.
 
 ### External tokens — `verify_external_jwt` (Path A)
 

--- a/crates/rise-backend-auth/src/claims.rs
+++ b/crates/rise-backend-auth/src/claims.rs
@@ -174,6 +174,92 @@ pub struct AccessClaims {
     pub principal: PrincipalClaims,
 }
 
+/// The longest delegation chain an identity token may record (ADR-0001 §7).
+///
+/// Counted in `act` entries: a workload-exchanged token has none; a token
+/// minted by that workload for another target has one; and so on. A request
+/// whose result would exceed this is refused rather than silently truncated,
+/// so the audit chain a token carries is always complete.
+pub const MAX_DELEGATION_DEPTH: usize = 4;
+
+/// One delegator in an identity token's `act` chain (RFC 8693 §4.1).
+///
+/// The nested shape records every principal that minted a token along the way,
+/// outermost first: `act` names the caller that requested this token, and its
+/// own `act` names whoever minted the credential *that* caller presented.
+/// Actor data is audit provenance only; it never grants access.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ActorClaim {
+    /// The delegator's canonical subject (`user:<name>`,
+    /// `serviceaccount:<org>/<name>`, or `controller:<name>`).
+    pub sub: String,
+    /// The delegator's resource UID at issuance time.
+    pub rise_uid: Uuid,
+    /// The delegator's own delegator, if it was itself acting on a delegated
+    /// token.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub act: Option<Box<ActorClaim>>,
+}
+
+impl ActorClaim {
+    /// How many delegators this chain records, this entry included.
+    pub fn depth(&self) -> usize {
+        1 + self.act.as_ref().map_or(0, |inner| inner.depth())
+    }
+}
+
+/// Claims for a Rise-issued **identity token** (HS256) — the credential of a
+/// ServiceAccount or Controller *resource* principal (ADR-0001 §7).
+///
+/// Minted only by a target's `/token` subresource, either from an external
+/// workload assertion matched against that target's trust policies or by a
+/// Rise principal holding `(create, <kind>, token)` on it. Consumed only by
+/// Rise's own middleware, which re-resolves `(sub, rise_uid)` to a live resource
+/// on every request: the token carries identity and an optional ceiling, never
+/// a snapshot of grants.
+///
+/// Kept structurally separate from [`AccessClaims`] (which encodes a resolved
+/// typed-table principal) and from [`RiseClaims`] so none of the three can be
+/// honored on another's path.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct IdentityClaims {
+    /// Issuer (Rise public URL).
+    pub iss: String,
+    /// Audience (Rise public URL) — verified by the middleware like a session token.
+    pub aud: String,
+    /// The principal's canonical subject: `serviceaccount:<org>/<name>` or
+    /// `controller:<name>`.
+    pub sub: String,
+    /// The principal's resource UID at issuance. Authentication requires `sub`
+    /// and `rise_uid` to identify the same live resource, so a token issued for
+    /// a deleted-and-recreated name fails even though the name resolves again.
+    pub rise_uid: Uuid,
+    /// Issued at timestamp.
+    pub iat: u64,
+    /// Expiration timestamp.
+    pub exp: u64,
+    /// Audit id.
+    pub jti: String,
+    /// RFC 9396 authorization details forming a signed Allow ceiling (ADR-0001
+    /// §7). Absent means the target's full live policy; present is parsed by
+    /// the authorization engine on every request and fails closed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authorization_details: Option<Vec<serde_json::Value>>,
+    /// The delegation chain, when this token was minted through delegated
+    /// issuance rather than workload exchange.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub act: Option<ActorClaim>,
+}
+
+impl IdentityClaims {
+    /// The number of delegators recorded in the `act` chain.
+    pub fn delegation_depth(&self) -> usize {
+        self.act.as_ref().map_or(0, ActorClaim::depth)
+    }
+}
+
 /// Subject info for workload identity JWT claims.
 pub struct WorkloadSubjectInfo<'a> {
     pub sub: &'a str,

--- a/crates/rise-backend-auth/src/error.rs
+++ b/crates/rise-backend-auth/src/error.rs
@@ -39,6 +39,10 @@ pub enum JwtSignerError {
     SystemTimeError(#[from] std::time::SystemTimeError),
     #[error("Missing required claim: {0}")]
     MissingClaim(String),
+    /// A delegated identity token would record more delegators than the
+    /// platform allows (ADR-0001 §7).
+    #[error("delegation chain exceeds the platform limit")]
+    DelegationChainTooLong,
     #[error("RSA key generation failed: {0}")]
     RsaKeyError(String),
     #[error("PEM encoding failed: {0}")]

--- a/crates/rise-backend-auth/src/lib.rs
+++ b/crates/rise-backend-auth/src/lib.rs
@@ -18,15 +18,17 @@ mod verify;
 mod workload;
 
 pub use claims::{
-    AccessClaims, ExternalClaims, PrincipalClaims, RiseClaims, Scope, WorkloadClaims,
-    WorkloadSubjectInfo,
+    AccessClaims, ActorClaim, ExternalClaims, IdentityClaims, PrincipalClaims, RiseClaims, Scope,
+    WorkloadClaims, WorkloadSubjectInfo, MAX_DELEGATION_DEPTH,
 };
 pub use error::{AuthError, JwtSignerError};
 pub use matchers::{
     audience_matches, match_trust_candidates, matches_wildcard_pattern, validate_custom_claims,
     validate_oidc_issuer, TrustCandidate, TrustMatch,
 };
-pub use signer::{compute_key_id, RiseTokenSigner, RISE_ACCESS_TYP};
+pub use signer::{
+    compute_key_id, IdentityTokenSpec, RiseTokenSigner, RISE_ACCESS_TYP, RISE_IDENTITY_TYP,
+};
 pub use verify::{verify_external_jwt, JwksKeySource, RiseToken};
 pub use workload::{
     generate_bootstrap_credential, sha256_hex, sign_audience_tokens, workload_subject,

--- a/crates/rise-backend-auth/src/signer.rs
+++ b/crates/rise-backend-auth/src/signer.rs
@@ -10,9 +10,11 @@ use jsonwebtoken::{encode, Algorithm, DecodingKey, EncodingKey, Header};
 use rsa::traits::PublicKeyParts;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
 
 use crate::claims::{
-    AccessClaims, PrincipalClaims, RiseClaims, WorkloadClaims, WorkloadSubjectInfo,
+    AccessClaims, ActorClaim, IdentityClaims, PrincipalClaims, RiseClaims, WorkloadClaims,
+    WorkloadSubjectInfo,
 };
 use crate::error::JwtSignerError;
 use crate::verify::RiseToken;
@@ -24,6 +26,33 @@ use crate::verify::RiseToken;
 /// [`RiseToken::Access`], and the legacy `verify_user_jwt` / `verify_jwt_skip_aud`
 /// adapters reject it. Session tokens carry the default `"JWT"` `typ`.
 pub const RISE_ACCESS_TYP: &str = "rise-access+jwt";
+
+/// JWT header `typ` for Rise identity tokens (ADR-0001 §7).
+///
+/// The discriminator that routes an HS256 token to [`RiseToken::Identity`].
+/// Matched exclusively, like [`RISE_ACCESS_TYP`].
+pub const RISE_IDENTITY_TYP: &str = "rise-identity+jwt";
+
+/// What an identity token is minted for.
+///
+/// The signer stamps `iss`, `iat`/`exp`, and a random `jti`; everything
+/// identity-specific arrives here, already validated by the `/token` handler.
+pub struct IdentityTokenSpec<'a> {
+    /// Canonical subject of the target identity.
+    pub subject: &'a str,
+    /// The target resource's UID.
+    pub rise_uid: Uuid,
+    /// The `aud` claim (the Rise public URL).
+    pub audience: &'a str,
+    /// Token lifetime in seconds (the caller clamps to the platform maximum).
+    pub ttl_secs: u64,
+    /// Canonical `rise.dev/rbac` authorization details, or `None` for the
+    /// target's full live policy.
+    pub authorization_details: Option<Vec<serde_json::Value>>,
+    /// The delegation chain for delegated issuance; `None` for a workload
+    /// exchange.
+    pub act: Option<ActorClaim>,
+}
 
 /// JWT signer supporting both HS256 (symmetric) and RS256 (asymmetric) algorithms
 ///
@@ -427,6 +456,49 @@ impl RiseTokenSigner {
         Ok((token, claims))
     }
 
+    /// Sign a Rise identity token (HS256) for a ServiceAccount or Controller
+    /// resource principal (ADR-0001 §7).
+    ///
+    /// Sets the header `typ` to [`RISE_IDENTITY_TYP`] so `verify_rise_jwt`
+    /// classifies it as [`RiseToken::Identity`] and every other adapter rejects
+    /// it. A delegation chain longer than [`crate::MAX_DELEGATION_DEPTH`] is
+    /// refused here as well as at the handler, so no signing path can produce a
+    /// token the platform limit forbids.
+    pub fn sign_identity_jwt(
+        &self,
+        spec: IdentityTokenSpec<'_>,
+    ) -> Result<(String, IdentityClaims), JwtSignerError> {
+        use rand::Rng;
+
+        if spec.act.as_ref().map_or(0, ActorClaim::depth) > crate::MAX_DELEGATION_DEPTH {
+            return Err(JwtSignerError::DelegationChainTooLong);
+        }
+
+        let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+
+        let mut jti_bytes = [0u8; 16];
+        rand::rng().fill_bytes(&mut jti_bytes);
+        let jti = BASE64URL.encode(jti_bytes);
+
+        let claims = IdentityClaims {
+            iss: self.issuer.clone(),
+            aud: spec.audience.to_string(),
+            sub: spec.subject.to_string(),
+            rise_uid: spec.rise_uid,
+            iat: now,
+            exp: now + spec.ttl_secs,
+            jti,
+            authorization_details: spec.authorization_details,
+            act: spec.act,
+        };
+
+        let mut header = Header::new(Algorithm::HS256);
+        header.typ = Some(RISE_IDENTITY_TYP.to_string());
+        let token = encode(&header, &claims, &self.hs256_encoding_key)?;
+
+        Ok((token, claims))
+    }
+
     /// Verify and decode a Rise user JWT (HS256 only) with audience validation.
     ///
     /// Adapter over [`Self::verify_rise_jwt`] for the API authentication path:
@@ -446,11 +518,14 @@ impl RiseTokenSigner {
             // A correctly-signed HS256 session token with the wrong audience:
             // labeled distinctly as an audience mismatch (still rejected).
             RiseToken::Session(_) => Err(JwtSignerError::AudienceMismatch),
-            // An RS256 ingress token, or an exchanged access token — genuinely the
-            // wrong token kind on the user-login path, so reject as an alg error.
-            RiseToken::Ingress(_) | RiseToken::Access(_) => Err(JwtSignerError::SigningFailed(
-                jsonwebtoken::errors::ErrorKind::InvalidAlgorithm.into(),
-            )),
+            // An RS256 ingress token, an exchanged access token, or a resource
+            // identity token — genuinely the wrong token kind on the user-login
+            // path, so reject as an alg error.
+            RiseToken::Ingress(_) | RiseToken::Access(_) | RiseToken::Identity(_) => {
+                Err(JwtSignerError::SigningFailed(
+                    jsonwebtoken::errors::ErrorKind::InvalidAlgorithm.into(),
+                ))
+            }
         }
     }
 
@@ -463,8 +538,9 @@ impl RiseTokenSigner {
     pub fn verify_jwt_skip_aud(&self, token: &str) -> Result<RiseClaims, JwtSignerError> {
         let claims = match self.verify_rise_jwt(token)? {
             RiseToken::Session(claims) | RiseToken::Ingress(claims) => claims,
-            // An exchanged access token must never be honored on the ingress path.
-            RiseToken::Access(_) => {
+            // An exchanged access token or a resource identity token must never
+            // be honored on the ingress path.
+            RiseToken::Access(_) | RiseToken::Identity(_) => {
                 return Err(JwtSignerError::SigningFailed(
                     jsonwebtoken::errors::ErrorKind::InvalidAlgorithm.into(),
                 ))
@@ -472,13 +548,14 @@ impl RiseTokenSigner {
         };
 
         // Defense-in-depth (§4.1 ingress hardening): the `typ` discriminator above
-        // already routes a Rise access token to `RiseToken::Access`, but because
-        // `RiseClaims` intentionally does NOT use `deny_unknown_fields`, a token
-        // *without* the access `typ` that nonetheless carries a `principal` claim
-        // would deserialize cleanly as a session/ingress token (extra field
-        // ignored). Reject any such token outright so an access-shaped payload can
-        // never be accepted on the ingress path. The payload was just
-        // signature-verified, so this peek reads authenticated bytes.
+        // already routes a Rise access or identity token to its own variant, but
+        // because `RiseClaims` intentionally does NOT use `deny_unknown_fields`,
+        // a token *without* that `typ` that nonetheless carries a `principal` or
+        // `rise_uid` claim would deserialize cleanly as a session/ingress token
+        // (extra field ignored). Reject any such token outright so a
+        // principal-shaped payload can never be accepted on the ingress path.
+        // The payload was just signature-verified, so this peek reads
+        // authenticated bytes.
         if rise_jwt_payload_has_principal(token) {
             return Err(JwtSignerError::SigningFailed(
                 jsonwebtoken::errors::ErrorKind::InvalidAlgorithm.into(),
@@ -490,9 +567,11 @@ impl RiseTokenSigner {
 }
 
 /// Whether a (already signature-verified) JWT's payload carries a top-level
-/// `principal` claim. Used to fail-close the ingress path against access-shaped
-/// tokens (§4.1). Returns `false` if the payload cannot be parsed (the caller has
-/// already verified the signature, so this only guards the claim shape).
+/// `principal` or `rise_uid` claim — the fields that mark an access token and
+/// an identity token respectively. Used to fail-close the ingress path against
+/// principal-shaped tokens (§4.1). Returns `false` if the payload cannot be
+/// parsed (the caller has already verified the signature, so this only guards
+/// the claim shape).
 fn rise_jwt_payload_has_principal(token: &str) -> bool {
     let Some(payload_b64) = token.split('.').nth(1) else {
         return false;
@@ -502,7 +581,10 @@ fn rise_jwt_payload_has_principal(token: &str) -> bool {
     };
     serde_json::from_slice::<serde_json::Value>(&payload)
         .ok()
-        .and_then(|v| v.as_object().map(|obj| obj.contains_key("principal")))
+        .and_then(|v| {
+            v.as_object()
+                .map(|obj| obj.contains_key("principal") || obj.contains_key("rise_uid"))
+        })
         .unwrap_or(false)
 }
 

--- a/crates/rise-backend-auth/src/signer.rs
+++ b/crates/rise-backend-auth/src/signer.rs
@@ -42,7 +42,8 @@ pub struct IdentityTokenSpec<'a> {
     pub subject: &'a str,
     /// The target resource's UID.
     pub rise_uid: Uuid,
-    /// The `aud` claim (the Rise public URL).
+    /// The `aud` claim: the Rise public URL for a token Rise's own API accepts,
+    /// or an external verifier's audience.
     pub audience: &'a str,
     /// Token lifetime in seconds (the caller clamps to the platform maximum).
     pub ttl_secs: u64,
@@ -456,14 +457,18 @@ impl RiseTokenSigner {
         Ok((token, claims))
     }
 
-    /// Sign a Rise identity token (HS256) for a ServiceAccount or Controller
+    /// Sign a Rise identity token (RS256) for a ServiceAccount or Controller
     /// resource principal (ADR-0001 §7).
     ///
-    /// Sets the header `typ` to [`RISE_IDENTITY_TYP`] so `verify_rise_jwt`
-    /// classifies it as [`RiseToken::Identity`] and every other adapter rejects
-    /// it. A delegation chain longer than [`crate::MAX_DELEGATION_DEPTH`] is
-    /// refused here as well as at the handler, so no signing path can produce a
-    /// token the platform limit forbids.
+    /// Always asymmetric, whatever the audience: a token for Rise's own API and
+    /// one for an external verifier are the same kind, signed with the RS256
+    /// key the JWKS publishes, so any audience can verify it and Rise has one
+    /// verification path rather than two. The header carries the `kid` and the
+    /// [`RISE_IDENTITY_TYP`] `typ` that routes `verify_rise_jwt` to
+    /// [`RiseToken::Identity`]; every other adapter rejects it. A delegation
+    /// chain longer than [`crate::MAX_DELEGATION_DEPTH`] is refused here as well
+    /// as at the handler, so no signing path can produce a token the platform
+    /// limit forbids.
     pub fn sign_identity_jwt(
         &self,
         spec: IdentityTokenSpec<'_>,
@@ -492,9 +497,10 @@ impl RiseTokenSigner {
             act: spec.act,
         };
 
-        let mut header = Header::new(Algorithm::HS256);
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(self.rs256_key_id.clone());
         header.typ = Some(RISE_IDENTITY_TYP.to_string());
-        let token = encode(&header, &claims, &self.hs256_encoding_key)?;
+        let token = encode(&header, &claims, &self.rs256_encoding_key)?;
 
         Ok((token, claims))
     }

--- a/crates/rise-backend-auth/src/verify.rs
+++ b/crates/rise-backend-auth/src/verify.rs
@@ -30,9 +30,11 @@ pub enum RiseToken {
     /// HS256, `typ = "rise-access+jwt"`, aud = public_url — exchanged SA /
     /// controller principal (RFC 8693 token exchange).
     Access(AccessClaims),
-    /// HS256, `typ = "rise-identity+jwt"`, aud = public_url — a ServiceAccount
-    /// or Controller resource principal (ADR-0001 §7). The middleware still has
-    /// to resolve `(sub, rise_uid)` to a live resource before it is a principal.
+    /// RS256, `typ = "rise-identity+jwt"` — a ServiceAccount or Controller
+    /// resource principal (ADR-0001 §7), for whatever audience it was minted.
+    /// The middleware accepts it only with `aud = public_url`, and still has to
+    /// resolve `(sub, rise_uid)` to a live resource before it is a principal;
+    /// an external audience verifies it against the published JWKS.
     Identity(IdentityClaims),
     /// RS256, aud = project_url — deployed-app ingress auth (aud not checked here).
     Ingress(RiseClaims),
@@ -42,14 +44,15 @@ impl RiseTokenSigner {
     /// Verify a Rise-issued JWT and classify it into a typed [`RiseToken`].
     ///
     /// Verifies the signature and `iss`, then disambiguates:
-    /// - **RS256** → [`RiseToken::Ingress`].
+    /// - **RS256** → the identity `typ` ([`RISE_IDENTITY_TYP`]) →
+    ///   [`RiseToken::Identity`]; anything else → [`RiseToken::Ingress`].
     /// - **HS256** → branch on the header `typ`: the access `typ`
-    ///   ([`RISE_ACCESS_TYP`]) → [`RiseToken::Access`]; the identity `typ`
-    ///   ([`RISE_IDENTITY_TYP`]) → [`RiseToken::Identity`]; anything else (the
-    ///   default `"JWT"`, a missing or unknown `typ`) → [`RiseToken::Session`].
-    ///   Legacy session tokens carry the default `"JWT"`, so the special `typ`s
-    ///   are matched *exclusively* — never requiring a session-specific `typ`
-    ///   that would break existing sessions.
+    ///   ([`RISE_ACCESS_TYP`]) → [`RiseToken::Access`]; the identity `typ` is
+    ///   rejected (identity tokens are never HS256); anything else (the default
+    ///   `"JWT"`, a missing or unknown `typ`) → [`RiseToken::Session`]. Legacy
+    ///   session and ingress tokens carry the default `"JWT"`, so the special
+    ///   `typ`s are matched *exclusively* — never requiring a session-specific
+    ///   `typ` that would break existing sessions.
     ///
     /// No `aud` check is performed here — callers enforce audience per context
     /// (the API middleware requires `aud == public_url` for `Session` and
@@ -76,9 +79,11 @@ impl RiseTokenSigner {
                         decode::<AccessClaims>(token, self.hs256_decoding_key(), &validation)?;
                     Ok(RiseToken::Access(token_data.claims))
                 } else if header.typ.as_deref() == Some(RISE_IDENTITY_TYP) {
-                    let token_data =
-                        decode::<IdentityClaims>(token, self.hs256_decoding_key(), &validation)?;
-                    Ok(RiseToken::Identity(token_data.claims))
+                    // Identity tokens are RS256 only; an HS256 token wearing
+                    // the identity typ is not something Rise ever minted.
+                    Err(AuthError::Jwt(
+                        jsonwebtoken::errors::ErrorKind::InvalidAlgorithm.into(),
+                    ))
                 } else {
                     let token_data =
                         decode::<RiseClaims>(token, self.hs256_decoding_key(), &validation)?;
@@ -90,6 +95,13 @@ impl RiseTokenSigner {
                 validation.set_issuer(&[self.issuer()]);
                 validation.validate_aud = false;
 
+                // The identity typ is matched exclusively, like the access typ
+                // on the HS256 branch: ingress tokens carry the default "JWT".
+                if header.typ.as_deref() == Some(RISE_IDENTITY_TYP) {
+                    let token_data =
+                        decode::<IdentityClaims>(token, self.rs256_decoding_key(), &validation)?;
+                    return Ok(RiseToken::Identity(token_data.claims));
+                }
                 let token_data =
                     decode::<RiseClaims>(token, self.rs256_decoding_key(), &validation)?;
                 Ok(RiseToken::Ingress(token_data.claims))
@@ -431,7 +443,11 @@ mod tests {
             .unwrap();
 
         let header = jsonwebtoken::decode_header(&token).unwrap();
-        assert_eq!(header.alg, Algorithm::HS256);
+        assert_eq!(header.alg, Algorithm::RS256);
+        let published_kid = signer.generate_jwks().unwrap()["keys"][0]["kid"]
+            .as_str()
+            .map(str::to_owned);
+        assert_eq!(header.kid, published_kid, "the kid is the JWKS's");
         assert_eq!(header.typ.as_deref(), Some(crate::RISE_IDENTITY_TYP));
 
         match signer.verify_rise_jwt(&token).unwrap() {
@@ -447,6 +463,74 @@ mod tests {
             }
             other => panic!("expected Identity, got {other:?}"),
         }
+    }
+
+    /// An audience-bound identity token is the same kind of token, and an
+    /// external verifier checks it with nothing but the published JWKS.
+    #[test]
+    fn test_identity_token_verifies_against_the_published_jwks() {
+        let signer = create_test_signer();
+        let uid = uuid::Uuid::new_v4();
+        let (token, _) = signer
+            .sign_identity_jwt(crate::IdentityTokenSpec {
+                subject: "serviceaccount:acme/ci",
+                rise_uid: uid,
+                audience: "https://vault.example.com",
+                ttl_secs: 600,
+                authorization_details: None,
+                act: None,
+            })
+            .unwrap();
+
+        // What a third party does: pick the key by `kid` out of the JWKS and
+        // verify signature, issuer, and its own audience.
+        let jwks = signer.generate_jwks().unwrap();
+        let header = jsonwebtoken::decode_header(&token).unwrap();
+        let key = jwks["keys"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|key| key["kid"].as_str() == header.kid.as_deref())
+            .expect("the token's kid is published");
+        let decoding_key = DecodingKey::from_rsa_components(
+            key["n"].as_str().unwrap(),
+            key["e"].as_str().unwrap(),
+        )
+        .unwrap();
+        let mut validation = Validation::new(Algorithm::RS256);
+        validation.set_issuer(&["https://rise.test"]);
+        validation.set_audience(&["https://vault.example.com"]);
+        let external = decode::<crate::IdentityClaims>(&token, &decoding_key, &validation)
+            .expect("an external verifier accepts the token for its audience");
+        assert_eq!(external.claims.sub, "serviceaccount:acme/ci");
+        assert_eq!(external.claims.rise_uid, uid);
+
+        // Rise's own verifier classifies it too; the audience check that keeps
+        // it off Rise's API is the middleware's.
+        match signer.verify_rise_jwt(&token).unwrap() {
+            RiseToken::Identity(c) => assert_eq!(c.aud, "https://vault.example.com"),
+            other => panic!("expected Identity, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_hs256_token_with_identity_typ_is_rejected() {
+        // Identity tokens are RS256 only. An HS256 token wearing the identity
+        // typ, even one correctly signed with the session secret, is refused
+        // rather than read as an identity or as a session.
+        let claims = serde_json::json!({
+            "iss": "https://rise.test",
+            "aud": "https://rise.test",
+            "sub": "serviceaccount:acme/ci",
+            "rise_uid": uuid::Uuid::new_v4(),
+            "iat": now(),
+            "exp": now() + 600,
+            "jti": "x",
+        });
+        let mut header = Header::new(Algorithm::HS256);
+        header.typ = Some(crate::RISE_IDENTITY_TYP.to_string());
+        let token = encode(&header, &claims, &hs256_key()).unwrap();
+        assert!(create_test_signer().verify_rise_jwt(&token).is_err());
     }
 
     #[test]
@@ -606,7 +690,7 @@ mod tests {
             RiseToken::Access(_)
         ));
 
-        // HS256 + identity typ → Identity.
+        // RS256 + identity typ → Identity.
         let (identity_token, _) = signer
             .sign_identity_jwt(identity_spec(
                 "serviceaccount:acme/ci",

--- a/crates/rise-backend-auth/src/verify.rs
+++ b/crates/rise-backend-auth/src/verify.rs
@@ -10,13 +10,14 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use jsonwebtoken::{decode, decode_header, Algorithm, DecodingKey, Validation};
 
-use crate::claims::{AccessClaims, ExternalClaims, RiseClaims};
+use crate::claims::{AccessClaims, ExternalClaims, IdentityClaims, RiseClaims};
 use crate::error::AuthError;
-use crate::signer::{RiseTokenSigner, RISE_ACCESS_TYP};
+use crate::signer::{RiseTokenSigner, RISE_ACCESS_TYP, RISE_IDENTITY_TYP};
 
 /// A verified Rise-issued token. The output type models only what the verifier
 /// can ever return: `Session` (HS256 session, UI/CLI login), `Access` (HS256
-/// exchanged SA / controller principal), and `Ingress` (RS256, deployed-app
+/// exchanged SA / controller principal), `Identity` (HS256 resource principal
+/// minted by a `/token` subresource), and `Ingress` (RS256, deployed-app
 /// ingress auth). Workload tokens are sign-only and never appear here.
 ///
 /// The variants carry their claim types; there is no public constructor other
@@ -29,6 +30,10 @@ pub enum RiseToken {
     /// HS256, `typ = "rise-access+jwt"`, aud = public_url — exchanged SA /
     /// controller principal (RFC 8693 token exchange).
     Access(AccessClaims),
+    /// HS256, `typ = "rise-identity+jwt"`, aud = public_url — a ServiceAccount
+    /// or Controller resource principal (ADR-0001 §7). The middleware still has
+    /// to resolve `(sub, rise_uid)` to a live resource before it is a principal.
+    Identity(IdentityClaims),
     /// RS256, aud = project_url — deployed-app ingress auth (aud not checked here).
     Ingress(RiseClaims),
 }
@@ -39,11 +44,12 @@ impl RiseTokenSigner {
     /// Verifies the signature and `iss`, then disambiguates:
     /// - **RS256** → [`RiseToken::Ingress`].
     /// - **HS256** → branch on the header `typ`: the access `typ`
-    ///   ([`RISE_ACCESS_TYP`]) → [`RiseToken::Access`]; anything else (the default
-    ///   `"JWT"`, a missing or unknown `typ`) → [`RiseToken::Session`]. Legacy
-    ///   session tokens carry the default `"JWT"`, so the access `typ` is matched
-    ///   *exclusively* — never requiring a session-specific `typ` that would break
-    ///   existing sessions.
+    ///   ([`RISE_ACCESS_TYP`]) → [`RiseToken::Access`]; the identity `typ`
+    ///   ([`RISE_IDENTITY_TYP`]) → [`RiseToken::Identity`]; anything else (the
+    ///   default `"JWT"`, a missing or unknown `typ`) → [`RiseToken::Session`].
+    ///   Legacy session tokens carry the default `"JWT"`, so the special `typ`s
+    ///   are matched *exclusively* — never requiring a session-specific `typ`
+    ///   that would break existing sessions.
     ///
     /// No `aud` check is performed here — callers enforce audience per context
     /// (the API middleware requires `aud == public_url` for `Session` and
@@ -69,6 +75,10 @@ impl RiseTokenSigner {
                     let token_data =
                         decode::<AccessClaims>(token, self.hs256_decoding_key(), &validation)?;
                     Ok(RiseToken::Access(token_data.claims))
+                } else if header.typ.as_deref() == Some(RISE_IDENTITY_TYP) {
+                    let token_data =
+                        decode::<IdentityClaims>(token, self.hs256_decoding_key(), &validation)?;
+                    Ok(RiseToken::Identity(token_data.claims))
                 } else {
                     let token_data =
                         decode::<RiseClaims>(token, self.hs256_decoding_key(), &validation)?;
@@ -380,6 +390,139 @@ mod tests {
         }
     }
 
+    fn identity_spec<'a>(
+        subject: &'a str,
+        rise_uid: uuid::Uuid,
+        act: Option<crate::ActorClaim>,
+    ) -> crate::IdentityTokenSpec<'a> {
+        crate::IdentityTokenSpec {
+            subject,
+            rise_uid,
+            audience: "https://rise.test",
+            ttl_secs: 600,
+            authorization_details: None,
+            act,
+        }
+    }
+
+    #[test]
+    fn test_verify_rise_jwt_identity_round_trip() {
+        let signer = create_test_signer();
+        let uid = uuid::Uuid::new_v4();
+        let details = vec![serde_json::json!({
+            "type": "rise.dev/rbac",
+            "scope": "rise.dev/Project/acme/app",
+            "permissions": [{"verbs": ["get"], "kinds": ["rise.dev/Deployment"]}],
+        })];
+        let actor = crate::ActorClaim {
+            sub: "user:u-01".into(),
+            rise_uid: uuid::Uuid::new_v4(),
+            act: None,
+        };
+        let (token, minted) = signer
+            .sign_identity_jwt(crate::IdentityTokenSpec {
+                subject: "serviceaccount:acme/ci",
+                rise_uid: uid,
+                audience: "https://rise.test",
+                ttl_secs: 600,
+                authorization_details: Some(details.clone()),
+                act: Some(actor.clone()),
+            })
+            .unwrap();
+
+        let header = jsonwebtoken::decode_header(&token).unwrap();
+        assert_eq!(header.alg, Algorithm::HS256);
+        assert_eq!(header.typ.as_deref(), Some(crate::RISE_IDENTITY_TYP));
+
+        match signer.verify_rise_jwt(&token).unwrap() {
+            RiseToken::Identity(c) => {
+                assert_eq!(c.sub, "serviceaccount:acme/ci");
+                assert_eq!(c.rise_uid, uid);
+                assert_eq!(c.aud, "https://rise.test");
+                assert_eq!(c.jti, minted.jti);
+                assert_eq!(c.exp, c.iat + 600);
+                assert_eq!(c.authorization_details, Some(details));
+                assert_eq!(c.act, Some(actor));
+                assert_eq!(c.delegation_depth(), 1);
+            }
+            other => panic!("expected Identity, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_identity_token_rejected_by_legacy_adapters() {
+        let signer = create_test_signer();
+        let (token, _) = signer
+            .sign_identity_jwt(identity_spec("controller:k8s", uuid::Uuid::new_v4(), None))
+            .unwrap();
+
+        assert!(
+            signer.verify_user_jwt(&token, "https://rise.test").is_err(),
+            "identity token must not verify as a user/session token"
+        );
+        assert!(
+            signer.verify_jwt_skip_aud(&token).is_err(),
+            "identity token must not verify on the ingress path"
+        );
+    }
+
+    #[test]
+    fn test_verify_jwt_skip_aud_rejects_rise_uid_claim() {
+        // The identity-shaped counterpart of the `principal` hardening: a token
+        // without the identity typ that carries `rise_uid` deserializes as a
+        // session token, so the ingress path must reject it by payload shape.
+        let claims = serde_json::json!({
+            "sub": "u",
+            "email": "u@example.com",
+            "iss": "https://rise.test",
+            "aud": "https://rise.test",
+            "iat": now(),
+            "exp": now() + 3600,
+            "rise_uid": uuid::Uuid::new_v4(),
+        });
+        let token = encode(&Header::new(Algorithm::HS256), &claims, &hs256_key()).unwrap();
+        let signer = create_test_signer();
+        assert!(matches!(
+            signer.verify_rise_jwt(&token).unwrap(),
+            RiseToken::Session(_)
+        ));
+        assert!(signer.verify_jwt_skip_aud(&token).is_err());
+    }
+
+    #[test]
+    fn test_sign_identity_jwt_refuses_overlong_delegation_chain() {
+        let signer = create_test_signer();
+        let mut chain: Option<Box<crate::ActorClaim>> = None;
+        for depth in 0..crate::MAX_DELEGATION_DEPTH + 1 {
+            chain = Some(Box::new(crate::ActorClaim {
+                sub: format!("controller:c{depth}"),
+                rise_uid: uuid::Uuid::new_v4(),
+                act: chain,
+            }));
+        }
+        let too_long = *chain.unwrap();
+        assert_eq!(too_long.depth(), crate::MAX_DELEGATION_DEPTH + 1);
+        let err = signer
+            .sign_identity_jwt(identity_spec(
+                "controller:k8s",
+                uuid::Uuid::new_v4(),
+                Some(too_long.clone()),
+            ))
+            .unwrap_err();
+        assert!(matches!(err, crate::JwtSignerError::DelegationChainTooLong));
+
+        // Exactly the limit is accepted.
+        let at_limit = *too_long.act.unwrap();
+        assert_eq!(at_limit.depth(), crate::MAX_DELEGATION_DEPTH);
+        signer
+            .sign_identity_jwt(identity_spec(
+                "controller:k8s",
+                uuid::Uuid::new_v4(),
+                Some(at_limit),
+            ))
+            .expect("a chain at the platform limit is accepted");
+    }
+
     #[test]
     fn test_access_token_rejected_by_legacy_adapters() {
         let signer = create_test_signer();
@@ -461,6 +604,19 @@ mod tests {
         assert!(matches!(
             signer.verify_rise_jwt(&access_token).unwrap(),
             RiseToken::Access(_)
+        ));
+
+        // HS256 + identity typ → Identity.
+        let (identity_token, _) = signer
+            .sign_identity_jwt(identity_spec(
+                "serviceaccount:acme/ci",
+                uuid::Uuid::new_v4(),
+                None,
+            ))
+            .unwrap();
+        assert!(matches!(
+            signer.verify_rise_jwt(&identity_token).unwrap(),
+            RiseToken::Identity(_)
         ));
 
         // HS256 + default "JWT" / missing / unknown typ → Session.

--- a/docs/engineering/src/content/docs/adr/0001-unified-permission-model.md
+++ b/docs/engineering/src/content/docs/adr/0001-unified-permission-model.md
@@ -6,6 +6,16 @@ title: "ADR-0001: Unified Permission Model"
 
 **Proposed** (under review). Date: 2026-07-10.
 
+Implementation progress: §1–§6 are live on the generic resource API — the
+policy and identity resources, the evaluation engine, the write-time grant
+gate, and the centralized choke point. §7's `token` subresource is live for
+`ServiceAccount` and `Controller`: target-bound workload exchange, delegated
+issuance, the `rise.dev/rbac` authorization-detail ceiling, UID-bound
+re-resolution on every request, and the bounded `act` chain. Still open: live
+`User`/`UserIdentity` resolution with operator selectors and JIT login,
+retirement of the typed-table exchange endpoint, and the conformance suite.
+`ROADMAP.md` §§1–3 hold the remaining steps.
+
 scope: the generic resource API (`/api/v1/resources/...`) and
 ServiceAccount/Controller token issuance (the `token` subresource). It does
 not change how `rise project create`, `rise deployment create`, or other

--- a/docs/engineering/src/content/docs/adr/0001-unified-permission-model.md
+++ b/docs/engineering/src/content/docs/adr/0001-unified-permission-model.md
@@ -873,7 +873,16 @@ audience, and `authorization_details` — a ceiling over Rise's RBAC that means
 nothing to another verifier — is refused together with an external audience.
 The same `(create, ResourceKind, token)` grant governs delegated issuance for
 every audience: minting a token in the target's name for a third party is the
-same authority as minting one for Rise.
+same authority as minting one for Rise. This mirrors Kubernetes'
+`TokenRequest` API, where a single `create` on `serviceaccounts/token`
+authorizes minting for any `spec.audiences` value, internal or external, with
+no separate grant per audience. Kubernetes has no per-token ceiling at all —
+RBAC is always re-evaluated live against the caller's current bindings, never
+baked into the token — so it has no analogue of `authorization_details`
+either. Rise's asymmetry, where a ceiling narrows a Rise-audience token but
+cannot apply to an external one, follows from `authorization_details` only
+ever meaning something against Rise's own RBAC, not from a difference in how
+the audience itself is authorized.
 
 Tokens carry identity and a ceiling, never a snapshot of grants. Every request
 re-resolves the target identity, Groups, Roles, bindings, and Denies. Narrowing

--- a/docs/engineering/src/content/docs/adr/0001-unified-permission-model.md
+++ b/docs/engineering/src/content/docs/adr/0001-unified-permission-model.md
@@ -862,6 +862,19 @@ EffectivePolicy must authorize token creation, but the child does not silently
 inherit the caller's cap: token-create is the explicit delegation boundary and
 the requested child details constrain the target.
 
+Both modes may also name an `audience` (RFC 8693). Omitted, the token is for
+Rise's own API. Any other value mints the same kind of token with that `aud`
+for an external verifier — a secrets manager, a cloud STS, a Controller the
+apiserver forwards to — which checks it against Rise's published JWKS. Identity
+tokens are therefore always signed asymmetrically, whatever their audience:
+one token kind and one verification path, rather than a symmetric internal
+variant beside an asymmetric external one. Rise's API accepts only its own
+audience, and `authorization_details` — a ceiling over Rise's RBAC that means
+nothing to another verifier — is refused together with an external audience.
+The same `(create, ResourceKind, token)` grant governs delegated issuance for
+every audience: minting a token in the target's name for a third party is the
+same authority as minting one for Rise.
+
 Tokens carry identity and a ceiling, never a snapshot of grants. Every request
 re-resolves the target identity, Groups, Roles, bindings, and Denies. Narrowing
 or deleting the target affects outstanding tokens immediately; recreating the

--- a/docs/engineering/src/content/docs/authentication.md
+++ b/docs/engineering/src/content/docs/authentication.md
@@ -16,6 +16,7 @@ algorithm/claim disambiguation rules, see the engineering reference in
 |---|---|---|---|---|---|
 | **[Session](#session-hs256)** | Issued | HS256 | Rise `public_url` | Rise API middleware | `server.jwt_signing_secret`, `server.jwt_expiry_seconds` |
 | **[Access](#access-hs256--token-exchange)** | Issued | HS256 | Rise `public_url` | Rise API middleware | `server.auth_token_max_ttl_seconds`, `auth.allow_raw_external_tokens` |
+| **[Identity](#identity-hs256--the-token-subresource)** | Issued | HS256 | Rise `public_url` | Rise API middleware, re-resolved against the resource store per request | `server.auth_token_max_ttl_seconds`; trust policies are resources |
 | **[Ingress](#ingress-rs256)** | Issued | RS256 | Project URL | Nginx/ingress via Rise JWKS | `server.rs256_private_key_pem` |
 | **[Workload identity](#workload-identity-rs256)** | Issued | RS256 | Caller-supplied (e.g. `sts.amazonaws.com`) | External system via Rise JWKS | `server.rs256_private_key_pem`, `deployment_controller.identity_token_ttl_seconds` |
 | **[User login (OIDC)](#user-login-oidc)** | Accepted | per IdP | — | Rise (JWKS of `auth.issuer`) | `auth.issuer`, `auth.client_id`, `auth.client_secret` |
@@ -91,6 +92,48 @@ environment restrictions only takes effect once it expires).
 > This STS-style endpoint is **distinct** from the OIDC `token_endpoint` (the
 > authorization-code exchange at `/api/v1/auth/code/exchange`); the discovery
 > document continues to advertise the latter.
+
+This endpoint resolves the *typed* service accounts and configured controllers
+that the project APIs use today. Its resource-model successor is the `token`
+subresource below; the two coexist until the typed-object migration moves
+service accounts onto the resource store.
+
+### Identity (HS256) — the `token` subresource
+
+A short-lived, Rise-issued token whose subject is a **ServiceAccount or
+Controller resource** of the generic resource API (`serviceaccount:<org>/<name>`
+or `controller:<name>`), carrying that resource's UID as `rise_uid`. It is minted
+only by the target's own `token` subresource —
+`POST /api/v1/resources/rise.dev/v1alpha1/serviceaccounts/{org}/{name}/token` or
+`…/controllers/{name}/token` — in one of two disjoint modes: **workload token
+exchange**, where an external OIDC JWT in the body is validated against the
+`ServiceAccountTrustPolicy` / `ControllerTrustPolicy` children of that exact
+target; or **delegated issuance**, where an already-authenticated Rise principal
+holding `(create, <kind>, token)` on the target mints for it. It is
+distinguished from the other HS256 tokens by its header `typ`
+(`rise-identity+jwt`), and is accepted only by the generic resource API.
+
+**What it carries and what it does not.** Identity and an optional ceiling,
+never a snapshot of grants. Rise re-resolves `(sub, rise_uid)` to one live
+resource on every request and evaluates the identity's *current* RBAC,
+intersected with the token's RFC 9396 `authorization_details` if present. So:
+
+- deleting the target, or a draining Organization above it, fails every
+  outstanding token immediately — there is nothing to revoke;
+- recreating the same name under a new UID does not revive old tokens;
+- narrowing the target's Roles takes effect on the next request;
+- revoking the *caller's* token-create grant stops new issuance only.
+
+Delegated tokens record their delegators in a bounded `act` chain (at most four),
+for audit; actor data never grants access. Lifetime is capped by
+`server.auth_token_max_ttl_seconds`, the platform-global maximum shared with
+Access tokens. Trust policies are ordinary governed resources: they hold public
+matching configuration (issuer, `aud`, further string claims with `*` globs),
+never keys, and may not name Rise's own issuer. Every failure of a workload
+exchange after the route is entered is one coarse `401`, so the route confirms
+nothing about which identities or policies exist. The request/response shape and
+the authorization rules are specified in the
+[resource HTTP API](/operator-docs/resources/api/#token-subresource-serviceaccount-and-controller).
 
 **Migrating off raw tokens (`auth.allow_raw_external_tokens`).** Defaults to
 `true`: a service account may still present its raw external OIDC token directly
@@ -184,7 +227,10 @@ token's `iss` byte-for-byte, matching `UserIdentity`.
 > `finalizers` subresources of a kind (or any other verb) through a
 > `PlatformRoleBinding` naming that subject. See
 > [Controller authorization](/operator-docs/resources/api/#controller-authorization)
-> for the full model and a worked example.
+> for the full model and a worked example. A controller may also exchange its
+> OIDC JWT once, at its own `token` subresource, for an
+> [identity token](#identity-hs256--the-token-subresource) that carries the
+> same `controller:<name>` principal.
 
 ## Security checklist
 

--- a/docs/engineering/src/content/docs/authentication.md
+++ b/docs/engineering/src/content/docs/authentication.md
@@ -16,7 +16,7 @@ algorithm/claim disambiguation rules, see the engineering reference in
 |---|---|---|---|---|---|
 | **[Session](#session-hs256)** | Issued | HS256 | Rise `public_url` | Rise API middleware | `server.jwt_signing_secret`, `server.jwt_expiry_seconds` |
 | **[Access](#access-hs256--token-exchange)** | Issued | HS256 | Rise `public_url` | Rise API middleware | `server.auth_token_max_ttl_seconds`, `auth.allow_raw_external_tokens` |
-| **[Identity](#identity-hs256--the-token-subresource)** | Issued | HS256 | Rise `public_url` | Rise API middleware, re-resolved against the resource store per request | `server.auth_token_max_ttl_seconds`; trust policies are resources |
+| **[Identity](#identity-rs256--the-token-subresource)** | Issued | RS256 | Rise `public_url`, or a caller-named external verifier | Rise API middleware (re-resolved against the resource store per request), or the external verifier via Rise JWKS | `server.rs256_private_key_pem`, `server.auth_token_max_ttl_seconds`; trust policies are resources |
 | **[Ingress](#ingress-rs256)** | Issued | RS256 | Project URL | Nginx/ingress via Rise JWKS | `server.rs256_private_key_pem` |
 | **[Workload identity](#workload-identity-rs256)** | Issued | RS256 | Caller-supplied (e.g. `sts.amazonaws.com`) | External system via Rise JWKS | `server.rs256_private_key_pem`, `deployment_controller.identity_token_ttl_seconds` |
 | **[User login (OIDC)](#user-login-oidc)** | Accepted | per IdP | — | Rise (JWKS of `auth.issuer`) | `auth.issuer`, `auth.client_id`, `auth.client_secret` |
@@ -98,7 +98,7 @@ that the project APIs use today. Its resource-model successor is the `token`
 subresource below; the two coexist until the typed-object migration moves
 service accounts onto the resource store.
 
-### Identity (HS256) — the `token` subresource
+### Identity (RS256) — the `token` subresource
 
 A short-lived, Rise-issued token whose subject is a **ServiceAccount or
 Controller resource** of the generic resource API (`serviceaccount:<org>/<name>`
@@ -109,9 +109,15 @@ only by the target's own `token` subresource —
 exchange**, where an external OIDC JWT in the body is validated against the
 `ServiceAccountTrustPolicy` / `ControllerTrustPolicy` children of that exact
 target; or **delegated issuance**, where an already-authenticated Rise principal
-holding `(create, <kind>, token)` on the target mints for it. It is
-distinguished from the other HS256 tokens by its header `typ`
-(`rise-identity+jwt`), and is accepted only by the generic resource API.
+holding `(create, <kind>, token)` on the target mints for it.
+
+It is always RS256, signed with the same key as ingress and workload tokens and
+distinguished from them by its header `typ` (`rise-identity+jwt`). The request
+may name an `audience`: omitted, the token is for Rise's own API, which is the
+only audience the API accepts; any other value mints the same token for that
+external verifier, which checks it against the JWKS above. One key and one
+token kind serve both, which is why the key is load-bearing for the resource
+API as well.
 
 **What it carries and what it does not.** Identity and an optional ceiling,
 never a snapshot of grants. Rise re-resolves `(sub, rise_uid)` to one live
@@ -176,10 +182,11 @@ Two paths produce these tokens:
 
 ### The RS256 key is operationally load-bearing
 
-`server.rs256_private_key_pem` signs **both** ingress and workload tokens and
+`server.rs256_private_key_pem` signs ingress, workload, and identity tokens and
 backs the JWKS. If you do **not** configure it, Rise generates a fresh key pair
-on every start — which silently invalidates all previously issued ingress and
-workload tokens and rotates the JWKS out from under any external verifier.
+on every start — which silently invalidates all previously issued ingress,
+workload, and identity tokens, differs between replicas, and rotates the JWKS
+out from under any external verifier.
 
 - **Always** set `rs256_private_key_pem` (and optionally `rs256_public_key_pem`,
   otherwise derived) in any non-ephemeral deployment.
@@ -229,7 +236,7 @@ token's `iss` byte-for-byte, matching `UserIdentity`.
 > [Controller authorization](/operator-docs/resources/api/#controller-authorization)
 > for the full model and a worked example. A controller may also exchange its
 > OIDC JWT once, at its own `token` subresource, for an
-> [identity token](#identity-hs256--the-token-subresource) that carries the
+> [identity token](#identity-rs256--the-token-subresource) that carries the
 > same `controller:<name>` principal.
 
 ## Security checklist

--- a/docs/engineering/src/content/docs/resources/api.md
+++ b/docs/engineering/src/content/docs/resources/api.md
@@ -456,10 +456,16 @@ Two request modes exist, and a request must be exactly one of them:
   minted identity may mint the next only through its own live token-create
   grant — actor data never grants anything.
 
-Both modes accept two optional fields. `expires_in` is clamped to
-`server.auth_token_max_ttl_seconds`, the platform-global maximum. `authorization_details`
-is an RFC 9396 list of `rise.dev/rbac` entries that only ever **narrows** the
-issued token:
+Both modes accept three optional fields. `expires_in` is clamped to
+`server.auth_token_max_ttl_seconds`, the platform-global maximum. `audience`
+(RFC 8693) names the verifier the token is for: omitted means Rise's own API;
+any other value mints the same token with that `aud`, which Rise's API refuses
+and the named verifier checks against Rise's JWKS at
+`GET {public_url}/api/v1/auth/jwks` (identity tokens are always RS256-signed
+with that key, whatever their audience). `authorization_details` is an RFC 9396
+list of `rise.dev/rbac` entries that only ever **narrows** the issued token; it
+is a statement about Rise's own RBAC, so it is rejected together with an
+external `audience`:
 
 ```json
 {

--- a/docs/engineering/src/content/docs/resources/api.md
+++ b/docs/engineering/src/content/docs/resources/api.md
@@ -22,9 +22,11 @@ A path always names the **leaf** collection first as `{group}/{version}/{plural}
 | `{group}/{version}/{plural}/{ancestor}…/{name}/status` (`D+2`) | PUT | Status subresource update |
 | `{group}/{version}/{plural}/{ancestor}…/{name}/finalizers` (`D+2`) | PUT | Finalizer subresource update |
 | `{group}/{version}/{plural}/{ancestor}…/{name}/deletion-blockers` (`D+2`) | GET | Deletion-blocker diagnostics |
+| `{group}/{version}/{plural}/{ancestor}…/{name}/token` (`D+2`) | POST | Token issuance — `ServiceAccount` and `Controller` only |
 | `{group}/{version}/{plural}/uid:{uuid}` | GET, PUT, DELETE | Item by UID |
 | `{group}/{version}/{plural}/uid:{uuid}/{sub}` | PUT | `status` or `finalizers` by UID |
 | `{group}/{version}/{plural}/uid:{uuid}/deletion-blockers` | GET | Deletion-blocker diagnostics by UID |
+| `{group}/{version}/{plural}/uid:{uuid}/token` | POST | Token issuance by UID |
 | `pending-deletion` | GET | List tombstoned resources awaiting GC |
 
 Ancestor segments are bare resource *names*; the ancestor *kinds* are derived from the leaf's `ResourceDefinition` parent chain and never appear in the URL. `pending-deletion` is only valid as the sole path segment, so a resource may be named `pending-deletion` without ambiguity.
@@ -53,13 +55,14 @@ exactly what stored policy grants them.
 |---|---|
 | Operator (`auth.operator_users`, `auth.operator_idp_groups`) | Expands to `system:operators`, whose seeded binding allows every verb on every kind and subresource |
 | Any other authenticated user | Live RBAC: bindings that name them, one of their Groups, `org:<name>`, or `system:authenticated`, plus dynamic ownership bindings resolved from `rise.dev/owner` |
+| A `ServiceAccount` or `Controller` resource, holding an identity token from its [`token` subresource](#token-subresource-serviceaccount-and-controller) | Live RBAC on its own subject (`serviceaccount:<org>/<name>`, `controller:<name>`), intersected with the token's `authorization_details` ceiling. It has no Group ties and is never an operator |
 | Controller (a live `Controller` resource) | Live RBAC like any other principal: bindings naming its `controller:<name>` subject. See [Controller authorization](#controller-authorization) |
 
 The verbs map onto the HTTP surface directly: `list` and `get` for reads,
-`create` for POST, `update` for item PUT and for the `status`/`finalizers`
-subresources, `delete` for DELETE. Subresource permissions are separate from the
-main resource — a statement with no `subresources` field permits the main
-resource only.
+`create` for POST (and for the `token` subresource), `update` for item PUT and
+for the `status`/`finalizers` subresources, `delete` for DELETE. Subresource
+permissions are separate from the main resource — a statement with no
+`subresources` field permits the main resource only.
 
 Two read granularities exist, and they are independent grants:
 
@@ -408,16 +411,95 @@ silently omits blockers is worse than one that says how many it withheld — but
 grant the subresource on that basis, not on the assumption that it reveals
 nothing about a subtree the caller cannot list.
 
+### Token subresource (ServiceAccount and Controller)
+
+```http
+POST /api/v1/resources/rise.dev/v1alpha1/serviceaccounts/acme/ci/token
+Content-Type: application/json
+
+{
+  "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+  "subject_token": "<external OIDC JWT>",
+  "subject_token_type": "urn:ietf:params:oauth:token-type:jwt"
+}
+```
+
+Issues a Rise **identity token** for exactly the resource the URL names, and
+persists nothing — the subresource is create-only, so `GET`, `PUT`, and
+`DELETE` on it are `405`. Only `rise.dev/ServiceAccount` and
+`rise.dev/Controller` register it; `/token` on any other kind is the ordinary
+route-not-found `404`, before authentication. The response is the RFC 8693
+shape: `access_token`, `token_type: Bearer`, `issued_token_type`, and
+`expires_in`.
+
+Two request modes exist, and a request must be exactly one of them:
+
+- **Workload token exchange** — the request carries `subject_token` and **no
+  Rise credential**. The assertion is validated only against the
+  `ServiceAccountTrustPolicy` / `ControllerTrustPolicy` children of the addressed
+  target (issuer, JWKS signature and expiry, then each policy's claim matcher,
+  with `aud` accepting a string or an array) and must match exactly one. There is
+  no RBAC check and no search across identities. Every failure after the route
+  is entered — a target that does not exist, is of another kind, or is being
+  deleted; an issuer no policy names; a signature that does not verify; zero or
+  several matching policies — returns the same `401` body, so the route never
+  confirms whether a given identity or policy exists. A trust policy may not
+  name Rise's own issuer; creating one is a `400`.
+- **Delegated issuance** — the request carries a Rise credential (a user
+  session, or an identity token) and **no** `subject_token`. The caller needs
+  `(create, rise.dev/ServiceAccount, token)` or `(create, rise.dev/Controller,
+  token)` on that exact target under its own capped effective policy; `get` on
+  the target, `create` on the main resource, and `get` on the subresource each
+  grant nothing here. A refused caller who cannot `get` the target is told `404`,
+  like any masked item. The minted token records the caller in a bounded `act`
+  chain (the platform limit is four delegators; a longer chain is `403`), and a
+  minted identity may mint the next only through its own live token-create
+  grant — actor data never grants anything.
+
+Both modes accept two optional fields. `expires_in` is clamped to
+`server.auth_token_max_ttl_seconds`, the platform-global maximum. `authorization_details`
+is an RFC 9396 list of `rise.dev/rbac` entries that only ever **narrows** the
+issued token:
+
+```json
+{
+  "authorization_details": [
+    {
+      "type": "rise.dev/rbac",
+      "scope": "rise.dev/Organization/acme",
+      "permissions": [
+        {"verbs": ["get", "list"], "kinds": ["rise.dev/ServiceAccount"]},
+        {"verbs": ["update"], "kinds": ["rise.dev/Deployment"], "subresources": ["status"]}
+      ]
+    }
+  ]
+}
+```
+
+Each entry has one qualified `scope` and one or more permission statements in
+Role grammar; entries union, statements union within their entry's scope, and
+omitted `subresources` means the main resource only. An empty list, an unknown
+`type`, an empty axis, or an unqualified kind or scope is a `400` — never a
+fallback to full policy — and a token whose stored claim is malformed fails
+authentication.
+
+The minted token is a bearer for this API. On every request Rise re-resolves
+its `(sub, rise_uid)` pair to one live resource and evaluates the identity's
+**current** policy intersected with the ceiling: narrowing or deleting the
+target affects outstanding tokens immediately, and recreating the same name
+under a new UID does not revive them. Revoking the caller's token-create grant
+stops new issuance only. Identity tokens are not accepted by the typed APIs.
+
 ## Status codes
 
 | Code | Meaning |
 |---|---|
 | 200 / 201 / 202 | Operation succeeded (200 read/update, 201 create, 202 cascade tombstoned) |
 | 400 | Malformed path, body validation, reserved finalizer prefix, wrong version |
-| 401 | No credentials or JWT verification failed |
-| 403 | Authorized to read the resource but not to perform this verb, or refused by the grant gate |
-| 404 | Unknown collection, unknown resource, kind/version mismatch on `uid:`, or a resource the caller may not read |
-| 405 | Method not valid for the addressed path (e.g. GET on `/status`) |
+| 401 | No credentials or JWT verification failed; an assertion the `token` subresource did not accept |
+| 403 | Authorized to read the resource but not to perform this verb, refused by the grant gate, or a delegation chain past the platform limit |
+| 404 | Unknown collection, unknown resource, kind/version mismatch on `uid:`, a resource the caller may not read, or `/token` on a kind that does not register it |
+| 405 | Method not valid for the addressed path (e.g. GET on `/status`, PUT on `/token`) |
 | 409 | Name conflict on create, revision conflict on update |
 | 422 | Write targeting a served non-storage version (no conversion yet) |
 | 503 | Discriminator generator exhausted (10 retries) |

--- a/docs/engineering/src/content/docs/upgrade-notes.md
+++ b/docs/engineering/src/content/docs/upgrade-notes.md
@@ -78,8 +78,14 @@ Merged to `develop`:
   layer; it is rate-limited through the OAuth limiter, and anything that is not
   a registered token route stays `401`. Identity tokens are accepted only by the
   generic resource API and are re-resolved against the live resource on every
-  request. The typed-table exchange at `POST /api/v1/auth/token` and the CLI
-  are unchanged. See [Authentication & Tokens](/operator-docs/authentication/#identity-hs256--the-token-subresource).
+  request. They are RS256-signed with `server.rs256_private_key_pem`, the key
+  behind the published JWKS, so a request may name an external `audience` and
+  hand the token to that verifier; this also means the key is now
+  load-bearing for the resource API itself — an unset key is regenerated on
+  every start and differs per replica, which invalidates identity tokens on
+  restart and across replicas exactly as it already does ingress and workload
+  tokens. The typed-table exchange at `POST /api/v1/auth/token` and the CLI
+  are unchanged. See [Authentication & Tokens](/operator-docs/authentication/#identity-rs256--the-token-subresource).
 
 - **ECS: a `capacity` setting, and service network configuration now converges.**
   *Config change.* `deployment_controller.capacity` selects where workload tasks

--- a/docs/engineering/src/content/docs/upgrade-notes.md
+++ b/docs/engineering/src/content/docs/upgrade-notes.md
@@ -67,6 +67,20 @@ Merged to `develop`:
   and [Controller authorization](/operator-docs/resources/api/#controller-authorization)
   for the full setup.
 
+- **Generic resource API: the `token` subresource on `ServiceAccount` and
+  `Controller`.** No config change; one new route shape.
+  `POST /api/v1/resources/rise.dev/v1alpha1/serviceaccounts/{org}/{name}/token`
+  and `…/controllers/{name}/token` issue Rise identity tokens, either by
+  exchanging an external OIDC JWT against that resource's trust-policy
+  children or by delegation from a principal holding
+  `(create, <kind>, token)` on it. A credential-less `POST` to such a path now
+  reaches the resource API rather than being refused by the authentication
+  layer; it is rate-limited through the OAuth limiter, and anything that is not
+  a registered token route stays `401`. Identity tokens are accepted only by the
+  generic resource API and are re-resolved against the live resource on every
+  request. The typed-table exchange at `POST /api/v1/auth/token` and the CLI
+  are unchanged. See [Authentication & Tokens](/operator-docs/authentication/#identity-hs256--the-token-subresource).
+
 - **ECS: a `capacity` setting, and service network configuration now converges.**
   *Config change.* `deployment_controller.capacity` selects where workload tasks
   run — `fargate` (the default, and what every existing install keeps doing) or

--- a/helm/rise/values-ci.yaml
+++ b/helm/rise/values-ci.yaml
@@ -60,6 +60,10 @@ config:
     issuer: http://rise-ci-chart-dex.rise-ci.svc.cluster.local:5556/dex
     client_id: rise-backend
     client_secret: rise-backend-secret
+    # The e2e CI bearer. Operator standing lets scenarios author resources
+    # through the generic resource API (`resource-token-exchange`).
+    operator_users:
+      - admin@example.com
 
   encryption:
     type: aes-gcm-256

--- a/src/server/auth/context.rs
+++ b/src/server/auth/context.rs
@@ -1,11 +1,12 @@
 use crate::db::models::User;
 use crate::db::service_accounts;
 use crate::server::auth::controller::{self, ControllerAuthContext, ControllerResolution};
+use crate::server::auth::identity::ResourcePrincipal;
 use crate::server::auth::sa_match::{match_service_account, SaMatchError};
 use crate::server::error::{ServerError, ServerErrorExt};
 use crate::server::resources::error_map::store_error_to_server_error;
 use crate::server::state::AppState;
-use axum::{extract::FromRequestParts, http::request::Parts};
+use axum::{extract::FromRequestParts, http::request::Parts, http::StatusCode};
 use rise_backend_auth::{AccessClaims, PrincipalClaims};
 use sqlx::PgPool;
 
@@ -36,6 +37,11 @@ pub enum AuthContext {
     /// only ever a service account or controller — the exchange never mints a
     /// `User` access token. Recognized by handlers via `resolve_for_project`.
     Access(AccessClaims),
+    /// A Rise identity token: a ServiceAccount or Controller *resource*
+    /// principal minted by its `/token` subresource and re-resolved against the
+    /// live store on this request (ADR-0001 §7). It is a principal of the
+    /// generic resource API; the typed APIs do not accept it.
+    Identity(ResourcePrincipal),
 }
 
 impl AuthContext {
@@ -47,7 +53,7 @@ impl AuthContext {
     pub fn user(&self) -> Result<&User, ServerError> {
         match self {
             AuthContext::User(user) => Ok(user),
-            AuthContext::ExternalToken(_) | AuthContext::Access(_) => {
+            AuthContext::ExternalToken(_) | AuthContext::Access(_) | AuthContext::Identity(_) => {
                 Err(ServerError::unauthorized(
                     "This endpoint does not support service account authentication",
                 ))
@@ -81,6 +87,11 @@ impl AuthContext {
         match self {
             AuthContext::User(user) => Ok((user.clone(), false)),
             AuthContext::Access(claims) => resolve_access_for_project(pool, project, claims).await,
+            // A resource principal is not bound to a typed Project; the typed
+            // APIs converge onto it with the typed-object migration.
+            AuthContext::Identity(_) => Err(ServerError::unauthorized(
+                "Identity tokens are not accepted by project-scoped endpoints",
+            )),
             AuthContext::ExternalToken(token) => {
                 // A token satisfying a live controller trust policy is never a
                 // service account, whatever claims it also happens to carry.
@@ -192,7 +203,32 @@ impl AuthContext {
             AuthContext::Access(claims) => {
                 matches!(&claims.principal, PrincipalClaims::ServiceAccount { .. })
             }
+            AuthContext::Identity(principal) => principal.subject.kind() == "serviceaccount",
             AuthContext::User(_) => false,
+        }
+    }
+}
+
+/// An `AnyAuth` that may be absent.
+///
+/// Only one route accepts an unauthenticated request: a `/token` subresource
+/// receiving a workload assertion, whose credential is in the body (ADR-0001
+/// §7). Every other handler keeps extracting `AnyAuth` and gets its 401 from
+/// the extractor; this wrapper lets that one route decide for itself.
+#[derive(Clone, Debug)]
+pub struct MaybeAuth(pub Option<AnyAuth>);
+
+impl FromRequestParts<AppState> for MaybeAuth {
+    type Rejection = ServerError;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        match AnyAuth::from_request_parts(parts, state).await {
+            Ok(auth) => Ok(Self(Some(auth))),
+            Err(error) if error.status == StatusCode::UNAUTHORIZED => Ok(Self(None)),
+            Err(error) => Err(error),
         }
     }
 }
@@ -262,6 +298,11 @@ impl FromRequestParts<AppState> for AuthContext {
         // Try the exchanged access-token extension (Rise access token path)
         if let Some(claims) = parts.extensions.get::<AccessClaims>().cloned() {
             return Ok(AuthContext::Access(claims));
+        }
+
+        // Try the resource-principal extension (Rise identity token path)
+        if let Some(principal) = parts.extensions.get::<ResourcePrincipal>().cloned() {
+            return Ok(AuthContext::Identity(principal));
         }
 
         // Try VerifiedExternalToken extension (legacy raw external JWT path)

--- a/src/server/auth/controller.rs
+++ b/src/server/auth/controller.rs
@@ -16,11 +16,12 @@
 //! **Transitional global search.** [`resolve_external`] matches a token
 //! against every live `ControllerTrustPolicy` for its issuer, with no target
 //! Controller known in advance — the same global-search shape the static
-//! config it replaced used. ADR-0001 §7 and `ROADMAP.md` §2 name the durable
-//! design as a target-bound `/token` subresource per Controller, which checks
-//! only that one target's own trust-policy children and never searches
-//! globally; that route is not built yet, so this module is what stands in
-//! until it lands.
+//! config it replaced used. The durable design (ADR-0001 §7) is each
+//! Controller's own target-bound `token` subresource
+//! (`crate::server::resources::token`), which checks only that one target's
+//! trust-policy children and mints an identity token the middleware
+//! re-resolves by UID on every request. This module stands in for controllers
+//! that still present a raw OIDC JWT per request; it retires with that path.
 
 use rise_backend_auth::{match_trust_candidates, TrustCandidate, TrustMatch};
 use rise_resource_api::{Issuer, ResourceApi, StoreError, API_VERSION_V1ALPHA1, CONTROLLER_KIND};

--- a/src/server/auth/identity.rs
+++ b/src/server/auth/identity.rs
@@ -126,7 +126,7 @@ pub async fn resolve_identity(
         Some(organization) => {
             let contained = chain.len() == 2
                 && chain[0].kind == ORGANIZATION_KIND
-                && chain[0].api_version.starts_with(API_GROUP)
+                && chain[0].api_version.split('/').next().unwrap_or_default() == API_GROUP
                 && chain[0].name == organization;
             if !contained {
                 return Err(IdentityRejection::NoLiveResource);

--- a/src/server/auth/identity.rs
+++ b/src/server/auth/identity.rs
@@ -1,0 +1,143 @@
+//! Authentication of Rise identity tokens as resource principals (ADR-0001 §7).
+//!
+//! An identity token names a ServiceAccount or Controller *resource* by
+//! canonical subject and UID. Verifying its signature only proves Rise minted
+//! it; it becomes a principal when `(sub, rise_uid)` still identifies one live
+//! resource. That check runs on every request, which is what makes deleting the
+//! target — or recreating the same name under a new UID — fail every token
+//! already issued for it, with nothing to revoke.
+
+use rise_authz::engine::AuthorizationCap;
+use rise_backend_auth::{ActorClaim, IdentityClaims};
+use rise_resource_api::{
+    ResourceStore, SubjectId, API_GROUP, CONTROLLER_KIND, ORGANIZATION_KIND, SERVICE_ACCOUNT_KIND,
+};
+use uuid::Uuid;
+
+/// A ServiceAccount or Controller resource that authenticated with an identity
+/// token, resolved against the live store for this request.
+#[derive(Clone, Debug)]
+pub struct ResourcePrincipal {
+    /// The canonical subject (`serviceaccount:<org>/<name>` or
+    /// `controller:<name>`).
+    pub subject: SubjectId,
+    /// The live resource's UID, equal to the credential's `rise_uid`.
+    pub uid: Uuid,
+    /// The credential's signed Allow ceiling.
+    pub cap: AuthorizationCap,
+    /// The delegation chain the credential records, for audit and for the next
+    /// hop of delegated issuance.
+    pub act: Option<ActorClaim>,
+    /// The credential's audit id.
+    pub jti: String,
+}
+
+/// Why an identity token did not resolve to a principal.
+///
+/// Every variant is reported to the caller as the same 401: which of these
+/// applied is a fact about a resource the caller may hold nothing on.
+#[derive(Debug)]
+pub enum IdentityRejection {
+    /// The subject is malformed, or names a kind that cannot hold a token.
+    Subject(String),
+    /// No live resource matches both the subject and the UID.
+    NoLiveResource,
+    /// `authorization_details` is present but not a valid ceiling.
+    Cap(String),
+    /// The store could not answer.
+    Store(rise_resource_api::StoreError),
+}
+
+impl std::fmt::Display for IdentityRejection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Subject(detail) => write!(f, "invalid subject: {detail}"),
+            Self::NoLiveResource => f.write_str("no live resource matches the subject and UID"),
+            Self::Cap(detail) => write!(f, "invalid authorization_details: {detail}"),
+            Self::Store(error) => write!(f, "store error: {error:?}"),
+        }
+    }
+}
+
+/// The resource kind an identity subject must resolve to.
+pub(crate) fn expected_kind(subject: &SubjectId) -> Option<&'static str> {
+    match subject.kind() {
+        "serviceaccount" => Some(SERVICE_ACCOUNT_KIND),
+        "controller" => Some(CONTROLLER_KIND),
+        _ => None,
+    }
+}
+
+/// Resolve verified identity claims to a live resource principal.
+///
+/// Requires, in order: a canonical ServiceAccount or Controller subject; a live
+/// (not tombstoned) resource at `rise_uid` whose group, kind, and name match
+/// the subject, contained — for a ServiceAccount — by a live Organization of
+/// the subject's org name; and a well-formed `authorization_details` claim, if
+/// one is present. The subject is compared to the resource *by name*, so the
+/// UID is what binds the credential to one incarnation of that name.
+pub async fn resolve_identity(
+    store: &dyn ResourceStore,
+    claims: &IdentityClaims,
+) -> Result<ResourcePrincipal, IdentityRejection> {
+    let subject: SubjectId = claims
+        .sub
+        .parse()
+        .map_err(|error| IdentityRejection::Subject(format!("{error}")))?;
+    let kind = expected_kind(&subject).ok_or_else(|| {
+        IdentityRejection::Subject(format!(
+            "{subject} is not a ServiceAccount or Controller subject"
+        ))
+    })?;
+
+    let chain = store
+        .ancestors(claims.rise_uid)
+        .await
+        .map_err(IdentityRejection::Store)?;
+    let Some(leaf) = chain.last() else {
+        return Err(IdentityRejection::NoLiveResource);
+    };
+    // A draining ancestor drains the identity with it: the Organization's
+    // policy resources are tombstoned alongside it, so a ServiceAccount under
+    // one must not keep authenticating into what remains of the subtree.
+    if chain.iter().any(|row| row.deletion_timestamp.is_some()) {
+        return Err(IdentityRejection::NoLiveResource);
+    }
+    let group = leaf.api_version.split('/').next().unwrap_or_default();
+    if leaf.uid != claims.rise_uid
+        || group != API_GROUP
+        || leaf.kind != kind
+        || leaf.name != subject.name()
+    {
+        return Err(IdentityRejection::NoLiveResource);
+    }
+    match subject.organization() {
+        // A ServiceAccount lives directly under its Organization (ADR-0001 §1).
+        Some(organization) => {
+            let contained = chain.len() == 2
+                && chain[0].kind == ORGANIZATION_KIND
+                && chain[0].api_version.starts_with(API_GROUP)
+                && chain[0].name == organization;
+            if !contained {
+                return Err(IdentityRejection::NoLiveResource);
+            }
+        }
+        // A Controller is root-scoped.
+        None => {
+            if chain.len() != 1 {
+                return Err(IdentityRejection::NoLiveResource);
+            }
+        }
+    }
+
+    let cap = AuthorizationCap::from_details(claims.authorization_details.as_deref())
+        .map_err(|error| IdentityRejection::Cap(error.to_string()))?;
+
+    Ok(ResourcePrincipal {
+        subject,
+        uid: leaf.uid,
+        cap,
+        act: claims.act.clone(),
+        jti: claims.jti.clone(),
+    })
+}

--- a/src/server/auth/identity.rs
+++ b/src/server/auth/identity.rs
@@ -38,6 +38,8 @@ pub struct ResourcePrincipal {
 /// applied is a fact about a resource the caller may hold nothing on.
 #[derive(Debug)]
 pub enum IdentityRejection {
+    /// The token was minted for another verifier, not for Rise's API.
+    Audience(String),
     /// The subject is malformed, or names a kind that cannot hold a token.
     Subject(String),
     /// No live resource matches both the subject and the UID.
@@ -51,6 +53,7 @@ pub enum IdentityRejection {
 impl std::fmt::Display for IdentityRejection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::Audience(audience) => write!(f, "token is for audience {audience:?}"),
             Self::Subject(detail) => write!(f, "invalid subject: {detail}"),
             Self::NoLiveResource => f.write_str("no live resource matches the subject and UID"),
             Self::Cap(detail) => write!(f, "invalid authorization_details: {detail}"),
@@ -70,16 +73,23 @@ pub(crate) fn expected_kind(subject: &SubjectId) -> Option<&'static str> {
 
 /// Resolve verified identity claims to a live resource principal.
 ///
-/// Requires, in order: a canonical ServiceAccount or Controller subject; a live
-/// (not tombstoned) resource at `rise_uid` whose group, kind, and name match
-/// the subject, contained — for a ServiceAccount — by a live Organization of
-/// the subject's org name; and a well-formed `authorization_details` claim, if
-/// one is present. The subject is compared to the resource *by name*, so the
-/// UID is what binds the credential to one incarnation of that name.
+/// Requires, in order: an `aud` equal to `expected_audience` (Rise's own
+/// public URL — a token minted for another verifier is never a principal
+/// here, however valid its signature); a canonical ServiceAccount or
+/// Controller subject; a live (not tombstoned) resource at `rise_uid` whose
+/// group, kind, and name match the subject, contained — for a ServiceAccount —
+/// by a live Organization of the subject's org name; and a well-formed
+/// `authorization_details` claim, if one is present. The subject is compared
+/// to the resource *by name*, so the UID is what binds the credential to one
+/// incarnation of that name.
 pub async fn resolve_identity(
     store: &dyn ResourceStore,
     claims: &IdentityClaims,
+    expected_audience: &str,
 ) -> Result<ResourcePrincipal, IdentityRejection> {
+    if claims.aud != expected_audience {
+        return Err(IdentityRejection::Audience(claims.aud.clone()));
+    }
     let subject: SubjectId = claims
         .sub
         .parse()

--- a/src/server/auth/middleware.rs
+++ b/src/server/auth/middleware.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::{Request, State},
-    http::{HeaderMap, StatusCode},
+    http::{HeaderMap, Method, StatusCode},
     middleware::Next,
     response::Response,
 };
@@ -11,6 +11,7 @@ use serde::Deserialize;
 use crate::db::{service_accounts, users, User};
 use crate::server::auth::context::VerifiedExternalToken;
 use crate::server::auth::cookie_helpers;
+use crate::server::auth::identity::{resolve_identity, ResourcePrincipal};
 use crate::server::state::AppState;
 use rise_backend_auth::{is_rise_issued_jwt, AccessClaims, PrincipalClaims, RiseToken};
 
@@ -172,6 +173,32 @@ pub async fn auth_middleware(
                     claims.principal
                 );
                 req.extensions_mut().insert(claims);
+            }
+            RiseToken::Identity(claims) => {
+                // Identity token — `aud` must be the Rise public URL, and the
+                // `(sub, rise_uid)` pair must still name one live resource
+                // (ADR-0001 §7). Every rejection is the same 401: which check
+                // failed is a fact about a resource the caller may not read.
+                if claims.aud != state.public_url {
+                    tracing::warn!("Auth middleware: identity token audience mismatch");
+                    return Err((StatusCode::UNAUTHORIZED, "Invalid token".to_string()));
+                }
+                let principal = resolve_identity(state.resource_store.as_ref(), &claims)
+                    .await
+                    .map_err(|rejection| {
+                        tracing::warn!(
+                            sub = %claims.sub,
+                            rise_uid = %claims.rise_uid,
+                            jti = %claims.jti,
+                            "Auth middleware: identity token rejected: {rejection}"
+                        );
+                        (StatusCode::UNAUTHORIZED, "Invalid token".to_string())
+                    })?;
+                tracing::debug!(
+                    subject = %principal.subject,
+                    "Auth middleware: Rise identity token accepted"
+                );
+                req.extensions_mut().insert(principal);
             }
             RiseToken::Ingress(_) => {
                 // RS256 ingress tokens are for deployed-app ingress auth only.
@@ -390,6 +417,14 @@ pub async fn platform_access_middleware(
         }
     }
 
+    // Resource principals carry no platform-access notion: what they reach is
+    // exactly what stored policy grants them (ADR-0001 §4), and the generic
+    // resource API is the only surface that accepts them.
+    if req.extensions().get::<ResourcePrincipal>().is_some() {
+        tracing::debug!("Skipping platform access check for identity token (resource principal)");
+        return Ok(next.run(req).await);
+    }
+
     // Extract user from extensions (injected by auth_middleware for Rise JWTs)
     let user = req.extensions().get::<User>().ok_or_else(|| {
         tracing::error!("platform_access_middleware called without user in extensions");
@@ -443,10 +478,109 @@ pub async fn platform_access_middleware(
     Ok(next.run(req).await)
 }
 
+/// Whether a request may reach its handler without a credential.
+///
+/// Exactly one shape qualifies: a `POST` to a path ending in `/token` that
+/// carries neither a bearer nor a session cookie. That is a workload token
+/// exchange, whose credential is the external assertion in the body (ADR-0001
+/// §7): the `/token` subresource authenticates it against the target's trust
+/// policies itself. The predicate is purely syntactic — it does not know
+/// whether the path really is a registered token route — so a request it lets
+/// through that turns out to be anything else is refused by the handler, which
+/// requires a principal for every other operation.
+pub fn is_unauthenticated_token_exchange(req: &Request) -> bool {
+    req.method() == Method::POST
+        && req.uri().path().trim_end_matches('/').ends_with("/token")
+        && extract_bearer_token(req.headers()).is_none()
+        && extract_rise_jwt_from_cookie(req.headers()).is_none()
+}
+
+/// [`auth_middleware`] for the generic resource API: identical, except that an
+/// unauthenticated workload token exchange passes through to its handler.
+pub async fn resource_auth_middleware(
+    state: State<AppState>,
+    headers: HeaderMap,
+    req: Request,
+    next: Next,
+) -> Result<Response, (StatusCode, String)> {
+    if is_unauthenticated_token_exchange(&req) {
+        return Ok(next.run(req).await);
+    }
+    auth_middleware(state, headers, req, next).await
+}
+
+/// [`platform_access_middleware`] for the generic resource API, with the same
+/// pass-through as [`resource_auth_middleware`].
+pub async fn resource_platform_access_middleware(
+    state: State<AppState>,
+    req: Request,
+    next: Next,
+) -> Result<Response, (StatusCode, String)> {
+    if is_unauthenticated_token_exchange(&req) {
+        return Ok(next.run(req).await);
+    }
+    platform_access_middleware(state, req, next).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use axum::http::HeaderValue;
+
+    fn request(method: Method, path: &str, authorization: Option<&str>) -> Request {
+        let mut builder = Request::builder().method(method).uri(path);
+        if let Some(value) = authorization {
+            builder = builder.header("Authorization", value);
+        }
+        builder.body(axum::body::Body::empty()).unwrap()
+    }
+
+    #[test]
+    fn unauthenticated_token_exchange_is_a_credential_less_post_to_token() {
+        let path = "/resources/rise.dev/v1alpha1/serviceaccounts/acme/ci/token";
+        assert!(is_unauthenticated_token_exchange(&request(
+            Method::POST,
+            path,
+            None
+        )));
+        assert!(is_unauthenticated_token_exchange(&request(
+            Method::POST,
+            &format!("{path}/"),
+            None
+        )));
+        // A credential means the ordinary middleware decides.
+        assert!(!is_unauthenticated_token_exchange(&request(
+            Method::POST,
+            path,
+            Some("Bearer x")
+        )));
+        let mut with_cookie = request(Method::POST, path, None);
+        with_cookie
+            .headers_mut()
+            .insert("Cookie", HeaderValue::from_static("rise_jwt=abc"));
+        assert!(!is_unauthenticated_token_exchange(&with_cookie));
+        // Other methods and other paths never pass through.
+        assert!(!is_unauthenticated_token_exchange(&request(
+            Method::GET,
+            path,
+            None
+        )));
+        assert!(!is_unauthenticated_token_exchange(&request(
+            Method::PUT,
+            path,
+            None
+        )));
+        assert!(!is_unauthenticated_token_exchange(&request(
+            Method::POST,
+            "/resources/rise.dev/v1alpha1/serviceaccounts/acme/ci/status",
+            None
+        )));
+        assert!(!is_unauthenticated_token_exchange(&request(
+            Method::POST,
+            "/resources/rise.dev/v1alpha1/serviceaccounts/acme",
+            None
+        )));
+    }
 
     #[test]
     fn test_extract_bearer_token_valid() {

--- a/src/server/auth/middleware.rs
+++ b/src/server/auth/middleware.rs
@@ -179,21 +179,18 @@ pub async fn auth_middleware(
                 // `(sub, rise_uid)` pair must still name one live resource
                 // (ADR-0001 §7). Every rejection is the same 401: which check
                 // failed is a fact about a resource the caller may not read.
-                if claims.aud != state.public_url {
-                    tracing::warn!("Auth middleware: identity token audience mismatch");
-                    return Err((StatusCode::UNAUTHORIZED, "Invalid token".to_string()));
-                }
-                let principal = resolve_identity(state.resource_store.as_ref(), &claims)
-                    .await
-                    .map_err(|rejection| {
-                        tracing::warn!(
-                            sub = %claims.sub,
-                            rise_uid = %claims.rise_uid,
-                            jti = %claims.jti,
-                            "Auth middleware: identity token rejected: {rejection}"
-                        );
-                        (StatusCode::UNAUTHORIZED, "Invalid token".to_string())
-                    })?;
+                let principal =
+                    resolve_identity(state.resource_store.as_ref(), &claims, &state.public_url)
+                        .await
+                        .map_err(|rejection| {
+                            tracing::warn!(
+                                sub = %claims.sub,
+                                rise_uid = %claims.rise_uid,
+                                jti = %claims.jti,
+                                "Auth middleware: identity token rejected: {rejection}"
+                            );
+                            (StatusCode::UNAUTHORIZED, "Invalid token".to_string())
+                        })?;
                 tracing::debug!(
                     subject = %principal.subject,
                     "Auth middleware: Rise identity token accepted"

--- a/src/server/auth/mod.rs
+++ b/src/server/auth/mod.rs
@@ -5,6 +5,7 @@ pub mod entra_sync;
 pub mod exchange;
 pub mod group_sync;
 pub mod handlers;
+pub mod identity;
 pub mod jwt;
 pub mod middleware;
 pub mod oauth;

--- a/src/server/authz/mod.rs
+++ b/src/server/authz/mod.rs
@@ -42,7 +42,7 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 use crate::db::models::User;
-use crate::server::auth::context::AnyAuth;
+use crate::server::auth::context::{AnyAuth, AuthContext};
 use crate::server::error::ServerError;
 use crate::server::resources::error_map::{store_error_to_server_error, RESOURCE_NOT_FOUND};
 
@@ -83,38 +83,45 @@ impl ResourceAuthorizer {
 
     /// The principal behind a credential.
     ///
-    /// A Rise-authenticated User or a Controller reaches the generic resource
-    /// API; both are evaluated identically by the engine from here on. A
-    /// Controller carries no `User` row, so the second element is `None` for
-    /// it and the third is the actor string audit records use in its place.
+    /// Three credentials reach the generic resource API, and the engine
+    /// evaluates all of them identically from here on: a Rise-authenticated
+    /// User; a Controller resolved from a JWT matched against its trust
+    /// policies; and an identity token for a ServiceAccount or Controller
+    /// resource minted by that resource's `/token` subresource (ADR-0001 §7).
+    /// Only a User carries a `User` row, so the second element is `None` for
+    /// the others and the third is the actor string audit records use.
     ///
     /// A User's subject is its stable identity as this install expresses it:
     /// the typed `users` row's UID, which is also the credential's `rise_uid`.
     /// ADR-0001 §1's generated `User` resource name replaces it when identity
     /// resources go live; both are opaque, immutable, and never the email. A
-    /// Controller's subject and UID are already its resource's — that identity
-    /// is already live.
+    /// Controller's or identity token's subject and UID are already its
+    /// resource's, and an identity token's ceiling travels with it: every
+    /// decision below intersects with that cap.
     ///
-    /// Workload principals other than Controllers (project-scoped service
-    /// accounts) still authenticate through the exchange endpoint but do not
-    /// reach the generic resource API: they are bound to a Project, which is a
-    /// typed concept the generic API does not share, and ADR-0001 §7's
-    /// target-bound `/token` route (which would make them principals here) is
-    /// not built yet.
+    /// The typed-table service accounts of the transitional exchange endpoint
+    /// do not reach this API: they are bound to a Project, which is a typed
+    /// concept the generic API does not share.
     fn principal(
         auth: &AnyAuth,
     ) -> Result<(AuthenticatedPrincipal, Option<User>, String), ServerError> {
         match auth {
+            AnyAuth::User(AuthContext::Identity(identity)) => {
+                let principal = AuthenticatedPrincipal::new(
+                    identity.subject.clone(),
+                    identity.uid,
+                    identity.cap.clone(),
+                )
+                .map_err(authorization_error_to_server_error)?;
+                Ok((principal, None, identity.subject.to_string()))
+            }
             AnyAuth::User(auth_ctx) => {
                 let user = auth_ctx.user()?.clone();
                 let subject: SubjectId = format!("user:{}", user.id).parse().map_err(|error| {
                     ServerError::internal(format!("principal is not a valid subject: {error}"))
                 })?;
+                // Unrestricted: a session token carries no authorization details.
                 let principal =
-                    // Unrestricted: authorization details (§7) are not issued
-                    // yet, so no credential carries a ceiling. When they are,
-                    // the parsed cap arrives here and every decision below
-                    // intersects with it, with no other change.
                     AuthenticatedPrincipal::new(subject, user.id, AuthorizationCap::Unrestricted)
                         .map_err(authorization_error_to_server_error)?;
                 let actor = user.email.clone();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -265,7 +265,8 @@ pub async fn run_server(settings: settings::Settings) -> Result<()> {
     }
 
     // Public routes (no authentication)
-    let public_routes = Router::new()
+    #[allow(unused_mut)]
+    let mut public_routes = Router::new()
         .route("/health", axum::routing::get(health_check))
         .route("/version", axum::routing::get(version_info))
         .route(
@@ -281,6 +282,15 @@ pub async fn run_server(settings: settings::Settings) -> Result<()> {
         // endpoint is public.
         .merge(auth::exchange::routes::routes())
         .merge(workload_tokens::routes::routes());
+
+    // The generic resource API carries its own authentication and
+    // platform-access layers: they are the platform-wide ones, except that a
+    // workload token exchange at a `/token` subresource reaches its handler
+    // without a Rise credential (ADR-0001 §7).
+    #[cfg(feature = "backend")]
+    {
+        public_routes = public_routes.merge(resources::routes::routes(state.clone()));
+    }
 
     // Auth-only routes (require authentication but NOT platform access)
     let auth_only_routes = Router::new()
@@ -306,9 +316,6 @@ pub async fn run_server(settings: settings::Settings) -> Result<()> {
         .merge(extensions::routes::routes())
         .merge(encryption::routes::routes())
         .merge(quickstart::routes::routes());
-
-    #[cfg(feature = "backend")]
-    let platform_routes = platform_routes.merge(resources::routes::routes());
 
     let platform_routes = platform_routes
         // Apply platform access middleware (runs second, after auth)

--- a/src/server/resources/handlers.rs
+++ b/src/server/resources/handlers.rs
@@ -39,9 +39,10 @@ use super::models::{
 use super::path::{
     parse_resource_path, parse_uid_token, CollectionRef, RawResourcePath, Subresource, UID_PREFIX,
 };
-use crate::server::auth::context::AnyAuth;
+use super::token::{self, TokenService};
 #[cfg(test)]
 use crate::server::auth::context::AuthContext;
+use crate::server::auth::context::{AnyAuth, MaybeAuth};
 #[cfg(test)]
 use crate::server::auth::controller::ControllerAuthContext;
 use crate::server::authz::{
@@ -71,6 +72,9 @@ pub(crate) struct ResourceApiCtx {
     /// and the row it authorizes are the same ones the write commits.
     store: Arc<dyn ResourceStore>,
     authz: ResourceAuthorizer,
+    /// What the `token` subresource needs: the signer, the JWKS source for
+    /// external assertions, the trust-policy lookup, and the platform limits.
+    tokens: Arc<TokenService>,
 }
 
 impl ResourceApiCtx {
@@ -78,6 +82,14 @@ impl ResourceApiCtx {
         Self {
             store: state.resource_store.clone(),
             authz: state.resource_authorizer.clone(),
+            tokens: Arc::new(TokenService::new(
+                state.jwt_signer.clone(),
+                state.jwt_validator.clone(),
+                rise_resource_store_postgres::TrustPolicyLookup::new(state.db_pool.clone()),
+                state.public_url.clone(),
+                state.server_settings.auth_token_max_ttl_seconds,
+                Some(state.oauth_rate_limiter.clone()),
+            )),
         }
     }
 }
@@ -108,9 +120,9 @@ fn response_resource(
 // Path resolution
 // -----------------------------------------------------------------------------
 
-struct ResolvedCollection {
+pub(super) struct ResolvedCollection {
     collection: String,
-    info: CollectionInfo,
+    pub(super) info: CollectionInfo,
 }
 
 async fn resolve_collection(
@@ -328,7 +340,7 @@ struct DeletionBlockerResponse {
 // -----------------------------------------------------------------------------
 
 /// How to resolve the leaf resource row of an item/subresource path.
-enum LeafRef {
+pub(super) enum LeafRef {
     /// Named form: `D` ancestor name segments plus the leaf name.
     Named {
         ancestor_segs: Vec<PathSegment>,
@@ -339,7 +351,7 @@ enum LeafRef {
 }
 
 /// A resource path classified against the leaf kind's parent-chain depth.
-enum ResolvedPath {
+pub(super) enum ResolvedPath {
     /// `pending-deletion`: resources tombstoned and awaiting GC.
     PendingDeletion,
     /// A collection listing — `D` ancestor name segments, no leaf.
@@ -387,7 +399,7 @@ fn segment_count_error(resolved: &ResolvedCollection, depth: usize, got: usize) 
 /// then either short-circuits the `uid:` form (a UID is globally unique, so the
 /// ancestor chain is irrelevant — no parent-chain walk) or walks the parent
 /// chain to learn `D` and classifies the named segments against it.
-async fn classify_path(
+pub(super) async fn classify_path(
     store: &Arc<dyn ResourceStore>,
     raw: RawResourcePath,
 ) -> Result<ResolvedPath, ServerError> {
@@ -521,7 +533,7 @@ async fn resolve_parent_row(
 /// leaf is missing, an ancestor is missing, the row is of another kind, the
 /// version is not declared — and each of those is itself a fact about a
 /// resource the caller may hold nothing on. One body, every time.
-async fn resolve_leaf(
+pub(super) async fn resolve_leaf(
     store: &Arc<dyn ResourceStore>,
     resolved: &ResolvedCollection,
     leaf: &LeafRef,
@@ -823,10 +835,59 @@ async fn dispatch_get_inner(
 pub async fn dispatch_post(
     State(state): State<AppState>,
     Path(raw): Path<String>,
-    auth: AnyAuth,
+    auth: MaybeAuth,
+    headers: axum::http::HeaderMap,
     Json(body): Json<serde_json::Value>,
 ) -> Result<Response, ServerError> {
-    dispatch_post_inner(&ResourceApiCtx::from_state(&state), raw, auth, body).await
+    let client_ip = crate::server::rate_limit::extract_client_ip(&headers);
+    dispatch_post_any(
+        &ResourceApiCtx::from_state(&state),
+        raw,
+        auth,
+        body,
+        &client_ip,
+    )
+    .await
+}
+
+/// POST, before the credential question is settled.
+///
+/// The `token` subresource is the one route that may be reached without a
+/// Rise credential, and — credential or not — the one POST that is not a
+/// serializable write: it persists nothing (ADR-0001 §2). Both of its modes are
+/// dispatched here; everything else is the ordinary create path.
+async fn dispatch_post_any(
+    ctx: &ResourceApiCtx,
+    raw: String,
+    auth: MaybeAuth,
+    body: serde_json::Value,
+    client_ip: &str,
+) -> Result<Response, ServerError> {
+    let raw_path = parse_resource_path(&raw)?;
+    let Some(auth) = auth.0 else {
+        return token::dispatch_unauthenticated(&ctx.store, &ctx.tokens, raw_path, body, client_ip)
+            .await;
+    };
+    if token::may_be_token_route(&raw_path) {
+        if let ResolvedPath::Subresource {
+            resolved,
+            leaf,
+            subresource: Subresource::Token,
+        } = classify_path(&ctx.store, raw_path).await?
+        {
+            return token::delegated_issuance(
+                &ctx.authz,
+                &ctx.store,
+                &ctx.tokens,
+                &auth,
+                &resolved,
+                &leaf,
+                body,
+            )
+            .await;
+        }
+    }
+    dispatch_post_inner(ctx, raw, auth, body).await
 }
 
 async fn dispatch_post_inner(
@@ -968,6 +1029,7 @@ async fn update_once(
                     StatusCode::METHOD_NOT_ALLOWED,
                     "deletion-blockers is a read-only subresource",
                 )),
+                Subresource::Token => Err(token_is_create_only()),
             }
         }
         _ => Err(ServerError::new(
@@ -977,6 +1039,15 @@ async fn update_once(
     }
 }
 
+/// `token` accepts `create` and nothing else (ADR-0001 §2): a Role may hold a
+/// broader wildcard, but only an operation the registered route serves can be
+/// authorized, and this one serves only POST.
+fn token_is_create_only() -> ServerError {
+    ServerError::new(
+        StatusCode::METHOD_NOT_ALLOWED,
+        "token is a create-only subresource: POST to it",
+    )
+}
 pub async fn dispatch_delete(
     State(state): State<AppState>,
     Path(raw): Path<String>,
@@ -1347,6 +1418,7 @@ async fn create_resource(
     let annotations: BTreeMap<String, String> = body.metadata.annotations.clone();
     let spec = serde_json::to_value(&body.spec)
         .map_err(|e| ServerError::bad_request(format!("invalid spec: {e}")))?;
+    token::reject_rise_issuer_in_trust_policy(&ctx.tokens, &resolved.info, &spec)?;
 
     authorize_owner_references(authz, None, &[], &body.metadata.owner_references).await?;
 
@@ -1848,12 +1920,13 @@ mod dispatch_tests {
             store,
             authz: ResourceAuthorizer::new(
                 pg_store,
-                pool,
+                pool.clone(),
                 crate::server::authz::OperatorSelectors {
                     users: Arc::new(operator_users),
                     idp_groups: Arc::new(operator_idp_groups),
                 },
             ),
+            tokens: Arc::new(token::tests::service(pool)),
         }
     }
 
@@ -5768,5 +5841,816 @@ mod dispatch_tests {
             .as_array()
             .expect("versions array");
         assert_eq!(versions.len(), 3, "expected 3 versions after update");
+    }
+
+    // -------------------------------------------------------------------------
+    // The token subresource (ADR-0001 §7)
+    // -------------------------------------------------------------------------
+
+    use crate::server::auth::identity::{resolve_identity, IdentityRejection};
+    use rise_backend_auth::{IdentityClaims, RiseToken};
+
+    const IP: &str = "203.0.113.7";
+
+    fn identity_body(name: &str, kind: &str) -> Value {
+        json!({
+            "apiVersion": "rise.dev/v1alpha1",
+            "kind": kind,
+            "metadata": {"name": name},
+            "spec": {},
+        })
+    }
+
+    async fn create_service_account(ctx: &ResourceApiCtx, org: &str, name: &str) -> Value {
+        create_at(
+            ctx,
+            &format!("rise.dev/v1alpha1/serviceaccounts/{org}"),
+            identity_body(name, "ServiceAccount"),
+        )
+        .await
+    }
+
+    fn trust_policy_body(kind: &str, name: &str, issuer: &str, claims: Value) -> Value {
+        json!({
+            "apiVersion": "rise.dev/v1alpha1",
+            "kind": kind,
+            "metadata": {"name": name},
+            "spec": {"issuer": issuer, "claims": claims},
+        })
+    }
+
+    async fn trust_service_account(
+        ctx: &ResourceApiCtx,
+        org: &str,
+        sa: &str,
+        name: &str,
+        issuer: &str,
+        claims: Value,
+    ) {
+        create_at(
+            ctx,
+            &format!("rise.dev/v1alpha1/serviceaccounttrustpolicies/{org}/{sa}"),
+            trust_policy_body("ServiceAccountTrustPolicy", name, issuer, claims),
+        )
+        .await;
+    }
+
+    async fn trust_controller(
+        ctx: &ResourceApiCtx,
+        controller: &str,
+        name: &str,
+        issuer: &str,
+        claims: Value,
+    ) {
+        create_at(
+            ctx,
+            &format!("rise.dev/v1alpha1/controllertrustpolicies/{controller}"),
+            trust_policy_body("ControllerTrustPolicy", name, issuer, claims),
+        )
+        .await;
+    }
+
+    fn exchange_body(assertion: &str) -> Value {
+        json!({
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token": assertion,
+            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+        })
+    }
+
+    /// A credential-less POST: the workload exchange path.
+    async fn exchange(
+        ctx: &ResourceApiCtx,
+        path: &str,
+        body: Value,
+    ) -> Result<Response, ServerError> {
+        dispatch_post_any(ctx, path.to_string(), MaybeAuth(None), body, IP).await
+    }
+
+    /// An authenticated POST: the delegated path, or an ordinary create.
+    async fn post_as(
+        ctx: &ResourceApiCtx,
+        path: &str,
+        auth: AnyAuth,
+        body: Value,
+    ) -> Result<Response, ServerError> {
+        dispatch_post_any(ctx, path.to_string(), MaybeAuth(Some(auth)), body, IP).await
+    }
+
+    /// Decode a minted token through the service's own verifier.
+    fn decode(ctx: &ResourceApiCtx, body: &Value) -> IdentityClaims {
+        let token = body["access_token"].as_str().expect("access_token");
+        match ctx
+            .tokens
+            .signer()
+            .verify_rise_jwt(token)
+            .expect("verifies")
+        {
+            RiseToken::Identity(claims) => claims,
+            other => panic!("expected an identity token, got {other:?}"),
+        }
+    }
+
+    /// Authenticate a minted token exactly as the middleware does.
+    async fn identity_auth(ctx: &ResourceApiCtx, body: &Value) -> AnyAuth {
+        let claims = decode(ctx, body);
+        AnyAuth::User(AuthContext::Identity(
+            resolve_identity(ctx.store.as_ref(), &claims)
+                .await
+                .expect("the minted token resolves to a live principal"),
+        ))
+    }
+
+    const SA_TOKEN: &str = "rise.dev/v1alpha1/serviceaccounts/acme/ci/token";
+    const CI_CLAIMS: &str = "repo:acme/app:ref:main";
+
+    #[sqlx::test]
+    async fn workload_exchange_mints_a_target_bound_identity_token(pool: sqlx::PgPool) {
+        let ctx = ctx(pool).await;
+        create_org(&ctx, "acme").await;
+        let sa = create_service_account(&ctx, "acme", "ci").await;
+        trust_service_account(
+            &ctx,
+            "acme",
+            "ci",
+            "github",
+            token::tests::ISSUER,
+            json!({"aud": "rise", "sub": "repo:acme/*"}),
+        )
+        .await;
+
+        let assertion = token::tests::assertion(json!({"aud": "rise", "sub": CI_CLAIMS}));
+        let resp = exchange(&ctx, SA_TOKEN, exchange_body(&assertion))
+            .await
+            .expect("exchange succeeds");
+        let (status, body) = read(resp).await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert_eq!(body["token_type"], "Bearer");
+        assert_eq!(body["expires_in"], 600);
+        let claims = decode(&ctx, &body);
+        assert_eq!(claims.sub, "serviceaccount:acme/ci");
+        assert_eq!(claims.rise_uid, uid_of(&sa));
+        assert_eq!(claims.aud, token::tests::RISE_URL);
+        assert!(
+            claims.act.is_none(),
+            "a workload exchange records no delegator"
+        );
+        assert!(claims.authorization_details.is_none());
+
+        // `aud` may be an array (RFC 7519 §4.1.3), and the UID form addresses
+        // the same target.
+        let assertion =
+            token::tests::assertion(json!({"aud": ["other", "rise"], "sub": CI_CLAIMS}));
+        let resp = exchange(
+            &ctx,
+            &format!(
+                "rise.dev/v1alpha1/serviceaccounts/uid:{}/token",
+                uid_of(&sa)
+            ),
+            exchange_body(&assertion),
+        )
+        .await
+        .expect("exchange by uid succeeds");
+        let (status, body) = read(resp).await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert_eq!(decode(&ctx, &body).sub, "serviceaccount:acme/ci");
+
+        // A Controller is root-scoped and exchanges the same way.
+        let controller = create_controller(&ctx, "k8s").await;
+        trust_controller(
+            &ctx,
+            "k8s",
+            "cluster",
+            token::tests::ISSUER,
+            json!({"aud": "rise-controller", "sub": "system:serviceaccount:rise:k8s"}),
+        )
+        .await;
+        let assertion = token::tests::assertion(
+            json!({"aud": "rise-controller", "sub": "system:serviceaccount:rise:k8s"}),
+        );
+        let resp = exchange(
+            &ctx,
+            "rise.dev/v1alpha1/controllers/k8s/token",
+            exchange_body(&assertion),
+        )
+        .await
+        .expect("controller exchange succeeds");
+        let (status, body) = read(resp).await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        let claims = decode(&ctx, &body);
+        assert_eq!(claims.sub, "controller:k8s");
+        assert_eq!(claims.rise_uid, uid_of(&controller));
+    }
+
+    /// Scenarios 44, 45 and 47: after the route is entered, every failure is
+    /// the same 401 body, and only a registered token route is entered at all.
+    #[sqlx::test]
+    async fn workload_exchange_failures_are_one_coarse_401(pool: sqlx::PgPool) {
+        let ctx = ctx(pool).await;
+        create_org(&ctx, "acme").await;
+        let sa = create_service_account(&ctx, "acme", "ci").await;
+        create_service_account(&ctx, "acme", "unpoliced").await;
+        create_service_account(&ctx, "acme", "ambiguous").await;
+        trust_service_account(
+            &ctx,
+            "acme",
+            "ci",
+            "github",
+            token::tests::ISSUER,
+            json!({"aud": "rise", "sub": CI_CLAIMS}),
+        )
+        .await;
+        trust_service_account(
+            &ctx,
+            "acme",
+            "ci",
+            "elsewhere",
+            "https://other.example.com",
+            json!({"aud": "rise"}),
+        )
+        .await;
+        for name in ["one", "two"] {
+            trust_service_account(
+                &ctx,
+                "acme",
+                "ambiguous",
+                name,
+                token::tests::ISSUER,
+                json!({"aud": "rise"}),
+            )
+            .await;
+        }
+        let good = token::tests::assertion(json!({"aud": "rise", "sub": CI_CLAIMS}));
+
+        let coarse = |label: &'static str, err: ServerError| {
+            assert_eq!(
+                err.status,
+                StatusCode::UNAUTHORIZED,
+                "{label}: {}",
+                err.message
+            );
+            assert_eq!(err.message, token::WORKLOAD_EXCHANGE_REJECTED, "{label}");
+        };
+        let sa_path = |name: &str| format!("rise.dev/v1alpha1/serviceaccounts/acme/{name}/token");
+
+        // Absent target.
+        coarse(
+            "missing target",
+            exchange(&ctx, &sa_path("ghost"), exchange_body(&good))
+                .await
+                .unwrap_err(),
+        );
+        // A UID that resolves to another kind.
+        let org_uid = ctx
+            .store
+            .get_by_name("rise.dev/v1alpha1", "Organization", "acme", None)
+            .await
+            .unwrap()
+            .unwrap()
+            .uid;
+        coarse(
+            "wrong kind by uid",
+            exchange(
+                &ctx,
+                &format!("rise.dev/v1alpha1/serviceaccounts/uid:{org_uid}/token"),
+                exchange_body(&good),
+            )
+            .await
+            .unwrap_err(),
+        );
+        // No trust policy for this issuer.
+        coarse(
+            "no policy",
+            exchange(&ctx, &sa_path("unpoliced"), exchange_body(&good))
+                .await
+                .unwrap_err(),
+        );
+        // Claim mismatch.
+        let wrong_sub = token::tests::assertion(json!({"aud": "rise", "sub": "repo:beta/app"}));
+        coarse(
+            "claim mismatch",
+            exchange(&ctx, &sa_path("ci"), exchange_body(&wrong_sub))
+                .await
+                .unwrap_err(),
+        );
+        // Two matching policies.
+        coarse(
+            "ambiguous",
+            exchange(&ctx, &sa_path("ambiguous"), exchange_body(&good))
+                .await
+                .unwrap_err(),
+        );
+        // A policy exists for the issuer but its keys do not verify.
+        let unverifiable = token::tests::assertion_from(
+            "https://other.example.com",
+            json!({"aud": "rise", "sub": CI_CLAIMS}),
+        );
+        coarse(
+            "unverifiable",
+            exchange(&ctx, &sa_path("ci"), exchange_body(&unverifiable))
+                .await
+                .unwrap_err(),
+        );
+        // Rise's own issuer is never an external source.
+        let rise_issued = token::tests::assertion_from(
+            token::tests::RISE_URL,
+            json!({"aud": "rise", "sub": CI_CLAIMS}),
+        );
+        coarse(
+            "rise-issued",
+            exchange(&ctx, &sa_path("ci"), exchange_body(&rise_issued))
+                .await
+                .unwrap_err(),
+        );
+        // Not a JWT at all.
+        coarse(
+            "malformed",
+            exchange(&ctx, &sa_path("ci"), exchange_body("not-a-jwt"))
+                .await
+                .unwrap_err(),
+        );
+        // A draining target.
+        ctx.store.delete(uid_of(&sa)).await.expect("tombstone ci");
+        coarse(
+            "draining target",
+            exchange(&ctx, &sa_path("ci"), exchange_body(&good))
+                .await
+                .unwrap_err(),
+        );
+
+        // A kind that does not register `token` has no such route: the ordinary
+        // 404, before any authentication.
+        let err = exchange(
+            &ctx,
+            "rise.dev/v1alpha1/organizations/acme/token",
+            exchange_body(&good),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.status, StatusCode::NOT_FOUND, "{}", err.message);
+        assert!(err.message.contains("no such route"), "{}", err.message);
+        // Any other credential-less request is simply unauthenticated —
+        // including one that reaches the same answer for an unknown collection.
+        for path in [
+            "rise.dev/v1alpha1/serviceaccounts/acme",
+            "rise.dev/v1alpha1/serviceaccounts/acme/ci/status",
+            "example.dev/v1/nothing/here/token",
+        ] {
+            let err = exchange(&ctx, path, exchange_body(&good))
+                .await
+                .unwrap_err();
+            assert_eq!(
+                err.status,
+                StatusCode::UNAUTHORIZED,
+                "{path}: {}",
+                err.message
+            );
+            assert_ne!(err.message, token::WORKLOAD_EXCHANGE_REJECTED, "{path}");
+        }
+        // No assertion and no credential is no credential.
+        let err = exchange(&ctx, &sa_path("ci"), json!({})).await.unwrap_err();
+        assert_eq!(err.status, StatusCode::UNAUTHORIZED);
+        // An assertion alongside a Rise credential is a malformed request, not
+        // an authentication failure (scenario 47).
+        let err = post_as(&ctx, &sa_path("ci"), auth(OPERATOR), exchange_body(&good))
+            .await
+            .unwrap_err();
+        assert_eq!(err.status, StatusCode::BAD_REQUEST, "{}", err.message);
+    }
+
+    /// Scenarios 46, 48 and 57: delegated issuance is RBAC only, needs `create`
+    /// on the `token` subresource of the exact target, and records the caller.
+    #[sqlx::test]
+    async fn delegated_issuance_requires_create_on_the_token_subresource(pool: sqlx::PgPool) {
+        let ctx = ctx(pool).await;
+        create_org(&ctx, "acme").await;
+        let sa = create_service_account(&ctx, "acme", "ci").await;
+        // No trust policy at all: delegated issuance never consults them.
+
+        let operator = auth(OPERATOR);
+        let operator_id = operator.user().unwrap().id;
+        let resp = post_as(&ctx, SA_TOKEN, operator, json!({}))
+            .await
+            .expect("an operator holds every subresource");
+        let (status, body) = read(resp).await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        let claims = decode(&ctx, &body);
+        assert_eq!(claims.sub, "serviceaccount:acme/ci");
+        assert_eq!(claims.rise_uid, uid_of(&sa));
+        let act = claims.act.expect("a delegated token records its delegator");
+        assert_eq!(act.sub, format!("user:{operator_id}"));
+        assert_eq!(act.rise_uid, operator_id);
+        assert!(act.act.is_none());
+
+        // A caller with no grant may not learn the target exists.
+        let err = post_as(&ctx, SA_TOKEN, auth(PLAIN_USER), json!({}))
+            .await
+            .unwrap_err();
+        assert_eq!(err.status, StatusCode::NOT_FOUND, "{}", err.message);
+
+        // `get` on the parent, `create` on the main resource, and `get` on the
+        // subresource each grant nothing here.
+        grant_authenticated(
+            &ctx,
+            "not-enough",
+            json!([
+                {"effect": "Allow", "kinds": ["rise.dev/ServiceAccount"], "verbs": ["get", "create"]},
+                {"effect": "Allow", "kinds": ["rise.dev/ServiceAccount"], "verbs": ["get"], "subresources": ["token"]},
+            ]),
+        )
+        .await;
+        let err = post_as(&ctx, SA_TOKEN, auth(PLAIN_USER), json!({}))
+            .await
+            .unwrap_err();
+        assert_eq!(err.status, StatusCode::FORBIDDEN, "{}", err.message);
+
+        // `(create, rise.dev/ServiceAccount, token)` is the grant.
+        grant_authenticated(
+            &ctx,
+            "token-minter",
+            json!([{
+                "effect": "Allow",
+                "kinds": ["rise.dev/ServiceAccount"],
+                "verbs": ["create"],
+                "subresources": ["token"],
+            }]),
+        )
+        .await;
+        let resp = post_as(&ctx, SA_TOKEN, auth(PLAIN_USER), json!({}))
+            .await
+            .expect("the token grant suffices");
+        let (status, body) = read(resp).await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert_eq!(decode(&ctx, &body).sub, "serviceaccount:acme/ci");
+
+        // The grant is on ServiceAccount, so a Controller target is still
+        // refused — masked, since the caller holds no `get` on Controllers.
+        create_controller(&ctx, "k8s").await;
+        let err = post_as(
+            &ctx,
+            "rise.dev/v1alpha1/controllers/k8s/token",
+            auth(PLAIN_USER),
+            json!({}),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.status, StatusCode::NOT_FOUND, "{}", err.message);
+
+        // A kind without the subresource has no route, whoever asks.
+        let err = post_as(
+            &ctx,
+            "rise.dev/v1alpha1/organizations/acme/token",
+            auth(OPERATOR),
+            json!({}),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.status, StatusCode::NOT_FOUND, "{}", err.message);
+        assert!(err.message.contains("no such route"), "{}", err.message);
+    }
+
+    /// Scenario 54 and §1's UID binding: a minted token is a principal of the
+    /// generic API, exercises the target's live policy, and dies with the
+    /// target's UID.
+    #[sqlx::test]
+    async fn a_minted_token_authenticates_as_the_target_until_its_uid_dies(pool: sqlx::PgPool) {
+        let ctx = ctx(pool).await;
+        create_org(&ctx, "acme").await;
+        let sa = create_service_account(&ctx, "acme", "ci").await;
+        let resp = post_as(&ctx, SA_TOKEN, auth(OPERATOR), json!({}))
+            .await
+            .expect("mint");
+        let (_, body) = read(resp).await;
+        let as_ci = identity_auth(&ctx, &body).await;
+        let AnyAuth::User(inner) = &as_ci else {
+            panic!("an identity token is an AuthContext principal");
+        };
+        assert!(inner.is_service_account());
+        assert!(inner.user().is_err(), "a resource principal is not a User");
+
+        // With no grant, the identity reaches nothing — not even itself.
+        let err = dispatch_get_inner(
+            &ctx,
+            "rise.dev/v1alpha1/serviceaccounts/acme/ci".to_string(),
+            as_ci.clone(),
+            PendingDeletionQuery::default(),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.status, StatusCode::NOT_FOUND, "{}", err.message);
+
+        // A live grant to the identity delivers on the next request: nothing
+        // is snapshotted in the token.
+        create_at(
+            &ctx,
+            "rise.dev/v1alpha1/platformroles",
+            json!({
+                "apiVersion": "rise.dev/v1alpha1",
+                "kind": "PlatformRole",
+                "metadata": {"name": "self-reader"},
+                "spec": {"statements": [
+                    {"effect": "Allow", "kinds": ["rise.dev/ServiceAccount"], "verbs": ["get"]}
+                ]},
+            }),
+        )
+        .await;
+        create_at(
+            &ctx,
+            "rise.dev/v1alpha1/platformrolebindings",
+            json!({
+                "apiVersion": "rise.dev/v1alpha1",
+                "kind": "PlatformRoleBinding",
+                "metadata": {"name": "ci-reads-itself"},
+                "spec": {
+                    "subject": "serviceaccount:acme/ci",
+                    "scope": "rise.dev/ServiceAccount/acme/ci",
+                    "roleRef": {"kind": "PlatformRole", "name": "self-reader"},
+                },
+            }),
+        )
+        .await;
+        let resp = dispatch_get_inner(
+            &ctx,
+            "rise.dev/v1alpha1/serviceaccounts/acme/ci".to_string(),
+            as_ci.clone(),
+            PendingDeletionQuery::default(),
+        )
+        .await
+        .expect("the live grant reaches the token holder");
+        let (status, read_back) = read(resp).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(read_back["metadata"]["uid"], sa["metadata"]["uid"]);
+
+        // Group ties and operator standing belong to Users alone, so the
+        // identity is neither an operator nor affiliated by group.
+        let read_ctx = ctx.authz.read_context(&as_ci).await.unwrap();
+        assert!(!read_ctx.is_operator());
+        assert_eq!(read_ctx.subject().to_string(), "serviceaccount:acme/ci");
+        assert_eq!(read_ctx.actor(), "serviceaccount:acme/ci");
+
+        // Delete and recreate the same name: the name-bound binding delivers to
+        // the replacement, but every token for the old UID fails immediately.
+        ctx.store.delete(uid_of(&sa)).await.expect("delete ci");
+        let claims = decode(&ctx, &body);
+        assert!(matches!(
+            resolve_identity(ctx.store.as_ref(), &claims).await,
+            Err(IdentityRejection::NoLiveResource)
+        ));
+        // A tombstone, if the delete left one, has to be collected before the
+        // name is free again.
+        let _ = ctx.store.try_collect(uid_of(&sa)).await;
+        let replacement = create_service_account(&ctx, "acme", "ci").await;
+        assert_ne!(uid_of(&replacement), uid_of(&sa));
+        assert!(matches!(
+            resolve_identity(ctx.store.as_ref(), &claims).await,
+            Err(IdentityRejection::NoLiveResource)
+        ));
+    }
+
+    /// Scenario 48: a minted identity may mint the next only through its own
+    /// live token-create grant, and the chain records every delegator.
+    #[sqlx::test]
+    async fn delegation_chains_only_across_explicit_grants(pool: sqlx::PgPool) {
+        let ctx = ctx(pool).await;
+        create_org(&ctx, "acme").await;
+        create_service_account(&ctx, "acme", "ci").await;
+        create_controller(&ctx, "k8s").await;
+
+        let operator = auth(OPERATOR);
+        let operator_id = operator.user().unwrap().id;
+        let resp = post_as(
+            &ctx,
+            "rise.dev/v1alpha1/controllers/k8s/token",
+            operator,
+            json!({}),
+        )
+        .await
+        .expect("operator mints for the controller");
+        let (_, controller_token) = read(resp).await;
+        let as_k8s = identity_auth(&ctx, &controller_token).await;
+
+        // The controller holds no token-create on the ServiceAccount.
+        let err = post_as(&ctx, SA_TOKEN, as_k8s.clone(), json!({}))
+            .await
+            .unwrap_err();
+        assert_eq!(err.status, StatusCode::NOT_FOUND, "{}", err.message);
+
+        // A Controller is org-agnostic, so its grant on an org-contained target
+        // arrives through a PlatformRoleBinding (ADR-0001 §7).
+        create_at(
+            &ctx,
+            "rise.dev/v1alpha1/platformroles",
+            json!({
+                "apiVersion": "rise.dev/v1alpha1",
+                "kind": "PlatformRole",
+                "metadata": {"name": "sa-token-minter"},
+                "spec": {"statements": [{
+                    "effect": "Allow",
+                    "kinds": ["rise.dev/ServiceAccount"],
+                    "verbs": ["create"],
+                    "subresources": ["token"],
+                }]},
+            }),
+        )
+        .await;
+        create_at(
+            &ctx,
+            "rise.dev/v1alpha1/platformrolebindings",
+            json!({
+                "apiVersion": "rise.dev/v1alpha1",
+                "kind": "PlatformRoleBinding",
+                "metadata": {"name": "k8s-mints-ci"},
+                "spec": {
+                    "subject": "controller:k8s",
+                    "scope": "rise.dev/Organization/acme",
+                    "roleRef": {"kind": "PlatformRole", "name": "sa-token-minter"},
+                },
+            }),
+        )
+        .await;
+        let resp = post_as(&ctx, SA_TOKEN, as_k8s, json!({}))
+            .await
+            .expect("the controller now holds token-create on the ServiceAccount");
+        let (status, sa_token) = read(resp).await;
+        assert_eq!(status, StatusCode::OK, "{sa_token}");
+        let claims = decode(&ctx, &sa_token);
+        assert_eq!(claims.sub, "serviceaccount:acme/ci");
+        assert_eq!(claims.delegation_depth(), 2);
+        let act = claims.act.expect("act");
+        assert_eq!(act.sub, "controller:k8s");
+        let inner = act.act.expect("the controller's own delegator");
+        assert_eq!(inner.sub, format!("user:{operator_id}"));
+        assert!(inner.act.is_none());
+
+        // Actor data never grants: the ServiceAccount token holds only what the
+        // ServiceAccount holds, which is nothing here.
+        let as_ci = identity_auth(&ctx, &sa_token).await;
+        let err = post_as(
+            &ctx,
+            "rise.dev/v1alpha1/controllers/k8s/token",
+            as_ci,
+            json!({}),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.status, StatusCode::NOT_FOUND, "{}", err.message);
+    }
+
+    /// Scenarios 52 and 53: `authorization_details` narrow the issued token,
+    /// the ceiling applies on every request, and a malformed set is refused.
+    #[sqlx::test]
+    async fn authorization_details_narrow_the_issued_token(pool: sqlx::PgPool) {
+        let ctx = ctx(pool).await;
+        create_org(&ctx, "acme").await;
+        create_org(&ctx, "beta").await;
+        create_service_account(&ctx, "acme", "ci").await;
+        // The identity may read every ServiceAccount, live.
+        grant_authenticated(
+            &ctx,
+            "sa-reader",
+            json!([{"effect": "Allow", "kinds": ["rise.dev/ServiceAccount"], "verbs": ["get", "list"]}]),
+        )
+        .await;
+        create_service_account(&ctx, "beta", "deploy").await;
+
+        let details = json!([{
+            "type": "rise.dev/rbac",
+            "scope": "rise.dev/Organization/acme",
+            "permissions": [{"verbs": ["get"], "kinds": ["rise.dev/ServiceAccount"]}],
+        }]);
+        let resp = post_as(
+            &ctx,
+            SA_TOKEN,
+            auth(OPERATOR),
+            json!({"authorization_details": details, "expires_in": 60}),
+        )
+        .await
+        .expect("mint a narrowed token");
+        let (status, body) = read(resp).await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert_eq!(body["expires_in"], 60);
+        let claims = decode(&ctx, &body);
+        assert_eq!(
+            claims.authorization_details.as_ref().map(|d| json!(d)),
+            Some(details),
+            "the token carries the canonical detail set"
+        );
+        let capped = identity_auth(&ctx, &body).await;
+
+        // Inside the ceiling, the live grant delivers.
+        let resp = dispatch_get_inner(
+            &ctx,
+            "rise.dev/v1alpha1/serviceaccounts/acme/ci".to_string(),
+            capped.clone(),
+            PendingDeletionQuery::default(),
+        )
+        .await
+        .expect("get inside the ceiling");
+        assert_eq!(read(resp).await.0, StatusCode::OK);
+        // Outside it, live RBAC is denied — and masked, as any denial is.
+        let err = dispatch_get_inner(
+            &ctx,
+            "rise.dev/v1alpha1/serviceaccounts/beta/deploy".to_string(),
+            capped.clone(),
+            PendingDeletionQuery::default(),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.status, StatusCode::NOT_FOUND, "{}", err.message);
+        // `list` is outside the ceiling too, so the listing is masked empty.
+        let resp = dispatch_get_inner(
+            &ctx,
+            "rise.dev/v1alpha1/serviceaccounts/acme".to_string(),
+            capped,
+            PendingDeletionQuery::default(),
+        )
+        .await
+        .expect("a list outside the ceiling is empty");
+        let (status, listing) = read(resp).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(listing["items"].as_array().map(Vec::len), Some(0));
+
+        // A malformed detail set is a bad request, never a fallback.
+        for details in [json!([]), json!({}), json!([{"type": "rise.dev/rbac"}])] {
+            let err = post_as(
+                &ctx,
+                SA_TOKEN,
+                auth(OPERATOR),
+                json!({"authorization_details": details}),
+            )
+            .await
+            .unwrap_err();
+            assert_eq!(err.status, StatusCode::BAD_REQUEST, "{}", err.message);
+        }
+        // And a token whose stored claim is malformed fails authentication.
+        let mut claims = decode(&ctx, &body);
+        claims.authorization_details = Some(vec![]);
+        assert!(matches!(
+            resolve_identity(ctx.store.as_ref(), &claims).await,
+            Err(IdentityRejection::Cap(_))
+        ));
+    }
+
+    /// `token` is create-only (ADR-0001 §2), and a trust policy may never name
+    /// Rise's own issuer (scenario 47).
+    #[sqlx::test]
+    async fn token_is_create_only_and_rise_is_never_an_external_issuer(pool: sqlx::PgPool) {
+        let ctx = ctx(pool).await;
+        create_org(&ctx, "acme").await;
+        create_service_account(&ctx, "acme", "ci").await;
+
+        let err = dispatch_put_inner(&ctx, SA_TOKEN.to_string(), auth(OPERATOR), json!({}))
+            .await
+            .unwrap_err();
+        assert_eq!(
+            err.status,
+            StatusCode::METHOD_NOT_ALLOWED,
+            "{}",
+            err.message
+        );
+        let err = dispatch_put_inner(
+            &ctx,
+            SA_TOKEN.to_string(),
+            any_controller("reconciler"),
+            json!({}),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(
+            err.status,
+            StatusCode::METHOD_NOT_ALLOWED,
+            "{}",
+            err.message
+        );
+        let err = dispatch_get_inner(
+            &ctx,
+            SA_TOKEN.to_string(),
+            auth(OPERATOR),
+            PendingDeletionQuery::default(),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(
+            err.status,
+            StatusCode::METHOD_NOT_ALLOWED,
+            "{}",
+            err.message
+        );
+
+        let err = post_as(
+            &ctx,
+            "rise.dev/v1alpha1/serviceaccounttrustpolicies/acme/ci",
+            auth(OPERATOR),
+            trust_policy_body(
+                "ServiceAccountTrustPolicy",
+                "self",
+                token::tests::RISE_URL,
+                json!({"aud": "rise"}),
+            ),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.status, StatusCode::BAD_REQUEST, "{}", err.message);
+        assert!(err.message.contains("Rise's own issuer"), "{}", err.message);
     }
 }

--- a/src/server/resources/handlers.rs
+++ b/src/server/resources/handlers.rs
@@ -5955,7 +5955,7 @@ mod dispatch_tests {
     async fn identity_auth(ctx: &ResourceApiCtx, body: &Value) -> AnyAuth {
         let claims = decode(ctx, body);
         AnyAuth::User(AuthContext::Identity(
-            resolve_identity(ctx.store.as_ref(), &claims)
+            resolve_identity(ctx.store.as_ref(), &claims, token::tests::RISE_URL)
                 .await
                 .expect("the minted token resolves to a live principal"),
         ))
@@ -6393,7 +6393,7 @@ mod dispatch_tests {
         ctx.store.delete(uid_of(&sa)).await.expect("delete ci");
         let claims = decode(&ctx, &body);
         assert!(matches!(
-            resolve_identity(ctx.store.as_ref(), &claims).await,
+            resolve_identity(ctx.store.as_ref(), &claims, token::tests::RISE_URL).await,
             Err(IdentityRejection::NoLiveResource)
         ));
         // A tombstone, if the delete left one, has to be collected before the
@@ -6402,7 +6402,7 @@ mod dispatch_tests {
         let replacement = create_service_account(&ctx, "acme", "ci").await;
         assert_ne!(uid_of(&replacement), uid_of(&sa));
         assert!(matches!(
-            resolve_identity(ctx.store.as_ref(), &claims).await,
+            resolve_identity(ctx.store.as_ref(), &claims, token::tests::RISE_URL).await,
             Err(IdentityRejection::NoLiveResource)
         ));
     }
@@ -6586,9 +6586,79 @@ mod dispatch_tests {
         let mut claims = decode(&ctx, &body);
         claims.authorization_details = Some(vec![]);
         assert!(matches!(
-            resolve_identity(ctx.store.as_ref(), &claims).await,
+            resolve_identity(ctx.store.as_ref(), &claims, token::tests::RISE_URL).await,
             Err(IdentityRejection::Cap(_))
         ));
+    }
+
+    /// An `audience` mints the same token for another verifier: Rise's own API
+    /// refuses it, and a ceiling cannot be combined with it.
+    #[sqlx::test]
+    async fn an_audience_bound_token_is_for_that_verifier_only(pool: sqlx::PgPool) {
+        let ctx = ctx(pool).await;
+        create_org(&ctx, "acme").await;
+        let sa = create_service_account(&ctx, "acme", "ci").await;
+
+        let resp = post_as(
+            &ctx,
+            SA_TOKEN,
+            auth(OPERATOR),
+            json!({"audience": "https://vault.example.com"}),
+        )
+        .await
+        .expect("mint for an external audience");
+        let (status, body) = read(resp).await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        let claims = decode(&ctx, &body);
+        assert_eq!(claims.aud, "https://vault.example.com");
+        assert_eq!(claims.sub, "serviceaccount:acme/ci");
+        assert_eq!(claims.rise_uid, uid_of(&sa));
+        assert!(matches!(
+            resolve_identity(ctx.store.as_ref(), &claims, token::tests::RISE_URL).await,
+            Err(IdentityRejection::Audience(_))
+        ));
+
+        // The audience defaults to Rise, and an explicit Rise audience is the
+        // same thing.
+        let resp = post_as(
+            &ctx,
+            SA_TOKEN,
+            auth(OPERATOR),
+            json!({"audience": token::tests::RISE_URL}),
+        )
+        .await
+        .expect("mint for Rise explicitly");
+        let (_, body) = read(resp).await;
+        assert!(resolve_identity(
+            ctx.store.as_ref(),
+            &decode(&ctx, &body),
+            token::tests::RISE_URL
+        )
+        .await
+        .is_ok());
+
+        // A ceiling is meaningless to another verifier, so the pair is refused
+        // before anything about the target is consulted.
+        let err = post_as(
+            &ctx,
+            SA_TOKEN,
+            auth(OPERATOR),
+            json!({
+                "audience": "https://vault.example.com",
+                "authorization_details": [{
+                    "type": "rise.dev/rbac",
+                    "scope": "rise.dev/Organization/acme",
+                    "permissions": [{"verbs": ["get"], "kinds": ["rise.dev/ServiceAccount"]}],
+                }],
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.status, StatusCode::BAD_REQUEST, "{}", err.message);
+        let err = post_as(&ctx, SA_TOKEN, auth(OPERATOR), json!({"audience": "  "}))
+            .await
+            .unwrap_err();
+        assert_eq!(err.status, StatusCode::BAD_REQUEST, "{}", err.message);
     }
 
     /// `token` is create-only (ADR-0001 §2), and a trust policy may never name

--- a/src/server/resources/mod.rs
+++ b/src/server/resources/mod.rs
@@ -13,3 +13,4 @@ mod organization;
 pub mod path;
 pub mod routes;
 pub mod schemas;
+pub mod token;

--- a/src/server/resources/path.rs
+++ b/src/server/resources/path.rs
@@ -45,10 +45,13 @@ pub enum Subresource {
     Status,
     Finalizers,
     DeletionBlockers,
+    /// Token issuance for a ServiceAccount or Controller (ADR-0001 §7):
+    /// create-only, and registered on those two kinds alone.
+    Token,
 }
 
 impl Subresource {
-    pub const KEYWORDS: &str = "status, finalizers, deletion-blockers";
+    pub const KEYWORDS: &str = "status, finalizers, deletion-blockers, token";
 
     /// The canonical keyword for this subresource — the same name policy
     /// statements and authorization details use (ADR-0001 §2).
@@ -57,6 +60,7 @@ impl Subresource {
             Self::Status => "status",
             Self::Finalizers => "finalizers",
             Self::DeletionBlockers => "deletion-blockers",
+            Self::Token => "token",
         }
     }
 
@@ -66,6 +70,7 @@ impl Subresource {
             "status" => Some(Self::Status),
             "finalizers" => Some(Self::Finalizers),
             "deletion-blockers" => Some(Self::DeletionBlockers),
+            "token" => Some(Self::Token),
             _ => None,
         }
     }
@@ -172,6 +177,7 @@ mod tests {
             Subresource::from_keyword("deletion-blockers"),
             Some(Subresource::DeletionBlockers)
         );
+        assert_eq!(Subresource::from_keyword("token"), Some(Subresource::Token));
         assert_eq!(Subresource::from_keyword("reparent"), None);
         assert_eq!(Subresource::from_keyword("widgets"), None);
     }

--- a/src/server/resources/routes.rs
+++ b/src/server/resources/routes.rs
@@ -6,13 +6,24 @@
 //!
 //! All resource paths are dispatched through four handler functions that parse
 //! the wildcard `{*path}` capture and classify it against the resource store.
+//!
+//! The router carries its own authentication and platform-access layers rather
+//! than the platform-wide ones, because one request shape must reach its
+//! handler without a credential: a workload token exchange at a `/token`
+//! subresource, whose credential is the external assertion in the body
+//! (ADR-0001 §7). Every other request is authenticated exactly as the
+//! platform-wide layers authenticate it.
 
 use axum::{
+    middleware::from_fn_with_state,
     routing::{delete, get, post, put},
     Router,
 };
 
 use super::handlers;
+use crate::server::auth::middleware::{
+    resource_auth_middleware, resource_platform_access_middleware,
+};
 use crate::server::state::AppState;
 
 /// Wildcard route pattern for the generic resource API. `{*path}` captures the
@@ -20,12 +31,18 @@ use crate::server::state::AppState;
 /// the full resource path rather than just its first component.
 const RESOURCE_PATH_ROUTE: &str = "/resources/{*path}";
 
-pub fn routes() -> Router<AppState> {
+pub fn routes(state: AppState) -> Router<AppState> {
     Router::new()
         .route(RESOURCE_PATH_ROUTE, get(handlers::dispatch_get))
         .route(RESOURCE_PATH_ROUTE, post(handlers::dispatch_post))
         .route(RESOURCE_PATH_ROUTE, put(handlers::dispatch_put))
         .route(RESOURCE_PATH_ROUTE, delete(handlers::dispatch_delete))
+        // Platform access runs second, after authentication.
+        .route_layer(from_fn_with_state(
+            state.clone(),
+            resource_platform_access_middleware,
+        ))
+        .route_layer(from_fn_with_state(state, resource_auth_middleware))
 }
 
 #[cfg(test)]
@@ -37,15 +54,6 @@ mod tests {
         http::{Request, StatusCode},
     };
     use tower::ServiceExt; // for `oneshot`
-
-    /// matchit (the router behind axum) panics at registration time when two
-    /// routes are ambiguous. Building the full router here catches that early
-    /// instead of at server startup. The router has no state at this stage —
-    /// `Router::<AppState>` is generic over state until it's mounted.
-    #[test]
-    fn routes_build_without_conflict() {
-        let _router: Router<crate::server::state::AppState> = routes();
-    }
 
     /// HTTP-layer test for the resource-API route table.
     ///

--- a/src/server/resources/token.rs
+++ b/src/server/resources/token.rs
@@ -1,0 +1,900 @@
+//! The `token` subresource of ServiceAccount and Controller resources
+//! (ADR-0001 §7).
+//!
+//! `POST …/serviceaccounts/{org}/{name}/token` and `POST …/controllers/{name}/token`
+//! issue a Rise identity token for exactly the resource the URL names, in one
+//! of two disjoint modes:
+//!
+//! - **Workload token exchange.** The request carries an external workload JWT
+//!   as `subject_token` and no Rise credential. Rise validates it against the
+//!   trust-policy children of that one target and, on exactly one match,
+//!   issues a token for the target. This is authentication *as* the workload's
+//!   configured identity: no RBAC check, and no search for which identity a
+//!   token might belong to. Every failure after the route is entered — a
+//!   missing or draining target, an unaccepted issuer, a bad signature, no or
+//!   several matching policies — is the same coarse 401, so the route never
+//!   confirms whether a named identity or policy exists.
+//! - **Delegated issuance.** The request carries a Rise credential and no
+//!   external assertion. The caller needs `(create, <kind>, token)` on that
+//!   exact target under its own capped effective policy; the minted token
+//!   records the caller in a bounded `act` chain and exercises the *target's*
+//!   live policy, never the caller's.
+//!
+//! Both modes accept `authorization_details` that only ever narrow the issued
+//! token. The subresource persists nothing: a token is a credential, not a
+//! resource, and it is create-only.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD as BASE64URL, Engine as _};
+use rise_authz::engine::{AuthorizationCap, ResourceTree};
+use rise_backend_auth::{
+    audience_matches, is_rise_issued_jwt, validate_custom_claims, ActorClaim, IdentityTokenSpec,
+    JwksKeySource, RiseTokenSigner, MAX_DELEGATION_DEPTH,
+};
+use rise_resource_api::{
+    CollectionInfo, Issuer, ResourceStore, SubjectId, TrustPolicyClaims, Verb, API_GROUP,
+    CONTROLLER_KIND, SERVICE_ACCOUNT_KIND,
+};
+use rise_resource_store_postgres::{TrustPolicyFact, TrustPolicyLookup};
+use serde::Deserialize;
+
+use super::handlers::{classify_path, resolve_leaf, LeafRef, ResolvedCollection, ResolvedPath};
+use super::path::{RawResourcePath, Subresource};
+use crate::server::auth::context::{AnyAuth, AuthContext};
+use crate::server::auth::exchange::models::{
+    ExchangeResponse, GRANT_TYPE_TOKEN_EXCHANGE, MAX_SUBJECT_TOKEN_LEN, TOKEN_TYPE_JWT,
+};
+use crate::server::authz::ResourceAuthorizer;
+use crate::server::error::ServerError;
+use crate::server::rate_limit::{rate_limit_response, OAuthRateLimiter};
+use crate::server::resources::error_map::{store_error_to_server_error, RESOURCE_NOT_FOUND};
+
+/// The one body every workload-exchange failure returns after the route is
+/// entered. Byte-identical across causes on purpose (ADR-0001 §7).
+pub const WORKLOAD_EXCHANGE_REJECTED: &str = "the assertion was not accepted for this target";
+
+/// Rate-limit bucket for assertions whose target is not yet resolved.
+const PRE_VALIDATION_BUCKET: &str = "resource-token-exchange";
+
+/// What a `/token` route needs beyond the resource store.
+pub struct TokenService {
+    signer: Arc<RiseTokenSigner>,
+    jwks: Arc<dyn JwksKeySource>,
+    trust_policies: TrustPolicyLookup,
+    /// The Rise public URL: the `aud` of every issued token, and the issuer no
+    /// trust policy may name as an external source.
+    audience: String,
+    /// The platform-global maximum token lifetime (ADR-0001 §7).
+    max_ttl_seconds: u64,
+    rate_limiter: Option<Arc<OAuthRateLimiter>>,
+}
+
+impl TokenService {
+    pub fn new(
+        signer: Arc<RiseTokenSigner>,
+        jwks: Arc<dyn JwksKeySource>,
+        trust_policies: TrustPolicyLookup,
+        audience: String,
+        max_ttl_seconds: u64,
+        rate_limiter: Option<Arc<OAuthRateLimiter>>,
+    ) -> Self {
+        Self {
+            signer,
+            jwks,
+            trust_policies,
+            audience,
+            max_ttl_seconds,
+            rate_limiter,
+        }
+    }
+
+    /// Rise's own issuer, which a trust policy may never name as an external
+    /// source (ADR-0001 §7, scenario 47).
+    pub fn rise_issuer(&self) -> &str {
+        &self.audience
+    }
+}
+
+/// The two kinds that register `token`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TargetKind {
+    ServiceAccount,
+    Controller,
+}
+
+/// Whether a collection registers the `token` subresource. Registration is
+/// fixed to the two built-in identity kinds (ADR-0001 §2).
+fn registered_target(info: &CollectionInfo) -> Option<TargetKind> {
+    if info.api_version.split('/').next() != Some(API_GROUP) {
+        return None;
+    }
+    match info.kind.as_str() {
+        SERVICE_ACCOUNT_KIND => Some(TargetKind::ServiceAccount),
+        CONTROLLER_KIND => Some(TargetKind::Controller),
+        _ => None,
+    }
+}
+
+/// The ordinary answer for a subresource route that does not exist. A kind
+/// that does not register `token` has no such route, so this is returned
+/// before any authentication or authorization (ADR-0001 §7, scenario 45).
+fn route_not_found() -> ServerError {
+    ServerError::not_found("no such route: this kind does not register the token subresource")
+}
+
+/// Request body of a `/token` POST.
+///
+/// `subject_token` selects workload exchange; its absence selects delegated
+/// issuance. The RFC 8693 fields are validated when present so a caller of the
+/// transitional exchange endpoint can move here with the same body.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TokenRequest {
+    #[serde(default)]
+    pub grant_type: Option<String>,
+    #[serde(default)]
+    pub subject_token: Option<String>,
+    #[serde(default)]
+    pub subject_token_type: Option<String>,
+    /// RFC 9396 narrowing; `null` is as invalid as any other malformed value.
+    #[serde(default, deserialize_with = "present_even_if_null")]
+    pub authorization_details: Option<serde_json::Value>,
+    /// Requested lifetime in seconds, clamped to the platform maximum.
+    #[serde(default)]
+    pub expires_in: Option<u64>,
+}
+
+/// Keep an explicit `null` distinct from an omitted field: the omitted claim
+/// means the full live policy, and `null` must not quietly mean the same.
+fn present_even_if_null<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Option<serde_json::Value>, D::Error> {
+    serde_json::Value::deserialize(deserializer).map(Some)
+}
+
+/// A request body after shape validation, which depends on nothing but the
+/// body itself — so a 400 here is never an answer about the target.
+#[derive(Debug)]
+struct ValidatedRequest {
+    assertion: Option<String>,
+    cap: AuthorizationCap,
+    ttl_seconds: u64,
+}
+
+fn validate_request(
+    service: &TokenService,
+    body: serde_json::Value,
+) -> Result<ValidatedRequest, ServerError> {
+    let body: TokenRequest = serde_json::from_value(body)
+        .map_err(|e| ServerError::bad_request(format!("invalid request body: {e}")))?;
+    if let Some(grant_type) = &body.grant_type {
+        if grant_type != GRANT_TYPE_TOKEN_EXCHANGE {
+            return Err(ServerError::bad_request("unsupported grant_type"));
+        }
+    }
+    let assertion = match body.subject_token.as_deref().map(str::trim) {
+        None => {
+            if body.subject_token_type.is_some() {
+                return Err(ServerError::bad_request(
+                    "subject_token_type requires a subject_token",
+                ));
+            }
+            None
+        }
+        Some(token) => {
+            if body.subject_token_type.as_deref() != Some(TOKEN_TYPE_JWT) {
+                return Err(ServerError::bad_request("unsupported subject_token_type"));
+            }
+            if token.is_empty() {
+                return Err(ServerError::bad_request("subject_token must not be empty"));
+            }
+            if token.len() > MAX_SUBJECT_TOKEN_LEN {
+                return Err(ServerError::bad_request("subject_token too large"));
+            }
+            Some(token.to_owned())
+        }
+    };
+    let cap = match &body.authorization_details {
+        None => AuthorizationCap::Unrestricted,
+        Some(serde_json::Value::Array(entries)) => AuthorizationCap::from_details(Some(entries))
+            .map_err(|error| ServerError::bad_request(error.to_string()))?,
+        Some(_) => {
+            return Err(ServerError::bad_request(
+                "authorization_details must be a non-empty list of rise.dev/rbac entries",
+            ))
+        }
+    };
+    let ttl_seconds = match body.expires_in {
+        None => service.max_ttl_seconds,
+        Some(0) => return Err(ServerError::bad_request("expires_in must be positive")),
+        Some(requested) => requested.min(service.max_ttl_seconds),
+    };
+    Ok(ValidatedRequest {
+        assertion,
+        cap,
+        ttl_seconds,
+    })
+}
+
+/// The identity a token is minted for: the resource, its evaluation target,
+/// and the canonical subject the two spell.
+struct Target {
+    uid: uuid::Uuid,
+    name: String,
+    kind: TargetKind,
+    subject: SubjectId,
+}
+
+impl Target {
+    fn from_tree(
+        uid: uuid::Uuid,
+        kind: TargetKind,
+        tree: ResourceTree,
+    ) -> Result<Self, ServerError> {
+        let name = tree.leaf().name.clone();
+        let subject = match kind {
+            TargetKind::ServiceAccount => {
+                let organization = tree.organization().ok_or_else(|| {
+                    ServerError::internal("a ServiceAccount is not contained by an Organization")
+                })?;
+                format!("serviceaccount:{organization}/{name}")
+            }
+            TargetKind::Controller => format!("controller:{name}"),
+        };
+        let subject: SubjectId = subject.parse().map_err(|error| {
+            ServerError::internal(format!("target is not a valid subject: {error}"))
+        })?;
+        Ok(Self {
+            uid,
+            name,
+            kind,
+            subject,
+        })
+    }
+
+    fn kind_name(&self) -> &'static str {
+        match self.kind {
+            TargetKind::ServiceAccount => SERVICE_ACCOUNT_KIND,
+            TargetKind::Controller => CONTROLLER_KIND,
+        }
+    }
+}
+
+fn mint(
+    service: &TokenService,
+    target: &Target,
+    request: &ValidatedRequest,
+    act: Option<ActorClaim>,
+) -> Result<Response, ServerError> {
+    let (token, claims) = service
+        .signer
+        .sign_identity_jwt(IdentityTokenSpec {
+            subject: target.subject.as_ref(),
+            rise_uid: target.uid,
+            audience: &service.audience,
+            ttl_secs: request.ttl_seconds,
+            authorization_details: request.cap.to_details(),
+            act,
+        })
+        .map_err(|error| {
+            ServerError::internal(format!("failed to sign identity token: {error:?}"))
+        })?;
+    Ok(Json(ExchangeResponse {
+        access_token: token,
+        token_type: "Bearer".to_string(),
+        issued_token_type: TOKEN_TYPE_JWT.to_string(),
+        expires_in: claims.exp.saturating_sub(claims.iat),
+    })
+    .into_response())
+}
+
+// -----------------------------------------------------------------------------
+// Workload token exchange
+// -----------------------------------------------------------------------------
+
+/// The unauthenticated POST path of the resource API.
+///
+/// A request without a Rise credential is a workload token exchange or it is
+/// nothing: any path that is not a registered `/token` route answers 401, and
+/// a `/token` route on a kind that does not register it answers the ordinary
+/// route-not-found, before authentication (ADR-0001 §7).
+pub(super) async fn dispatch_unauthenticated(
+    store: &Arc<dyn ResourceStore>,
+    service: &TokenService,
+    raw_path: RawResourcePath,
+    body: serde_json::Value,
+    client_ip: &str,
+) -> Result<Response, ServerError> {
+    let not_authenticated = || {
+        ServerError::unauthorized("Missing authentication token (cookie or Authorization header)")
+    };
+    // Body shape first: it depends on nothing about the target, so its 400s
+    // reveal nothing, and a request with no assertion carries no credential of
+    // any kind.
+    let request = validate_request(service, body)?;
+    let Some(assertion) = request.assertion.as_deref() else {
+        return Err(not_authenticated());
+    };
+    if let Some(limiter) = &service.rate_limiter {
+        if let Err(retry_after) = limiter
+            .increment_and_check(client_ip, None, PRE_VALIDATION_BUCKET)
+            .await
+        {
+            return Ok(rate_limit_response(retry_after));
+        }
+    }
+
+    // Which collections exist is visible to authenticated callers only, so an
+    // unresolvable path is answered as the missing credential it is. A store
+    // that cannot answer at all is a different matter and is reported as such.
+    let (resolved, leaf) = match classify_path(store, raw_path).await {
+        Ok(ResolvedPath::Subresource {
+            resolved,
+            leaf,
+            subresource: Subresource::Token,
+        }) => (resolved, leaf),
+        Err(error) if error.status.is_server_error() => return Err(error),
+        Ok(_) | Err(_) => return Err(not_authenticated()),
+    };
+    let Some(kind) = registered_target(&resolved.info) else {
+        return Err(route_not_found());
+    };
+
+    workload_exchange(
+        store, service, &resolved, &leaf, kind, assertion, &request, client_ip,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn workload_exchange(
+    store: &Arc<dyn ResourceStore>,
+    service: &TokenService,
+    resolved: &ResolvedCollection,
+    leaf: &LeafRef,
+    kind: TargetKind,
+    assertion: &str,
+    request: &ValidatedRequest,
+    client_ip: &str,
+) -> Result<Response, ServerError> {
+    // From here on every refusal is the same 401 (ADR-0001 §7, scenario 45).
+    // The cause is logged for the operator; the caller learns only that the
+    // assertion was not accepted for the route it chose.
+    let rejected = |reason: &str| {
+        tracing::warn!(
+            target: "rise::audit",
+            kind = %resolved.info.kind,
+            "resource.token_exchange_rejected: {reason}"
+        );
+        ServerError::unauthorized(WORKLOAD_EXCHANGE_REJECTED)
+    };
+
+    let Some(issuer) = peek_issuer(assertion) else {
+        return Err(rejected("assertion is not a well-formed JWT"));
+    };
+    if is_rise_issued_jwt(&issuer, service.rise_issuer()) {
+        return Err(rejected(
+            "assertion is Rise-issued; only external assertions are exchanged",
+        ));
+    }
+    let Ok(issuer) = Issuer::new(&issuer) else {
+        return Err(rejected("assertion issuer is not a canonical issuer URL"));
+    };
+
+    // Target resolution is part of authentication on this route: a target that
+    // is absent, of another kind, or draining fails the same way as a bad
+    // assertion.
+    let row = match resolve_leaf(store, resolved, leaf).await {
+        Ok(row) => row,
+        Err(error) => {
+            return Err(rejected(&format!(
+                "target did not resolve: {}",
+                error.message
+            )))
+        }
+    };
+    let chain = store
+        .ancestors(row.uid)
+        .await
+        .map_err(store_error_to_server_error)?;
+    if chain.iter().any(|node| node.deletion_timestamp.is_some()) {
+        return Err(rejected("target or an ancestor is being deleted"));
+    }
+    let tree = ResourceTree::from_rows(&chain)
+        .map_err(|error| ServerError::internal(format!("target ancestry is invalid: {error}")))?;
+    let target = Target::from_tree(row.uid, kind, tree)?;
+
+    // Only trust-policy children of this exact target are consulted, narrowed
+    // by issuer before any signature work; no other identity's policies exist
+    // as far as this route is concerned.
+    let policies = trust_policies_for(service, &target, &issuer).await?;
+    if policies.is_empty() {
+        return Err(rejected(
+            "no trust policy of the target accepts this issuer",
+        ));
+    }
+    if let Some(limiter) = &service.rate_limiter {
+        // Keyed on the issuer, which a trust policy has now vouched for.
+        if let Err(retry_after) = limiter
+            .increment_and_check(client_ip, None, issuer.as_str())
+            .await
+        {
+            return Ok(rate_limit_response(retry_after));
+        }
+    }
+    let verified =
+        match rise_backend_auth::verify_external_jwt(assertion, issuer.as_str(), &*service.jwks)
+            .await
+        {
+            Ok(verified) => verified,
+            Err(error) => {
+                return Err(rejected(&format!("assertion did not verify: {error:?}")));
+            }
+        };
+    let claims = verified.claims();
+
+    let matching: Vec<&TrustPolicyFact<TrustPolicyClaims>> = policies
+        .iter()
+        .filter(|policy| claims_match(claims, &policy.spec))
+        .collect();
+    let policy = match matching.as_slice() {
+        [policy] => *policy,
+        [] => {
+            return Err(rejected(
+                "assertion claims match no trust policy of the target",
+            ))
+        }
+        _ => {
+            return Err(rejected(
+                "assertion claims match more than one trust policy",
+            ))
+        }
+    };
+
+    let response = mint(service, &target, request, None)?;
+    tracing::info!(
+        target: "rise::audit",
+        subject = %target.subject,
+        uid = %target.uid,
+        kind = %target.kind_name(),
+        name = %target.name,
+        trust_policy = %policy.name,
+        source_iss = %issuer,
+        source_sub = claims.get("sub").and_then(|v| v.as_str()).unwrap_or(""),
+        restricted = !matches!(request.cap, AuthorizationCap::Unrestricted),
+        "resource.token_exchanged"
+    );
+    Ok(response)
+}
+
+/// The target's live trust policies for one issuer, as one claim-matcher
+/// shape regardless of the target kind.
+async fn trust_policies_for(
+    service: &TokenService,
+    target: &Target,
+    issuer: &Issuer,
+) -> Result<Vec<TrustPolicyFact<TrustPolicyClaims>>, ServerError> {
+    let policies = match target.kind {
+        TargetKind::ServiceAccount => service
+            .trust_policies
+            .for_service_account(target.uid, issuer)
+            .await
+            .map_err(store_error_to_server_error)?
+            .into_iter()
+            .map(|fact| TrustPolicyFact {
+                uid: fact.uid,
+                name: fact.name,
+                parent_uid: fact.parent_uid,
+                spec: fact.spec.claims,
+            })
+            .collect(),
+        TargetKind::Controller => service
+            .trust_policies
+            .for_controller(target.uid, issuer)
+            .await
+            .map_err(store_error_to_server_error)?
+            .into_iter()
+            .map(|fact| TrustPolicyFact {
+                uid: fact.uid,
+                name: fact.name,
+                parent_uid: fact.parent_uid,
+                spec: fact.spec.claims,
+            })
+            .collect(),
+    };
+    Ok(policies)
+}
+
+/// Whether verified claims satisfy one trust policy's closed matcher: `aud`
+/// accepts a string or an array (RFC 7519 §4.1.3), every other constraint is a
+/// string claim with glob `*` support.
+fn claims_match(claims: &serde_json::Value, policy: &TrustPolicyClaims) -> bool {
+    let Some(expected_aud) = policy.get("aud") else {
+        return false;
+    };
+    if !audience_matches(
+        claims.get("aud").unwrap_or(&serde_json::Value::Null),
+        expected_aud,
+    ) {
+        return false;
+    }
+    let expected: HashMap<String, String> = policy
+        .iter()
+        .filter(|(key, _)| *key != "aud")
+        .map(|(key, value)| (key.to_owned(), value.to_owned()))
+        .collect();
+    validate_custom_claims(claims, &expected).is_ok()
+}
+
+/// Peek the (unvalidated) `iss` claim of a JWT without verifying its signature.
+fn peek_issuer(token: &str) -> Option<String> {
+    let payload_b64 = token.split('.').nth(1)?;
+    let payload = BASE64URL.decode(payload_b64).ok()?;
+    let value: serde_json::Value = serde_json::from_slice(&payload).ok()?;
+    value.get("iss")?.as_str().map(str::to_owned)
+}
+
+// -----------------------------------------------------------------------------
+// Delegated issuance
+// -----------------------------------------------------------------------------
+
+/// The authenticated `/token` path.
+///
+/// The caller must hold `(create, <kind>, token)` on the exact target under
+/// its own capped policy (ADR-0001 §7, scenarios 46 and 57). Target trust
+/// policies play no part, and an external assertion in the body is refused
+/// outright: the two modes never mix (scenario 47).
+pub(super) async fn delegated_issuance(
+    authz: &ResourceAuthorizer,
+    store: &Arc<dyn ResourceStore>,
+    service: &TokenService,
+    auth: &AnyAuth,
+    resolved: &ResolvedCollection,
+    leaf: &LeafRef,
+    body: serde_json::Value,
+) -> Result<Response, ServerError> {
+    let request = validate_request(service, body)?;
+    if request.assertion.is_some() {
+        return Err(ServerError::bad_request(
+            "a request carries either a subject_token or a Rise credential, never both",
+        ));
+    }
+    let Some(kind) = registered_target(&resolved.info) else {
+        return Err(route_not_found());
+    };
+
+    let authz = authz.read_context(auth).await?;
+    let row = resolve_leaf(store, resolved, leaf).await?;
+    let target_tree = authz
+        .tree(row.uid)
+        .await
+        .map_err(|error| match error.status {
+            StatusCode::NOT_FOUND | StatusCode::BAD_REQUEST => {
+                ServerError::not_found(RESOURCE_NOT_FOUND)
+            }
+            _ => error,
+        })?;
+    let token_subresource = Subresource::Token.keyword().parse().map_err(|error| {
+        ServerError::internal(format!("subresource keyword is not a valid name: {error}"))
+    })?;
+    authz
+        .require_visible(&target_tree, Verb::Create, Some(&token_subresource))
+        .await?;
+    // A draining identity is no longer a token target: the token would fail
+    // authentication on its first use, so it is refused at issuance instead.
+    if row.deletion_timestamp.is_some() {
+        return Err(ServerError::not_found(RESOURCE_NOT_FOUND));
+    }
+    let target = Target::from_tree(row.uid, kind, target_tree)?;
+
+    // The chain records every delegator, this caller outermost. Its length is
+    // bounded so the audit provenance a token carries is always complete.
+    let (act, caller_jti) = match auth {
+        AnyAuth::User(AuthContext::Identity(identity)) => (
+            ActorClaim {
+                sub: identity.subject.to_string(),
+                rise_uid: identity.uid,
+                act: identity.act.clone().map(Box::new),
+            },
+            Some(identity.jti.as_str()),
+        ),
+        AnyAuth::Controller(controller) => (
+            ActorClaim {
+                sub: format!("controller:{}", controller.0.name),
+                rise_uid: controller.0.uid,
+                act: None,
+            },
+            None,
+        ),
+        AnyAuth::User(other) => {
+            let user = other.user()?;
+            (
+                ActorClaim {
+                    sub: format!("user:{}", user.id),
+                    rise_uid: user.id,
+                    act: None,
+                },
+                None,
+            )
+        }
+    };
+    if act.depth() > MAX_DELEGATION_DEPTH {
+        return Err(ServerError::forbidden(format!(
+            "delegation chain would exceed the platform limit of {MAX_DELEGATION_DEPTH}"
+        )));
+    }
+
+    let response = mint(service, &target, &request, Some(act))?;
+    tracing::info!(
+        target: "rise::audit",
+        actor = %authz.actor(),
+        actor_subject = %authz.subject(),
+        actor_jti = caller_jti,
+        subject = %target.subject,
+        uid = %target.uid,
+        kind = %target.kind_name(),
+        name = %target.name,
+        restricted = !matches!(request.cap, AuthorizationCap::Unrestricted),
+        "resource.token_delegated"
+    );
+    Ok(response)
+}
+
+/// Whether a raw resource path could address a `token` subresource. Purely
+/// syntactic: the authenticated POST path uses it to decide whether to
+/// classify before entering the create loop.
+pub(super) fn may_be_token_route(raw_path: &RawResourcePath) -> bool {
+    match raw_path {
+        RawResourcePath::Collection { segments, .. } => {
+            segments.last().map(String::as_str) == Some(Subresource::Token.keyword())
+        }
+        RawResourcePath::PendingDeletion => false,
+    }
+}
+
+/// Refuse a trust policy that names Rise's own issuer as its external source
+/// (ADR-0001 §7, scenario 47). Called on every trust-policy create; the spec
+/// is immutable afterwards.
+pub(super) fn reject_rise_issuer_in_trust_policy(
+    service: &TokenService,
+    info: &CollectionInfo,
+    spec: &serde_json::Value,
+) -> Result<(), ServerError> {
+    let is_trust_policy = info.api_version.split('/').next() == Some(API_GROUP)
+        && matches!(
+            info.kind.as_str(),
+            rise_resource_api::CONTROLLER_TRUST_POLICY_KIND
+                | rise_resource_api::SERVICE_ACCOUNT_TRUST_POLICY_KIND
+        );
+    if !is_trust_policy {
+        return Ok(());
+    }
+    let issuer = spec.get("issuer").and_then(|value| value.as_str());
+    if issuer.is_some_and(|issuer| is_rise_issued_jwt(issuer, service.rise_issuer())) {
+        return Err(ServerError::bad_request(
+            "a trust policy may not name Rise's own issuer as an external source",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+impl TokenService {
+    /// The signer, so a test can decode what the route minted.
+    pub(super) fn signer(&self) -> &RiseTokenSigner {
+        &self.signer
+    }
+}
+
+/// Test support: a signer for `https://rise.test`, a static JWKS for one
+/// external issuer, and assertions signed by that issuer.
+#[cfg(test)]
+pub(super) mod tests {
+    use std::sync::OnceLock;
+
+    use base64::engine::general_purpose::STANDARD as BASE64;
+    use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header};
+    use rise_backend_auth::AuthError;
+
+    use super::*;
+
+    /// The external issuer the static JWKS answers for.
+    pub const ISSUER: &str = "https://ci.example.com";
+    /// Rise's own public URL: the issuer and audience of every minted token.
+    pub const RISE_URL: &str = "https://rise.test";
+    const KID: &str = "test-kid";
+
+    /// One RSA key pair for the whole test binary: generating one per test
+    /// would dominate the suite's runtime.
+    fn issuer_keys() -> &'static (EncodingKey, DecodingKey) {
+        static KEYS: OnceLock<(EncodingKey, DecodingKey)> = OnceLock::new();
+        KEYS.get_or_init(|| {
+            use rsa::pkcs8::{EncodePrivateKey, EncodePublicKey};
+            let private = rsa::RsaPrivateKey::new(&mut rsa::rand_core::OsRng, 2048)
+                .expect("generate issuer key");
+            let public = rsa::RsaPublicKey::from(&private);
+            let private_pem = private
+                .to_pkcs8_pem(rsa::pkcs8::LineEnding::LF)
+                .expect("encode private key");
+            let public_pem = public
+                .to_public_key_pem(rsa::pkcs8::LineEnding::LF)
+                .expect("encode public key");
+            (
+                EncodingKey::from_rsa_pem(private_pem.as_bytes()).expect("encoding key"),
+                DecodingKey::from_rsa_pem(public_pem.as_bytes()).expect("decoding key"),
+            )
+        })
+    }
+
+    struct StaticJwks;
+
+    #[async_trait::async_trait]
+    impl JwksKeySource for StaticJwks {
+        async fn decoding_keys(
+            &self,
+            issuer: &str,
+        ) -> Result<HashMap<String, DecodingKey>, AuthError> {
+            if issuer != ISSUER {
+                return Err(AuthError::Jwks {
+                    issuer: issuer.to_owned(),
+                    detail: "no JWKS for this issuer".to_owned(),
+                });
+            }
+            Ok(HashMap::from([(KID.to_owned(), issuer_keys().1.clone())]))
+        }
+    }
+
+    pub fn signer() -> Arc<RiseTokenSigner> {
+        Arc::new(
+            RiseTokenSigner::new(
+                &BASE64.encode([7u8; 32]),
+                RISE_URL.to_owned(),
+                3600,
+                vec!["sub".into(), "email".into()],
+                None,
+                None,
+            )
+            .expect("test signer"),
+        )
+    }
+
+    /// A service over the test database with a 600-second platform maximum
+    /// and no rate limiting.
+    pub fn service(pool: sqlx::PgPool) -> TokenService {
+        TokenService::new(
+            signer(),
+            Arc::new(StaticJwks),
+            TrustPolicyLookup::new(pool),
+            RISE_URL.to_owned(),
+            600,
+            None,
+        )
+    }
+
+    /// An assertion from [`ISSUER`] carrying `claims`, with `iss`, `iat`, and
+    /// `exp` filled in unless the caller set them.
+    pub fn assertion(claims: serde_json::Value) -> String {
+        assertion_from(ISSUER, claims)
+    }
+
+    /// An assertion claiming to come from `issuer`, signed with the test
+    /// issuer's key. The JWKS only vouches for [`ISSUER`], so any other value
+    /// fails verification — which is what a test naming one wants to prove.
+    pub fn assertion_from(issuer: &str, mut claims: serde_json::Value) -> String {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_secs();
+        let object = claims.as_object_mut().expect("claims are an object");
+        object
+            .entry("iss")
+            .or_insert_with(|| serde_json::Value::String(issuer.to_owned()));
+        object.entry("iat").or_insert_with(|| now.into());
+        object.entry("exp").or_insert_with(|| (now + 300).into());
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(KID.to_owned());
+        jsonwebtoken::encode(&header, &claims, &issuer_keys().0).expect("sign assertion")
+    }
+
+    #[test]
+    fn claims_match_treats_aud_as_string_or_array_and_the_rest_as_string_globs() {
+        let policy = TrustPolicyClaims::new(
+            [
+                ("aud".to_owned(), "rise".to_owned()),
+                ("sub".to_owned(), "repo:acme/*".to_owned()),
+            ]
+            .into_iter()
+            .collect(),
+        )
+        .unwrap();
+        assert!(claims_match(
+            &serde_json::json!({ "aud": "rise", "sub": "repo:acme/app" }),
+            &policy
+        ));
+        assert!(claims_match(
+            &serde_json::json!({ "aud": ["other", "rise"], "sub": "repo:acme/app" }),
+            &policy
+        ));
+        assert!(!claims_match(
+            &serde_json::json!({ "aud": "other", "sub": "repo:acme/app" }),
+            &policy
+        ));
+        assert!(!claims_match(
+            &serde_json::json!({ "aud": "rise", "sub": "repo:beta/app" }),
+            &policy
+        ));
+        assert!(!claims_match(
+            &serde_json::json!({ "aud": "rise" }),
+            &policy
+        ));
+    }
+
+    #[tokio::test]
+    async fn validate_request_checks_only_the_body() {
+        let service = TokenService::new(
+            signer(),
+            Arc::new(StaticJwks),
+            TrustPolicyLookup::new(sqlx::PgPool::connect_lazy("postgres://unused").unwrap()),
+            RISE_URL.to_owned(),
+            600,
+            None,
+        );
+        let ok = validate_request(&service, serde_json::json!({})).unwrap();
+        assert!(ok.assertion.is_none());
+        assert_eq!(ok.cap, AuthorizationCap::Unrestricted);
+        assert_eq!(ok.ttl_seconds, 600);
+
+        let clamped =
+            validate_request(&service, serde_json::json!({ "expires_in": 99999 })).unwrap();
+        assert_eq!(clamped.ttl_seconds, 600);
+        let shorter = validate_request(&service, serde_json::json!({ "expires_in": 30 })).unwrap();
+        assert_eq!(shorter.ttl_seconds, 30);
+
+        let rejected = [
+            serde_json::json!({ "expires_in": 0 }),
+            serde_json::json!({ "grant_type": "password" }),
+            serde_json::json!({ "subject_token": "a.b.c" }),
+            serde_json::json!({ "subject_token": "a.b.c", "subject_token_type": "urn:ietf:params:oauth:token-type:access_token" }),
+            serde_json::json!({ "subject_token": "  ", "subject_token_type": TOKEN_TYPE_JWT }),
+            serde_json::json!({ "subject_token_type": TOKEN_TYPE_JWT }),
+            serde_json::json!({ "authorization_details": [] }),
+            serde_json::json!({ "authorization_details": null }),
+            serde_json::json!({ "authorization_details": {} }),
+            serde_json::json!({ "authorization_details": [{ "type": "other", "scope": "*", "permissions": [{ "verbs": "*", "kinds": "*" }] }] }),
+            serde_json::json!({ "unknown": true }),
+        ];
+        for body in rejected {
+            let err = validate_request(&service, body.clone()).unwrap_err();
+            assert_eq!(
+                err.status,
+                StatusCode::BAD_REQUEST,
+                "{body}: {}",
+                err.message
+            );
+        }
+
+        let narrowed = validate_request(
+            &service,
+            serde_json::json!({
+                "grant_type": GRANT_TYPE_TOKEN_EXCHANGE,
+                "subject_token": "a.b.c",
+                "subject_token_type": TOKEN_TYPE_JWT,
+                "authorization_details": [{
+                    "type": "rise.dev/rbac",
+                    "scope": "rise.dev/Organization/acme",
+                    "permissions": [{ "verbs": ["get"], "kinds": ["rise.dev/ServiceAccount"] }]
+                }]
+            }),
+        )
+        .unwrap();
+        assert_eq!(narrowed.assertion.as_deref(), Some("a.b.c"));
+        assert!(
+            matches!(narrowed.cap, AuthorizationCap::Restricted(ref entries) if entries.len() == 1)
+        );
+    }
+}

--- a/src/server/resources/token.rs
+++ b/src/server/resources/token.rs
@@ -309,7 +309,8 @@ fn mint(
             act,
         })
         .map_err(|error| {
-            ServerError::internal(format!("failed to sign identity token: {error:?}"))
+            tracing::error!("failed to sign identity token: {error:?}");
+            ServerError::internal("failed to sign identity token")
         })?;
     Ok(Json(ExchangeResponse {
         access_token: token,

--- a/src/server/resources/token.rs
+++ b/src/server/resources/token.rs
@@ -144,10 +144,18 @@ pub struct TokenRequest {
     /// RFC 9396 narrowing; `null` is as invalid as any other malformed value.
     #[serde(default, deserialize_with = "present_even_if_null")]
     pub authorization_details: Option<serde_json::Value>,
+    /// The `aud` to mint for (RFC 8693 `audience`). Omitted means Rise's own
+    /// API; any other value produces a token for an external verifier, which
+    /// checks it against Rise's published JWKS and which Rise's API refuses.
+    #[serde(default)]
+    pub audience: Option<String>,
     /// Requested lifetime in seconds, clamped to the platform maximum.
     #[serde(default)]
     pub expires_in: Option<u64>,
 }
+
+/// Longest accepted `audience`, matching the workload identity endpoint.
+const MAX_AUDIENCE_LEN: usize = 1024;
 
 /// Keep an explicit `null` distinct from an omitted field: the omitted claim
 /// means the full live policy, and `null` must not quietly mean the same.
@@ -163,6 +171,8 @@ fn present_even_if_null<'de, D: serde::Deserializer<'de>>(
 struct ValidatedRequest {
     assertion: Option<String>,
     cap: AuthorizationCap,
+    /// The `aud` to mint; Rise's own URL unless the caller named another.
+    audience: String,
     ttl_seconds: u64,
 }
 
@@ -209,6 +219,22 @@ fn validate_request(
             ))
         }
     };
+    let audience = match body.audience.as_deref().map(str::trim) {
+        None => service.audience.clone(),
+        Some("") => return Err(ServerError::bad_request("audience must not be empty")),
+        Some(audience) if audience.len() > MAX_AUDIENCE_LEN => {
+            return Err(ServerError::bad_request("audience value too long"))
+        }
+        Some(audience) => audience.to_owned(),
+    };
+    // A ceiling is a statement about Rise's own RBAC; on a token another
+    // verifier reads it would only look like a restriction.
+    if audience != service.audience && !matches!(cap, AuthorizationCap::Unrestricted) {
+        return Err(ServerError::bad_request(
+            "authorization_details narrows a token for Rise's own API; \
+             it cannot be combined with an external audience",
+        ));
+    }
     let ttl_seconds = match body.expires_in {
         None => service.max_ttl_seconds,
         Some(0) => return Err(ServerError::bad_request("expires_in must be positive")),
@@ -217,6 +243,7 @@ fn validate_request(
     Ok(ValidatedRequest {
         assertion,
         cap,
+        audience,
         ttl_seconds,
     })
 }
@@ -276,7 +303,7 @@ fn mint(
         .sign_identity_jwt(IdentityTokenSpec {
             subject: target.subject.as_ref(),
             rise_uid: target.uid,
-            audience: &service.audience,
+            audience: &request.audience,
             ttl_secs: request.ttl_seconds,
             authorization_details: request.cap.to_details(),
             act,
@@ -466,6 +493,7 @@ async fn workload_exchange(
         trust_policy = %policy.name,
         source_iss = %issuer,
         source_sub = claims.get("sub").and_then(|v| v.as_str()).unwrap_or(""),
+        audience = %request.audience,
         restricted = !matches!(request.cap, AuthorizationCap::Unrestricted),
         "resource.token_exchanged"
     );
@@ -639,6 +667,7 @@ pub(super) async fn delegated_issuance(
         uid = %target.uid,
         kind = %target.kind_name(),
         name = %target.name,
+        audience = %request.audience,
         restricted = !matches!(request.cap, AuthorizationCap::Unrestricted),
         "resource.token_delegated"
     );
@@ -867,6 +896,12 @@ pub(super) mod tests {
             serde_json::json!({ "authorization_details": {} }),
             serde_json::json!({ "authorization_details": [{ "type": "other", "scope": "*", "permissions": [{ "verbs": "*", "kinds": "*" }] }] }),
             serde_json::json!({ "unknown": true }),
+            serde_json::json!({ "audience": "" }),
+            serde_json::json!({ "audience": "x".repeat(MAX_AUDIENCE_LEN + 1) }),
+            serde_json::json!({
+                "audience": "https://vault.example.com",
+                "authorization_details": [{ "type": "rise.dev/rbac", "scope": "*", "permissions": [{ "verbs": "*", "kinds": "*" }] }]
+            }),
         ];
         for body in rejected {
             let err = validate_request(&service, body.clone()).unwrap_err();
@@ -893,6 +928,15 @@ pub(super) mod tests {
         )
         .unwrap();
         assert_eq!(narrowed.assertion.as_deref(), Some("a.b.c"));
+        assert_eq!(narrowed.audience, RISE_URL);
+
+        let external = validate_request(
+            &service,
+            serde_json::json!({ "audience": " https://vault.example.com " }),
+        )
+        .unwrap();
+        assert_eq!(external.audience, "https://vault.example.com");
+        assert_eq!(external.cap, AuthorizationCap::Unrestricted);
         assert!(
             matches!(narrowed.cap, AuthorizationCap::Restricted(ref entries) if entries.len() == 1)
         );

--- a/tests/e2e/Cargo.lock
+++ b/tests/e2e/Cargo.lock
@@ -1519,6 +1519,7 @@ dependencies = [
  "anyhow",
  "base64",
  "chrono",
+ "jsonwebtoken",
  "reqwest",
  "rise-backend-auth",
  "serde",

--- a/tests/e2e/Cargo.lock
+++ b/tests/e2e/Cargo.lock
@@ -353,12 +353,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
-name = "dyn-clone"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
-
-[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,26 +1429,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
-name = "ref-cast"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1530,7 +1504,6 @@ dependencies = [
  "jsonwebtoken",
  "rand 0.10.1",
  "rsa",
- "schemars",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -1693,33 +1666,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schemars"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
-dependencies = [
- "chrono",
- "dyn-clone",
- "ref-cast",
- "schemars_derive",
- "serde",
- "serde_json",
- "uuid",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn",
-]
-
-[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1786,17 +1732,6 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -37,3 +37,6 @@ serde_json = "1.0.145"
 reqwest = { version = "0.13", features = ["blocking", "json", "form"] }
 # Reused to mint the HS256 CI bearer the same way the server signs sessions.
 rise-backend-auth = { path = "../../crates/rise-backend-auth" }
+# Verifies an audience-bound identity token the way an external party would:
+# RS256 against the JWKS Rise publishes, nothing else.
+jsonwebtoken = { version = "10.0", features = ["rust_crypto"] }

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -216,11 +216,14 @@ terraform -chdir=tests/e2e/run destroy -auto-approve
 |---------------------|--------|----------|------|---------|
 | `public-deploy`     | Run    | Run      | Run  | deploy a sample app → Healthy; HTTP 200 (+ body marker) |
 | `sa-token-exchange` | Run    | Run      | Run  | SA + Dex password-grant id_token + `RISE_IDENTITY` → `project list` returns the SA's project; un-exchanged token rejected |
+| `resource-token-exchange` | Run | Run    | Skip² | resource `ServiceAccount` + `ServiceAccountTrustPolicy` (Dex); credential-less `POST …/token` with the Dex id_token mints an identity token; that token reaches the resource API only once a `PlatformRoleBinding` grants it; wrong claims and an unknown target are the same 401; operator delegation mints too |
 | `persistent-log-retention` | Skip | Run | Run | stop deployment, workload gone, `/logs/volume` total>0 + `rise deployment logs` returns retained backlog |
 | `helm-idempotency`  | Skip   | Run      | Skip | re-run `helm upgrade` applies cleanly |
 | `workload-identity` | Run    | Run¹     | Skip | build fixture from source; `/identity` reports valid file+exchanged tokens, project-bound sub, matching iss; file token re-mints (new jti) |
 
 ¹ minikube only in `jfrog-vault` registry mode (source build needs a cluster-pullable registry); otherwise `Skip`.
+
+² the ECS stack grants no operator, and the generic resource API needs one to author the resources the scenario exercises.
 
 ## Standalone Suites
 

--- a/tests/e2e/src/backend/docker.rs
+++ b/tests/e2e/src/backend/docker.rs
@@ -165,6 +165,10 @@ impl DockerBackend {
         c.current_dir(&self.repo_root)
             .env("RISE_IMAGE_REPOSITORY", &self.image_repository)
             .env("RISE_IMAGE_TAG", &self.image_tag)
+            // The CI bearer is the stack's admin; operator standing on top is
+            // what lets scenarios author resources through the generic
+            // resource API (the `resource-token-exchange` scenario needs it).
+            .env("RISE_OPERATOR_EMAIL", "admin@example.com")
             .args([
                 "compose",
                 "-f",

--- a/tests/e2e/src/backend/mod.rs
+++ b/tests/e2e/src/backend/mod.rs
@@ -124,7 +124,33 @@ pub trait Backend {
 
     /// Authenticated GET against the Rise API (`path` starts with `/`).
     fn api_get(&self, path: &str) -> Result<HttpResponse> {
-        crate::http::get_auth(&format!("{}{}", self.api_base(), path), self.ci_bearer())
+        self.api_get_as(path, self.ci_bearer())
+    }
+
+    /// GET against the Rise API with an explicit bearer — for exercising a token
+    /// the scenario itself obtained.
+    fn api_get_as(&self, path: &str, bearer: &str) -> Result<HttpResponse> {
+        crate::http::get_auth(&format!("{}{}", self.api_base(), path), bearer)
+    }
+
+    /// Authenticated JSON POST against the Rise API, as the admin CI bearer.
+    fn api_post(&self, path: &str, body: &serde_json::Value) -> Result<HttpResponse> {
+        self.api_post_as(path, Some(self.ci_bearer()), body)
+    }
+
+    /// Authenticated DELETE against the Rise API, as the admin CI bearer.
+    fn api_delete(&self, path: &str) -> Result<HttpResponse> {
+        crate::http::delete_auth(&format!("{}{}", self.api_base(), path), self.ci_bearer())
+    }
+
+    /// JSON POST against the Rise API with an explicit bearer, or none at all.
+    fn api_post_as(
+        &self,
+        path: &str,
+        bearer: Option<&str>,
+        body: &serde_json::Value,
+    ) -> Result<HttpResponse> {
+        crate::http::post_json(&format!("{}{}", self.api_base(), path), bearer, body)
     }
 
     /// Poll the deployments API until the project's latest deployment reports

--- a/tests/e2e/src/http.rs
+++ b/tests/e2e/src/http.rs
@@ -57,6 +57,36 @@ pub fn get_auth(url: &str, bearer: &str) -> Result<HttpResponse> {
     Ok(HttpResponse { status, body })
 }
 
+/// POST a JSON body to `url`, with an optional `Bearer` token — for Rise API
+/// calls. `None` sends no credential at all, which is what a workload token
+/// exchange at a `/token` subresource looks like.
+pub fn post_json(
+    url: &str,
+    bearer: Option<&str>,
+    body: &serde_json::Value,
+) -> Result<HttpResponse> {
+    let mut req = shared_client().post(url).json(body);
+    if let Some(bearer) = bearer {
+        req = req.bearer_auth(bearer);
+    }
+    let resp = req.send().with_context(|| format!("POST {url}"))?;
+    let status = resp.status().as_u16();
+    let body = resp.text().unwrap_or_default();
+    Ok(HttpResponse { status, body })
+}
+
+/// DELETE `url` with a `Bearer` token — for authenticated Rise API calls.
+pub fn delete_auth(url: &str, bearer: &str) -> Result<HttpResponse> {
+    let resp = shared_client()
+        .delete(url)
+        .bearer_auth(bearer)
+        .send()
+        .with_context(|| format!("DELETE {url}"))?;
+    let status = resp.status().as_u16();
+    let body = resp.text().unwrap_or_default();
+    Ok(HttpResponse { status, body })
+}
+
 /// A client that does NOT follow redirects — for asserting 3xx + `Location`.
 fn no_redirect_client() -> &'static reqwest::blocking::Client {
     static CLIENT: OnceLock<reqwest::blocking::Client> = OnceLock::new();

--- a/tests/e2e/src/scenario.rs
+++ b/tests/e2e/src/scenario.rs
@@ -604,6 +604,56 @@ impl Scenario for ResourceTokenExchange {
             delegated.body
         );
 
+        // An audience-bound token: what an external verifier does with it is
+        // check the RS256 signature against Rise's published JWKS and its own
+        // audience. Rise's API refuses it.
+        let audience = "https://vault.example.com";
+        let external = b.api_post(&token_path, &serde_json::json!({"audience": audience}))?;
+        anyhow::ensure!(
+            external.status == 200,
+            "audience-bound issuance returned {}:\n{}",
+            external.status,
+            external.body
+        );
+        let external: serde_json::Value =
+            serde_json::from_str(&external.body).context("parse audience-bound token")?;
+        let external = external["access_token"]
+            .as_str()
+            .context("no access_token in audience-bound response")?;
+        let jwks = http::get(&format!("{}/api/v1/auth/jwks", b.api_base()), None)?;
+        anyhow::ensure!(jwks.status == 200, "JWKS returned {}", jwks.status);
+        let jwks: serde_json::Value = serde_json::from_str(&jwks.body).context("parse JWKS")?;
+        let header = jsonwebtoken::decode_header(external).context("decode token header")?;
+        let key = jwks["keys"]
+            .as_array()
+            .context("JWKS has no keys")?
+            .iter()
+            .find(|key| key["kid"].as_str() == header.kid.as_deref())
+            .context("the token's kid is not in the published JWKS")?;
+        let decoding_key = jsonwebtoken::DecodingKey::from_rsa_components(
+            key["n"].as_str().context("JWKS key has no n")?,
+            key["e"].as_str().context("JWKS key has no e")?,
+        )
+        .context("build decoding key from JWKS")?;
+        let mut validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::RS256);
+        validation.set_audience(&[audience]);
+        validation.validate_exp = true;
+        let verified =
+            jsonwebtoken::decode::<serde_json::Value>(external, &decoding_key, &validation)
+                .context("the audience-bound token must verify against the JWKS")?;
+        anyhow::ensure!(
+            verified.claims["sub"] == serde_json::json!(format!("serviceaccount:{org}/ci")),
+            "unexpected subject on the audience-bound token:\n{}",
+            verified.claims
+        );
+        let refused = b.api_get_as(&format!("{}/{sa_path}", Self::RESOURCES), external)?;
+        anyhow::ensure!(
+            refused.status == 401,
+            "Rise's API must refuse a token for another audience, got {}:\n{}",
+            refused.status,
+            refused.body
+        );
+
         // Tidy up: the Organization cascades over everything beneath it.
         let _ = b.api_delete(&format!("{}/organizations/{org}", Self::RESOURCES));
         Ok(())

--- a/tests/e2e/src/scenario.rs
+++ b/tests/e2e/src/scenario.rs
@@ -31,6 +31,7 @@ pub fn all() -> Vec<Box<dyn Scenario>> {
         Box::new(PublicDeploy),
         Box::new(RegistryBuildPushPull),
         Box::new(SaTokenExchange),
+        Box::new(ResourceTokenExchange),
         Box::new(PrivateIngressAuth),
         Box::new(RouteAccessOverride),
         Box::new(HealthRollingCutover),
@@ -400,6 +401,211 @@ impl Scenario for SaTokenExchange {
             "expected the un-exchanged external token to be rejected, but it succeeded:\n{}",
             raw.combined()
         );
+        Ok(())
+    }
+}
+
+// ---- (c') resource-API token exchange at the /token subresource -------------
+
+struct ResourceTokenExchange;
+
+impl ResourceTokenExchange {
+    const RESOURCES: &'static str = "/api/v1/resources/rise.dev/v1alpha1";
+    const TOKEN_EXCHANGE_GRANT: &'static str = "urn:ietf:params:oauth:grant-type:token-exchange";
+    const JWT_TOKEN_TYPE: &'static str = "urn:ietf:params:oauth:token-type:jwt";
+
+    /// POST a resource as the operator and assert `201`.
+    fn create(b: &dyn Backend, collection: &str, body: serde_json::Value) -> Result<()> {
+        let resp = b.api_post(&format!("{}/{collection}", Self::RESOURCES), &body)?;
+        anyhow::ensure!(
+            resp.status == 201,
+            "create {collection} {} returned {}:\n{}",
+            body["metadata"]["name"],
+            resp.status,
+            resp.body
+        );
+        Ok(())
+    }
+
+    fn exchange_body(assertion: &str) -> serde_json::Value {
+        serde_json::json!({
+            "grant_type": Self::TOKEN_EXCHANGE_GRANT,
+            "subject_token": assertion,
+            "subject_token_type": Self::JWT_TOKEN_TYPE,
+        })
+    }
+}
+
+impl Scenario for ResourceTokenExchange {
+    fn id(&self) -> &'static str {
+        "resource-token-exchange"
+    }
+
+    fn applies_to(&self, b: &dyn Backend) -> Applicability {
+        match b.kind() {
+            BackendKind::Docker | BackendKind::Minikube => Applicability::Run,
+            BackendKind::Ecs => Applicability::Skip(
+                "the ECS stack grants no operator, which authoring resources needs",
+            ),
+        }
+    }
+
+    fn run(&self, b: &dyn Backend) -> Result<()> {
+        let dexep = b.dex().context("backend exposes no reachable Dex")?;
+        let org = unique("e2e-org");
+        let sa_path = format!("serviceaccounts/{org}/ci");
+        let token_path = format!("{}/{sa_path}/token", Self::RESOURCES);
+
+        // As the operator: an Organization, a ServiceAccount beneath it, and one
+        // trust policy accepting the Dex id_token the password grant mints.
+        Self::create(
+            b,
+            "organizations",
+            serde_json::json!({
+                "apiVersion": "rise.dev/v1alpha1",
+                "kind": "Organization",
+                "metadata": {"name": org},
+                "spec": {"displayName": org},
+            }),
+        )?;
+        Self::create(
+            b,
+            &format!("serviceaccounts/{org}"),
+            serde_json::json!({
+                "apiVersion": "rise.dev/v1alpha1",
+                "kind": "ServiceAccount",
+                "metadata": {"name": "ci"},
+                "spec": {},
+            }),
+        )?;
+        Self::create(
+            b,
+            &format!("serviceaccounttrustpolicies/{org}/ci"),
+            serde_json::json!({
+                "apiVersion": "rise.dev/v1alpha1",
+                "kind": "ServiceAccountTrustPolicy",
+                "metadata": {"name": "dex"},
+                "spec": {
+                    "issuer": dexep.issuer,
+                    // `aud` is the Dex client id the id_token is minted for.
+                    "claims": {"aud": "rise-backend", "email": "user@example.com"},
+                },
+            }),
+        )?;
+
+        // The proof: a real Dex id_token for the federated user, presented with
+        // no Rise credential at the target's own /token route.
+        let oidc = dex::mint_password_token(dexep, "user@example.com", "password")
+            .context("mint Dex OIDC token (password grant)")?;
+        let minted = b.api_post_as(&token_path, None, &Self::exchange_body(&oidc))?;
+        anyhow::ensure!(
+            minted.status == 200,
+            "workload exchange returned {}:\n{}",
+            minted.status,
+            minted.body
+        );
+        let minted: serde_json::Value =
+            serde_json::from_str(&minted.body).context("parse token response")?;
+        let identity = minted["access_token"]
+            .as_str()
+            .context("no access_token in token response")?
+            .to_string();
+        anyhow::ensure!(
+            minted["token_type"] == serde_json::json!("Bearer"),
+            "unexpected token_type:\n{minted}"
+        );
+        eprintln!(
+            "[e2e] resource-token-exchange: minted an identity token for serviceaccount:{org}/ci"
+        );
+
+        // The identity holds nothing yet: reading its own resource is masked.
+        let masked = b.api_get_as(&format!("{}/{sa_path}", Self::RESOURCES), &identity)?;
+        anyhow::ensure!(
+            masked.status == 404,
+            "an ungranted identity must be masked (404), got {}:\n{}",
+            masked.status,
+            masked.body
+        );
+
+        // A live grant delivers on the next request — nothing is snapshotted in
+        // the token.
+        Self::create(
+            b,
+            "platformroles",
+            serde_json::json!({
+                "apiVersion": "rise.dev/v1alpha1",
+                "kind": "PlatformRole",
+                "metadata": {"name": format!("{org}-sa-reader")},
+                "spec": {"statements": [
+                    {"effect": "Allow", "kinds": ["rise.dev/ServiceAccount"], "verbs": ["get"]}
+                ]},
+            }),
+        )?;
+        Self::create(
+            b,
+            "platformrolebindings",
+            serde_json::json!({
+                "apiVersion": "rise.dev/v1alpha1",
+                "kind": "PlatformRoleBinding",
+                "metadata": {"name": format!("{org}-ci-reads-itself")},
+                "spec": {
+                    "subject": format!("serviceaccount:{org}/ci"),
+                    "scope": format!("rise.dev/Organization/{org}"),
+                    "roleRef": {"kind": "PlatformRole", "name": format!("{org}-sa-reader")},
+                },
+            }),
+        )?;
+        let read = b.api_get_as(&format!("{}/{sa_path}", Self::RESOURCES), &identity)?;
+        anyhow::ensure!(
+            read.status == 200,
+            "granted identity could not read its resource: {}:\n{}",
+            read.status,
+            read.body
+        );
+        let read: serde_json::Value =
+            serde_json::from_str(&read.body).context("parse ServiceAccount")?;
+        anyhow::ensure!(
+            read["metadata"]["name"] == serde_json::json!("ci"),
+            "unexpected resource read back:\n{read}"
+        );
+
+        // Negatives, both the same coarse 401: claims no policy accepts, and a
+        // target that does not exist.
+        let other = dex::mint_password_token(dexep, "admin@example.com", "password")
+            .context("mint Dex OIDC token for another user")?;
+        let mismatch = b.api_post_as(&token_path, None, &Self::exchange_body(&other))?;
+        let ghost = b.api_post_as(
+            &format!("{}/serviceaccounts/{org}/ghost/token", Self::RESOURCES),
+            None,
+            &Self::exchange_body(&oidc),
+        )?;
+        anyhow::ensure!(
+            mismatch.status == 401 && ghost.status == 401,
+            "expected 401 for a claim mismatch and an absent target, got {} and {}:\n{}\n{}",
+            mismatch.status,
+            ghost.status,
+            mismatch.body,
+            ghost.body
+        );
+        anyhow::ensure!(
+            mismatch.body == ghost.body,
+            "workload-exchange failures must be indistinguishable:\n{}\n{}",
+            mismatch.body,
+            ghost.body
+        );
+
+        // Delegated issuance: the operator holds token-create on everything and
+        // mints without any assertion.
+        let delegated = b.api_post(&token_path, &serde_json::json!({}))?;
+        anyhow::ensure!(
+            delegated.status == 200,
+            "delegated issuance returned {}:\n{}",
+            delegated.status,
+            delegated.body
+        );
+
+        // Tidy up: the Organization cascades over everything beneath it.
+        let _ = b.api_delete(&format!("{}/organizations/{org}", Self::RESOURCES));
         Ok(())
     }
 }


### PR DESCRIPTION
Implements ADR-0001 §7: the `/token` subresource on `ServiceAccount` and `Controller` resources, enabling both workload token exchange and delegated issuance.

## Summary

This change adds a new `token` subresource to the generic resource API that allows minting Rise identity tokens for ServiceAccount and Controller resources. The implementation supports two distinct modes:

1. **Workload token exchange**: Unauthenticated requests carrying an external workload JWT are validated against the target's trust policies and, on exactly one match, issued a token for that target.
2. **Delegated issuance**: Authenticated requests with `(create, <kind>, token)` authorization mint a token that records the caller in a bounded `act` chain and exercises the target's live policy.

## Key Changes

- **New `token.rs` module** (`src/server/resources/token.rs`): Complete implementation of token issuance logic, including workload exchange validation, delegated issuance authorization, and trust-policy matching.

- **Identity token support**: Extended `rise-backend-auth` to support a new `RiseToken::Identity` variant with `IdentityClaims`, signed with `RISE_IDENTITY_TYP` header. Identity tokens carry `rise_uid` for live re-resolution on every request.

- **New identity authentication** (`src/server/auth/identity.rs`): `ResourcePrincipal` type and `resolve_identity()` function that validates identity tokens by re-resolving `(sub, rise_uid)` against the live resource store on each request. Deletion or UID change invalidates all issued tokens.

- **Authorization cap parsing**: Extended `rise-authz` to parse RFC 9396 `authorization_details` into `AuthorizationCap`, allowing tokens to carry a narrowed ceiling of the target's live policy.

- **Middleware integration**: Updated auth middleware to handle identity tokens, re-resolving them to live principals before request dispatch.

- **Handler changes**:
  - Modified `dispatch_post()` to accept `MaybeAuth` (credential-optional) and extract client IP for rate limiting.
  - New `dispatch_post_any()` routes unauthenticated requests to workload exchange and authenticated requests to either delegated issuance or ordinary create.
  - Added `token_is_create_only()` error for non-POST operations on the subresource.
  - Added validation in `create_resource()` to reject Rise as an external issuer in trust policies.

- **Path and routing**: Added `Subresource::Token` variant to path parsing; updated route documentation.

- **Test infrastructure**: Added comprehensive test suite covering workload exchange, delegated issuance, trust-policy matching, authorization-details narrowing, and delegation-depth limits.

## Notable Implementation Details

- **Coarse error responses**: Every workload-exchange failure after route entry returns the same 401 message, preventing information leakage about which identities or policies exist.
- **Rate limiting**: Pre-validation bucket for assertions whose target is not yet resolved, protecting against enumeration attacks.
- **Bounded delegation**: Identity tokens record a maximum of 4 delegators in the `act` chain; requests exceeding this are refused rather than silently truncated.
- **Live re-resolution**: Identity tokens are validated on every request by re-resolving `(sub, rise_uid)` against the store, making deletion or UID change immediately invalidate all issued tokens without explicit revocation.
- **Authorization details**: Tokens may carry RFC 9396 `authorization_details` that narrow (but never expand) the target's live policy; omission means full policy.

https://claude.ai/code/session_01RGKUuoiXZ2mGaceU2agJy6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rise-deploy/codesmith/rise/pr/494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791309913&installation_model_id=432987&pr_number=494&repository=rise-deploy%2Frise&return_to=https%3A%2F%2Fgithub.com%2Frise-deploy%2Frise%2Fpull%2F494&signature=f2dd7b540f4a0e9b6b2923b37e05b5eea07a2f38a2fc1a60c8b3dbabd2242ac9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->