### PR TITLE
authz: label-backed audit detectors and list_label_setters

### DIFF
--- a/crates/rise-authz/src/engine/audit.rs
+++ b/crates/rise-authz/src/engine/audit.rs
@@ -9,11 +9,14 @@
 //! thing [`AuthorizationEngine::audit`] adds is loading the binding facts
 //! once per tier and running them in a fixed order.
 
+use std::collections::BTreeMap;
+
 use rise_resource_api::{
-    PathSegment, ResourceRow, ResourceStore, RoleRefKind, StoreError, SubjectId, SubjectMembership,
-    UserSpec, API_GROUP, API_VERSION_V1ALPHA1, CONTROLLER_KIND, GROUP_KIND, GROUP_MEMBERSHIP_KIND,
-    MAX_PARENT_CHAIN_DEPTH, ORGANIZATION_KIND, ORG_ADMIN_PLATFORM_ROLE, SERVICE_ACCOUNT_KIND,
-    USER_KIND,
+    resource_owner_binding_spec, LabelKey, LabelSelector, PathSegment, ResourceRow, ResourceStore,
+    RoleRefKind, Scope, StoreError, SubjectId, SubjectMembership, UserSpec, API_GROUP,
+    API_VERSION_V1ALPHA1, CONTROLLER_KIND, GROUP_KIND, GROUP_MEMBERSHIP_KIND,
+    MAX_PARENT_CHAIN_DEPTH, ORGANIZATION_KIND, ORG_ADMIN_PLATFORM_ROLE, OWNER_LABEL_KEY,
+    SERVICE_ACCOUNT_KIND, USER_KIND,
 };
 use uuid::Uuid;
 
@@ -22,8 +25,9 @@ use crate::engine::bindings::{
 };
 use crate::engine::{
     qualifies_as_org_admin, AuthorizationEngine, AuthorizationError, MembershipResolver,
+    ResourceTree,
 };
-use crate::policy::BindingTier;
+use crate::policy::{resolve_subject, BindingTier};
 
 /// What to audit, and how much work to do.
 ///
@@ -171,6 +175,33 @@ impl AuthorizationEngine {
             scope.max_findings,
             detect_no_op_membership_constraint(&platform),
         );
+
+        // Every live `rise.dev/owner` setter, resolved to its own organization
+        // once so the per-organization loop below can filter without a second
+        // store round trip per row. Root-scoped setters (no organization) are
+        // only in scope when the whole install is being audited: a named-org
+        // scope can never contain one.
+        let owner_setters = owner_label_setters_by_organization(store).await?;
+        if scope.organization.is_none() {
+            let root_scoped: Vec<ResourceRow> = owner_setters
+                .iter()
+                .filter(|(_, organization)| organization.is_none())
+                .map(|(row, _)| row.clone())
+                .collect();
+            append_capped(
+                &mut findings,
+                &mut truncated,
+                scope.max_findings,
+                detect_inert_owner_label(store, memberships, None, &[], &root_scoped).await?,
+            );
+        }
+        append_capped(
+            &mut findings,
+            &mut truncated,
+            scope.max_findings,
+            detect_selector_matches_nothing(store, &platform).await?,
+        );
+
         append_capped(
             &mut findings,
             &mut truncated,
@@ -211,6 +242,32 @@ impl AuthorizationEngine {
                 scope.max_findings,
                 detect_recipient_boundary_no_op(memberships, &organization.name, &org_bindings)
                     .await?,
+            );
+            let org_setters: Vec<ResourceRow> = owner_setters
+                .iter()
+                .filter(|(_, setter_organization)| {
+                    setter_organization.as_deref() == Some(organization.name.as_str())
+                })
+                .map(|(row, _)| row.clone())
+                .collect();
+            append_capped(
+                &mut findings,
+                &mut truncated,
+                scope.max_findings,
+                detect_inert_owner_label(
+                    store,
+                    memberships,
+                    Some(&organization.name),
+                    &org_bindings,
+                    &org_setters,
+                )
+                .await?,
+            );
+            append_capped(
+                &mut findings,
+                &mut truncated,
+                scope.max_findings,
+                detect_selector_matches_nothing(store, &org_bindings).await?,
             );
             append_capped(
                 &mut findings,
@@ -704,6 +761,276 @@ async fn user_belongs_to_organization(
     Ok(org_bindings.iter().any(|candidate| {
         qualifies_as_org_admin(candidate, organization) && candidate.subject.literal() == Some(user)
     }))
+}
+
+// ---------------------------------------------------------------------------
+// Row 7: InertOwnerLabel
+// ---------------------------------------------------------------------------
+
+/// Every live `rise.dev/owner` setter in the store, paired with the
+/// organization its own ancestry resolves to (`None` for a root-scoped
+/// resource).
+///
+/// Resolved once regardless of [`AuditScope`]: `list_label_setters` has no
+/// per-organization form, so the audit reads it once and filters in memory
+/// rather than repeat the same bounded scan per organization in scope.
+async fn owner_label_setters_by_organization(
+    store: &dyn ResourceStore,
+) -> Result<Vec<(ResourceRow, Option<String>)>, AuthorizationError> {
+    let key: LabelKey = OWNER_LABEL_KEY
+        .parse()
+        .expect("shipped owner label key parses");
+    let setters = store
+        .list_label_setters(&key, LABEL_SETTER_SCAN_LIMIT)
+        .await?;
+    let mut resolved = Vec::with_capacity(setters.len());
+    for row in setters {
+        let ancestry = store.ancestors(row.uid).await?;
+        let organization = ResourceTree::from_rows(&ancestry)?
+            .organization()
+            .map(str::to_owned);
+        resolved.push((row, organization));
+    }
+    Ok(resolved)
+}
+
+/// A `rise.dev/owner` value that the seeded `${ref.subject}` ownership binding
+/// (ADR-0001 §6.2) cannot turn into a live grant.
+///
+/// Resolution mirrors exactly what the live binding does: parse the value as
+/// the seeded binding's dynamic subject against the resource's own
+/// organization. A value that fails to parse is always `Warning` — nothing
+/// about it self-heals. A Group or ServiceAccount it names is org-native, so a
+/// missing live row is also permanent and `Warning`. A User it names is only
+/// `Info`: the seeded binding's `ResourceOrganization` clamp means the grant is
+/// live exactly while that User is affiliated with the resource's
+/// organization, which can change without anyone touching the label.
+/// Root-scoped resources (no organization) are skipped for the User case only
+/// — the clamp has nothing to compare against there — but a malformed value on
+/// a root-scoped resource is still reported.
+pub async fn detect_inert_owner_label(
+    store: &dyn ResourceStore,
+    memberships: &dyn MembershipResolver,
+    organization: Option<&str>,
+    org_bindings: &[BindingFact],
+    setters: &[ResourceRow],
+) -> Result<Vec<AuditFinding>, AuthorizationError> {
+    let seeded_subject = resource_owner_binding_spec().subject;
+    let mut findings = Vec::new();
+    for row in setters {
+        let Some(value) = row.labels.get(OWNER_LABEL_KEY) else {
+            // Cannot happen for a row `list_label_setters(OWNER_LABEL_KEY, _)`
+            // returned, but a detector must not panic on a store's promise.
+            continue;
+        };
+        let subject = || FindingSubject {
+            uid: row.uid,
+            kind: row.kind.clone(),
+            name: row.name.clone(),
+            organization: organization.map(str::to_owned),
+        };
+
+        let resolved = match resolve_subject(&seeded_subject, Some(value.as_str()), organization) {
+            Ok(resolved) => resolved,
+            Err(_) => {
+                findings.push(AuditFinding {
+                    subject: subject(),
+                    category: FindingCategory::InertOwnerLabel,
+                    severity: Severity::Warning,
+                    related: Vec::new(),
+                    detail: format!(
+                        "label '{OWNER_LABEL_KEY}' is set to '{value}', which does not resolve to a valid subject; the seeded ownership binding grants nobody."
+                    ),
+                });
+                continue;
+            }
+        };
+
+        match resolved.kind() {
+            "group" | "serviceaccount" => {
+                let kind = if resolved.kind() == "group" {
+                    GROUP_KIND
+                } else {
+                    SERVICE_ACCOUNT_KIND
+                };
+                if stale_org_native(store, kind, &resolved).await? {
+                    findings.push(AuditFinding {
+                        subject: subject(),
+                        category: FindingCategory::InertOwnerLabel,
+                        severity: Severity::Warning,
+                        related: Vec::new(),
+                        detail: format!(
+                            "label '{OWNER_LABEL_KEY}' is set to '{value}', which resolves to '{resolved}'; that subject names no live resource, so ownership grants nobody."
+                        ),
+                    });
+                }
+            }
+            "user" => {
+                let Some(organization) = organization else {
+                    continue;
+                };
+                if user_belongs_to_organization(memberships, org_bindings, &resolved, organization)
+                    .await?
+                {
+                    continue;
+                }
+                findings.push(AuditFinding {
+                    subject: subject(),
+                    category: FindingCategory::InertOwnerLabel,
+                    severity: Severity::Info,
+                    related: Vec::new(),
+                    detail: format!(
+                        "label '{OWNER_LABEL_KEY}' is set to '{value}', naming subject '{resolved}', which has no live Group tie in Organization '{organization}' and is not a qualifying admin there; ownership currently grants nothing."
+                    ),
+                });
+            }
+            _ => {}
+        }
+    }
+    Ok(findings)
+}
+
+// ---------------------------------------------------------------------------
+// Row 8: SelectorMatchesNothing
+// ---------------------------------------------------------------------------
+
+/// How many live setters [`detect_selector_matches_nothing`] reads before
+/// giving up on proving a selector matches nothing. Also the bound
+/// [`owner_label_setters_by_organization`] applies to its single global scan.
+///
+/// Both detectors need this to stay exact rather than heuristic: reporting
+/// "matches nothing" past this point would risk a false positive on a large
+/// install, so a scan that hits the limit without a match is treated as
+/// unknown and produces no finding instead.
+const LABEL_SETTER_SCAN_LIMIT: i64 = 1000;
+
+/// A binding's `labelSelector` that no resource in its scope can ever satisfy.
+///
+/// Exact and cheap without a subtree walk: a non-wildcard scope is first
+/// checked through its own effective labels (nearest-wins inheritance already
+/// covers every resource that inherits, rather than sets, the key), and only a
+/// scope whose own root does not carry it falls back to
+/// [`ResourceStore::list_label_setters`] to look for a setter at or below that
+/// root. A wildcard scope has no root to check first, so only the setter scan
+/// applies.
+pub async fn detect_selector_matches_nothing(
+    store: &dyn ResourceStore,
+    bindings: &[BindingFact],
+) -> Result<Vec<AuditFinding>, AuthorizationError> {
+    let mut findings = Vec::new();
+    for binding in bindings {
+        let Some(selector) = &binding.selector else {
+            continue;
+        };
+        if selector_matches_something(store, &binding.scope, selector).await? != Some(false) {
+            continue;
+        }
+        let value_clause = match &selector.value {
+            Some(value) => format!("value '{value}'"),
+            None => "any value".to_owned(),
+        };
+        findings.push(AuditFinding {
+            subject: binding_subject(binding),
+            category: FindingCategory::SelectorMatchesNothing,
+            severity: Severity::Warning,
+            related: Vec::new(),
+            detail: format!(
+                "labelSelector key '{}' ({value_clause}) matches no resource in scope '{}'; the binding grants nothing.",
+                selector.key, binding.scope,
+            ),
+        });
+    }
+    Ok(findings)
+}
+
+/// `Some(true)`/`Some(false)` when whether `selector` matches anything in
+/// `scope` is decided; `None` when the scope does not resolve (row 3 already
+/// reports that separately) or the setter scan hit [`LABEL_SETTER_SCAN_LIMIT`]
+/// before a match turned up, leaving the true answer unknown.
+async fn selector_matches_something(
+    store: &dyn ResourceStore,
+    scope: &Scope,
+    selector: &LabelSelector,
+) -> Result<Option<bool>, AuthorizationError> {
+    let Some(resource_kind) = scope.resource_kind() else {
+        return matches_via_setters(store, selector, None).await;
+    };
+    let Some(chain) = kind_chain(store, resource_kind.group(), resource_kind.kind()).await? else {
+        // Unregistered kind: nothing to validate the scope against, matching
+        // `detect_stale_scope`'s own skip for the same shape.
+        return Ok(None);
+    };
+    let names: Vec<&str> = scope.names().collect();
+    if names.len() != chain.len() {
+        // Malformed scope: never this detector's concern either.
+        return Ok(None);
+    }
+    let segments: Vec<PathSegment> = chain
+        .into_iter()
+        .zip(names)
+        .map(|((kind, api_versions), name)| PathSegment::Name {
+            api_versions,
+            kind,
+            name: name.to_owned(),
+        })
+        .collect();
+    let root = match store.resolve_path(&segments).await {
+        Ok(rows) if rows.iter().any(|row| row.deletion_timestamp.is_some()) => return Ok(None),
+        Ok(rows) => rows
+            .into_iter()
+            .last()
+            .expect("a non-empty scope resolves to a leaf row"),
+        Err(StoreError::NotFound | StoreError::ParentNotFound) => return Ok(None),
+        Err(other) => return Err(other.into()),
+    };
+
+    let ancestry = store.ancestors(root.uid).await?;
+    let effective = ResourceTree::from_rows(&ancestry)?.effective_labels();
+    if selector_matches_labels(&effective, selector) {
+        return Ok(Some(true));
+    }
+    matches_via_setters(store, selector, Some(root.uid)).await
+}
+
+/// Whether some live resource that sets `selector.key` (and `selector.value`,
+/// when given) lies at or below `scope_root` — or anywhere, for a wildcard
+/// scope's `None`.
+async fn matches_via_setters(
+    store: &dyn ResourceStore,
+    selector: &LabelSelector,
+    scope_root: Option<Uuid>,
+) -> Result<Option<bool>, AuthorizationError> {
+    let setters = store
+        .list_label_setters(&selector.key, LABEL_SETTER_SCAN_LIMIT)
+        .await?;
+    let exhausted = setters.len() as i64 == LABEL_SETTER_SCAN_LIMIT;
+    for setter in &setters {
+        if !selector_matches_labels(&setter.labels, selector) {
+            continue;
+        }
+        let in_scope = match scope_root {
+            None => true,
+            Some(root_uid) => store
+                .ancestors(setter.uid)
+                .await?
+                .iter()
+                .any(|ancestor| ancestor.uid == root_uid),
+        };
+        if in_scope {
+            return Ok(Some(true));
+        }
+    }
+    Ok(if exhausted { None } else { Some(false) })
+}
+
+fn selector_matches_labels(labels: &BTreeMap<String, String>, selector: &LabelSelector) -> bool {
+    match labels.get(selector.key.as_ref()) {
+        Some(value) => selector
+            .value
+            .as_deref()
+            .is_none_or(|expected| expected == value),
+        None => false,
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rise-authz/src/engine/audit.rs
+++ b/crates/rise-authz/src/engine/audit.rs
@@ -929,13 +929,23 @@ pub async fn detect_selector_matches_nothing(
             Some(value) => format!("value '{value}'"),
             None => "any value".to_owned(),
         };
+        // A dynamic-subject binding exists to wait for labels: the seeded
+        // `resource-owner` binding matches nothing on a fresh install by
+        // design, and starts mattering the moment a resource is labelled. A
+        // literal subject selecting on a key nobody sets is the shape worth a
+        // warning.
+        let severity = if binding.subject.is_dynamic() {
+            Severity::Info
+        } else {
+            Severity::Warning
+        };
         findings.push(AuditFinding {
             subject: binding_subject(binding),
             category: FindingCategory::SelectorMatchesNothing,
-            severity: Severity::Warning,
+            severity,
             related: Vec::new(),
             detail: format!(
-                "labelSelector key '{}' ({value_clause}) matches no resource in scope '{}'; the binding grants nothing.",
+                "labelSelector key '{}' ({value_clause}) matches no resource in scope '{}'; the binding currently grants nothing.",
                 selector.key, binding.scope,
             ),
         });

--- a/crates/rise-authz/tests/audit.rs
+++ b/crates/rise-authz/tests/audit.rs
@@ -367,6 +367,196 @@ async fn recipient_boundary_no_op_positive_and_negative() {
 }
 
 #[tokio::test]
+async fn inert_owner_label_positive_and_negative() {
+    let mut builder = StoreBuilder::new();
+    let acme = builder.resource(ORGANIZATION, "acme", None);
+    // A Group named `leads` exists, but under a *different* organization. The
+    // seeded template always substitutes the resource's own organization when
+    // resolving a relative `group:` value, so `group:leads` set on a resource
+    // in `acme` can never reach it.
+    let other_org = builder.resource(ORGANIZATION, "other-org", None);
+    let _foreign_leads = builder.resource(GROUP, "leads", Some(other_org));
+
+    builder.row(USER, "u-alice", None, BTreeMap::new(), user_spec(true));
+    builder.row(USER, "u-bob", None, BTreeMap::new(), user_spec(true));
+
+    builder.labeled(
+        PROJECT,
+        "malformed",
+        Some(acme),
+        &[("rise.dev/owner", "not-a-subject")],
+    );
+    builder.labeled(
+        PROJECT,
+        "foreign-group",
+        Some(acme),
+        &[("rise.dev/owner", "group:leads")],
+    );
+    builder.labeled(
+        PROJECT,
+        "unaffiliated",
+        Some(acme),
+        &[("rise.dev/owner", "user:u-bob")],
+    );
+    builder.labeled(
+        PROJECT,
+        "affiliated",
+        Some(acme),
+        &[("rise.dev/owner", "user:u-alice")],
+    );
+
+    let store = builder.build();
+    let memberships =
+        FakeMemberships::none().with_user_groups("user:u-alice", &["group:acme/platform"]);
+    let engine = engine(store, memberships);
+
+    let report = engine.audit(&one_org("acme")).await.unwrap();
+    let flagged: Vec<(&str, Severity)> = report
+        .findings
+        .iter()
+        .filter(|finding| finding.category == FindingCategory::InertOwnerLabel)
+        .map(|finding| (finding.subject.name.as_str(), finding.severity))
+        .collect();
+    assert!(flagged.contains(&("malformed", Severity::Warning)));
+    assert!(flagged.contains(&("foreign-group", Severity::Warning)));
+    assert!(flagged.contains(&("unaffiliated", Severity::Info)));
+    assert!(
+        !flagged.iter().any(|(name, _)| *name == "affiliated"),
+        "{flagged:#?}"
+    );
+    assert_eq!(flagged.len(), 3, "{flagged:#?}");
+}
+
+#[tokio::test]
+async fn selector_matches_nothing_positive_and_negative() {
+    fn selector_binding(
+        scope: &str,
+        role: &str,
+        key: &str,
+        value: Option<&str>,
+    ) -> serde_json::Value {
+        let mut label_selector = json!({ "key": key });
+        if let Some(value) = value {
+            label_selector["value"] = json!(value);
+        }
+        json!({
+            "subject": "user:u-alice",
+            "scope": scope,
+            "roleRef": { "kind": "Role", "name": role },
+            "labelSelector": label_selector
+        })
+    }
+
+    let mut builder = StoreBuilder::new();
+    // The Organization itself sets one key (ancestor-match) and one more
+    // (wildcard-match).
+    let acme = builder.labeled(
+        ORGANIZATION,
+        "acme",
+        None,
+        &[("rise.dev/team", "x"), ("rise.dev/anything", "v")],
+    );
+    builder.role(
+        ROLE,
+        "reader",
+        Some(acme),
+        json!([{ "effect": "Allow", "kinds": "*", "verbs": ["get"] }]),
+    );
+    builder.role(PLATFORM_ROLE, "everything", None, allow_all());
+
+    // Scenario A: the key is set on an ancestor of the scope root (the
+    // Organization), so nearest-wins inheritance answers it directly.
+    let app = builder.resource(PROJECT, "app", Some(acme));
+    builder.binding(
+        ROLE_BINDING,
+        "ancestor-match",
+        Some(acme),
+        selector_binding("rise.dev/Project/acme/app", "reader", "rise.dev/team", None),
+    );
+    let _ = app;
+
+    // Scenario B: the key is set on a descendant *inside* the scope, which the
+    // root's own effective labels do not carry, so the setter scan finds it.
+    let app2 = builder.resource(PROJECT, "app2", Some(acme));
+    builder.labeled(
+        "Environment",
+        "prod",
+        Some(app2),
+        &[("rise.dev/stage", "beta")],
+    );
+    builder.binding(
+        ROLE_BINDING,
+        "descendant-match",
+        Some(acme),
+        selector_binding(
+            "rise.dev/Project/acme/app2",
+            "reader",
+            "rise.dev/stage",
+            Some("beta"),
+        ),
+    );
+
+    // Scenario C: the only setter of the key lies outside the binding's scope
+    // (a sibling Project, not a descendant of the scope root).
+    let app3 = builder.resource(PROJECT, "app3", Some(acme));
+    builder.labeled(PROJECT, "far", Some(acme), &[("rise.dev/region", "us")]);
+    builder.binding(
+        ROLE_BINDING,
+        "outside-scope",
+        Some(acme),
+        selector_binding(
+            "rise.dev/Project/acme/app3",
+            "reader",
+            "rise.dev/region",
+            Some("us"),
+        ),
+    );
+    let _ = app3;
+
+    // Scenario D: the scope root sets the key, but with a different value than
+    // the selector requires.
+    let _app4 = builder.labeled(PROJECT, "app4", Some(acme), &[("rise.dev/env", "staging")]);
+    builder.binding(
+        ROLE_BINDING,
+        "value-mismatch",
+        Some(acme),
+        selector_binding(
+            "rise.dev/Project/acme/app4",
+            "reader",
+            "rise.dev/env",
+            Some("production"),
+        ),
+    );
+
+    // Scenario E: a wildcard-scoped binding, matched by a setter anywhere.
+    builder.binding(
+        PLATFORM_ROLE_BINDING,
+        "wildcard-match",
+        None,
+        json!({
+            "subject": "system:authenticated",
+            "subjectMembership": "Any",
+            "scope": "*",
+            "labelSelector": { "key": "rise.dev/anything" },
+            "roleRef": { "kind": "PlatformRole", "name": "everything" }
+        }),
+    );
+
+    let store = builder.build();
+    let engine = engine(store, FakeMemberships::none());
+
+    let report = engine.audit(&every_org()).await.unwrap();
+    let mut flagged = category_names(&report.findings, FindingCategory::SelectorMatchesNothing);
+    flagged.sort_unstable();
+    assert_eq!(
+        flagged,
+        vec!["outside-scope", "value-mismatch"],
+        "{:#?}",
+        report.findings
+    );
+}
+
+#[tokio::test]
 async fn organization_without_admin_positive_and_negative() {
     let mut builder = StoreBuilder::new();
     let no_admin = builder.resource(ORGANIZATION, "no-admin", None);

--- a/crates/rise-authz/tests/audit.rs
+++ b/crates/rise-authz/tests/audit.rs
@@ -542,6 +542,22 @@ async fn selector_matches_nothing_positive_and_negative() {
         }),
     );
 
+    // Scenario F: a dynamic-subject binding selecting on a key nobody sets.
+    // The seeded ownership binding has exactly this shape on a fresh install,
+    // so it is reported at `Info`, not `Warning`.
+    builder.binding(
+        PLATFORM_ROLE_BINDING,
+        "template-unmatched",
+        None,
+        json!({
+            "subject": "${ref.subject}",
+            "subjectMembership": "ResourceOrganization",
+            "scope": "*",
+            "labelSelector": { "key": "rise.dev/owner" },
+            "roleRef": { "kind": "PlatformRole", "name": "everything" }
+        }),
+    );
+
     let store = builder.build();
     let engine = engine(store, FakeMemberships::none());
 
@@ -550,10 +566,23 @@ async fn selector_matches_nothing_positive_and_negative() {
     flagged.sort_unstable();
     assert_eq!(
         flagged,
-        vec!["outside-scope", "value-mismatch"],
+        vec!["outside-scope", "template-unmatched", "value-mismatch"],
         "{:#?}",
         report.findings
     );
+    let severity_of = |name: &str| {
+        report
+            .findings
+            .iter()
+            .find(|finding| {
+                finding.category == FindingCategory::SelectorMatchesNothing
+                    && finding.subject.name == name
+            })
+            .map(|finding| finding.severity)
+            .unwrap()
+    };
+    assert_eq!(severity_of("outside-scope"), Severity::Warning);
+    assert_eq!(severity_of("template-unmatched"), Severity::Info);
 }
 
 #[tokio::test]

--- a/crates/rise-authz/tests/support/mod.rs
+++ b/crates/rise-authz/tests/support/mod.rs
@@ -302,6 +302,23 @@ impl ResourceStore for FakeStore {
         }
         Ok(descendants)
     }
+    /// Live rows carrying `key`, oldest-first (build order) and capped at
+    /// `limit` — mirroring the Postgres `created_at, uid` ordering closely
+    /// enough for tests, since fixture rows are built in ascending order.
+    async fn list_label_setters(
+        &self,
+        key: &rise_resource_api::LabelKey,
+        limit: i64,
+    ) -> Result<Vec<ResourceRow>, StoreError> {
+        Ok(self
+            .rows
+            .iter()
+            .filter(|row| row.deletion_timestamp.is_none())
+            .filter(|row| row.labels.contains_key(key.as_ref()))
+            .take(limit.max(0) as usize)
+            .cloned()
+            .collect())
+    }
     async fn try_collect(&self, _: Uuid) -> Result<DeleteOutcome, StoreError> {
         unimplemented!("authorization never writes")
     }

--- a/crates/rise-resource-api/src/store.rs
+++ b/crates/rise-resource-api/src/store.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
-use crate::{OwnerReference, ResourceParentRef, ResourceRow, ValidationError};
+use crate::{LabelKey, OwnerReference, ResourceParentRef, ResourceRow, ValidationError};
 
 /// Reserved finalizer prefix for store-managed finalizers. Controllers cannot
 /// add or remove finalizers in this namespace.
@@ -468,6 +468,23 @@ pub trait ResourceStore: ResourceApi {
         &self,
         uid: Uuid,
         label_key: &str,
+    ) -> Result<Vec<ResourceRow>, StoreError>;
+    /// Live rows whose own `labels` carry `key`, of any kind, ordered oldest
+    /// first, capped at `limit`.
+    ///
+    /// The complement of [`Self::label_inheriting_descendants`]: that walks
+    /// one resource's subtree for what inherits a value, this finds every
+    /// resource in the store that sets a key itself — the seed set the audit's
+    /// label-backed detectors need to reason about who `rise.dev/owner` names,
+    /// or whether a `labelSelector` can ever match anything, without a subtree
+    /// walk from every binding's scope. `limit` keeps a single call bounded
+    /// regardless of install size; a result of exactly `limit` rows means the
+    /// answer may be incomplete and the caller should treat it as such rather
+    /// than assume it has seen every setter.
+    async fn list_label_setters(
+        &self,
+        key: &LabelKey,
+        limit: i64,
     ) -> Result<Vec<ResourceRow>, StoreError>;
     /// Force-update status as an operator, storing the value under
     /// `status.controllers.operator:<operator>`.

--- a/crates/rise-resource-api/tests/resource_store_contract.rs
+++ b/crates/rise-resource-api/tests/resource_store_contract.rs
@@ -98,6 +98,13 @@ impl ResourceStore for FakeStore {
     ) -> Result<Vec<ResourceRow>, StoreError> {
         Ok(vec![])
     }
+    async fn list_label_setters(
+        &self,
+        _: &rise_resource_api::LabelKey,
+        _: i64,
+    ) -> Result<Vec<ResourceRow>, StoreError> {
+        Ok(vec![])
+    }
     async fn operator_update_status(
         &self,
         _: Uuid,

--- a/crates/rise-resource-store-postgres/migrations/20260907000000_labels_index.sql
+++ b/crates/rise-resource-store-postgres/migrations/20260907000000_labels_index.sql
@@ -1,0 +1,13 @@
+-- Index `resources.labels` for key-existence lookups.
+--
+-- `list_label_setters` (the audit's label-backed detectors) finds every live
+-- resource that sets one label key, across the whole store, with `labels ?
+-- $1`. That operator is JSONB key-existence, which only the default
+-- `jsonb_ops` GIN operator class supports; `jsonb_path_ops` (used by
+-- `owner_references`) does not implement `?` at all, so it is not a model
+-- here. Partial on live rows: a tombstoned resource's labels are never a
+-- setter the detectors care about.
+CREATE INDEX resources_labels_gin
+    ON resource_store.resources
+    USING GIN (labels)
+    WHERE deletion_timestamp IS NULL;

--- a/crates/rise-resource-store-postgres/src/pg_store.rs
+++ b/crates/rise-resource-store-postgres/src/pg_store.rs
@@ -5,9 +5,9 @@ use uuid::Uuid;
 use rise_resource_api::{
     is_immutable_policy_seed, validate_controller_id, validate_labels, validate_resource_name,
     CollectionInfo, CreateResourceParams, DeleteOutcome, DeletionBlocker,
-    DeletionBlockerRelationship, DeletionBlockerReport, NoOpValidator, OwnerReference, PathSegment,
-    PathWalk, ResourceApi, ResourceDefinitionSpec, ResourceKind, ResourceRow, ResourceStore,
-    SpecValidator, StoreError, UpdateResourceParams, API_VERSION_V1ALPHA1,
+    DeletionBlockerRelationship, DeletionBlockerReport, LabelKey, NoOpValidator, OwnerReference,
+    PathSegment, PathWalk, ResourceApi, ResourceDefinitionSpec, ResourceKind, ResourceRow,
+    ResourceStore, SpecValidator, StoreError, UpdateResourceParams, API_VERSION_V1ALPHA1,
     CASCADE_DELETION_FINALIZER, MAX_PARENT_CHAIN_DEPTH, ORGANIZATION_KIND,
     RESOURCE_DEFINITION_KIND, SYSTEM_FINALIZER_PREFIX,
 };
@@ -1894,6 +1894,38 @@ impl ResourceStore for PgResourceStore {
         .bind(uid)
         .bind(label_key)
         .bind(MAX_PARENT_CHAIN_DEPTH as i32)
+        .fetch_all(&mut *connection)
+        .await
+        .map_err(Self::db_error)?;
+
+        Ok(rows.into_iter().map(Into::into).collect())
+    }
+
+    async fn list_label_setters(
+        &self,
+        key: &LabelKey,
+        limit: i64,
+    ) -> Result<Vec<ResourceRow>, StoreError> {
+        // `?` is JSONB key-existence, which the default `jsonb_ops` GIN class
+        // supports and `jsonb_path_ops` does not — the reason this index (and
+        // this query) does not follow the `owner_references` GIN's operator
+        // class. Ordered oldest-first so a capped caller sees the longest-lived
+        // setters first and a repeated call with a growing limit is stable.
+        let mut connection = self.connection().await?;
+        let rows = sqlx::query_as::<_, PgResourceRow>(
+            r#"
+            SELECT uid, api_version, kind, parent_uid, name, discriminator, labels, metadata,
+                   spec, status, revision, finalizers, owner_references, deletion_timestamp,
+                   created_at, updated_at
+            FROM resource_store.resources
+            WHERE deletion_timestamp IS NULL
+              AND labels ? $1
+            ORDER BY created_at, uid
+            LIMIT $2
+            "#,
+        )
+        .bind(key.as_ref())
+        .bind(limit)
         .fetch_all(&mut *connection)
         .await
         .map_err(Self::db_error)?;

--- a/crates/rise-resource-store-postgres/tests/integration_tests.rs
+++ b/crates/rise-resource-store-postgres/tests/integration_tests.rs
@@ -1,7 +1,7 @@
 use rise_resource_api::{
-    CreateResourceParams, DeleteOutcome, ExternalSubject, Issuer, NoOpValidator, OwnerReference,
-    PathSegment, ResourceApi, ResourceRow, ResourceStore, StoreError, UpdateResourceParams,
-    API_VERSION_V1ALPHA1, CASCADE_DELETION_FINALIZER, CONTROLLER_KIND,
+    CreateResourceParams, DeleteOutcome, ExternalSubject, Issuer, LabelKey, NoOpValidator,
+    OwnerReference, PathSegment, ResourceApi, ResourceRow, ResourceStore, StoreError,
+    UpdateResourceParams, API_VERSION_V1ALPHA1, CASCADE_DELETION_FINALIZER, CONTROLLER_KIND,
     CONTROLLER_TRUST_POLICY_KIND, GROUP_KIND, GROUP_MEMBERSHIP_KIND, IDENTITY_KIND_DEFINITIONS,
     ORGANIZATION_KIND, PLATFORM_ROLE_BINDING_KIND, PLATFORM_ROLE_KIND, POLICY_KIND_DEFINITIONS,
     RESOURCE_DEFINITION_KIND, ROLE_BINDING_KIND, ROLE_KIND, SERVICE_ACCOUNT_KIND,
@@ -5806,6 +5806,133 @@ async fn label_inheriting_descendants_of_an_unknown_uid_are_empty(
         .await
         .unwrap()
         .is_empty());
+    Ok(())
+}
+
+// -----------------------------------------------------------------------------
+// The audit's label-backed detectors — `list_label_setters`
+// -----------------------------------------------------------------------------
+
+/// The complement of `label_inheriting_descendants`: every live resource that
+/// sets a key itself, any kind, unaffected by a value it does not carry, a
+/// tombstone, or a different key.
+#[sqlx::test]
+async fn list_label_setters_finds_every_live_setter_of_the_key(
+    pool: sqlx::PgPool,
+) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    register_org_widget_rd(&store).await;
+    let key: LabelKey = "rise.dev/owner".parse().unwrap();
+
+    // A root kind (Organization) and a child kind (OrgWidget) both count: the
+    // primitive is kind-agnostic.
+    let acme = create_labeled(
+        &store,
+        ORGANIZATION_KIND,
+        "acme",
+        None,
+        &[("rise.dev/owner", "user:alice")],
+    )
+    .await;
+    let widget = create_labeled(
+        &store,
+        "OrgWidget",
+        "with-owner",
+        Some(acme.uid),
+        &[("rise.dev/owner", "user:bob")],
+    )
+    .await;
+    // Neither is a setter: one carries no labels, the other carries a
+    // different key.
+    let _no_labels = create_labeled(&store, "OrgWidget", "bare", Some(acme.uid), &[]).await;
+    let _other_key = create_labeled(
+        &store,
+        "OrgWidget",
+        "unrelated",
+        Some(acme.uid),
+        &[("rise.dev/team", "group:x")],
+    )
+    .await;
+
+    let found = store.list_label_setters(&key, 100).await.unwrap();
+    let uids: Vec<Uuid> = found.iter().map(|row| row.uid).collect();
+    assert_eq!(uids.len(), 2);
+    assert!(uids.contains(&acme.uid));
+    assert!(uids.contains(&widget.uid));
+
+    Ok(())
+}
+
+/// A tombstoned setter is excluded — unlike `label_inheriting_descendants`,
+/// which deliberately keeps a draining resource's inherited authority visible,
+/// a tombstoned row is no longer a live grant of anything and must not name
+/// anybody as an owner or satisfy a selector.
+#[sqlx::test]
+async fn list_label_setters_excludes_tombstoned_rows(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    register_org_widget_rd(&store).await;
+    let key: LabelKey = "rise.dev/owner".parse().unwrap();
+
+    let acme = create_labeled(&store, ORGANIZATION_KIND, "acme", None, &[]).await;
+    let draining = create_labeled(
+        &store,
+        "OrgWidget",
+        "draining",
+        Some(acme.uid),
+        &[("rise.dev/owner", "user:alice")],
+    )
+    .await;
+    // A finalizer keeps the row present as a tombstone rather than hard-deleting.
+    store
+        .operator_update_finalizers(draining.uid, "test", &["example.dev/hold".to_string()], &[])
+        .await
+        .unwrap();
+    store.delete(draining.uid).await.unwrap();
+    let tombstoned = store.get(draining.uid).await.unwrap().unwrap();
+    assert!(tombstoned.deletion_timestamp.is_some());
+
+    let found = store.list_label_setters(&key, 100).await.unwrap();
+    assert!(!found.iter().any(|row| row.uid == draining.uid));
+
+    Ok(())
+}
+
+/// `limit` bounds the read, and a caller that pages with an increasing limit
+/// sees a stable, growing prefix — the oldest-first contract, checked without
+/// depending on exact timestamp resolution between two `create` calls.
+#[sqlx::test]
+async fn list_label_setters_respects_the_limit(pool: sqlx::PgPool) -> sqlx::Result<()> {
+    let store = PgResourceStore::new(pool);
+    let key: LabelKey = "rise.dev/owner".parse().unwrap();
+
+    let mut created = Vec::new();
+    for i in 0..5 {
+        created.push(
+            create_labeled(
+                &store,
+                ORGANIZATION_KIND,
+                &format!("org-{i}"),
+                None,
+                &[("rise.dev/owner", "user:alice")],
+            )
+            .await
+            .uid,
+        );
+    }
+
+    let capped = store.list_label_setters(&key, 2).await.unwrap();
+    assert_eq!(capped.len(), 2);
+    let full = store.list_label_setters(&key, 100).await.unwrap();
+    assert_eq!(full.len(), 5);
+
+    let capped_uids: Vec<Uuid> = capped.iter().map(|row| row.uid).collect();
+    let full_uids: Vec<Uuid> = full.iter().map(|row| row.uid).collect();
+    assert_eq!(
+        capped_uids,
+        full_uids[..2],
+        "a smaller limit returns a prefix of the unlimited result"
+    );
+
     Ok(())
 }
 

--- a/docs/engineering/src/content/docs/resources/storage.md
+++ b/docs/engineering/src/content/docs/resources/storage.md
@@ -104,6 +104,20 @@ reference with `blockOwnerDeletion: true` additionally keeps that owner visible
 until the dependent is collected. Owner references are lifecycle-only and
 confer no authorization.
 
+## Labels
+
+`metadata.labels` is a flat string-to-string map, stored in the
+`resources.labels` JSONB column. A resource's *effective* labels are resolved
+by nearest-wins inheritance down its ancestry (ADR-0001 §6.1), not stored
+per-row, so `labels` always holds only what that resource sets itself.
+
+Two GIN indexes support the two directions authorization reads this column: a
+default `jsonb_ops` index (`resources_labels_gin`, partial on live rows)
+accelerates `labels ? <key>` existence lookups — `list_label_setters` uses it
+to find every resource that sets a given key without a subtree walk. It uses
+the default operator class rather than `owner_references`'s `jsonb_path_ops`
+because `?` is not supported by `jsonb_path_ops`.
+
 ## Lifecycle: create
 
 The create path validates the spec (via the typed validator for built-ins, JSON Schema for external custom resources), generates a discriminator, and inserts the row at `revision = 1`. Same-level name and discriminator conflicts surface as `409 Conflict`.

--- a/src/server/resources/gc.rs
+++ b/src/server/resources/gc.rs
@@ -1013,6 +1013,14 @@ mod tests {
                 .await
         }
 
+        async fn list_label_setters(
+            &self,
+            key: &rise_resource_api::LabelKey,
+            limit: i64,
+        ) -> Result<Vec<ResourceRow>, StoreError> {
+            self.inner.list_label_setters(key, limit).await
+        }
+
         async fn try_collect(&self, uid: Uuid) -> Result<DeleteOutcome, StoreError> {
             if uid == self.fail_for {
                 return Err(StoreError::Validation("injected".to_string()));
@@ -1207,6 +1215,14 @@ mod tests {
             self.inner
                 .label_inheriting_descendants(uid, label_key)
                 .await
+        }
+
+        async fn list_label_setters(
+            &self,
+            key: &rise_resource_api::LabelKey,
+            limit: i64,
+        ) -> Result<Vec<ResourceRow>, StoreError> {
+            self.inner.list_label_setters(key, limit).await
         }
 
         async fn try_collect(&self, _uid: Uuid) -> Result<DeleteOutcome, StoreError> {


### PR DESCRIPTION
Second of the five-PR policy-audit stack; builds on `-1` (engine audit core).

## What

- New `ResourceStore::list_label_setters(key, limit)`: live rows whose own `labels` carry a key, any kind, oldest first, capped. Implemented in `rise-resource-store-postgres` with a runtime `labels ? $1` query, plus a new migration adding a partial GIN index on `labels` with the default `jsonb_ops` class (the `?` operator is not supported by `jsonb_path_ops`, so the owner-references index was not a model). The existing labels migration has shipped in release tags and is untouched.
- Two more detectors in `engine::audit`:
  - `InertOwnerLabel`: a `rise.dev/owner` value the seeded `${ref.subject}` binding cannot turn into a grant (malformed, names a missing Group/ServiceAccount, or names a User with no affiliation in the resource's org — the last at `Info`, since affiliation is live).
  - `SelectorMatchesNothing`: a binding whose `labelSelector` no resource under its scope satisfies, decided exactly without a subtree walk: the scope root's effective labels, then explicit setters at or below the root. A scan that hits the limit without a match is "unknown" and produces no finding. A dynamic-subject binding (the seeded `resource-owner` shape on a fresh install) is reported at `Info`; a literal subject on an unset key keeps the `Warning`.
- `storage.md` documents the labels column and its index.

## Verification

- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test -p rise-authz --all-features`, `cargo test -p rise-resource-api --all-features`, `cargo test -p rise-resource-store-postgres --all-features` (three new `list_label_setters` integration tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016orpm2Btwa7KmcnAzTNwKX

---
_Generated by [Claude Code](https://claude.ai/code/session_016orpm2Btwa7KmcnAzTNwKX)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rise-deploy/codesmith/rise/pr/499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791403557&installation_model_id=432987&pr_number=499&repository=rise-deploy%2Frise&return_to=https%3A%2F%2Fgithub.com%2Frise-deploy%2Frise%2Fpull%2F499&signature=fc885a3494e178c30676b6a63356b8b0dc972315be637338d164513ee8c838cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->