### PR TITLE
authz: detect Allows shadowed by platform Denies or wildcard replacement

### DIFF
--- a/crates/rise-authz/src/engine/audit.rs
+++ b/crates/rise-authz/src/engine/audit.rs
@@ -12,9 +12,9 @@
 use std::collections::BTreeMap;
 
 use rise_resource_api::{
-    resource_owner_binding_spec, LabelKey, LabelSelector, PathSegment, ResourceRow, ResourceStore,
-    RoleRefKind, Scope, StoreError, SubjectId, SubjectMembership, UserSpec, API_GROUP,
-    API_VERSION_V1ALPHA1, CONTROLLER_KIND, GROUP_KIND, GROUP_MEMBERSHIP_KIND,
+    resource_owner_binding_spec, Effect, LabelKey, LabelSelector, PathSegment, PolicyStatement,
+    ResourceRow, ResourceStore, RoleRefKind, Scope, StoreError, SubjectId, SubjectMembership,
+    UserSpec, API_GROUP, API_VERSION_V1ALPHA1, CONTROLLER_KIND, GROUP_KIND, GROUP_MEMBERSHIP_KIND,
     MAX_PARENT_CHAIN_DEPTH, ORGANIZATION_KIND, ORG_ADMIN_PLATFORM_ROLE, OWNER_LABEL_KEY,
     SERVICE_ACCOUNT_KIND, USER_KIND,
 };
@@ -27,7 +27,10 @@ use crate::engine::{
     qualifies_as_org_admin, AuthorizationEngine, AuthorizationError, MembershipResolver,
     ResourceTree,
 };
-use crate::policy::{resolve_subject, BindingTier};
+use crate::policy::{
+    deny_covers_allow, domain_covers, replaces, resolve_subject, subject_covers, ApplicableBinding,
+    BindingTier, PolicyDomain,
+};
 
 /// What to audit, and how much work to do.
 ///
@@ -201,6 +204,18 @@ impl AuthorizationEngine {
             scope.max_findings,
             detect_selector_matches_nothing(store, &platform).await?,
         );
+        append_capped(
+            &mut findings,
+            &mut truncated,
+            scope.max_findings,
+            detect_shadowed_by_deny(&platform, &platform),
+        );
+        append_capped(
+            &mut findings,
+            &mut truncated,
+            scope.max_findings,
+            detect_shadowed_by_replacement(&platform, &platform),
+        );
 
         append_capped(
             &mut findings,
@@ -268,6 +283,18 @@ impl AuthorizationEngine {
                 &mut truncated,
                 scope.max_findings,
                 detect_selector_matches_nothing(store, &org_bindings).await?,
+            );
+            append_capped(
+                &mut findings,
+                &mut truncated,
+                scope.max_findings,
+                detect_shadowed_by_deny(&platform, &org_bindings),
+            );
+            append_capped(
+                &mut findings,
+                &mut truncated,
+                scope.max_findings,
+                detect_shadowed_by_replacement(&platform, &org_bindings),
             );
             append_capped(
                 &mut findings,
@@ -1041,6 +1068,166 @@ fn selector_matches_labels(labels: &BTreeMap<String, String>, selector: &LabelSe
             .is_none_or(|expected| expected == value),
         None => false,
     }
+}
+
+// ---------------------------------------------------------------------------
+// Row 9: ShadowedAllow { by: Deny }
+// ---------------------------------------------------------------------------
+
+/// A binding's `PolicyDomain`: the same `(scope, selector)` pair
+/// [`domain_covers`] and [`replaces`] compare over, borrowed straight from the
+/// binding facts the audit already loaded.
+fn binding_domain(binding: &BindingFact) -> PolicyDomain {
+    PolicyDomain {
+        scope: binding.scope.clone(),
+        selector: binding.selector.clone(),
+    }
+}
+
+/// A `binding`'s field values reduced to what [`replaces`] and
+/// [`wildcard_allows_suppressed`](crate::policy::wildcard_allows_suppressed)
+/// need — the subject, scope and selector its placement is judged by — without
+/// cloning its (possibly large) statement list.
+fn as_applicable(binding: &BindingFact) -> ApplicableBinding<()> {
+    ApplicableBinding {
+        provenance: (),
+        subject: binding.subject.clone(),
+        scope: binding.scope.clone(),
+        selector: binding.selector.clone(),
+        tier: binding.tier.clone(),
+        statements: Vec::new(),
+    }
+}
+
+/// An Allow statement in a live binding that a platform-tier Deny shadows.
+///
+/// Platform Denies only: an org Deny is escaped by that org's own admins
+/// (ADR-0001 §5's exemption), so it never shadows an Allow for every caller
+/// the way a platform Deny does. `Info`, not `Warning`: a platform ceiling
+/// sitting over a narrower Allow is usually deliberate defense in depth, not a
+/// mistake — unlike a dangling reference or a stale scope, nothing here is
+/// obviously wrong.
+pub fn detect_shadowed_by_deny(
+    platform: &[BindingFact],
+    bindings: &[BindingFact],
+) -> Vec<AuditFinding> {
+    let mut findings = Vec::new();
+    for binding in bindings {
+        let allows: Vec<&PolicyStatement> = binding
+            .statements
+            .iter()
+            .filter(|statement| statement.effect == Effect::Allow)
+            .collect();
+        if allows.is_empty() {
+            continue;
+        }
+        let domain = binding_domain(binding);
+        for deny_binding in platform {
+            if deny_binding.provenance.uid == binding.provenance.uid {
+                continue;
+            }
+            let denies: Vec<&PolicyStatement> = deny_binding
+                .statements
+                .iter()
+                .filter(|statement| statement.effect == Effect::Deny)
+                .collect();
+            if denies.is_empty() {
+                continue;
+            }
+            if !subject_covers(&deny_binding.subject, &binding.subject) {
+                continue;
+            }
+            if !domain_covers(&binding_domain(deny_binding), &domain) {
+                continue;
+            }
+            let covered = allows
+                .iter()
+                .filter(|allow| denies.iter().any(|deny| deny_covers_allow(deny, allow)))
+                .count();
+            if covered == 0 {
+                continue;
+            }
+            findings.push(AuditFinding {
+                subject: binding_subject(binding),
+                category: FindingCategory::ShadowedAllow { by: Shadow::Deny },
+                severity: Severity::Info,
+                related: vec![binding_subject(deny_binding)],
+                detail: format!(
+                    "{} '{}' denies {covered} of this binding's {} Allow statements; they grant nothing under it.",
+                    deny_binding.provenance.kind,
+                    deny_binding
+                        .provenance
+                        .name
+                        .clone()
+                        .unwrap_or_else(|| deny_binding.provenance.uid.to_string()),
+                    allows.len(),
+                ),
+            });
+        }
+    }
+    findings
+}
+
+// ---------------------------------------------------------------------------
+// Row 10: ShadowedAllow { by: Replacement }
+// ---------------------------------------------------------------------------
+
+/// An Allow statement a wildcard-scoped platform binding loses to a more
+/// specific binding through ADR-0001 §1's wildcard-replacement pairing.
+///
+/// Only platform bindings can carry `scope: "*"` at all — org containment
+/// keeps an org binding's scope inside its own parent's subtree — so the
+/// candidate that replaces it can be platform or org tier, but the wildcard
+/// side is always read from `platform`. Always `Warning`: unlike a platform
+/// Deny ceiling, this is a specific binding actively taking over from a
+/// broader one the moment both are applicable, which is worth surfacing even
+/// when intentional.
+pub fn detect_shadowed_by_replacement(
+    platform: &[BindingFact],
+    bindings: &[BindingFact],
+) -> Vec<AuditFinding> {
+    let mut findings = Vec::new();
+    for wildcard in platform
+        .iter()
+        .filter(|binding| binding.scope.is_wildcard())
+    {
+        if !wildcard
+            .statements
+            .iter()
+            .any(|statement| statement.effect == Effect::Allow)
+        {
+            // Nothing for a more specific binding to drop.
+            continue;
+        }
+        let wildcard_applicable = as_applicable(wildcard);
+        for candidate in bindings {
+            if candidate.provenance.uid == wildcard.provenance.uid {
+                continue;
+            }
+            if !replaces(&as_applicable(candidate), &wildcard_applicable) {
+                continue;
+            }
+            findings.push(AuditFinding {
+                subject: binding_subject(wildcard),
+                category: FindingCategory::ShadowedAllow {
+                    by: Shadow::Replacement,
+                },
+                severity: Severity::Warning,
+                related: vec![binding_subject(candidate)],
+                detail: format!(
+                    "on resources inside scope '{}', this binding's Allow statements are dropped by wildcard replacement; {} '{}' applies its own statements there instead.",
+                    candidate.scope,
+                    candidate.provenance.kind,
+                    candidate
+                        .provenance
+                        .name
+                        .clone()
+                        .unwrap_or_else(|| candidate.provenance.uid.to_string()),
+                ),
+            });
+        }
+    }
+    findings
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rise-authz/src/policy.rs
+++ b/crates/rise-authz/src/policy.rs
@@ -184,19 +184,84 @@ pub fn wildcard_allows_suppressed<P>(bindings: &[ApplicableBinding<P>]) -> Vec<b
     bindings
         .iter()
         .map(|binding| {
-            binding.scope.is_wildcard()
-                && bindings.iter().any(|candidate| {
-                    !candidate.scope.is_wildcard()
-                        && candidate.subject == binding.subject
-                        && selector_key(candidate.selector.as_ref())
-                            == selector_key(binding.selector.as_ref())
-                })
+            bindings
+                .iter()
+                .any(|candidate| replaces(candidate, binding))
         })
         .collect()
 }
 
 fn selector_key(selector: Option<&LabelSelector>) -> Option<&rise_resource_api::LabelKey> {
     selector.map(|selector| &selector.key)
+}
+
+/// The ADR-0001 §1 wildcard-replacement pairing: `specific` drops
+/// `wildcard`'s Allow content on every resource where both are applicable —
+/// same authored subject, same selector key, `wildcard`'s scope is `*` and
+/// `specific`'s is not.
+///
+/// Extracted from [`wildcard_allows_suppressed`], which is this predicate
+/// applied pairwise; its behavior is unchanged by the extraction.
+pub fn replaces<P>(specific: &ApplicableBinding<P>, wildcard: &ApplicableBinding<P>) -> bool {
+    wildcard.scope.is_wildcard()
+        && !specific.scope.is_wildcard()
+        && specific.subject == wildcard.subject
+        && selector_key(specific.selector.as_ref()) == selector_key(wildcard.selector.as_ref())
+}
+
+/// Whether `deny` matches every tuple `allow` does.
+///
+/// Implemented by turning `deny`'s matchers into an Allow and asking whether
+/// it dominates `allow`'s tuples through the same representative-based subset
+/// machinery [`policy_is_subset`] uses, so the answer agrees with [`evaluate`]
+/// by construction rather than by a second, possibly-diverging comparison.
+/// Either statement having the wrong effect for its position (a `Deny` asked
+/// to cover, or an `Allow` asked to be covered) answers `false`.
+pub fn deny_covers_allow(deny: &PolicyStatement, allow: &PolicyStatement) -> bool {
+    if deny.effect != Effect::Deny || allow.effect != Effect::Allow {
+        return false;
+    }
+    let deny_as_allow = PolicyStatement {
+        effect: Effect::Allow,
+        kinds: deny.kinds.clone(),
+        verbs: deny.verbs.clone(),
+        subresources: deny.subresources.clone(),
+    };
+    policy_is_subset(
+        std::slice::from_ref(allow),
+        std::slice::from_ref(&deny_as_allow),
+    )
+}
+
+/// Whether every principal `covered` can match is one `covering` also
+/// matches, decided from the two subjects' authored forms alone.
+///
+/// Only two shapes are decidable this way, both definitional in ADR-0001 §1:
+/// `system:authenticated` reaches every subject, and `org:<o>` reaches every
+/// org-native (`group:`/`serviceaccount:`) subject naming `o`. A `user:`
+/// subject is only ever *contingently* a member of an org — deciding that
+/// needs a live membership lookup this function deliberately has no access
+/// to — so `org:<o>` never covers one here. A dynamic template is authored
+/// per binding and is covered by, or covers, nothing but an identical
+/// template.
+pub fn subject_covers(covering: &BindingSubject, covered: &BindingSubject) -> bool {
+    if covering == covered {
+        return true;
+    }
+    let Some(covering) = covering.literal() else {
+        return false;
+    };
+    if covering.as_ref() == "system:authenticated" {
+        return true;
+    }
+    if covering.kind() != "org" {
+        return false;
+    }
+    let Some(covered) = covered.literal() else {
+        return false;
+    };
+    matches!(covered.kind(), "group" | "serviceaccount")
+        && covered.organization() == Some(covering.name())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -508,4 +573,230 @@ fn probe_subresource(existing: &BTreeSet<SubresourceName>) -> SubresourceName {
         }
     }
     unreachable!()
+}
+
+#[cfg(test)]
+mod shadowing_tests {
+    use super::*;
+    use rise_resource_api::ResourceKindPattern;
+
+    fn kind(group: &str, kind: &str) -> ResourceKind {
+        ResourceKind::new(group, kind).expect("valid kind")
+    }
+
+    fn kinds(patterns: &[ResourceKind]) -> KindMatcher {
+        KindMatcher::Patterns(
+            patterns
+                .iter()
+                .cloned()
+                .map(ResourceKindPattern::Exact)
+                .collect(),
+        )
+    }
+
+    fn verbs(vs: &[Verb]) -> VerbMatcher {
+        VerbMatcher::Verbs(vs.iter().copied().collect())
+    }
+
+    fn allow_statement(kinds: KindMatcher, verbs: VerbMatcher) -> PolicyStatement {
+        PolicyStatement {
+            effect: Effect::Allow,
+            kinds,
+            verbs,
+            subresources: None,
+        }
+    }
+
+    fn deny_statement(kinds: KindMatcher, verbs: VerbMatcher) -> PolicyStatement {
+        PolicyStatement {
+            effect: Effect::Deny,
+            kinds,
+            verbs,
+            subresources: None,
+        }
+    }
+
+    #[test]
+    fn deny_covers_allow_when_deny_is_wildcard() {
+        let deny = deny_statement(KindMatcher::All, VerbMatcher::All);
+        let allow = allow_statement(kinds(&[kind("rise.dev", "Project")]), verbs(&[Verb::Get]));
+        assert!(deny_covers_allow(&deny, &allow));
+    }
+
+    #[test]
+    fn deny_covers_allow_exact_match() {
+        let matcher = kinds(&[kind("rise.dev", "Project")]);
+        let deny = deny_statement(matcher.clone(), verbs(&[Verb::Get, Verb::List]));
+        let allow = allow_statement(matcher, verbs(&[Verb::Get]));
+        assert!(deny_covers_allow(&deny, &allow));
+    }
+
+    #[test]
+    fn deny_covers_allow_false_when_deny_is_narrower_on_verbs() {
+        let deny = deny_statement(KindMatcher::All, verbs(&[Verb::Get]));
+        let allow = allow_statement(KindMatcher::All, verbs(&[Verb::Get, Verb::List]));
+        assert!(!deny_covers_allow(&deny, &allow));
+    }
+
+    #[test]
+    fn deny_covers_allow_false_when_deny_is_narrower_on_kinds() {
+        let deny = deny_statement(kinds(&[kind("rise.dev", "Project")]), VerbMatcher::All);
+        let allow = allow_statement(KindMatcher::All, VerbMatcher::All);
+        assert!(!deny_covers_allow(&deny, &allow));
+    }
+
+    #[test]
+    fn deny_covers_allow_requires_the_expected_effect_on_each_side() {
+        let statement = allow_statement(KindMatcher::All, VerbMatcher::All);
+        // Passing an Allow where a Deny is expected never covers, regardless
+        // of how permissive it is.
+        assert!(!deny_covers_allow(&statement, &statement));
+    }
+
+    fn literal(subject: &str) -> BindingSubject {
+        BindingSubject::Literal(subject.parse().expect("valid subject"))
+    }
+
+    #[test]
+    fn subject_covers_identical_subjects() {
+        let subject = literal("user:alice");
+        assert!(subject_covers(&subject, &subject));
+        assert!(subject_covers(
+            &BindingSubject::UserNameTemplate,
+            &BindingSubject::UserNameTemplate
+        ));
+    }
+
+    #[test]
+    fn subject_covers_system_authenticated_covers_every_subject() {
+        let authenticated = literal("system:authenticated");
+        assert!(subject_covers(&authenticated, &literal("user:alice")));
+        assert!(subject_covers(
+            &authenticated,
+            &literal("group:acme/platform")
+        ));
+        assert!(subject_covers(
+            &authenticated,
+            &literal("controller:reconciler")
+        ));
+        assert!(subject_covers(
+            &authenticated,
+            &BindingSubject::SubjectRefTemplate
+        ));
+    }
+
+    #[test]
+    fn subject_covers_org_covers_its_own_group_and_service_account() {
+        let org = literal("org:acme");
+        assert!(subject_covers(&org, &literal("group:acme/platform")));
+        assert!(subject_covers(&org, &literal("serviceaccount:acme/ci")));
+    }
+
+    #[test]
+    fn subject_covers_org_does_not_cover_a_user() {
+        // A `user:` subject is only ever contingently a member of an org, so
+        // `org:<o>` never covers one from the authored forms alone.
+        let org = literal("org:acme");
+        assert!(!subject_covers(&org, &literal("user:alice")));
+    }
+
+    #[test]
+    fn subject_covers_org_does_not_cover_a_different_org() {
+        let org = literal("org:acme");
+        assert!(!subject_covers(&org, &literal("group:other-org/platform")));
+    }
+
+    #[test]
+    fn subject_covers_a_template_covers_nothing_but_itself() {
+        assert!(!subject_covers(
+            &BindingSubject::UserNameTemplate,
+            &literal("user:alice")
+        ));
+        assert!(!subject_covers(
+            &BindingSubject::UserNameTemplate,
+            &BindingSubject::GroupNameTemplate
+        ));
+    }
+
+    fn applicable_binding(
+        subject: BindingSubject,
+        scope: &str,
+        selector: Option<LabelSelector>,
+    ) -> ApplicableBinding<()> {
+        ApplicableBinding {
+            provenance: (),
+            subject,
+            scope: scope.parse().expect("valid scope"),
+            selector,
+            tier: BindingTier::Platform,
+            statements: Vec::new(),
+        }
+    }
+
+    fn selector(key: &str) -> LabelSelector {
+        LabelSelector {
+            key: key.parse().expect("valid label key"),
+            value: None,
+        }
+    }
+
+    #[test]
+    fn replaces_same_subject_and_selector_key() {
+        let subject = literal("user:alice");
+        let wildcard = applicable_binding(subject.clone(), "*", Some(selector("rise.dev/team")));
+        let specific = applicable_binding(
+            subject,
+            "rise.dev/Project/acme/app",
+            Some(selector("rise.dev/team")),
+        );
+        assert!(replaces(&specific, &wildcard));
+    }
+
+    #[test]
+    fn replaces_true_with_no_selector_on_either_side() {
+        let subject = literal("user:alice");
+        let wildcard = applicable_binding(subject.clone(), "*", None);
+        let specific = applicable_binding(subject, "rise.dev/Project/acme/app", None);
+        assert!(replaces(&specific, &wildcard));
+    }
+
+    #[test]
+    fn replaces_false_on_different_selector_keys() {
+        let subject = literal("user:alice");
+        let wildcard = applicable_binding(subject.clone(), "*", Some(selector("rise.dev/team")));
+        let specific = applicable_binding(
+            subject,
+            "rise.dev/Project/acme/app",
+            Some(selector("rise.dev/other")),
+        );
+        assert!(!replaces(&specific, &wildcard));
+    }
+
+    #[test]
+    fn replaces_false_on_different_subjects() {
+        let wildcard =
+            applicable_binding(literal("user:alice"), "*", Some(selector("rise.dev/team")));
+        let specific = applicable_binding(
+            literal("user:bob"),
+            "rise.dev/Project/acme/app",
+            Some(selector("rise.dev/team")),
+        );
+        assert!(!replaces(&specific, &wildcard));
+    }
+
+    #[test]
+    fn replaces_false_when_wildcard_argument_is_not_wildcard_scoped() {
+        let subject = literal("user:alice");
+        let not_wildcard = applicable_binding(subject.clone(), "rise.dev/Project/acme/app", None);
+        let specific = applicable_binding(subject, "rise.dev/Project/acme/app2", None);
+        assert!(!replaces(&specific, &not_wildcard));
+    }
+
+    #[test]
+    fn replaces_false_when_specific_argument_is_also_wildcard_scoped() {
+        let subject = literal("user:alice");
+        let wildcard = applicable_binding(subject.clone(), "*", None);
+        let also_wildcard = applicable_binding(subject, "*", None);
+        assert!(!replaces(&also_wildcard, &wildcard));
+    }
 }

--- a/crates/rise-authz/tests/audit.rs
+++ b/crates/rise-authz/tests/audit.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use rise_authz::engine::{
-    AuditScope, AuthorizationEngine, FindingCategory, Severity, ORG_ADMIN_PLATFORM_ROLE,
+    AuditScope, AuthorizationEngine, FindingCategory, Severity, Shadow, ORG_ADMIN_PLATFORM_ROLE,
 };
 use rise_resource_api::ResourceStore;
 use serde_json::json;
@@ -583,6 +583,269 @@ async fn selector_matches_nothing_positive_and_negative() {
     };
     assert_eq!(severity_of("outside-scope"), Severity::Warning);
     assert_eq!(severity_of("template-unmatched"), Severity::Info);
+}
+
+#[tokio::test]
+async fn shadowed_by_deny_positive_and_negative() {
+    fn deny_binding(name: &str, scope: &str) -> serde_json::Value {
+        json!({
+            "subject": "system:authenticated",
+            "subjectMembership": "Any",
+            "scope": scope,
+            "roleRef": { "kind": "PlatformRole", "name": format!("{name}-role") }
+        })
+    }
+
+    let mut builder = StoreBuilder::new();
+    let acme = builder.resource(ORGANIZATION, "acme", None);
+    let other_org = builder.resource(ORGANIZATION, "other-org", None);
+
+    // Three platform-tier Denies, each covering a different slice, so the
+    // positive and negative cases can be told apart by which one is (or is
+    // not) named in a finding's `related`.
+    builder.role(
+        PLATFORM_ROLE,
+        "covers-role",
+        None,
+        json!([{ "effect": "Deny", "kinds": "*", "verbs": ["get", "list"] }]),
+    );
+    builder.binding(
+        PLATFORM_ROLE_BINDING,
+        "covers",
+        None,
+        deny_binding("covers", "*"),
+    );
+    // Negative: narrower on verbs than any Allow it is tested against below.
+    builder.role(
+        PLATFORM_ROLE,
+        "narrow-role",
+        None,
+        json!([{ "effect": "Deny", "kinds": "*", "verbs": ["delete"] }]),
+    );
+    builder.binding(
+        PLATFORM_ROLE_BINDING,
+        "narrow",
+        None,
+        deny_binding("narrow", "*"),
+    );
+    // Negative: a concrete-scope Deny cannot cover a wildcard-scoped Allow,
+    // regardless of how permissive it otherwise is.
+    builder.role(
+        PLATFORM_ROLE,
+        "scoped-role",
+        None,
+        json!([{ "effect": "Deny", "kinds": "*", "verbs": "*" }]),
+    );
+    builder.binding(
+        PLATFORM_ROLE_BINDING,
+        "scoped",
+        None,
+        deny_binding("scoped", "rise.dev/Organization/acme"),
+    );
+
+    // Positive: an org Allow fully covered by both `covers` (identical verbs)
+    // and `scoped` (wildcard verbs, matching concrete scope); `narrow` misses
+    // it because "list" is not among the verbs it denies.
+    builder.role(
+        ROLE,
+        "reader",
+        Some(acme),
+        json!([{ "effect": "Allow", "kinds": "*", "verbs": ["get", "list"] }]),
+    );
+    builder.binding(
+        ROLE_BINDING,
+        "shadowed",
+        Some(acme),
+        json!({
+            "subject": "user:u-alice",
+            "scope": "rise.dev/Organization/acme",
+            "roleRef": { "kind": "Role", "name": "reader" }
+        }),
+    );
+
+    // Negative: a platform-tier Allow with a wildcard scope. `scoped`'s
+    // concrete scope can never cover it, and its verb ("update") is missed by
+    // both `covers` and `narrow`, so nothing shadows it.
+    builder.role(
+        PLATFORM_ROLE,
+        "wide-allow-role",
+        None,
+        json!([{ "effect": "Allow", "kinds": "*", "verbs": ["update"] }]),
+    );
+    builder.binding(
+        PLATFORM_ROLE_BINDING,
+        "wide-allow",
+        None,
+        json!({
+            "subject": "system:authenticated",
+            "subjectMembership": "Any",
+            "scope": "*",
+            "roleRef": { "kind": "PlatformRole", "name": "wide-allow-role" }
+        }),
+    );
+
+    // Negative: an org-tier Deny is never a shadowing candidate — only
+    // `platform` bindings are, because an org Deny is escaped by that org's
+    // own admins. Its Allow target's verb ("update") is also outside every
+    // platform Deny's reach, so this row only turns up empty-handed.
+    builder.role(
+        ROLE,
+        "org-ceiling",
+        Some(other_org),
+        json!([{ "effect": "Deny", "kinds": "*", "verbs": "*" }]),
+    );
+    builder.binding(
+        ROLE_BINDING,
+        "org-deny",
+        Some(other_org),
+        json!({
+            "subject": "system:authenticated",
+            "scope": "rise.dev/Organization/other-org",
+            "roleRef": { "kind": "Role", "name": "org-ceiling" }
+        }),
+    );
+    builder.role(
+        ROLE,
+        "updater",
+        Some(other_org),
+        json!([{ "effect": "Allow", "kinds": "*", "verbs": ["update"] }]),
+    );
+    builder.binding(
+        ROLE_BINDING,
+        "clean-target",
+        Some(other_org),
+        json!({
+            "subject": "user:u-dave",
+            "scope": "rise.dev/Organization/other-org",
+            "roleRef": { "kind": "Role", "name": "updater" }
+        }),
+    );
+
+    let store = builder.build();
+    let engine = engine(store, FakeMemberships::none());
+
+    let report = engine.audit(&every_org()).await.unwrap();
+    let mut flagged: Vec<(&str, &str)> = report
+        .findings
+        .iter()
+        .filter(|finding| finding.category == FindingCategory::ShadowedAllow { by: Shadow::Deny })
+        .map(|finding| {
+            (
+                finding.subject.name.as_str(),
+                finding.related[0].name.as_str(),
+            )
+        })
+        .collect();
+    flagged.sort_unstable();
+    assert_eq!(
+        flagged,
+        vec![("shadowed", "covers"), ("shadowed", "scoped")],
+        "{:#?}",
+        report.findings
+    );
+    assert!(report
+        .findings
+        .iter()
+        .filter(|finding| finding.category == FindingCategory::ShadowedAllow { by: Shadow::Deny })
+        .all(|finding| finding.severity == Severity::Info));
+}
+
+#[tokio::test]
+async fn shadowed_by_replacement_positive_and_negative() {
+    let mut builder = StoreBuilder::new();
+    let acme = builder.resource(ORGANIZATION, "acme", None);
+
+    // A platform wildcard binding with an Allow, selecting on `rise.dev/team`.
+    builder.role(PLATFORM_ROLE, "wildcard-role", None, allow_all());
+    builder.binding(
+        PLATFORM_ROLE_BINDING,
+        "wildcard",
+        None,
+        json!({
+            "subject": "user:u-alice",
+            "subjectMembership": "Any",
+            "scope": "*",
+            "labelSelector": { "key": "rise.dev/team" },
+            "roleRef": { "kind": "PlatformRole", "name": "wildcard-role" }
+        }),
+    );
+
+    // Positive: same subject, same selector key, a non-wildcard scope — this
+    // replaces the wildcard binding's Allows wherever both apply.
+    builder.role(ROLE, "reader", Some(acme), allow_all());
+    builder.binding(
+        ROLE_BINDING,
+        "specific",
+        Some(acme),
+        json!({
+            "subject": "user:u-alice",
+            "scope": "rise.dev/Organization/acme",
+            "labelSelector": { "key": "rise.dev/team" },
+            "roleRef": { "kind": "Role", "name": "reader" }
+        }),
+    );
+
+    // Negative: same subject, but a different selector key never pairs up.
+    builder.binding(
+        ROLE_BINDING,
+        "different-key",
+        Some(acme),
+        json!({
+            "subject": "user:u-alice",
+            "scope": "rise.dev/Organization/acme",
+            "labelSelector": { "key": "rise.dev/other" },
+            "roleRef": { "kind": "Role", "name": "reader" }
+        }),
+    );
+
+    // Negative: same selector key, but a different subject never pairs up.
+    builder.binding(
+        ROLE_BINDING,
+        "different-subject",
+        Some(acme),
+        json!({
+            "subject": "user:u-bob",
+            "scope": "rise.dev/Organization/acme",
+            "labelSelector": { "key": "rise.dev/team" },
+            "roleRef": { "kind": "Role", "name": "reader" }
+        }),
+    );
+
+    let store = builder.build();
+    let engine = engine(store, FakeMemberships::none());
+
+    let report = engine.audit(&every_org()).await.unwrap();
+    let flagged: Vec<(&str, &str)> = report
+        .findings
+        .iter()
+        .filter(|finding| {
+            finding.category
+                == FindingCategory::ShadowedAllow {
+                    by: Shadow::Replacement,
+                }
+        })
+        .map(|finding| {
+            (
+                finding.subject.name.as_str(),
+                finding.related[0].name.as_str(),
+            )
+        })
+        .collect();
+    assert_eq!(
+        flagged,
+        vec![("wildcard", "specific")],
+        "{:#?}",
+        report.findings
+    );
+    assert_eq!(
+        report
+            .findings
+            .iter()
+            .find(|finding| finding.subject.name == "wildcard")
+            .unwrap()
+            .severity,
+        Severity::Warning
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Third of the five-PR policy-audit stack; builds on `-2`.

## What

- Pure Tier-0 predicates in `rise_authz::policy`: `deny_covers_allow` (a Deny matches every tuple an Allow permits, computed through the same representative-based subset machinery the grant gate uses, so it agrees with the evaluator by construction), `subject_covers` (`system:authenticated` covers everything; `org:<o>` covers org-native subjects in `o`; a `user:` is never covered structurally), and `replaces` (the ADR-0001 §1 wildcard-replacement pairing, extracted from `wildcard_allows_suppressed`, whose behavior is unchanged).
- Two detectors in `engine::audit`:
  - `ShadowedAllow { by: Deny }` at `Info`: a binding's Allow fully covered by a platform-tier Deny on a covering subject and domain. Platform Denies only, since an org Deny is escaped by that org's admins.
  - `ShadowedAllow { by: Replacement }` at `Warning`: a wildcard-scoped platform binding whose Allows are dropped inside a more specific binding's scope on the same subject and selector key. The related binding is named in the finding.

## Verification

- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test -p rise-authz --all-features` (17 new predicate unit tests, two new audit tests, healthy install still yields zero findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016orpm2Btwa7KmcnAzTNwKX

---
_Generated by [Claude Code](https://claude.ai/code/session_016orpm2Btwa7KmcnAzTNwKX)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rise-deploy/codesmith/rise/pr/500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791403564&installation_model_id=432987&pr_number=500&repository=rise-deploy%2Frise&return_to=https%3A%2F%2Fgithub.com%2Frise-deploy%2Frise%2Fpull%2F500&signature=2390e5f2107a0176d66284f79296fcd0a28a194a77812b083300189cc702e758"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->