### PR TITLE
authz: policy audit engine core

### DIFF
--- a/crates/rise-authz/src/engine/audit.rs
+++ b/crates/rise-authz/src/engine/audit.rs
@@ -1,0 +1,835 @@
+//! Diagnostics over shapes admission accepts but that grant nothing, or
+//! nothing durable.
+//!
+//! Audit never rejects a write — that stays admission's job — and it is
+//! deliberately bounded: every entry point takes a [`AuditScope`] naming one
+//! Organization (or every live one) and a finding cap, and never scans the
+//! whole store. Detectors are ordinary functions, named one per
+//! [`FindingCategory`] row, so each can be exercised on its own; the only
+//! thing [`AuthorizationEngine::audit`] adds is loading the binding facts
+//! once per tier and running them in a fixed order.
+
+use rise_resource_api::{
+    PathSegment, ResourceRow, ResourceStore, RoleRefKind, StoreError, SubjectId, SubjectMembership,
+    UserSpec, API_GROUP, API_VERSION_V1ALPHA1, CONTROLLER_KIND, GROUP_KIND, GROUP_MEMBERSHIP_KIND,
+    MAX_PARENT_CHAIN_DEPTH, ORGANIZATION_KIND, ORG_ADMIN_PLATFORM_ROLE, SERVICE_ACCOUNT_KIND,
+    USER_KIND,
+};
+use uuid::Uuid;
+
+use crate::engine::bindings::{
+    is_live, load_organization_bindings, load_platform_bindings, BindingFact, BindingKind,
+};
+use crate::engine::{
+    qualifies_as_org_admin, AuthorizationEngine, AuthorizationError, MembershipResolver,
+};
+use crate::policy::BindingTier;
+
+/// What to audit, and how much work to do.
+///
+/// Every detector is bounded by this: one Organization (or every live one
+/// when `organization` is `None`), and a hard cap on findings so a large or
+/// unhealthy install cannot make one audit call unbounded.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuditScope {
+    pub organization: Option<String>,
+    pub max_findings: usize,
+}
+
+/// The result of one [`AuthorizationEngine::audit`] call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuditReport {
+    pub findings: Vec<AuditFinding>,
+    /// Whether more findings existed than `max_findings` allowed through.
+    pub truncated: bool,
+}
+
+/// How urgently a finding deserves attention.
+///
+/// `Info` marks a shape that is *currently* inert but self-heals if the
+/// install's live facts change (a membership marker outliving its User, a
+/// binding that will start mattering once someone joins a Group) — nothing an
+/// operator broke. `Warning` marks a shape that is permanently inert, or
+/// actively misleading, until someone edits it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    Info,
+    Warning,
+}
+
+/// The resource a finding is about, or one it names in `related`.
+///
+/// `kind` is the resource's own kind name (`RoleBinding`, `Organization`,
+/// `GroupMembership`, ...), not a [`rise_resource_api::ResourceKind`]: a
+/// finding can be about a root-parented resource with no API group ambiguity
+/// to carry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FindingSubject {
+    pub uid: Uuid,
+    pub kind: String,
+    pub name: String,
+    pub organization: Option<String>,
+}
+
+/// Which side of a wildcard replacement shadows an Allow.
+///
+/// Populated by the shadowing detectors added alongside `ShadowedAllow`'s
+/// pure predicates; declared now so every category this crate ever emits is
+/// visible on [`FindingCategory`] from this change forward.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Shadow {
+    Deny,
+    Replacement,
+}
+
+/// One diagnosable shape ADR-0001's admission accepts.
+///
+/// Every variant here is a row in the audit's detector table; a detector
+/// function produces exactly one category.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FindingCategory {
+    /// `roleRef` names no live Role/PlatformRole.
+    DanglingRoleRef,
+    /// A literal subject names no live, active identity.
+    StaleSubject,
+    /// A non-wildcard scope names a resource that no longer exists.
+    StaleScope,
+    /// A `GroupMembership` names a User with no live, active row.
+    StaleMembership,
+    /// `subjectMembership: ResourceOrganization` can never bite.
+    NoOpMembershipConstraint,
+    /// An org `RoleBinding`'s subject can never, or does not currently,
+    /// belong to that Organization.
+    RecipientBoundaryNoOp,
+    /// `rise.dev/owner` resolves to nobody the seeded ownership binding reaches.
+    InertOwnerLabel,
+    /// A binding's `labelSelector` matches no resource in its scope.
+    SelectorMatchesNothing,
+    /// A more specific binding drops this Allow, either through a Deny or
+    /// through wildcard replacement.
+    ShadowedAllow { by: Shadow },
+    /// No qualifying binding gives this Organization a live, active admin.
+    OrganizationWithoutAdmin,
+    /// A `PlatformRole/org-admin` reference that does not satisfy the exact
+    /// org-root, scope-only shape ADR-0001 §5 requires to confer standing.
+    NonQualifyingOrgAdminReference,
+}
+
+/// One diagnosed shape.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuditFinding {
+    /// The resource the finding is about: a binding, Role, GroupMembership,
+    /// labelled resource, or Organization.
+    pub subject: FindingSubject,
+    pub category: FindingCategory,
+    pub severity: Severity,
+    /// Other live rows involved (the shadowing binding, ...). Empty when the
+    /// finding names something that does not exist — there is no row to
+    /// reference, so `detail` carries that identification instead.
+    pub related: Vec<FindingSubject>,
+    /// One actionable sentence, naming the missing or related thing by kind
+    /// and name.
+    pub detail: String,
+}
+
+impl AuthorizationEngine {
+    /// Run every detector this change carries, over the bindings in scope.
+    ///
+    /// Findings on tombstoned rows are never produced: platform bindings, org
+    /// bindings, Groups, and Organizations are all read live-filtered before a
+    /// detector ever sees them. There is no [`crate::engine::AuthorizationSnapshot`]
+    /// here — the audit has no principal, so it evaluates nothing and decides
+    /// nothing.
+    pub async fn audit(&self, scope: &AuditScope) -> Result<AuditReport, AuthorizationError> {
+        let store = self.store.as_ref();
+        let memberships = self.memberships.as_ref();
+        let mut findings = Vec::new();
+        let mut truncated = false;
+
+        let platform = load_platform_bindings(store).await?;
+        append_capped(
+            &mut findings,
+            &mut truncated,
+            scope.max_findings,
+            detect_dangling_role_ref(&platform),
+        );
+        append_capped(
+            &mut findings,
+            &mut truncated,
+            scope.max_findings,
+            detect_stale_subject(store, &platform).await?,
+        );
+        append_capped(
+            &mut findings,
+            &mut truncated,
+            scope.max_findings,
+            detect_stale_scope(store, &platform).await?,
+        );
+        append_capped(
+            &mut findings,
+            &mut truncated,
+            scope.max_findings,
+            detect_no_op_membership_constraint(&platform),
+        );
+        append_capped(
+            &mut findings,
+            &mut truncated,
+            scope.max_findings,
+            detect_non_qualifying_org_admin_reference(&platform),
+        );
+
+        for organization in self.audit_organizations(scope).await? {
+            let org_bindings = load_organization_bindings(store, &organization.name).await?;
+            append_capped(
+                &mut findings,
+                &mut truncated,
+                scope.max_findings,
+                detect_dangling_role_ref(&org_bindings),
+            );
+            append_capped(
+                &mut findings,
+                &mut truncated,
+                scope.max_findings,
+                detect_stale_subject(store, &org_bindings).await?,
+            );
+            append_capped(
+                &mut findings,
+                &mut truncated,
+                scope.max_findings,
+                detect_stale_scope(store, &org_bindings).await?,
+            );
+            let groups = live_groups(store, organization.uid).await?;
+            append_capped(
+                &mut findings,
+                &mut truncated,
+                scope.max_findings,
+                detect_stale_membership(store, &organization.name, &groups).await?,
+            );
+            append_capped(
+                &mut findings,
+                &mut truncated,
+                scope.max_findings,
+                detect_recipient_boundary_no_op(memberships, &organization.name, &org_bindings)
+                    .await?,
+            );
+            append_capped(
+                &mut findings,
+                &mut truncated,
+                scope.max_findings,
+                detect_organization_without_admin(store, &organization, &org_bindings).await?,
+            );
+            append_capped(
+                &mut findings,
+                &mut truncated,
+                scope.max_findings,
+                detect_non_qualifying_org_admin_reference(&org_bindings),
+            );
+        }
+
+        Ok(AuditReport {
+            findings,
+            truncated,
+        })
+    }
+
+    /// The live Organizations `scope` names: one, or every live one.
+    async fn audit_organizations(
+        &self,
+        scope: &AuditScope,
+    ) -> Result<Vec<ResourceRow>, AuthorizationError> {
+        match &scope.organization {
+            Some(name) => Ok(self
+                .store
+                .get_by_name(API_VERSION_V1ALPHA1, ORGANIZATION_KIND, name, None)
+                .await?
+                .filter(is_live)
+                .into_iter()
+                .collect()),
+            None => Ok(self
+                .store
+                .list(API_VERSION_V1ALPHA1, ORGANIZATION_KIND, None)
+                .await?
+                .into_iter()
+                .filter(is_live)
+                .collect()),
+        }
+    }
+}
+
+/// Append findings up to the cap, latching `truncated` once it is hit.
+///
+/// Once latched, later calls append nothing more: a report is either whole or
+/// marked partial, never partially-marked.
+fn append_capped(
+    findings: &mut Vec<AuditFinding>,
+    truncated: &mut bool,
+    max_findings: usize,
+    mut new: Vec<AuditFinding>,
+) {
+    if *truncated || new.is_empty() {
+        return;
+    }
+    if findings.len() + new.len() > max_findings {
+        new.truncate(max_findings.saturating_sub(findings.len()));
+        *truncated = true;
+    }
+    findings.append(&mut new);
+}
+
+/// The [`FindingSubject`] identifying a binding row itself.
+fn binding_subject(binding: &BindingFact) -> FindingSubject {
+    FindingSubject {
+        uid: binding.provenance.uid,
+        kind: binding.provenance.kind.to_string(),
+        name: binding
+            .provenance
+            .name
+            .clone()
+            .unwrap_or_else(|| binding.provenance.uid.to_string()),
+        organization: match &binding.tier {
+            BindingTier::Platform => None,
+            BindingTier::Organization(organization) => Some(organization.clone()),
+        },
+    }
+}
+
+async fn live_row_by_name(
+    store: &dyn ResourceStore,
+    kind: &str,
+    name: &str,
+    parent_uid: Option<Uuid>,
+) -> Result<Option<ResourceRow>, AuthorizationError> {
+    Ok(store
+        .get_by_name(API_VERSION_V1ALPHA1, kind, name, parent_uid)
+        .await?
+        .filter(is_live))
+}
+
+async fn live_groups(
+    store: &dyn ResourceStore,
+    organization_uid: Uuid,
+) -> Result<Vec<ResourceRow>, AuthorizationError> {
+    Ok(store
+        .list(API_VERSION_V1ALPHA1, GROUP_KIND, Some(organization_uid))
+        .await?
+        .into_iter()
+        .filter(is_live)
+        .collect())
+}
+
+/// A stored `User`'s `spec.active`, failing closed on a row that will not parse.
+fn user_is_active(row: &ResourceRow) -> Result<bool, AuthorizationError> {
+    let spec: UserSpec = serde_json::from_value(row.spec.clone()).map_err(|error| {
+        AuthorizationError::corrupt_policy(format!(
+            "stored User '{}' ({}) is not valid: {error}",
+            row.name, row.uid
+        ))
+    })?;
+    Ok(spec.active)
+}
+
+// ---------------------------------------------------------------------------
+// Row 1: DanglingRoleRef
+// ---------------------------------------------------------------------------
+
+/// A live binding whose `roleRef` names no live Role/PlatformRole.
+///
+/// Evaluation already treats this as zero statements (`RoleCache::resolve`);
+/// this only reports it. Always `Warning`: nothing about a dangling reference
+/// self-heals — an operator has to repair or remove the binding.
+pub fn detect_dangling_role_ref(bindings: &[BindingFact]) -> Vec<AuditFinding> {
+    bindings
+        .iter()
+        .filter(|binding| !binding.role_resolved)
+        .map(|binding| {
+            let role_kind = match binding.provenance.role.kind {
+                RoleRefKind::Role => "Role",
+                RoleRefKind::PlatformRole => "PlatformRole",
+            };
+            let placement = match (&binding.tier, binding.provenance.role.kind) {
+                (BindingTier::Organization(organization), RoleRefKind::Role) => {
+                    format!(" in Organization '{organization}'")
+                }
+                _ => String::new(),
+            };
+            AuditFinding {
+                subject: binding_subject(binding),
+                category: FindingCategory::DanglingRoleRef,
+                severity: Severity::Warning,
+                related: Vec::new(),
+                detail: format!(
+                    "roleRef names {role_kind} '{}'{placement}, which no longer exists; the binding grants nothing.",
+                    binding.provenance.role.name
+                ),
+            }
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Row 2: StaleSubject
+// ---------------------------------------------------------------------------
+
+/// A literal subject that names no live, active identity.
+///
+/// Templates and virtual subjects (`system:*`, `org:*`) are skipped: they name
+/// a population or a predicate, never a stored row.
+pub async fn detect_stale_subject(
+    store: &dyn ResourceStore,
+    bindings: &[BindingFact],
+) -> Result<Vec<AuditFinding>, AuthorizationError> {
+    let mut findings = Vec::new();
+    for binding in bindings {
+        let Some(subject) = binding.subject.literal() else {
+            continue;
+        };
+        let stale = match subject.kind() {
+            "user" => match live_row_by_name(store, USER_KIND, subject.name(), None).await? {
+                Some(row) => !user_is_active(&row)?,
+                None => true,
+            },
+            "controller" => live_row_by_name(store, CONTROLLER_KIND, subject.name(), None)
+                .await?
+                .is_none(),
+            "group" => stale_org_native(store, GROUP_KIND, subject).await?,
+            "serviceaccount" => stale_org_native(store, SERVICE_ACCOUNT_KIND, subject).await?,
+            _ => continue,
+        };
+        if stale {
+            findings.push(AuditFinding {
+                subject: binding_subject(binding),
+                category: FindingCategory::StaleSubject,
+                severity: Severity::Warning,
+                related: Vec::new(),
+                detail: format!(
+                    "subject '{subject}' names no live, active identity; the binding grants nothing."
+                ),
+            });
+        }
+    }
+    Ok(findings)
+}
+
+/// Whether an org-native (`group:`/`serviceaccount:`) subject names no live row.
+async fn stale_org_native(
+    store: &dyn ResourceStore,
+    kind: &str,
+    subject: &SubjectId,
+) -> Result<bool, AuthorizationError> {
+    let Some(organization) = subject.organization() else {
+        return Ok(true);
+    };
+    let Some(org_row) = live_row_by_name(store, ORGANIZATION_KIND, organization, None).await?
+    else {
+        return Ok(true);
+    };
+    Ok(
+        live_row_by_name(store, kind, subject.name(), Some(org_row.uid))
+            .await?
+            .is_none(),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Row 3: StaleScope
+// ---------------------------------------------------------------------------
+
+/// A non-wildcard scope whose `(kind, names...)` chain resolves to no live row.
+pub async fn detect_stale_scope(
+    store: &dyn ResourceStore,
+    bindings: &[BindingFact],
+) -> Result<Vec<AuditFinding>, AuthorizationError> {
+    let mut findings = Vec::new();
+    for binding in bindings {
+        let Some(resource_kind) = binding.scope.resource_kind() else {
+            continue;
+        };
+        let Some(chain) = kind_chain(store, resource_kind.group(), resource_kind.kind()).await?
+        else {
+            // The kind itself is unregistered; nothing to validate the scope
+            // against, and admission would have refused the write anyway.
+            continue;
+        };
+        let names: Vec<&str> = binding.scope.names().collect();
+        if names.len() != chain.len() {
+            // A malformed scope is not this detector's concern; it should
+            // never have passed admission.
+            continue;
+        }
+        let segments: Vec<PathSegment> = chain
+            .into_iter()
+            .zip(names)
+            .map(|((kind, api_versions), name)| PathSegment::Name {
+                api_versions,
+                kind,
+                name: name.to_owned(),
+            })
+            .collect();
+        let stale = match store.resolve_path(&segments).await {
+            Ok(rows) => rows.iter().any(|row| row.deletion_timestamp.is_some()),
+            Err(StoreError::NotFound | StoreError::ParentNotFound) => true,
+            Err(other) => return Err(other.into()),
+        };
+        if stale {
+            findings.push(AuditFinding {
+                subject: binding_subject(binding),
+                category: FindingCategory::StaleScope,
+                severity: Severity::Warning,
+                related: Vec::new(),
+                detail: format!(
+                    "scope '{}' names no live resource; the binding grants nothing.",
+                    binding.scope
+                ),
+            });
+        }
+    }
+    Ok(findings)
+}
+
+/// The `(kind, declared API versions)` chain a kind hangs under, root-first,
+/// walked through the same registry admission resolves a `Scope` against.
+///
+/// `None` when the leaf kind, or an ancestor it declares, is not registered.
+async fn kind_chain(
+    store: &dyn ResourceStore,
+    group: &str,
+    kind: &str,
+) -> Result<Option<Vec<(String, Vec<String>)>>, AuthorizationError> {
+    let mut chain = Vec::new();
+    let mut current_group = group.to_owned();
+    let mut current_kind = kind.to_owned();
+    loop {
+        if chain.len() >= MAX_PARENT_CHAIN_DEPTH {
+            return Ok(None);
+        }
+        let Some(info) = store
+            .resolve_collection_by_kind(&current_group, &current_kind)
+            .await?
+        else {
+            return Ok(None);
+        };
+        chain.push((current_kind.clone(), info.declared_api_versions.clone()));
+        match info.parent {
+            Some(parent) => {
+                let Some((parent_group, _)) = parent.api_version.split_once('/') else {
+                    return Ok(None);
+                };
+                current_group = parent_group.to_owned();
+                current_kind = parent.kind.clone();
+            }
+            None => break,
+        }
+    }
+    chain.reverse();
+    Ok(Some(chain))
+}
+
+// ---------------------------------------------------------------------------
+// Row 4: StaleMembership
+// ---------------------------------------------------------------------------
+
+/// A `GroupMembership` naming a User with no live, active root row.
+///
+/// Markers deliberately outlive Users (ADR-0001 §1) — recreating or
+/// reactivating the name makes the tie live again — so this is `Info`, never
+/// `Warning`.
+pub async fn detect_stale_membership(
+    store: &dyn ResourceStore,
+    organization: &str,
+    groups: &[ResourceRow],
+) -> Result<Vec<AuditFinding>, AuthorizationError> {
+    let mut findings = Vec::new();
+    for group in groups {
+        let memberships = store
+            .list(API_VERSION_V1ALPHA1, GROUP_MEMBERSHIP_KIND, Some(group.uid))
+            .await?;
+        for membership in memberships.iter().filter(|row| is_live(row)) {
+            let live_active =
+                match live_row_by_name(store, USER_KIND, &membership.name, None).await? {
+                    Some(row) => user_is_active(&row)?,
+                    None => false,
+                };
+            if live_active {
+                continue;
+            }
+            findings.push(AuditFinding {
+                subject: FindingSubject {
+                    uid: membership.uid,
+                    kind: GROUP_MEMBERSHIP_KIND.to_owned(),
+                    name: membership.name.clone(),
+                    organization: Some(organization.to_owned()),
+                },
+                category: FindingCategory::StaleMembership,
+                severity: Severity::Info,
+                related: Vec::new(),
+                detail: format!(
+                    "GroupMembership names User '{}', which does not exist or is inactive.",
+                    membership.name
+                ),
+            });
+        }
+    }
+    Ok(findings)
+}
+
+// ---------------------------------------------------------------------------
+// Row 5: NoOpMembershipConstraint
+// ---------------------------------------------------------------------------
+
+/// A `PlatformRoleBinding` whose `subjectMembership: ResourceOrganization`
+/// constraint can never bite.
+///
+/// Purely structural: admission has already fixed a scope's ancestor-name
+/// count to match its registered kind depth, so a single-segment scope is
+/// provably root-scoped without a store lookup.
+pub fn detect_no_op_membership_constraint(bindings: &[BindingFact]) -> Vec<AuditFinding> {
+    bindings
+        .iter()
+        .filter(|binding| binding.provenance.kind == BindingKind::PlatformRoleBinding)
+        .filter(|binding| binding.subject_membership == SubjectMembership::ResourceOrganization)
+        .filter_map(|binding| {
+            let detail = no_op_membership_reason(binding)?;
+            Some(AuditFinding {
+                subject: binding_subject(binding),
+                category: FindingCategory::NoOpMembershipConstraint,
+                severity: Severity::Warning,
+                related: Vec::new(),
+                detail,
+            })
+        })
+        .collect()
+}
+
+fn no_op_membership_reason(binding: &BindingFact) -> Option<String> {
+    if let Some(subject) = binding.subject.literal() {
+        match subject.kind() {
+            "group" | "serviceaccount" | "org" => {
+                return Some(format!(
+                    "subjectMembership: ResourceOrganization can never bite: subject '{subject}' already carries its own organization."
+                ));
+            }
+            "controller" => {
+                return Some(format!(
+                    "subjectMembership: ResourceOrganization can never bite: subject '{subject}' belongs to no organization and is never affiliated."
+                ));
+            }
+            _ => {}
+        }
+    }
+    let is_root_scoped_non_organization = binding.scope.names().len() == 1
+        && binding
+            .scope
+            .resource_kind()
+            .is_some_and(|kind| !(kind.group() == API_GROUP && kind.kind() == ORGANIZATION_KIND));
+    if is_root_scoped_non_organization {
+        return Some(format!(
+            "subjectMembership: ResourceOrganization can never bite: scope '{}' names a root-scoped resource with no organization to compare against.",
+            binding.scope
+        ));
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Row 6: RecipientBoundaryNoOp
+// ---------------------------------------------------------------------------
+
+/// An org `RoleBinding` whose literal subject can never, or does not
+/// currently, belong to its own Organization.
+///
+/// Admission already rejects the foreign-org shapes (a `group:`/`serviceaccount:`/
+/// `org:` subject naming another Organization), so only `controller:` (permanent)
+/// and `user:` (contingent on live membership) reach this detector.
+pub async fn detect_recipient_boundary_no_op(
+    memberships: &dyn MembershipResolver,
+    organization: &str,
+    org_bindings: &[BindingFact],
+) -> Result<Vec<AuditFinding>, AuthorizationError> {
+    let mut findings = Vec::new();
+    for binding in org_bindings {
+        let Some(subject) = binding.subject.literal() else {
+            continue;
+        };
+        match subject.kind() {
+            "controller" => {
+                findings.push(AuditFinding {
+                    subject: binding_subject(binding),
+                    category: FindingCategory::RecipientBoundaryNoOp,
+                    severity: Severity::Warning,
+                    related: Vec::new(),
+                    detail: format!(
+                        "subject '{subject}' belongs to no organization; this RoleBinding can never reach it."
+                    ),
+                });
+            }
+            "user" => {
+                if user_belongs_to_organization(memberships, org_bindings, subject, organization)
+                    .await?
+                {
+                    continue;
+                }
+                findings.push(AuditFinding {
+                    subject: binding_subject(binding),
+                    category: FindingCategory::RecipientBoundaryNoOp,
+                    severity: Severity::Info,
+                    related: Vec::new(),
+                    detail: format!(
+                        "subject '{subject}' has no live Group tie in Organization '{organization}' and is not a qualifying admin there; this RoleBinding currently grants nothing."
+                    ),
+                });
+            }
+            _ => {}
+        }
+    }
+    Ok(findings)
+}
+
+/// Whether a `user:` subject currently belongs to `organization`, either
+/// through a live Group tie or the direct org-admin bootstrap edge (ADR-0001
+/// §5) — the same two paths `AuthorizationEngine::subject_belongs_to` checks
+/// for a live caller.
+async fn user_belongs_to_organization(
+    memberships: &dyn MembershipResolver,
+    org_bindings: &[BindingFact],
+    user: &SubjectId,
+    organization: &str,
+) -> Result<bool, AuthorizationError> {
+    let groups = memberships.groups_for_user(user).await?;
+    if groups
+        .iter()
+        .any(|group| group.organization() == Some(organization))
+    {
+        return Ok(true);
+    }
+    Ok(org_bindings.iter().any(|candidate| {
+        qualifies_as_org_admin(candidate, organization) && candidate.subject.literal() == Some(user)
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Row 11: OrganizationWithoutAdmin
+// ---------------------------------------------------------------------------
+
+/// An Organization with no qualifying binding naming a live, active admin.
+pub async fn detect_organization_without_admin(
+    store: &dyn ResourceStore,
+    organization: &ResourceRow,
+    org_bindings: &[BindingFact],
+) -> Result<Vec<AuditFinding>, AuthorizationError> {
+    if organization_has_live_admin(store, &organization.name, org_bindings).await? {
+        return Ok(Vec::new());
+    }
+    Ok(vec![AuditFinding {
+        subject: FindingSubject {
+            uid: organization.uid,
+            kind: ORGANIZATION_KIND.to_owned(),
+            name: organization.name.clone(),
+            organization: Some(organization.name.clone()),
+        },
+        category: FindingCategory::OrganizationWithoutAdmin,
+        severity: Severity::Warning,
+        related: Vec::new(),
+        detail: format!(
+            "Organization '{}' has no live, active admin: no qualifying binding names a live User directly or through a Group with a live, active member.",
+            organization.name
+        ),
+    }])
+}
+
+/// Whether some qualifying binding names a live, active User, or a Group with
+/// at least one live, active member.
+async fn organization_has_live_admin(
+    store: &dyn ResourceStore,
+    organization: &str,
+    org_bindings: &[BindingFact],
+) -> Result<bool, AuthorizationError> {
+    for binding in org_bindings
+        .iter()
+        .filter(|binding| qualifies_as_org_admin(binding, organization))
+    {
+        let Some(subject) = binding.subject.literal() else {
+            continue;
+        };
+        let qualifies = match subject.kind() {
+            "user" => match live_row_by_name(store, USER_KIND, subject.name(), None).await? {
+                Some(row) => user_is_active(&row)?,
+                None => false,
+            },
+            "group" => group_has_live_admin_member(store, subject).await?,
+            _ => false,
+        };
+        if qualifies {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// Whether a `group:<org>/<name>` subject names a live Group with at least one
+/// `GroupMembership` naming a live, active User.
+async fn group_has_live_admin_member(
+    store: &dyn ResourceStore,
+    group: &SubjectId,
+) -> Result<bool, AuthorizationError> {
+    let Some(organization) = group.organization() else {
+        return Ok(false);
+    };
+    let Some(org_row) = live_row_by_name(store, ORGANIZATION_KIND, organization, None).await?
+    else {
+        return Ok(false);
+    };
+    let Some(group_row) =
+        live_row_by_name(store, GROUP_KIND, group.name(), Some(org_row.uid)).await?
+    else {
+        return Ok(false);
+    };
+    let memberships = store
+        .list(
+            API_VERSION_V1ALPHA1,
+            GROUP_MEMBERSHIP_KIND,
+            Some(group_row.uid),
+        )
+        .await?;
+    for membership in memberships.iter().filter(|row| is_live(row)) {
+        if let Some(user_row) = live_row_by_name(store, USER_KIND, &membership.name, None).await? {
+            if user_is_active(&user_row)? {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
+}
+
+// ---------------------------------------------------------------------------
+// Row 12: NonQualifyingOrgAdminReference
+// ---------------------------------------------------------------------------
+
+/// A `PlatformRole/org-admin` reference that fails ADR-0001 §5's exact
+/// org-root, scope-only shape for its own placement.
+///
+/// Every `PlatformRoleBinding` fails this unconditionally: the tier alone
+/// disqualifies it, regardless of what its scope names.
+pub fn detect_non_qualifying_org_admin_reference(bindings: &[BindingFact]) -> Vec<AuditFinding> {
+    bindings
+        .iter()
+        .filter(|binding| {
+            binding.provenance.role.kind == RoleRefKind::PlatformRole
+                && binding.provenance.role.name == ORG_ADMIN_PLATFORM_ROLE
+        })
+        .filter(|binding| match &binding.tier {
+            BindingTier::Organization(organization) => {
+                !qualifies_as_org_admin(binding, organization)
+            }
+            BindingTier::Platform => true,
+        })
+        .map(|binding| AuditFinding {
+            subject: binding_subject(binding),
+            category: FindingCategory::NonQualifyingOrgAdminReference,
+            severity: Severity::Warning,
+            related: Vec::new(),
+            detail: format!(
+                "roleRef names PlatformRole/{ORG_ADMIN_PLATFORM_ROLE} but this binding is not an exact org-root, scope-only reference; it grants the baseline statements without conferring admin standing or the Deny exemption."
+            ),
+        })
+        .collect()
+}

--- a/crates/rise-authz/src/engine/bindings.rs
+++ b/crates/rise-authz/src/engine/bindings.rs
@@ -45,6 +45,10 @@ pub struct BindingProvenance {
     pub uid: Uuid,
     pub kind: BindingKind,
     pub role: RoleReference,
+    /// The binding's own resource name, so an audit finding can identify it
+    /// without a second lookup. `None` for a binding the grant gate simulates
+    /// from a request rather than loads from a stored row.
+    pub name: Option<String>,
 }
 
 /// One live binding with its `roleRef` already resolved to policy statements.
@@ -61,6 +65,14 @@ pub struct BindingFact {
     pub scope: rise_resource_api::Scope,
     pub selector: Option<rise_resource_api::LabelSelector>,
     pub statements: Vec<PolicyStatement>,
+    /// Whether `roleRef` resolved to a live Role/PlatformRole body.
+    ///
+    /// `false` always pairs with empty `statements` — evaluation treats a
+    /// dangling reference as contributing nothing either way — but the audit
+    /// needs to tell a dangling reference apart from a resolved Role whose
+    /// body happens to hold zero statements, which is `true` with the same
+    /// empty list.
+    pub role_resolved: bool,
 }
 
 /// Root-parented `PlatformRoleBinding`s, which are the complete platform tier.
@@ -74,7 +86,7 @@ pub(crate) async fn load_platform_bindings(
     let mut bindings = Vec::new();
     for row in rows.iter().filter(|row| is_live(row)) {
         let spec: LocallyNormalizedPlatformRoleBindingSpec = parse_spec(row)?;
-        let statements = roles
+        let resolved = roles
             .resolve(
                 store,
                 RoleRefKind::PlatformRole,
@@ -82,6 +94,7 @@ pub(crate) async fn load_platform_bindings(
                 None,
             )
             .await?;
+        let role_resolved = resolved.is_some();
         bindings.push(BindingFact {
             provenance: BindingProvenance {
                 uid: row.uid,
@@ -90,13 +103,15 @@ pub(crate) async fn load_platform_bindings(
                     kind: RoleRefKind::PlatformRole,
                     name: spec.role_ref().name.clone(),
                 },
+                name: Some(row.name.clone()),
             },
             tier: BindingTier::Platform,
             subject: spec.subject().clone(),
             subject_membership: spec.subject_membership(),
             scope: spec.scope().clone(),
             selector: spec.label_selector().cloned(),
-            statements,
+            statements: resolved.unwrap_or_default(),
+            role_resolved,
         });
     }
     Ok(bindings)
@@ -133,9 +148,10 @@ pub(crate) async fn load_organization_bindings(
             RoleRefKind::Role => Some(org_row.uid),
             RoleRefKind::PlatformRole => None,
         };
-        let statements = roles
+        let resolved = roles
             .resolve(store, role_ref.kind, role_ref.name.as_str(), role_parent)
             .await?;
+        let role_resolved = resolved.is_some();
         bindings.push(BindingFact {
             provenance: BindingProvenance {
                 uid: row.uid,
@@ -144,6 +160,7 @@ pub(crate) async fn load_organization_bindings(
                     kind: role_ref.kind,
                     name: role_ref.name.clone(),
                 },
+                name: Some(row.name.clone()),
             },
             tier: BindingTier::Organization(organization.to_owned()),
             subject: spec.subject().clone(),
@@ -152,11 +169,16 @@ pub(crate) async fn load_organization_bindings(
             subject_membership: SubjectMembership::Any,
             scope: spec.scope().clone(),
             selector: spec.label_selector().cloned(),
-            statements,
+            statements: resolved.unwrap_or_default(),
+            role_resolved,
         });
     }
     Ok(bindings)
 }
+
+/// A cached resolution: `None` for a dangling reference, `Some` for a resolved
+/// Role's statements (possibly empty).
+type ResolvedRole = Option<Vec<PolicyStatement>>;
 
 /// Role bodies resolved during one load.
 ///
@@ -165,39 +187,45 @@ pub(crate) async fn load_organization_bindings(
 /// answer for another's the moment this cache outlives a single org's load.
 #[derive(Default)]
 struct RoleCache {
-    statements: HashMap<(&'static str, Option<Uuid>, String), Vec<PolicyStatement>>,
+    statements: HashMap<(&'static str, Option<Uuid>, String), ResolvedRole>,
 }
 
 impl RoleCache {
+    /// Resolve a `roleRef` to its live statements.
+    ///
+    /// `None` marks a dangling reference — no live Role/PlatformRole at that
+    /// placement — distinctly from a resolved Role whose body happens to have
+    /// zero statements, which is `Some(vec![])`. Evaluation folds both into
+    /// "contributes nothing"; the audit needs to tell them apart.
     async fn resolve(
         &mut self,
         store: &dyn ResourceStore,
         kind: RoleRefKind,
         name: &str,
         parent_uid: Option<Uuid>,
-    ) -> Result<Vec<PolicyStatement>, AuthorizationError> {
+    ) -> Result<ResolvedRole, AuthorizationError> {
         let stored_kind = match kind {
             RoleRefKind::Role => ROLE_KIND,
             RoleRefKind::PlatformRole => PLATFORM_ROLE_KIND,
         };
         let key = (stored_kind, parent_uid, name.to_owned());
-        if let Some(statements) = self.statements.get(&key) {
-            return Ok(statements.clone());
+        if let Some(resolved) = self.statements.get(&key) {
+            return Ok(resolved.clone());
         }
-        let statements = match store
+        let resolved = match store
             .get_by_name(API_VERSION_V1ALPHA1, stored_kind, name, parent_uid)
             .await?
             .filter(is_live)
         {
-            Some(row) => parse_spec::<RoleSpec>(&row)?.statements,
-            None => Vec::new(),
+            Some(row) => Some(parse_spec::<RoleSpec>(&row)?.statements),
+            None => None,
         };
-        self.statements.insert(key, statements.clone());
-        Ok(statements)
+        self.statements.insert(key, resolved.clone());
+        Ok(resolved)
     }
 }
 
-fn is_live(row: &ResourceRow) -> bool {
+pub(crate) fn is_live(row: &ResourceRow) -> bool {
     row.deletion_timestamp.is_none()
 }
 

--- a/crates/rise-authz/src/engine/gate.rs
+++ b/crates/rise-authz/src/engine/gate.rs
@@ -120,6 +120,10 @@ impl BindingState {
                 uid: self.uid,
                 kind: self.kind,
                 role: self.role.clone(),
+                // The gate simulates a binding's before/after policy from the
+                // write's own claims, not a stored row — a create has no name
+                // yet, and nothing here ever feeds an audit finding.
+                name: None,
             },
             tier: self.tier()?,
             subject: self.subject.clone(),
@@ -129,6 +133,9 @@ impl BindingState {
             statements: engine
                 .role_statements(&self.role, self.organization.as_deref())
                 .await?,
+            // Irrelevant to the gate's own comparisons — it only ever reads
+            // `statements` — and this fact is never routed through the audit.
+            role_resolved: true,
         })
     }
 }

--- a/crates/rise-authz/src/engine/mod.rs
+++ b/crates/rise-authz/src/engine/mod.rs
@@ -11,6 +11,7 @@
 //! requests: tightening a cap or narrowing a Role takes effect on the next
 //! request, with nothing carried in a token.
 
+mod audit;
 mod bindings;
 mod gate;
 mod membership;
@@ -32,6 +33,9 @@ use crate::policy::{
     BindingTier, Decision, PermissionTuple,
 };
 
+pub use audit::{
+    AuditFinding, AuditReport, AuditScope, FindingCategory, FindingSubject, Severity, Shadow,
+};
 pub use bindings::{BindingKind, BindingProvenance, RoleReference};
 pub use gate::{
     AuthorizationChange, BindingChange, BindingState, GateDomain, GateOutcome, GateRejection,
@@ -112,6 +116,9 @@ pub enum InertReason {
     /// `subjectMembership: ResourceOrganization` excluded the resolved subject
     /// from this resource's organization.
     ResourceOrganization,
+    /// The binding's `roleRef` names no live Role/PlatformRole, so it resolved
+    /// to zero statements before subject matching even ran.
+    DanglingRoleRef,
 }
 
 /// A binding that applies to the caller by scope, selector, and subject, but
@@ -537,6 +544,14 @@ impl AuthorizationEngine {
                 });
                 continue;
             }
+            if !binding.role_resolved {
+                inert.push(InertBinding {
+                    provenance: binding.provenance.clone(),
+                    tier: binding.tier.clone(),
+                    reason: InertReason::DanglingRoleRef,
+                });
+                continue;
+            }
 
             applicable.push(ApplicableBinding {
                 provenance: binding.provenance.clone(),
@@ -800,7 +815,7 @@ fn universal_allow() -> Vec<PolicyStatement> {
 /// reference. A label-selected binding can therefore never confer admin
 /// standing, which is what keeps admin access independent of any
 /// access-driving label an orphaned resource might carry.
-fn qualifies_as_org_admin(binding: &BindingFact, organization: &str) -> bool {
+pub(crate) fn qualifies_as_org_admin(binding: &BindingFact, organization: &str) -> bool {
     binding.selector.is_none()
         && binding.provenance.role.kind == RoleRefKind::PlatformRole
         && binding.provenance.role.name == ORG_ADMIN_PLATFORM_ROLE

--- a/crates/rise-authz/tests/audit.rs
+++ b/crates/rise-authz/tests/audit.rs
@@ -1,0 +1,498 @@
+mod support;
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use rise_authz::engine::{
+    AuditScope, AuthorizationEngine, FindingCategory, Severity, ORG_ADMIN_PLATFORM_ROLE,
+};
+use rise_resource_api::ResourceStore;
+use serde_json::json;
+use support::{FakeMemberships, FakeStore, StoreBuilder};
+
+const ORGANIZATION: &str = "Organization";
+const PROJECT: &str = "Project";
+const ROLE: &str = "Role";
+const ROLE_BINDING: &str = "RoleBinding";
+const PLATFORM_ROLE: &str = "PlatformRole";
+const PLATFORM_ROLE_BINDING: &str = "PlatformRoleBinding";
+const USER: &str = "User";
+const GROUP: &str = "Group";
+const GROUP_MEMBERSHIP: &str = "GroupMembership";
+
+fn engine(store: Arc<FakeStore>, memberships: Arc<FakeMemberships>) -> AuthorizationEngine {
+    AuthorizationEngine::new(store as Arc<dyn ResourceStore>, memberships)
+}
+
+/// Audit every live Organization with a generous cap.
+fn every_org() -> AuditScope {
+    AuditScope {
+        organization: None,
+        max_findings: 1000,
+    }
+}
+
+fn one_org(name: &str) -> AuditScope {
+    AuditScope {
+        organization: Some(name.to_owned()),
+        max_findings: 1000,
+    }
+}
+
+/// An org `RoleBinding` that satisfies ADR-0001 §5's exact structural admin
+/// predicate.
+fn org_admin_binding(subject: &str, organization: &str) -> serde_json::Value {
+    json!({
+        "subject": subject,
+        "scope": format!("rise.dev/Organization/{organization}"),
+        "roleRef": { "kind": "PlatformRole", "name": ORG_ADMIN_PLATFORM_ROLE }
+    })
+}
+
+fn user_spec(active: bool) -> serde_json::Value {
+    json!({ "active": active })
+}
+
+fn allow_all() -> serde_json::Value {
+    json!([
+        { "effect": "Allow", "kinds": "*", "verbs": "*" },
+        { "effect": "Allow", "kinds": "*", "verbs": "*", "subresources": "*" }
+    ])
+}
+
+fn category_names(
+    findings: &[rise_authz::engine::AuditFinding],
+    category: FindingCategory,
+) -> Vec<&str> {
+    findings
+        .iter()
+        .filter(|finding| finding.category == category)
+        .map(|finding| finding.subject.name.as_str())
+        .collect()
+}
+
+/// The seeded shape a healthy install ships: a `PlatformRole/org-admin`, one
+/// Organization, and one qualifying direct admin binding to a live, active
+/// User.
+#[tokio::test]
+async fn a_healthy_install_produces_no_findings() {
+    let mut builder = StoreBuilder::new();
+    let acme = builder.resource(ORGANIZATION, "acme", None);
+    builder.role(PLATFORM_ROLE, ORG_ADMIN_PLATFORM_ROLE, None, allow_all());
+    builder.row(USER, "u-alice", None, BTreeMap::new(), user_spec(true));
+    builder.binding(
+        ROLE_BINDING,
+        "admin",
+        Some(acme),
+        org_admin_binding("user:u-alice", "acme"),
+    );
+    let store = builder.build();
+    let engine = engine(store, FakeMemberships::none());
+
+    let report = engine.audit(&every_org()).await.unwrap();
+    assert!(report.findings.is_empty(), "{:#?}", report.findings);
+    assert!(!report.truncated);
+}
+
+#[tokio::test]
+async fn dangling_role_ref_positive_and_negative() {
+    let mut builder = StoreBuilder::new();
+    let acme = builder.resource(ORGANIZATION, "acme", None);
+    builder.role(
+        ROLE,
+        "reader",
+        Some(acme),
+        json!([{ "effect": "Allow", "kinds": "*", "verbs": ["get"] }]),
+    );
+    builder.binding(
+        ROLE_BINDING,
+        "resolved",
+        Some(acme),
+        json!({
+            "subject": "user:u-alice",
+            "scope": "rise.dev/Organization/acme",
+            "roleRef": { "kind": "Role", "name": "reader" }
+        }),
+    );
+    builder.binding(
+        ROLE_BINDING,
+        "dangling",
+        Some(acme),
+        json!({
+            "subject": "user:u-alice",
+            "scope": "rise.dev/Organization/acme",
+            "roleRef": { "kind": "Role", "name": "role-that-does-not-exist" }
+        }),
+    );
+    let store = builder.build();
+    let engine = engine(store, FakeMemberships::none());
+
+    let report = engine.audit(&one_org("acme")).await.unwrap();
+    let dangling = category_names(&report.findings, FindingCategory::DanglingRoleRef);
+    assert_eq!(dangling, vec!["dangling"]);
+    assert_eq!(
+        report
+            .findings
+            .iter()
+            .find(|finding| finding.category == FindingCategory::DanglingRoleRef)
+            .unwrap()
+            .severity,
+        Severity::Warning
+    );
+}
+
+#[tokio::test]
+async fn stale_subject_positive_and_negative() {
+    let mut builder = StoreBuilder::new();
+    let acme = builder.resource(ORGANIZATION, "acme", None);
+    builder.role(
+        ROLE,
+        "reader",
+        Some(acme),
+        json!([{ "effect": "Allow", "kinds": "*", "verbs": ["get"] }]),
+    );
+    builder.row(USER, "u-live", None, BTreeMap::new(), user_spec(true));
+    builder.row(USER, "u-inactive", None, BTreeMap::new(), user_spec(false));
+    for (name, subject) in [
+        ("live", "user:u-live"),
+        ("inactive", "user:u-inactive"),
+        ("missing", "user:u-ghost"),
+    ] {
+        builder.binding(
+            ROLE_BINDING,
+            name,
+            Some(acme),
+            json!({
+                "subject": subject,
+                "scope": "rise.dev/Organization/acme",
+                "roleRef": { "kind": "Role", "name": "reader" }
+            }),
+        );
+    }
+    let store = builder.build();
+    let engine = engine(store, FakeMemberships::none());
+
+    let report = engine.audit(&one_org("acme")).await.unwrap();
+    let mut stale = category_names(&report.findings, FindingCategory::StaleSubject);
+    stale.sort_unstable();
+    assert_eq!(stale, vec!["inactive", "missing"]);
+}
+
+#[tokio::test]
+async fn stale_scope_positive_and_negative() {
+    let mut builder = StoreBuilder::new();
+    let acme = builder.resource(ORGANIZATION, "acme", None);
+    let _app = builder.resource(PROJECT, "app", Some(acme));
+    builder.role(
+        ROLE,
+        "reader",
+        Some(acme),
+        json!([{ "effect": "Allow", "kinds": "*", "verbs": ["get"] }]),
+    );
+    builder.binding(
+        ROLE_BINDING,
+        "live-scope",
+        Some(acme),
+        json!({
+            "subject": "user:u-alice",
+            "scope": "rise.dev/Project/acme/app",
+            "roleRef": { "kind": "Role", "name": "reader" }
+        }),
+    );
+    builder.binding(
+        ROLE_BINDING,
+        "stale-scope",
+        Some(acme),
+        json!({
+            "subject": "user:u-alice",
+            "scope": "rise.dev/Project/acme/ghost",
+            "roleRef": { "kind": "Role", "name": "reader" }
+        }),
+    );
+    let store = builder.build();
+    let engine = engine(store, FakeMemberships::none());
+
+    let report = engine.audit(&one_org("acme")).await.unwrap();
+    let stale = category_names(&report.findings, FindingCategory::StaleScope);
+    assert_eq!(stale, vec!["stale-scope"]);
+}
+
+#[tokio::test]
+async fn stale_membership_positive_and_negative() {
+    let mut builder = StoreBuilder::new();
+    let acme = builder.resource(ORGANIZATION, "acme", None);
+    let platform = builder.resource(GROUP, "platform", Some(acme));
+    builder.row(USER, "u-live", None, BTreeMap::new(), user_spec(true));
+    // A live tie: the GroupMembership names a live, active User.
+    builder.row(
+        GROUP_MEMBERSHIP,
+        "u-live",
+        Some(platform),
+        BTreeMap::new(),
+        json!({}),
+    );
+    // A stale tie: names a User that was never created.
+    builder.row(
+        GROUP_MEMBERSHIP,
+        "u-ghost",
+        Some(platform),
+        BTreeMap::new(),
+        json!({}),
+    );
+    let store = builder.build();
+    let engine = engine(store, FakeMemberships::none());
+
+    let report = engine.audit(&one_org("acme")).await.unwrap();
+    let stale = category_names(&report.findings, FindingCategory::StaleMembership);
+    assert_eq!(stale, vec!["u-ghost"]);
+    assert_eq!(
+        report
+            .findings
+            .iter()
+            .find(|finding| finding.category == FindingCategory::StaleMembership)
+            .unwrap()
+            .severity,
+        Severity::Info
+    );
+}
+
+#[tokio::test]
+async fn no_op_membership_constraint_positive_and_negative() {
+    let mut builder = StoreBuilder::new();
+    let _acme = builder.resource(ORGANIZATION, "acme", None);
+    builder.role(PLATFORM_ROLE, "everything", None, allow_all());
+    // Negative: a `user:` subject genuinely spans organizations, so the clamp
+    // is a live constraint.
+    builder.binding(
+        PLATFORM_ROLE_BINDING,
+        "clamped-user",
+        None,
+        json!({
+            "subject": "user:u-alice",
+            "subjectMembership": "ResourceOrganization",
+            "scope": "*",
+            "roleRef": { "kind": "PlatformRole", "name": "everything" }
+        }),
+    );
+    // Positive: a Controller belongs to no organization, so the clamp can
+    // never bite.
+    builder.binding(
+        PLATFORM_ROLE_BINDING,
+        "clamped-controller",
+        None,
+        json!({
+            "subject": "controller:reconciler",
+            "subjectMembership": "ResourceOrganization",
+            "scope": "*",
+            "roleRef": { "kind": "PlatformRole", "name": "everything" }
+        }),
+    );
+    // Positive: a root-scoped, non-Organization scope has no organization to
+    // compare the resolved subject against.
+    builder.binding(
+        PLATFORM_ROLE_BINDING,
+        "clamped-root-scope",
+        None,
+        json!({
+            "subject": "user:u-bob",
+            "subjectMembership": "ResourceOrganization",
+            "scope": "rise.dev/RuntimeClass/gpu",
+            "roleRef": { "kind": "PlatformRole", "name": "everything" }
+        }),
+    );
+    let store = builder.build();
+    let engine = engine(store, FakeMemberships::none());
+
+    let report = engine.audit(&every_org()).await.unwrap();
+    let mut no_op = category_names(&report.findings, FindingCategory::NoOpMembershipConstraint);
+    no_op.sort_unstable();
+    assert_eq!(no_op, vec!["clamped-controller", "clamped-root-scope"]);
+}
+
+#[tokio::test]
+async fn recipient_boundary_no_op_positive_and_negative() {
+    let mut builder = StoreBuilder::new();
+    let acme = builder.resource(ORGANIZATION, "acme", None);
+    builder.role(
+        ROLE,
+        "reader",
+        Some(acme),
+        json!([{ "effect": "Allow", "kinds": "*", "verbs": ["get"] }]),
+    );
+    builder.binding(
+        ROLE_BINDING,
+        "controller-subject",
+        Some(acme),
+        json!({
+            "subject": "controller:reconciler",
+            "scope": "rise.dev/Organization/acme",
+            "roleRef": { "kind": "Role", "name": "reader" }
+        }),
+    );
+    builder.binding(
+        ROLE_BINDING,
+        "unaffiliated-user",
+        Some(acme),
+        json!({
+            "subject": "user:u-bob",
+            "scope": "rise.dev/Organization/acme",
+            "roleRef": { "kind": "Role", "name": "reader" }
+        }),
+    );
+    builder.binding(
+        ROLE_BINDING,
+        "affiliated-user",
+        Some(acme),
+        json!({
+            "subject": "user:u-alice",
+            "scope": "rise.dev/Organization/acme",
+            "roleRef": { "kind": "Role", "name": "reader" }
+        }),
+    );
+    let store = builder.build();
+    let memberships =
+        FakeMemberships::none().with_user_groups("user:u-alice", &["group:acme/platform"]);
+    let engine = engine(store, memberships);
+
+    let report = engine.audit(&one_org("acme")).await.unwrap();
+    let flagged: Vec<(&str, Severity)> = report
+        .findings
+        .iter()
+        .filter(|finding| finding.category == FindingCategory::RecipientBoundaryNoOp)
+        .map(|finding| (finding.subject.name.as_str(), finding.severity))
+        .collect();
+    assert!(flagged.contains(&("controller-subject", Severity::Warning)));
+    assert!(flagged.contains(&("unaffiliated-user", Severity::Info)));
+    assert!(!flagged.iter().any(|(name, _)| *name == "affiliated-user"));
+}
+
+#[tokio::test]
+async fn organization_without_admin_positive_and_negative() {
+    let mut builder = StoreBuilder::new();
+    let no_admin = builder.resource(ORGANIZATION, "no-admin", None);
+    let _ = no_admin;
+    let direct_admin = builder.resource(ORGANIZATION, "direct-admin", None);
+    let group_admin = builder.resource(ORGANIZATION, "group-admin", None);
+    builder.role(PLATFORM_ROLE, ORG_ADMIN_PLATFORM_ROLE, None, allow_all());
+    builder.row(USER, "u-alice", None, BTreeMap::new(), user_spec(true));
+    builder.binding(
+        ROLE_BINDING,
+        "admin",
+        Some(direct_admin),
+        org_admin_binding("user:u-alice", "direct-admin"),
+    );
+    let leads = builder.resource(GROUP, "leads", Some(group_admin));
+    builder.row(USER, "u-carol", None, BTreeMap::new(), user_spec(true));
+    builder.row(
+        GROUP_MEMBERSHIP,
+        "u-carol",
+        Some(leads),
+        BTreeMap::new(),
+        json!({}),
+    );
+    builder.binding(
+        ROLE_BINDING,
+        "admin",
+        Some(group_admin),
+        org_admin_binding("group:group-admin/leads", "group-admin"),
+    );
+    let store = builder.build();
+    let engine = engine(store, FakeMemberships::none());
+
+    let report = engine.audit(&every_org()).await.unwrap();
+    let flagged = category_names(&report.findings, FindingCategory::OrganizationWithoutAdmin);
+    assert_eq!(flagged, vec!["no-admin"]);
+    assert_eq!(
+        report
+            .findings
+            .iter()
+            .find(|finding| finding.category == FindingCategory::OrganizationWithoutAdmin)
+            .unwrap()
+            .severity,
+        Severity::Warning
+    );
+}
+
+#[tokio::test]
+async fn non_qualifying_org_admin_reference_positive_and_negative() {
+    let mut builder = StoreBuilder::new();
+    let acme = builder.resource(ORGANIZATION, "acme", None);
+    builder.role(PLATFORM_ROLE, ORG_ADMIN_PLATFORM_ROLE, None, allow_all());
+    builder.row(USER, "u-alice", None, BTreeMap::new(), user_spec(true));
+    // Negative: exact org-root, scope-only.
+    builder.binding(
+        ROLE_BINDING,
+        "qualifying",
+        Some(acme),
+        org_admin_binding("user:u-alice", "acme"),
+    );
+    // Positive: label-selected, so it can never confer admin standing.
+    builder.binding(
+        ROLE_BINDING,
+        "selected",
+        Some(acme),
+        json!({
+            "subject": "group:acme/whatever",
+            "scope": "rise.dev/Organization/acme",
+            "labelSelector": { "key": "rise.dev/squad", "value": "platform" },
+            "roleRef": { "kind": "PlatformRole", "name": ORG_ADMIN_PLATFORM_ROLE }
+        }),
+    );
+    // Positive: reached through a `PlatformRoleBinding`, which never confers
+    // admin standing regardless of scope.
+    builder.binding(
+        PLATFORM_ROLE_BINDING,
+        "platform-wide",
+        None,
+        json!({
+            "subject": "system:authenticated",
+            "subjectMembership": "Any",
+            "scope": "rise.dev/Organization/acme",
+            "roleRef": { "kind": "PlatformRole", "name": ORG_ADMIN_PLATFORM_ROLE }
+        }),
+    );
+    let store = builder.build();
+    let engine = engine(store, FakeMemberships::none());
+
+    let report = engine.audit(&every_org()).await.unwrap();
+    let mut flagged = category_names(
+        &report.findings,
+        FindingCategory::NonQualifyingOrgAdminReference,
+    );
+    flagged.sort_unstable();
+    assert_eq!(flagged, vec!["platform-wide", "selected"]);
+}
+
+#[tokio::test]
+async fn max_findings_truncates_and_sets_truncated() {
+    let mut builder = StoreBuilder::new();
+    let acme = builder.resource(ORGANIZATION, "acme", None);
+    for i in 0..5 {
+        builder.binding(
+            ROLE_BINDING,
+            &format!("dangling-{i}"),
+            Some(acme),
+            json!({
+                "subject": "user:u-alice",
+                "scope": "rise.dev/Organization/acme",
+                "roleRef": { "kind": "Role", "name": "role-that-does-not-exist" }
+            }),
+        );
+    }
+    let store = builder.build();
+    let engine = engine(store, FakeMemberships::none());
+
+    let capped = engine
+        .audit(&AuditScope {
+            organization: Some("acme".to_owned()),
+            max_findings: 2,
+        })
+        .await
+        .unwrap();
+    assert_eq!(capped.findings.len(), 2);
+    assert!(capped.truncated);
+
+    let full = engine.audit(&one_org("acme")).await.unwrap();
+    assert!(full.findings.len() > 2, "{:#?}", full.findings);
+    assert!(!full.truncated);
+}

--- a/crates/rise-authz/tests/engine.rs
+++ b/crates/rise-authz/tests/engine.rs
@@ -1337,6 +1337,15 @@ async fn tombstoned_bindings_and_dangling_role_refs_contribute_nothing() {
         policy.contributions().is_empty(),
         "a dangling reference resolves to no statements rather than an error"
     );
+    assert_eq!(
+        policy.inert_bindings().len(),
+        1,
+        "only the live, dangling binding is reported; the tombstoned one is never loaded"
+    );
+    assert_eq!(
+        policy.inert_bindings()[0].reason,
+        InertReason::DanglingRoleRef
+    );
 }
 
 #[tokio::test]

--- a/crates/rise-authz/tests/support/mod.rs
+++ b/crates/rise-authz/tests/support/mod.rs
@@ -19,8 +19,8 @@ use rise_authz::engine::{
 };
 use rise_resource_api::{
     CollectionInfo, CreateResourceParams, DeleteOutcome, DeletionBlockerReport, NoOpValidator,
-    PathSegment, ResourceApi, ResourceParentRef, ResourceRow, ResourceStore, StoreError, SubjectId,
-    UpdateResourceParams, API_VERSION_V1ALPHA1,
+    PathSegment, PathWalk, ResourceApi, ResourceParentRef, ResourceRow, ResourceStore, StoreError,
+    SubjectId, UpdateResourceParams, API_VERSION_V1ALPHA1,
 };
 use uuid::Uuid;
 
@@ -311,36 +311,22 @@ impl ResourceStore for FakeStore {
     async fn list_deletion_blockers(&self, _: Uuid) -> Result<DeletionBlockerReport, StoreError> {
         unimplemented!("unused by the engine")
     }
-    /// Mirrors the Postgres store's per-segment walk: each segment is matched
-    /// by kind, name, and the previous segment's UID as parent. Tombstoned
-    /// rows are returned rather than skipped, exactly like the real store —
-    /// interpreting them is the caller's job.
     async fn resolve_path(&self, segments: &[PathSegment]) -> Result<Vec<ResourceRow>, StoreError> {
-        if segments.is_empty() {
-            return Err(StoreError::EmptyPath);
-        }
-        let mut chain = Vec::with_capacity(segments.len());
-        let mut parent_uid: Option<Uuid> = None;
-        for (idx, segment) in segments.iter().enumerate() {
+        let mut walk = PathWalk::new(segments)?;
+        while let Some((segment, parent)) = walk.pending() {
             let row = match segment {
-                PathSegment::Name { kind, name, .. } => self.rows.iter().find(|row| {
-                    row.kind == *kind && row.name == *name && row.parent_uid == parent_uid
-                }),
-                PathSegment::Uid { kind, uid, .. } => self.rows.iter().find(|row| {
-                    row.uid == *uid && row.kind == *kind && row.parent_uid == parent_uid
-                }),
+                PathSegment::Name { kind, name, .. } => self
+                    .rows
+                    .iter()
+                    .find(|row| row.kind == *kind && row.name == *name && row.parent_uid == parent)
+                    .cloned(),
+                PathSegment::Uid { uid, .. } => {
+                    self.rows.iter().find(|row| row.uid == *uid).cloned()
+                }
             };
-            let Some(row) = row else {
-                return Err(if idx + 1 == segments.len() {
-                    StoreError::NotFound
-                } else {
-                    StoreError::ParentNotFound
-                });
-            };
-            parent_uid = Some(row.uid);
-            chain.push(row.clone());
+            walk.advance(row)?;
         }
-        Ok(chain)
+        Ok(walk.finish())
     }
     async fn operator_update_status(
         &self,

--- a/crates/rise-authz/tests/support/mod.rs
+++ b/crates/rise-authz/tests/support/mod.rs
@@ -311,8 +311,36 @@ impl ResourceStore for FakeStore {
     async fn list_deletion_blockers(&self, _: Uuid) -> Result<DeletionBlockerReport, StoreError> {
         unimplemented!("unused by the engine")
     }
-    async fn resolve_path(&self, _: &[PathSegment]) -> Result<Vec<ResourceRow>, StoreError> {
-        unimplemented!("unused by the engine")
+    /// Mirrors the Postgres store's per-segment walk: each segment is matched
+    /// by kind, name, and the previous segment's UID as parent. Tombstoned
+    /// rows are returned rather than skipped, exactly like the real store —
+    /// interpreting them is the caller's job.
+    async fn resolve_path(&self, segments: &[PathSegment]) -> Result<Vec<ResourceRow>, StoreError> {
+        if segments.is_empty() {
+            return Err(StoreError::EmptyPath);
+        }
+        let mut chain = Vec::with_capacity(segments.len());
+        let mut parent_uid: Option<Uuid> = None;
+        for (idx, segment) in segments.iter().enumerate() {
+            let row = match segment {
+                PathSegment::Name { kind, name, .. } => self.rows.iter().find(|row| {
+                    row.kind == *kind && row.name == *name && row.parent_uid == parent_uid
+                }),
+                PathSegment::Uid { kind, uid, .. } => self.rows.iter().find(|row| {
+                    row.uid == *uid && row.kind == *kind && row.parent_uid == parent_uid
+                }),
+            };
+            let Some(row) = row else {
+                return Err(if idx + 1 == segments.len() {
+                    StoreError::NotFound
+                } else {
+                    StoreError::ParentNotFound
+                });
+            };
+            parent_uid = Some(row.uid);
+            chain.push(row.clone());
+        }
+        Ok(chain)
     }
     async fn operator_update_status(
         &self,

--- a/crates/rise-resource-api/src/lib.rs
+++ b/crates/rise-resource-api/src/lib.rs
@@ -38,9 +38,9 @@ pub use resource_row::ResourceRow;
 pub use scope::Scope;
 pub use store::{
     CollectionInfo, CreateResourceParams, DeleteOutcome, DeletionBlocker,
-    DeletionBlockerRelationship, DeletionBlockerReport, NoOpValidator, PathSegment, ResourceApi,
-    ResourceStore, SpecValidator, StoreError, UpdateResourceParams, CASCADE_DELETION_FINALIZER,
-    MAX_PARENT_CHAIN_DEPTH, SYSTEM_FINALIZER_PREFIX,
+    DeletionBlockerRelationship, DeletionBlockerReport, NoOpValidator, PathSegment, PathWalk,
+    ResourceApi, ResourceStore, SpecValidator, StoreError, UpdateResourceParams,
+    CASCADE_DELETION_FINALIZER, MAX_PARENT_CHAIN_DEPTH, SYSTEM_FINALIZER_PREFIX,
 };
 pub use subject_id::SubjectId;
 pub use subject_ref::SubjectRef;

--- a/crates/rise-resource-api/src/store.rs
+++ b/crates/rise-resource-api/src/store.rs
@@ -170,6 +170,112 @@ pub enum PathSegment {
     },
 }
 
+/// The store-independent half of [`ResourceStore::resolve_path`].
+///
+/// Resolving a path is one lookup per segment plus the rules that turn those
+/// lookups into a chain, and only the lookup is store-specific. This walk owns
+/// the rules, so every implementation agrees on them by construction:
+///
+/// - the first segment resolves under the root (`parent` is `None`), each
+///   later one under the row the previous segment produced;
+/// - a `Name` segment is looked up by kind, name, and that parent;
+/// - a `Uid` segment is looked up by UID alone, then verified against the
+///   expected kind and API versions ([`StoreError::KindMismatch`]) and against
+///   the walk's current parent ([`StoreError::ParentNotFound`]), so a UID
+///   from another subtree cannot be spliced into a path;
+/// - a missing leaf is [`StoreError::NotFound`], a missing ancestor is
+///   [`StoreError::ParentNotFound`], and no segments at all is
+///   [`StoreError::EmptyPath`].
+///
+/// A store drives it as a loop: ask [`PathWalk::pending`] what to look up,
+/// fetch that one row however it likes, and hand the answer to
+/// [`PathWalk::advance`]. Tombstoned rows pass through like any other;
+/// interpreting a deletion timestamp is the caller's job.
+///
+/// ```
+/// # use rise_resource_api::{PathSegment, PathWalk, ResourceRow, StoreError};
+/// # fn fetch(_: &PathSegment, _: Option<uuid::Uuid>) -> Option<ResourceRow> { None }
+/// # fn resolve(segments: &[PathSegment]) -> Result<Vec<ResourceRow>, StoreError> {
+/// let mut walk = PathWalk::new(segments)?;
+/// while let Some((segment, parent)) = walk.pending() {
+///     let row = fetch(segment, parent);
+///     walk.advance(row)?;
+/// }
+/// Ok(walk.finish())
+/// # }
+/// ```
+#[derive(Debug)]
+pub struct PathWalk<'a> {
+    segments: &'a [PathSegment],
+    chain: Vec<ResourceRow>,
+}
+
+impl<'a> PathWalk<'a> {
+    /// Start a walk. An empty path is refused here, before any lookup.
+    pub fn new(segments: &'a [PathSegment]) -> Result<Self, StoreError> {
+        if segments.is_empty() {
+            return Err(StoreError::EmptyPath);
+        }
+        Ok(Self {
+            segments,
+            chain: Vec::with_capacity(segments.len()),
+        })
+    }
+
+    /// The parent the next lookup runs under: the last resolved row, or the
+    /// root before the first.
+    fn parent(&self) -> Option<Uuid> {
+        self.chain.last().map(|row| row.uid)
+    }
+
+    /// The next segment to look up and the parent to look it up under, or
+    /// `None` once every segment has resolved.
+    pub fn pending(&self) -> Option<(&'a PathSegment, Option<Uuid>)> {
+        self.segments
+            .get(self.chain.len())
+            .map(|segment| (segment, self.parent()))
+    }
+
+    /// Record the answer to the pending lookup, applying the chain rules.
+    ///
+    /// Calling this with nothing pending is a caller bug and panics, the same
+    /// way indexing past the end would.
+    pub fn advance(&mut self, row: Option<ResourceRow>) -> Result<(), StoreError> {
+        let (segment, parent) = self
+            .pending()
+            .expect("advance called after every segment resolved");
+        let Some(row) = row else {
+            return Err(if self.chain.len() + 1 == self.segments.len() {
+                StoreError::NotFound
+            } else {
+                StoreError::ParentNotFound
+            });
+        };
+        if let PathSegment::Uid {
+            api_versions, kind, ..
+        } = segment
+        {
+            if row.kind != *kind || !api_versions.contains(&row.api_version) {
+                return Err(StoreError::KindMismatch {
+                    expected: format!("kind {kind} in one of {api_versions:?}"),
+                    got: format!("{}/{}", row.api_version, row.kind),
+                });
+            }
+            if row.parent_uid != parent {
+                return Err(StoreError::ParentNotFound);
+            }
+        }
+        self.chain.push(row);
+        Ok(())
+    }
+
+    /// The resolved chain, root-first. Meaningful once [`Self::pending`] is
+    /// `None`; a walk abandoned early returns what it resolved so far.
+    pub fn finish(self) -> Vec<ResourceRow> {
+        self.chain
+    }
+}
+
 pub enum DeleteOutcome {
     Deleted,
     MarkedForDeletion(Box<ResourceRow>),
@@ -415,4 +521,131 @@ pub trait ResourceStore: ResourceApi {
         uid: Uuid,
         params: UpdateResourceParams,
     ) -> Result<ResourceRow, StoreError>;
+}
+
+#[cfg(test)]
+mod path_walk_tests {
+    use super::*;
+
+    fn row(kind: &str, name: &str, parent_uid: Option<Uuid>) -> ResourceRow {
+        let now = Utc::now();
+        ResourceRow {
+            uid: Uuid::new_v4(),
+            api_version: "rise.dev/v1alpha1".to_owned(),
+            kind: kind.to_owned(),
+            parent_uid,
+            name: name.to_owned(),
+            discriminator: String::new(),
+            labels: BTreeMap::new(),
+            metadata: serde_json::json!({}),
+            spec: serde_json::json!({}),
+            status: serde_json::json!({}),
+            revision: 1,
+            finalizers: Vec::new(),
+            owner_references: Vec::new(),
+            deletion_timestamp: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn name(kind: &str, name: &str) -> PathSegment {
+        PathSegment::Name {
+            api_versions: vec!["rise.dev/v1alpha1".to_owned()],
+            kind: kind.to_owned(),
+            name: name.to_owned(),
+        }
+    }
+
+    fn uid(kind: &str, uid: Uuid) -> PathSegment {
+        PathSegment::Uid {
+            api_versions: vec!["rise.dev/v1alpha1".to_owned()],
+            kind: kind.to_owned(),
+            uid,
+        }
+    }
+
+    /// The one lookup every store supplies, over an in-memory table.
+    fn walk(
+        rows: &[ResourceRow],
+        segments: &[PathSegment],
+    ) -> Result<Vec<ResourceRow>, StoreError> {
+        let mut walk = PathWalk::new(segments)?;
+        while let Some((segment, parent)) = walk.pending() {
+            let row = match segment {
+                PathSegment::Name { kind, name, .. } => rows
+                    .iter()
+                    .find(|row| row.kind == *kind && row.name == *name && row.parent_uid == parent)
+                    .cloned(),
+                PathSegment::Uid { uid, .. } => rows.iter().find(|row| row.uid == *uid).cloned(),
+            };
+            walk.advance(row)?;
+        }
+        Ok(walk.finish())
+    }
+
+    #[test]
+    fn walks_names_root_first() {
+        let org = row("Organization", "acme", None);
+        let project = row("Project", "app", Some(org.uid));
+        let rows = vec![org.clone(), project.clone()];
+        let chain = walk(
+            &rows,
+            &[name("Organization", "acme"), name("Project", "app")],
+        )
+        .unwrap();
+        assert_eq!(
+            chain.iter().map(|row| row.uid).collect::<Vec<_>>(),
+            vec![org.uid, project.uid]
+        );
+    }
+
+    #[test]
+    fn a_missing_leaf_and_a_missing_ancestor_are_told_apart() {
+        let org = row("Organization", "acme", None);
+        let rows = vec![org];
+        assert!(matches!(
+            walk(
+                &rows,
+                &[name("Organization", "acme"), name("Project", "nope")]
+            ),
+            Err(StoreError::NotFound)
+        ));
+        assert!(matches!(
+            walk(
+                &rows,
+                &[name("Organization", "nope"), name("Project", "app")]
+            ),
+            Err(StoreError::ParentNotFound)
+        ));
+        assert!(matches!(walk(&rows, &[]), Err(StoreError::EmptyPath)));
+    }
+
+    #[test]
+    fn a_uid_segment_is_checked_against_kind_and_parent() {
+        let acme = row("Organization", "acme", None);
+        let beta = row("Organization", "beta", None);
+        let project = row("Project", "app", Some(acme.uid));
+        let rows = vec![acme.clone(), beta.clone(), project.clone()];
+
+        let chain = walk(&rows, &[uid("Organization", acme.uid)]).unwrap();
+        assert_eq!(chain[0].uid, acme.uid);
+
+        assert!(matches!(
+            walk(&rows, &[uid("Project", acme.uid)]),
+            Err(StoreError::KindMismatch { .. })
+        ));
+        // A real UID from another subtree cannot be spliced under a different parent.
+        assert!(matches!(
+            walk(
+                &rows,
+                &[name("Organization", "beta"), uid("Project", project.uid)]
+            ),
+            Err(StoreError::ParentNotFound)
+        ));
+        assert!(matches!(
+            walk(&rows, &[uid("Organization", Uuid::new_v4())]),
+            Err(StoreError::NotFound)
+        ));
+    }
 }

--- a/crates/rise-resource-store-postgres/src/pg_store.rs
+++ b/crates/rise-resource-store-postgres/src/pg_store.rs
@@ -6,9 +6,10 @@ use rise_resource_api::{
     is_immutable_policy_seed, validate_controller_id, validate_labels, validate_resource_name,
     CollectionInfo, CreateResourceParams, DeleteOutcome, DeletionBlocker,
     DeletionBlockerRelationship, DeletionBlockerReport, NoOpValidator, OwnerReference, PathSegment,
-    ResourceApi, ResourceDefinitionSpec, ResourceKind, ResourceRow, ResourceStore, SpecValidator,
-    StoreError, UpdateResourceParams, API_VERSION_V1ALPHA1, CASCADE_DELETION_FINALIZER,
-    MAX_PARENT_CHAIN_DEPTH, ORGANIZATION_KIND, RESOURCE_DEFINITION_KIND, SYSTEM_FINALIZER_PREFIX,
+    PathWalk, ResourceApi, ResourceDefinitionSpec, ResourceKind, ResourceRow, ResourceStore,
+    SpecValidator, StoreError, UpdateResourceParams, API_VERSION_V1ALPHA1,
+    CASCADE_DELETION_FINALIZER, MAX_PARENT_CHAIN_DEPTH, ORGANIZATION_KIND,
+    RESOURCE_DEFINITION_KIND, SYSTEM_FINALIZER_PREFIX,
 };
 use sqlx::{PgPool, Row};
 
@@ -1901,86 +1902,54 @@ impl ResourceStore for PgResourceStore {
     }
 
     async fn resolve_path(&self, segments: &[PathSegment]) -> Result<Vec<ResourceRow>, StoreError> {
-        if segments.is_empty() {
-            return Err(StoreError::EmptyPath);
-        }
-
+        // `PathWalk` owns the chain rules — root parent first, kind and
+        // parent checks on a `uid:` segment, leaf versus ancestor misses.
+        // This store only answers one row per segment, inside one
+        // transaction so the chain is read from a single snapshot.
+        let mut walk = PathWalk::new(segments)?;
         let mut connection = self.connection().await?;
         let mut tx = connection.begin().await.map_err(Self::db_error)?;
-        let mut chain: Vec<ResourceRow> = Vec::with_capacity(segments.len());
-        let mut current_parent: Option<Uuid> = None;
-
-        for (idx, segment) in segments.iter().enumerate() {
-            let row = match segment {
+        while let Some((segment, parent)) = walk.pending() {
+            let row: Option<PgResourceRow> = match segment {
                 PathSegment::Name {
                     api_versions,
                     kind,
                     name,
-                } => {
-                    let row: Option<PgResourceRow> = match current_parent {
-                        None => sqlx::query_as::<_, PgResourceRow>(
-                            "SELECT * FROM resource_store.resources WHERE api_version = ANY($1) AND kind = $2 AND name = $3 AND parent_uid IS NULL",
-                        )
-                        .bind(api_versions)
-                        .bind(kind)
-                        .bind(name)
-                        .fetch_optional(&mut *tx)
-                        .await
-                        .map_err(Self::db_error)?,
-                        Some(pid) => sqlx::query_as::<_, PgResourceRow>(
-                            "SELECT * FROM resource_store.resources WHERE api_version = ANY($1) AND kind = $2 AND name = $3 AND parent_uid = $4",
-                        )
-                        .bind(api_versions)
-                        .bind(kind)
-                        .bind(name)
-                        .bind(pid)
-                        .fetch_optional(&mut *tx)
-                        .await
-                        .map_err(Self::db_error)?,
-                    };
-                    match row {
-                        Some(r) => r,
-                        None if idx + 1 == segments.len() => return Err(StoreError::NotFound),
-                        None => return Err(StoreError::ParentNotFound),
-                    }
-                }
-                PathSegment::Uid {
-                    api_versions,
-                    kind,
-                    uid,
-                } => {
-                    let row: PgResourceRow = match sqlx::query_as::<_, PgResourceRow>(
+                } => match parent {
+                    None => sqlx::query_as::<_, PgResourceRow>(
+                        "SELECT * FROM resource_store.resources WHERE api_version = ANY($1) AND kind = $2 AND name = $3 AND parent_uid IS NULL",
+                    )
+                    .bind(api_versions)
+                    .bind(kind)
+                    .bind(name)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .map_err(Self::db_error)?,
+                    Some(parent) => sqlx::query_as::<_, PgResourceRow>(
+                        "SELECT * FROM resource_store.resources WHERE api_version = ANY($1) AND kind = $2 AND name = $3 AND parent_uid = $4",
+                    )
+                    .bind(api_versions)
+                    .bind(kind)
+                    .bind(name)
+                    .bind(parent)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .map_err(Self::db_error)?,
+                },
+                PathSegment::Uid { uid, .. } => {
+                    sqlx::query_as::<_, PgResourceRow>(
                         "SELECT * FROM resource_store.resources WHERE uid = $1",
                     )
                     .bind(uid)
                     .fetch_optional(&mut *tx)
                     .await
                     .map_err(Self::db_error)?
-                    {
-                        Some(r) => r,
-                        None if idx + 1 == segments.len() => return Err(StoreError::NotFound),
-                        None => return Err(StoreError::ParentNotFound),
-                    };
-                    if row.kind != *kind || !api_versions.iter().any(|v| v == &row.api_version) {
-                        return Err(StoreError::KindMismatch {
-                            expected: format!("kind {kind} in one of {api_versions:?}"),
-                            got: format!("{}/{}", row.api_version, row.kind),
-                        });
-                    }
-                    if row.parent_uid != current_parent {
-                        // UID is from a different subtree.
-                        return Err(StoreError::ParentNotFound);
-                    }
-                    row
                 }
             };
-
-            current_parent = Some(row.uid);
-            chain.push(row.into());
+            walk.advance(row.map(Into::into))?;
         }
-
         tx.commit().await.map_err(Self::db_error)?;
-        Ok(chain)
+        Ok(walk.finish())
     }
 
     async fn operator_update_status(


### PR DESCRIPTION
First of a five-PR stack implementing the ROADMAP §1 "Role/policy audit and explain diagnostics" item and closing the atomic Organization bootstrap gap. Stack order: this PR → `-2` (label-backed detectors) → `-3` (shadowed Allows) → `-4` (HTTP surface) → `-5` (Organization bootstrap).

## What

Adds `rise_authz::engine::audit`: a bounded, non-blocking diagnostics pass over the same binding facts the evaluator reads, per ADR-0001 §6.7 ("semantically inert policy is an auditing concern, not a write-time validity error"). Nothing in admission changes.

- `AuditScope` (one Organization or every live one, plus a finding cap), `AuditReport`, `AuditFinding { subject, category, severity, related, detail }`, `FindingCategory` with every category the stack emits, and `Severity { Info, Warning }` (currently-inert shapes are `Info`; permanently-inert or misleading ones are `Warning`).
- Detectors, one function per category so each is testable alone: `DanglingRoleRef`, `StaleSubject`, `StaleScope`, `StaleMembership`, `NoOpMembershipConstraint`, `RecipientBoundaryNoOp`, `OrganizationWithoutAdmin`, `NonQualifyingOrgAdminReference`.
- `AuthorizationEngine::audit(&AuditScope)`: loads each tier once, runs detectors in a fixed order, truncates at the cap.
- `RoleCache::resolve` now distinguishes a dangling `roleRef` (`None`) from a resolved Role with zero statements; `BindingFact` carries `role_resolved` and `BindingProvenance` carries the row's `name`. Evaluation behavior is unchanged, but `effective_policy` now records `InertReason::DanglingRoleRef` for a matched binding whose Role is gone, so explain output says why it contributed nothing.

## Verification

- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test -p rise-authz --all-features`: new `tests/audit.rs` (positive and negative case per detector, a healthy-install zero-findings case, and cap/truncation), plus the existing suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016orpm2Btwa7KmcnAzTNwKX

---
_Generated by [Claude Code](https://claude.ai/code/session_016orpm2Btwa7KmcnAzTNwKX)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rise-deploy/codesmith/rise/pr/498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791403549&installation_model_id=432987&pr_number=498&repository=rise-deploy%2Frise&return_to=https%3A%2F%2Fgithub.com%2Frise-deploy%2Frise%2Fpull%2F498&signature=da130c29e41e82ae444a176e1adfdcf0e1d6ddce429c28a57748c2f1f43e96d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->